### PR TITLE
Disable Geneve proxy in CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,7 +174,7 @@ jobs:
       - name: Start Elastic Stack ${{ matrix.stack-version }}
         env:
           TEST_STACK_VERSION: ${{ matrix.stack-version }}
-          TEST_ELASTICSEARCH_PROXY: "http://host.docker.internal:9280"
+          # TEST_ELASTICSEARCH_PROXY: "http://host.docker.internal:9280"
         run: make up
 
       - name: Run online tests


### PR DESCRIPTION
It provokes this in Kibana:
```
[2023-09-06T15:08:54.613+00:00][ERROR][http] ConnectionError: socket hang up - Local: 172.18.0.3:45090, Remote: 192.168.65.254:9280
    at KibanaTransport.request (/usr/share/kibana/node_modules/@elastic/transport/lib/Transport.js:528:31)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at KibanaTransport.request (/usr/share/kibana/node_modules/@kbn/core-elasticsearch-client-server-internal/src/create_transport.js:51:16)
    at ClientTraced.SearchApi [as search] (/usr/share/kibana/node_modules/@elastic/elasticsearch/lib/api/api/search.js:66:12)
```