### PR TITLE
Update rules to 8.19.22, 9.2.14, 9.3.10, and 9.4.2

### DIFF
--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -35,19 +35,19 @@ emitter_rules:
     # renovate: datasource=epr package=security_detection_engine-8.18
     "8.18": "8.18.15"
     # renovate: datasource=epr package=security_detection_engine-8.19
-    "8.19": "8.19.21"
+    "8.19": "8.19.22"
     # renovate: datasource=epr package=security_detection_engine-9.0
     "9.0": "9.0.19"
     # renovate: datasource=epr package=security_detection_engine-9.1
     "9.1": "9.1.20"
     # renovate: datasource=epr package=security_detection_engine-9.2
-    "9.2": "9.2.13"
+    "9.2": "9.2.14"
     # renovate: datasource=epr package=security_detection_engine-9.3
-    "9.3": "9.3.9"
+    "9.3": "9.3.10"
     # renovate: datasource=epr package=security_detection_engine-9.4
-    "9.4": "9.4.1"
+    "9.4": "9.4.2"
     # renovate: datasource=epr package=security_detection_engine
-    "serverless": "9.4.1"
+    "serverless": "9.4.2"
 
   stack_signals:
     "8.2":

--- a/tests/reports/alerts_from_rules-8.19.md
+++ b/tests/reports/alerts_from_rules-8.19.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.21
+Rules version: 8.19.22
 
 ## Table of contents
    1. [Failed rules (14)](#failed-rules-14)
    1. [Unsuccessful rules with signals (14)](#unsuccessful-rules-with-signals-14)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (17)](#rules-with-too-few-signals-17)
-   1. [Rules with the correct signals (741)](#rules-with-the-correct-signals-741)
+   1. [Rules with the correct signals (742)](#rules-with-the-correct-signals-742)
 
 ## Failed rules (14)
 
@@ -1847,7 +1847,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 
 
-## Rules with the correct signals (741)
+## Rules with the correct signals (742)
 
 ### A scheduled task was created
 
@@ -8025,6 +8025,28 @@ event.dataset: "okta.system"
     and event.category: "authentication"
     and okta.target.alternate_id: "Okta Admin Console"
     and okta.outcome.result: "FAILURE"
+```
+
+
+
+### Okta Alerts Following Unusual Proxy Authentication
+
+Branch count: 1  
+Document count: 2  
+Index: geneve-ut-0881
+
+```python
+sequence by user.name with maxspan=30m
+    [any where event.dataset == "okta.system" and
+        kibana.alert.rule.rule_id == "6f1bb4b2-7dc8-11ee-92b2-f661ea17fbcd"]
+    [any where event.dataset == "okta.system" and
+        kibana.alert.rule.rule_id != null and
+        kibana.alert.severity != "low" and
+        kibana.alert.rule.rule_id not in  (
+            "6f1bb4b2-7dc8-11ee-92b2-f661ea17fbcd",
+            "af2d8e4c-3b7c-4e91-8f5a-6c9d0e1f2a3b"
+        )
+    ]
 ```
 
 

--- a/tests/reports/alerts_from_rules-9.2.md
+++ b/tests/reports/alerts_from_rules-9.2.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.2.13
+Rules version: 9.2.14
 
 ## Table of contents
    1. [Failed rules (13)](#failed-rules-13)
    1. [Unsuccessful rules with signals (13)](#unsuccessful-rules-with-signals-13)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (16)](#rules-with-too-few-signals-16)
-   1. [Rules with the correct signals (741)](#rules-with-the-correct-signals-741)
+   1. [Rules with the correct signals (742)](#rules-with-the-correct-signals-742)
 
 ## Failed rules (13)
 
@@ -1773,7 +1773,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 
 
-## Rules with the correct signals (741)
+## Rules with the correct signals (742)
 
 ### A scheduled task was created
 
@@ -7951,6 +7951,28 @@ event.dataset: "okta.system"
     and event.category: "authentication"
     and okta.target.alternate_id: "Okta Admin Console"
     and okta.outcome.result: "FAILURE"
+```
+
+
+
+### Okta Alerts Following Unusual Proxy Authentication
+
+Branch count: 1  
+Document count: 2  
+Index: geneve-ut-0885
+
+```python
+sequence by user.name with maxspan=30m
+    [any where event.dataset == "okta.system" and
+        kibana.alert.rule.rule_id == "6f1bb4b2-7dc8-11ee-92b2-f661ea17fbcd"]
+    [any where event.dataset == "okta.system" and
+        kibana.alert.rule.rule_id != null and
+        kibana.alert.severity != "low" and
+        kibana.alert.rule.rule_id not in  (
+            "6f1bb4b2-7dc8-11ee-92b2-f661ea17fbcd",
+            "af2d8e4c-3b7c-4e91-8f5a-6c9d0e1f2a3b"
+        )
+    ]
 ```
 
 

--- a/tests/reports/alerts_from_rules-9.3.md
+++ b/tests/reports/alerts_from_rules-9.3.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.9
+Rules version: 9.3.10
 
 ## Table of contents
    1. [Failed rules (20)](#failed-rules-20)
    1. [Unsuccessful rules with signals (20)](#unsuccessful-rules-with-signals-20)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (23)](#rules-with-too-few-signals-23)
-   1. [Rules with the correct signals (769)](#rules-with-the-correct-signals-769)
+   1. [Rules with the correct signals (770)](#rules-with-the-correct-signals-770)
 
 ## Failed rules (20)
 
@@ -2651,7 +2651,7 @@ process.interactive == true and container.id like "*"
 
 
 
-## Rules with the correct signals (769)
+## Rules with the correct signals (770)
 
 ### A scheduled task was created
 
@@ -9250,6 +9250,28 @@ event.dataset: "okta.system"
     and event.category: "authentication"
     and okta.target.alternate_id: "Okta Admin Console"
     and okta.outcome.result: "FAILURE"
+```
+
+
+
+### Okta Alerts Following Unusual Proxy Authentication
+
+Branch count: 1  
+Document count: 2  
+Index: geneve-ut-0918
+
+```python
+sequence by user.name with maxspan=30m
+    [any where event.dataset == "okta.system" and
+        kibana.alert.rule.rule_id == "6f1bb4b2-7dc8-11ee-92b2-f661ea17fbcd"]
+    [any where event.dataset == "okta.system" and
+        kibana.alert.rule.rule_id != null and
+        kibana.alert.severity != "low" and
+        kibana.alert.rule.rule_id not in  (
+            "6f1bb4b2-7dc8-11ee-92b2-f661ea17fbcd",
+            "af2d8e4c-3b7c-4e91-8f5a-6c9d0e1f2a3b"
+        )
+    ]
 ```
 
 

--- a/tests/reports/alerts_from_rules-9.4.md
+++ b/tests/reports/alerts_from_rules-9.4.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.1
+Rules version: 9.4.2
 
 ## Table of contents
    1. [Failed rules (20)](#failed-rules-20)
    1. [Unsuccessful rules with signals (20)](#unsuccessful-rules-with-signals-20)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (23)](#rules-with-too-few-signals-23)
-   1. [Rules with the correct signals (769)](#rules-with-the-correct-signals-769)
+   1. [Rules with the correct signals (770)](#rules-with-the-correct-signals-770)
 
 ## Failed rules (20)
 
@@ -2651,7 +2651,7 @@ process.interactive == true and container.id like "*"
 
 
 
-## Rules with the correct signals (769)
+## Rules with the correct signals (770)
 
 ### A scheduled task was created
 
@@ -9250,6 +9250,28 @@ event.dataset: "okta.system"
     and event.category: "authentication"
     and okta.target.alternate_id: "Okta Admin Console"
     and okta.outcome.result: "FAILURE"
+```
+
+
+
+### Okta Alerts Following Unusual Proxy Authentication
+
+Branch count: 1  
+Document count: 2  
+Index: geneve-ut-0994
+
+```python
+sequence by user.name with maxspan=30m
+    [any where event.dataset == "okta.system" and
+        kibana.alert.rule.rule_id == "6f1bb4b2-7dc8-11ee-92b2-f661ea17fbcd"]
+    [any where event.dataset == "okta.system" and
+        kibana.alert.rule.rule_id != null and
+        kibana.alert.severity != "low" and
+        kibana.alert.rule.rule_id not in  (
+            "6f1bb4b2-7dc8-11ee-92b2-f661ea17fbcd",
+            "af2d8e4c-3b7c-4e91-8f5a-6c9d0e1f2a3b"
+        )
+    ]
 ```
 
 

--- a/tests/reports/alerts_from_rules-serverless.md
+++ b/tests/reports/alerts_from_rules-serverless.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.1
+Rules version: 9.4.2
 
 ## Table of contents
    1. [Failed rules (20)](#failed-rules-20)
    1. [Unsuccessful rules with signals (20)](#unsuccessful-rules-with-signals-20)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (23)](#rules-with-too-few-signals-23)
-   1. [Rules with the correct signals (769)](#rules-with-the-correct-signals-769)
+   1. [Rules with the correct signals (770)](#rules-with-the-correct-signals-770)
 
 ## Failed rules (20)
 
@@ -2651,7 +2651,7 @@ process.interactive == true and container.id like "*"
 
 
 
-## Rules with the correct signals (769)
+## Rules with the correct signals (770)
 
 ### A scheduled task was created
 
@@ -9250,6 +9250,28 @@ event.dataset: "okta.system"
     and event.category: "authentication"
     and okta.target.alternate_id: "Okta Admin Console"
     and okta.outcome.result: "FAILURE"
+```
+
+
+
+### Okta Alerts Following Unusual Proxy Authentication
+
+Branch count: 1  
+Document count: 2  
+Index: geneve-ut-0994
+
+```python
+sequence by user.name with maxspan=30m
+    [any where event.dataset == "okta.system" and
+        kibana.alert.rule.rule_id == "6f1bb4b2-7dc8-11ee-92b2-f661ea17fbcd"]
+    [any where event.dataset == "okta.system" and
+        kibana.alert.rule.rule_id != null and
+        kibana.alert.severity != "low" and
+        kibana.alert.rule.rule_id not in  (
+            "6f1bb4b2-7dc8-11ee-92b2-f661ea17fbcd",
+            "af2d8e4c-3b7c-4e91-8f5a-6c9d0e1f2a3b"
+        )
+    ]
 ```
 
 

--- a/tests/reports/documents_from_rules-8.19.md
+++ b/tests/reports/documents_from_rules-8.19.md
@@ -5,7 +5,7 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.21
+Rules version: 8.19.22
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
@@ -16,7 +16,7 @@ Rules version: 8.19.21
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
       1. [Unsupported query language: lucene (4)](#unsupported-query-language-lucene-4)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (275)](#field-type-solver-constant_keyword-275)
+      1. [Field type solver: constant_keyword (274)](#field-type-solver-constant_keyword-274)
       1. [Unsupported function: match (32)](#unsupported-function-match-32)
       1. [Unsupported function: stringContains (23)](#unsupported-function-stringcontains-23)
       1. [Root with too many branches (limit: 10000) (18)](#root-with-too-many-branches-limit-10000-18)
@@ -609,9 +609,9 @@ Rules version: 8.19.21
 
 ## Generation errors
 
-### Field type solver: constant_keyword (275)
+### Field type solver: constant_keyword (274)
 
-275 rules:
+274 rules:
 * AWS CloudShell Environment Created
 * AWS CloudTrail Log Created
 * AWS CloudTrail Log Deleted
@@ -848,7 +848,6 @@ Rules version: 8.19.21
 * New GitHub Owner Added
 * New GitHub Personal Access Token (PAT) Added
 * New Okta Identity Provider (IdP) Added by Admin
-* Okta Alerts Following Unusual Proxy Authentication
 * Okta FastPass Phishing Detection
 * Okta ThreatInsight Threat Suspected Promotion
 * Okta User Assigned Administrator Role

--- a/tests/reports/documents_from_rules-9.2.md
+++ b/tests/reports/documents_from_rules-9.2.md
@@ -5,7 +5,7 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.2.13
+Rules version: 9.2.14
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
@@ -16,7 +16,7 @@ Rules version: 9.2.13
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
       1. [Unsupported query language: lucene (4)](#unsupported-query-language-lucene-4)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (275)](#field-type-solver-constant_keyword-275)
+      1. [Field type solver: constant_keyword (274)](#field-type-solver-constant_keyword-274)
       1. [Unsupported function: match (32)](#unsupported-function-match-32)
       1. [Unsupported function: stringContains (23)](#unsupported-function-stringcontains-23)
       1. [Root with too many branches (limit: 10000) (19)](#root-with-too-many-branches-limit-10000-19)
@@ -616,9 +616,9 @@ Rules version: 9.2.13
 
 ## Generation errors
 
-### Field type solver: constant_keyword (275)
+### Field type solver: constant_keyword (274)
 
-275 rules:
+274 rules:
 * AWS CloudShell Environment Created
 * AWS CloudTrail Log Created
 * AWS CloudTrail Log Deleted
@@ -855,7 +855,6 @@ Rules version: 9.2.13
 * New GitHub Owner Added
 * New GitHub Personal Access Token (PAT) Added
 * New Okta Identity Provider (IdP) Added by Admin
-* Okta Alerts Following Unusual Proxy Authentication
 * Okta FastPass Phishing Detection
 * Okta ThreatInsight Threat Suspected Promotion
 * Okta User Assigned Administrator Role

--- a/tests/reports/documents_from_rules-9.3.md
+++ b/tests/reports/documents_from_rules-9.3.md
@@ -5,7 +5,7 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.9
+Rules version: 9.3.10
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
@@ -16,7 +16,7 @@ Rules version: 9.3.9
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
       1. [Unsupported query language: lucene (4)](#unsupported-query-language-lucene-4)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (279)](#field-type-solver-constant_keyword-279)
+      1. [Field type solver: constant_keyword (278)](#field-type-solver-constant_keyword-278)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Unsupported function: stringContains (23)](#unsupported-function-stringcontains-23)
       1. [Root with too many branches (limit: 10000) (22)](#root-with-too-many-branches-limit-10000-22)
@@ -632,9 +632,9 @@ Rules version: 9.3.9
 
 ## Generation errors
 
-### Field type solver: constant_keyword (279)
+### Field type solver: constant_keyword (278)
 
-279 rules:
+278 rules:
 * AWS CloudShell Environment Created
 * AWS CloudTrail Log Created
 * AWS CloudTrail Log Deleted
@@ -874,7 +874,6 @@ Rules version: 9.3.9
 * New GitHub Owner Added
 * New GitHub Personal Access Token (PAT) Added
 * New Okta Identity Provider (IdP) Added by Admin
-* Okta Alerts Following Unusual Proxy Authentication
 * Okta FastPass Phishing Detection
 * Okta ThreatInsight Threat Suspected Promotion
 * Okta User Assigned Administrator Role

--- a/tests/reports/documents_from_rules-9.4.md
+++ b/tests/reports/documents_from_rules-9.4.md
@@ -5,7 +5,7 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.1
+Rules version: 9.4.2
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
@@ -17,7 +17,7 @@ Rules version: 9.4.1
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
       1. [Unsupported query language: lucene (4)](#unsupported-query-language-lucene-4)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (279)](#field-type-solver-constant_keyword-279)
+      1. [Field type solver: constant_keyword (278)](#field-type-solver-constant_keyword-278)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Unsupported function: stringContains (23)](#unsupported-function-stringcontains-23)
       1. [Root with too many branches (limit: 10000) (22)](#root-with-too-many-branches-limit-10000-22)
@@ -750,9 +750,9 @@ Rules version: 9.4.1
 
 ## Generation errors
 
-### Field type solver: constant_keyword (279)
+### Field type solver: constant_keyword (278)
 
-279 rules:
+278 rules:
 * AWS CloudShell Environment Created
 * AWS CloudTrail Log Created
 * AWS CloudTrail Log Deleted
@@ -992,7 +992,6 @@ Rules version: 9.4.1
 * New GitHub Owner Added
 * New GitHub Personal Access Token (PAT) Added
 * New Okta Identity Provider (IdP) Added by Admin
-* Okta Alerts Following Unusual Proxy Authentication
 * Okta FastPass Phishing Detection
 * Okta ThreatInsight Threat Suspected Promotion
 * Okta User Assigned Administrator Role

--- a/tests/reports/documents_from_rules-serverless.md
+++ b/tests/reports/documents_from_rules-serverless.md
@@ -5,7 +5,7 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.1
+Rules version: 9.4.2
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
@@ -17,7 +17,7 @@ Rules version: 9.4.1
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
       1. [Unsupported query language: lucene (4)](#unsupported-query-language-lucene-4)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (279)](#field-type-solver-constant_keyword-279)
+      1. [Field type solver: constant_keyword (278)](#field-type-solver-constant_keyword-278)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Unsupported function: stringContains (23)](#unsupported-function-stringcontains-23)
       1. [Root with too many branches (limit: 10000) (22)](#root-with-too-many-branches-limit-10000-22)
@@ -750,9 +750,9 @@ Rules version: 9.4.1
 
 ## Generation errors
 
-### Field type solver: constant_keyword (279)
+### Field type solver: constant_keyword (278)
 
-279 rules:
+278 rules:
 * AWS CloudShell Environment Created
 * AWS CloudTrail Log Created
 * AWS CloudTrail Log Deleted
@@ -992,7 +992,6 @@ Rules version: 9.4.1
 * New GitHub Owner Added
 * New GitHub Personal Access Token (PAT) Added
 * New Okta Identity Provider (IdP) Added by Admin
-* Okta Alerts Following Unusual Proxy Authentication
 * Okta FastPass Phishing Detection
 * Okta ThreatInsight Threat Suspected Promotion
 * Okta User Assigned Administrator Role


### PR DESCRIPTION
## Summary

Applies pending Renovate PRs for `security_detection_engine` packages.

### ECH version bumps
| Stack | Old | New | Renovate PR |
|---|---|---|---|
| 8.19 | 8.19.21 | 8.19.22 | #772 |
| 9.2 | 9.2.13 | 9.2.14 | #766 |
| 9.3 | 9.3.9 | 9.3.10 | #767 |
| 9.4 | 9.4.1 | 9.4.2 | #769 |

### Serverless version bump
| Stack | Old | New | Renovate PR |
|---|---|---|---|
| serverless | 9.4.1 | 9.4.2 | #768 |

### Reports updated
- `alerts_from_rules-{8.19,9.2,9.3,9.4}.md`
- `documents_from_rules-{8.19,9.2,9.3,9.4,serverless}.md`

### stack_signals
No changes — counts are unchanged across all updated versions.