### PR TITLE
Deploy the QA serverless environment

### DIFF
--- a/.buildkite/serverless-security-quality-gate/pipeline.yml
+++ b/.buildkite/serverless-security-quality-gate/pipeline.yml
@@ -1,7 +1,32 @@
+agents:
+  image: docker.elastic.co/employees/dolaru/qaf:latest
+
+env:
+  EC_REGISTER_BACKEND: "appex-qa-team-cluster"
+  EC_REGION: "aws-eu-west-1"
+  EC_ENV: "qa"
+  EC_PROJECT_NAME: "bk-serverless-security-geneve-${BUILDKITE_BUILD_NUMBER}"
+  EC_PROJECT_TYPE: "security"
+
 steps:
-  - label: Geneve security serverless quality gate
-    env:
-      TEST_SCHEMA_URI: ./etc/ecs-v8.11.0.tar.gz
+  - label: ":pipeline: Create environment `serverless-geneve-test-environment`"
+    key: create_geneve_environment
+    command:
+      - "qaf elastic-cloud projects create"
+
+  - label: ":rocket: Deploy Geneve quality gate"
+    key: geneve_quality_gate
+    depends_on: create_geneve_environment
     command:
       - python3 -m pip install -r requirements.txt
-      - ./scripts/test-stacks.sh --online -v --queries custom
+      - ./scripts/test-qaf-stack.sh --online -v --queries
+
+  - label: ":pipeline: Delete environment `serverless-geneve-test-environment`"
+    key: delete_geneve_environment
+    depends_on:
+      - create_geneve_environment
+      - geneve_quality_gate
+    command:
+      - "qaf elastic-cloud projects delete"
+      - "qaf elastic-cloud projects list"
+    allow_dependency_failure: true

--- a/.license_ignore
+++ b/.license_ignore
@@ -9,6 +9,7 @@
 *.zip
 .gitignore
 .license_ignore
+
 LICENSE.txt
 Makefile
 catalog-info.yaml
@@ -21,6 +22,7 @@ geneve/solver/datasets/*
 scripts/generate-alerts.sh
 scripts/generate-network-events.sh
 scripts/test-stacks.sh
+scripts/test-qaf-stack.sh
 
 tests/deployment.json
 tests/data/config_elastic-package.yaml

--- a/scripts/test-qaf-stack.sh
+++ b/scripts/test-qaf-stack.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+PROJECT=`qaf elastic-cloud projects describe --show-credentials --as-json`
+
+export TEST_API_KEY=`echo $PROJECT | jq -r '.credentials.api_key'`
+export TEST_ELASTICSEARCH_URL=`echo $PROJECT | jq -r '.elasticsearch.url'`
+export TEST_KIBANA_URL=`echo $PROJECT | jq -r '.kibana.url'`
+export TEST_STACK_VERSION=`echo $PROJECT | jq -r '.kibana.version'`
+export TEST_SCHEMA_URI=./etc/ecs-v8.11.0.tar.gz
+
+`dirname $0`/test-stacks.sh custom "$@"


### PR DESCRIPTION
This PR brings the serverless create/delete steps inside the Geneve pipeline. In this way the pipeline can be invoked separately from the whole quality gate and on branches different from `main`.

Needs https://github.com/elastic/ci/pull/2584.