### PR TITLE
Make renovate ignore `tests/reports/**`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "local>elastic/renovate-config"
   ],
   "ignorePaths": [
+    "tests/reports/**"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Closes https://github.com/elastic/geneve/pull/490.