### PR TITLE
Harmonize Geneve and Faker randomness

### DIFF
--- a/docs/events_generation_presentation/presentation.py
+++ b/docs/events_generation_presentation/presentation.py
@@ -18,9 +18,10 @@
 """Helper for the presentation."""
 
 import os
-import random
 
 presentation_dir = os.path.split(__file__)[0]
 os.chdir(os.path.abspath(os.path.join(presentation_dir, "..", "..")))
+
+from geneve.utils import random
 
 random.seed("presentation")

--- a/geneve/events_emitter.py
+++ b/geneve/events_emitter.py
@@ -17,7 +17,6 @@
 
 """Functions for generating event documents that would trigger a given rule."""
 
-import random
 from collections import namedtuple
 from datetime import datetime, timedelta, timezone
 from itertools import chain
@@ -25,7 +24,7 @@ from itertools import chain
 from .events_emitter_eql import collect_constraints as collect_constraints_eql
 from .events_emitter_eql import get_ast_stats  # noqa: F401
 from .solver import emit_field
-from .utils import deep_merge
+from .utils import deep_merge, random
 
 __all__ = ("SourceEvents",)
 

--- a/geneve/solver/__init__.py
+++ b/geneve/solver/__init__.py
@@ -17,11 +17,10 @@
 
 """Constraints solver helper class."""
 
-import random
 from functools import wraps
 
 from ..constraints import ConflictError
-from ..utils import deep_merge
+from ..utils import deep_merge, random
 
 _max_attempts = 100000
 

--- a/geneve/solver/__init__.py
+++ b/geneve/solver/__init__.py
@@ -19,9 +19,12 @@
 
 from functools import wraps
 
+import faker
+
 from ..constraints import ConflictError
 from ..utils import deep_merge, random
 
+faker.generator.random = random
 _max_attempts = 100000
 
 ecs_constraints = {

--- a/geneve/solver/geo.py
+++ b/geneve/solver/geo.py
@@ -17,15 +17,11 @@
 
 """Geo group constraints solver."""
 
-import random
-
 from faker import Faker
 
 from geneve.solver import emit_group, solver
 
-# https://faker.readthedocs.io/en/master/index.html#seeding-the-generator
 faker = Faker()
-faker.seed_instance(random.random())
 
 
 @solver("source.geo.")

--- a/geneve/solver/ip.py
+++ b/geneve/solver/ip.py
@@ -18,9 +18,9 @@
 """Constraints solver for ip fields."""
 
 import ipaddress
-import random
 
 from ..constraints import ConflictError
+from ..utils import random
 from . import solver
 
 

--- a/geneve/solver/keyword.py
+++ b/geneve/solver/keyword.py
@@ -17,11 +17,11 @@
 
 """Constraints solver for keyword fields."""
 
-import random
 import string
 from fnmatch import fnmatch
 
 from ..constraints import ConflictError
+from ..utils import random
 from . import solver
 
 

--- a/geneve/solver/long.py
+++ b/geneve/solver/long.py
@@ -17,10 +17,10 @@
 
 """Constraints solver for long fields."""
 
-import random
 from collections import namedtuple
 
 from ..constraints import ConflictError
+from ..utils import random
 from . import solver
 
 NumberLimits = namedtuple("NumberLimits", ["MIN", "MAX"])

--- a/geneve/utils/__init__.py
+++ b/geneve/utils/__init__.py
@@ -22,9 +22,12 @@ import shutil
 from contextlib import contextmanager
 from glob import glob
 from pathlib import Path
+from random import Random
 from tempfile import mkdtemp
 from types import SimpleNamespace
 from urllib.parse import urlparse
+
+random = Random()
 
 
 @contextmanager

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1072,27 +1072,21 @@ class TestConstraints(tu.SeededTestCase, unittest.TestCase):
 
         self.assertEqual(
             {
-                "destination": {
-                    "geo": {
-                        "city_name": "Jinotepe",
-                        "country_iso_code": "NI",
-                        "location": {
-                            "lat": 11.84962,
-                            "lon": -86.19903,
-                        },
-                        "timezone": "America/Managua",
-                    },
-                },
                 "source": {
                     "geo": {
-                        "city_name": "Amreli",
-                        "country_iso_code": "IN",
-                        "location": {
-                            "lat": 21.59983,
-                            "lon": 71.21169,
-                        },
-                        "timezone": "Asia/Kolkata",
-                    },
+                        "city_name": "Changzhi",
+                        "country_iso_code": "CN",
+                        "location": {"lat": 35.20889, "lon": 111.73861},
+                        "timezone": "Asia/Shanghai",
+                    }
+                },
+                "destination": {
+                    "geo": {
+                        "city_name": "Thomazeau",
+                        "country_iso_code": "HT",
+                        "location": {"lat": 18.65297, "lon": -72.09391},
+                        "timezone": "America/Port-au-Prince",
+                    }
                 },
             },
             c.solve(schema),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,7 +22,6 @@ import hashlib
 import itertools
 import json
 import os
-import random
 import subprocess
 import sys
 import textwrap
@@ -34,7 +33,7 @@ from functools import partial
 from pathlib import Path
 
 from geneve.events_emitter import SourceEvents
-from geneve.utils import load_rules, load_schema
+from geneve.utils import load_rules, load_schema, random
 
 from . import jupyter
 


### PR DESCRIPTION
Until now Geneve drawn randomness using the shared [Random](https://docs.python.org/3/library/random.html#random.Random) instance hidden in the `random` module.

With this PR Geneve is decoupled from that and gets its own instance. Faker, which also has its own instance of Random, is now set to use the same of Geneve.

Tests control Geneve's random state and therefore control also the Faker one.