### PR TITLE
QG2: skip intermediate builds

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -33,6 +33,7 @@ spec:
     spec:
       repository: elastic/geneve
       pipeline_file: .buildkite/serverless-security-quality-gate/pipeline.yml
+      skip_intermediate_builds: false
       provider_settings:
         build_branches: true
         trigger_mode: none


### PR DESCRIPTION
What this means is:
* If a build is kicked by quality gate
* And another build gets kicked by periodic pipeline

Then with `skip_intermediate_builds: false`, both builds will run. With this flag true, one gets cancelled.
