### PR TITLE
Create rules before generating documents

### DIFF
--- a/tests/reports/alerts_from_rules-8.7.md
+++ b/tests/reports/alerts_from_rules-8.7.md
@@ -76,7 +76,7 @@ Branch count: 4608
 Document count: 13824  
 Index: geneve-ut-0252  
 Failure message(s):  
-  got 1000 signals, expected 4608  
+  got 2000 signals, expected 4608  
 
 ```python
 sequence by host.id, user.id with maxspan=1m

--- a/tests/test_emitter_rules.py
+++ b/tests/test_emitter_rules.py
@@ -213,7 +213,7 @@ class TestSignalsRules(tu.SignalsTestCase, tu.OnlineTestCase, tu.SeededTestCase,
         rules, asts = self.parse_from_collection(collection)
         pending = self.load_rules_and_docs(rules, asts)
         try:
-            self.check_signals(rules, pending)
+            self.check_signals(rules, pending, timeout=180)
         except AssertionError:
             tu.assertReportUnchanged(self, self.nb, f"alerts_from_rules-{major_minor}{mf_ext}.md")
             raise


### PR DESCRIPTION
This makes a difference especially when using an high signals multiplier, you don't want to wait for all the documents to be ingested before starting to execute rules and trigger signals.