### PR TITLE
Quality gates - add privileges for cloud tooling and release operators

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -39,5 +39,9 @@ spec:
         trigger_mode: none
       teams:
         security-engineering-productivity: {}
+        cloud-tooling:
+          access_level: BUILD_AND_READ
+        kibana-release-operators:
+          access_level: BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
This PR adds build privileges for cloud tooling and release operators to the quality gates pipeline. This is required in order to run this pipeline as part of the Kibana quality gates during the serverless release process.