### PR TITLE
github-actions: fixes make -f code/Makefile pkg-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ ifeq ($(PYTHON),)
 	PYTHON := $(ACTIVATE)python3
 endif
 
+# if golang is installed only
+ifneq ($(shell command -v go 2>/dev/null),)
 PYGOLO_DIR := $(shell go list -f '{{.Dir}}' -m gitlab.com/pygolo/py)
 ifeq ($(PYGOLO_DIR),)
 	PYGOLO_DIR := $(shell go get gitlab.com/pygolo/py && go list -f '{{.Dir}}' -m gitlab.com/pygolo/py)
@@ -22,6 +24,7 @@ else
 define embed-python
 	$(error Embedding Python is not supported on this platform)
 endef
+endif
 endif
 
 rwildcard=$(foreach d,$(wildcard $(1:=/*)),$(call rwildcard,$d,$2) $(filter $(subst *,%,$2),$d))
@@ -88,6 +91,7 @@ cli-bench:
 clean:
 	go clean -cache -testcache
 	rm -rf gnv
+	echo $(PYGOLO_DIR)
 
 pkg-build:
 	$(PYTHON) -m build


### PR DESCRIPTION
I've just found `go` is required for running the Makefile always, that's producing same errors in the console output even though if the build successfully ran:


```
Run make -f code/Makefile pkg-install
  make -f code/Makefile pkg-install
  shell: /bin/bash -e {0}
...
make: go: Command not found
/bin/sh: go: command not found

```

See https://github.com/elastic/geneve/actions/runs/11591889953/job/32272670681#step:5:13

<img width="790" alt="image" src="https://github.com/user-attachments/assets/0a059855-6f54-42f6-96fb-73102627d246">

I discovered this as we run some logs alerting for the GH actions that contain some `command not found` in their logs.  Taht's part of our initiative to Observe the CICD and act at a large scale


<img width="1165" alt="image" src="https://github.com/user-attachments/assets/fcd3d47c-d02f-4cf6-a73e-17d7b76bde68">
