### PR TITLE
Update rules to 8.19.27, 9.2.19, 9.3.15, 9.4.7, and serverless 9.4.7

### DIFF
--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -35,19 +35,19 @@ emitter_rules:
     # renovate: datasource=epr package=security_detection_engine-8.18
     "8.18": "8.18.15"
     # renovate: datasource=epr package=security_detection_engine-8.19
-    "8.19": "8.19.22"
+    "8.19": "8.19.27"
     # renovate: datasource=epr package=security_detection_engine-9.0
     "9.0": "9.0.19"
     # renovate: datasource=epr package=security_detection_engine-9.1
     "9.1": "9.1.20"
     # renovate: datasource=epr package=security_detection_engine-9.2
-    "9.2": "9.2.14"
+    "9.2": "9.2.19"
     # renovate: datasource=epr package=security_detection_engine-9.3
-    "9.3": "9.3.10"
+    "9.3": "9.3.15"
     # renovate: datasource=epr package=security_detection_engine-9.4
-    "9.4": "9.4.2"
+    "9.4": "9.4.7"
     # renovate: datasource=epr package=security_detection_engine
-    "serverless": "9.4.2"
+    "serverless": "9.4.7"
 
   stack_signals:
     "8.2":
@@ -124,10 +124,10 @@ emitter_rules:
       ack_no_signals: 7
       ack_too_few_signals: 15
     "8.19":
-      ack_failed: 14
-      ack_unsuccessful_with_signals: 14
+      ack_failed: 18
+      ack_unsuccessful_with_signals: 18
       ack_no_signals: 5
-      ack_too_few_signals: 17
+      ack_too_few_signals: 22
     "9.0":
       ack_failed: 17
       ack_unsuccessful_with_signals: 16
@@ -139,22 +139,22 @@ emitter_rules:
       ack_no_signals: 8
       ack_too_few_signals: 14
     "9.2":
-      ack_failed: 13
-      ack_unsuccessful_with_signals: 13
+      ack_failed: 17
+      ack_unsuccessful_with_signals: 17
       ack_no_signals: 5
-      ack_too_few_signals: 16
+      ack_too_few_signals: 21
     "9.3":
-      ack_failed: 20
-      ack_unsuccessful_with_signals: 20
+      ack_failed: 24
+      ack_unsuccessful_with_signals: 24
       ack_no_signals: 5
-      ack_too_few_signals: 23
+      ack_too_few_signals: 28
     "9.4":
-      ack_failed: 20
-      ack_unsuccessful_with_signals: 20
+      ack_failed: 24
+      ack_unsuccessful_with_signals: 24
       ack_no_signals: 5
-      ack_too_few_signals: 23
+      ack_too_few_signals: 28
     "serverless":
-      ack_failed: 20
-      ack_unsuccessful_with_signals: 20
+      ack_failed: 24
+      ack_unsuccessful_with_signals: 24
       ack_no_signals: 5
-      ack_too_few_signals: 23
+      ack_too_few_signals: 28

--- a/tests/reports/alerts_from_rules-8.19.md
+++ b/tests/reports/alerts_from_rules-8.19.md
@@ -5,22 +5,22 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.22
+Rules version: 8.19.27
 
 ## Table of contents
-   1. [Failed rules (14)](#failed-rules-14)
-   1. [Unsuccessful rules with signals (14)](#unsuccessful-rules-with-signals-14)
+   1. [Failed rules (18)](#failed-rules-18)
+   1. [Unsuccessful rules with signals (18)](#unsuccessful-rules-with-signals-18)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
-   1. [Rules with too few signals (17)](#rules-with-too-few-signals-17)
-   1. [Rules with the correct signals (742)](#rules-with-the-correct-signals-742)
+   1. [Rules with too few signals (22)](#rules-with-too-few-signals-22)
+   1. [Rules with the correct signals (770)](#rules-with-the-correct-signals-770)
 
-## Failed rules (14)
+## Failed rules (18)
 
 ### Execution of a Downloaded Windows Script
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0443  
+Index: geneve-ut-0524  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -46,7 +46,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0446  
+Index: geneve-ut-0527  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -115,7 +115,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0468  
+Index: geneve-ut-0549  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -144,7 +144,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0548  
+Index: geneve-ut-0643  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -171,11 +171,64 @@ not process.name in ("git", "dirname")
 
 
 
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0821  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Multi-Base64 Decoding Attempt from Suspicious Location
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0815  
+Index: geneve-ut-0944  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -208,7 +261,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-0926  
+Index: geneve-ut-1061  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -234,7 +287,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-0942  
+Index: geneve-ut-1078  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -272,7 +325,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-0997  
+Index: geneve-ut-1137  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -294,7 +347,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1011  
+Index: geneve-ut-1152  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -333,7 +386,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1091  
+Index: geneve-ut-1234  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -396,7 +449,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1365  
+Index: geneve-ut-1530  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -440,11 +493,46 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1544  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Execution via Scheduled Task
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1398  
+Index: geneve-ut-1565  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -507,7 +595,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1403  
+Index: geneve-ut-1570  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -531,11 +619,82 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1579  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1625  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1498  
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1669  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -545,13 +704,16 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -581,7 +743,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -589,23 +750,28 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
 
-## Unsuccessful rules with signals (14)
+## Unsuccessful rules with signals (18)
 
 ### Execution of a Downloaded Windows Script
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0443
+Index: geneve-ut-0524
 
 ```python
 sequence by host.id, user.id with maxspan=3m
@@ -628,7 +794,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0446
+Index: geneve-ut-0527
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -694,7 +860,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0468
+Index: geneve-ut-0549
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -720,7 +886,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0548
+Index: geneve-ut-0643
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -744,11 +910,61 @@ not process.name in ("git", "dirname")
 
 
 
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0821
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Multi-Base64 Decoding Attempt from Suspicious Location
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0815
+Index: geneve-ut-0944
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -778,7 +994,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-0926
+Index: geneve-ut-1061
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -801,7 +1017,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-0942
+Index: geneve-ut-1078
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -836,7 +1052,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-0997
+Index: geneve-ut-1137
 
 ```python
 sequence by host.id with maxspan=1m
@@ -855,7 +1071,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1011
+Index: geneve-ut-1152
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -891,7 +1107,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1091
+Index: geneve-ut-1234
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -951,7 +1167,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1365
+Index: geneve-ut-1530
 
 ```python
 sequence by host.id with maxspan=5s
@@ -992,11 +1208,43 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1544
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Execution via Scheduled Task
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1398
+Index: geneve-ut-1565
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1056,7 +1304,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1403
+Index: geneve-ut-1570
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1077,24 +1325,92 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1579
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1625
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1498
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1669
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -1124,7 +1440,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -1132,12 +1447,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -1148,7 +1468,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0164
+Index: geneve-ut-0214
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1162,7 +1482,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0697
+Index: geneve-ut-0822
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1174,7 +1494,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0704
+Index: geneve-ut-0828
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1186,7 +1506,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1043
+Index: geneve-ut-1185
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1200,27 +1520,28 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 
 
-### Potential Privacy Control Bypass via TCCDB Modification
+### Protected Storage Service Access via SMB
 
-Branch count: 16  
-Document count: 16  
-Index: geneve-ut-1079
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1370
 
 ```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "sqlite*" and
- process.args like "/*/Application Support/com.apple.TCC/TCC.db" and
- (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+host.os.type:windows and event.category:file and event.code:5145 and
+  winlog.event_data.ShareName:"\\\\*\\IPC$" and
+  winlog.event_data.RelativeTargetName:"protected_storage" and
+  not source.ip:("::" or "::1" or "0.0.0.0" or "127.0.0.1")
 ```
 
 
 
-## Rules with too few signals (17)
+## Rules with too few signals (22)
 
 ### Execution of a Downloaded Windows Script
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0443  
+Index: geneve-ut-0524  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -1245,7 +1566,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0446  
+Index: geneve-ut-0527  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -1313,7 +1634,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0468  
+Index: geneve-ut-0549  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -1341,7 +1662,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0548  
+Index: geneve-ut-0643  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -1367,11 +1688,82 @@ not process.name in ("git", "dirname")
 
 
 
+### Kubernetes Secrets List Across Cluster or Sensitive Namespaces
+
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0800  
+Failure message(s):  
+  got 3 signals, expected 6  
+
+```python
+event.dataset:"kubernetes.audit_logs" and event.action:list and 
+kubernetes.audit.objectRef.resource:secrets and 
+kubernetes.audit.requestURI :(/api/v1/secrets or /api/v1/secrets?limit* or /api/v1/namespaces/kube-system/secrets or /api/v1/namespaces/kube-system/secrets?limit* or /api/v1/namespaces/default/secrets or /api/v1/namespaces/default/secrets?limit*) and 
+source.ip:(* and not ("::1" or "127.0.0.1")) and 
+not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator) and 
+not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
+```
+
+
+
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0821  
+Failure message(s):  
+  got 1000 signals, expected 6552  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Microsoft IIS Service Account Password Dumped
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0796  
+Index: geneve-ut-0925  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -1391,7 +1783,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0815  
+Index: geneve-ut-0944  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -1423,7 +1815,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-0926  
+Index: geneve-ut-1061  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -1448,7 +1840,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-0942  
+Index: geneve-ut-1078  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -1485,7 +1877,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-0997  
+Index: geneve-ut-1137  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -1506,7 +1898,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1011  
+Index: geneve-ut-1152  
 Failure message(s):  
   got 1000 signals, expected 1085  
 
@@ -1544,7 +1936,7 @@ process.command_line like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1083  
+Index: geneve-ut-1226  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -1561,7 +1953,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1091  
+Index: geneve-ut-1234  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -1623,7 +2015,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1183  
+Index: geneve-ut-1339  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -1648,7 +2040,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1365  
+Index: geneve-ut-1530  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -1691,11 +2083,45 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1544  
+Failure message(s):  
+  got 1000 signals, expected 5280  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Execution via Scheduled Task
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1398  
+Index: geneve-ut-1565  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -1757,7 +2183,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1403  
+Index: geneve-ut-1570  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -1780,26 +2206,98 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1579  
+Failure message(s):  
+  got 1000 signals, expected 2457  
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1625  
+Failure message(s):  
+  got 1000 signals, expected 8576  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1498  
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1669  
 Failure message(s):  
-  got 1000 signals, expected 1053  
+  got 1000 signals, expected 2442  
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -1829,7 +2327,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -1837,17 +2334,22 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
 
-## Rules with the correct signals (742)
+## Rules with the correct signals (770)
 
 ### A scheduled task was created
 
@@ -1870,7 +2372,15 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
               "\\Hewlett-Packard\\HP Web Products Detection",
               "\\Microsoft\\VisualStudio\\Updates\\BackgroundDownload",
               "\\OneDrive Standalone Update Task-S-1-5-21*",
-              "\\OneDrive Standalone Update Task-S-1-12-1-*"
+              "\\OneDrive Standalone Update Task-S-1-12-1-*",
+              "\\SoftLanding\\S-1-5-21-*\\SoftLanding*",
+              "\\SoftLanding\\S-1-12-*\\SoftLanding*",
+              "\\OneDrive Reporting Task-S-1-5-21-*",
+              "\\OneDrive Reporting Task-S-1-12-1-*",
+              "\\GoogleUserPEH\\RunPlatformExperienceHelper*",
+              "\\Mozilla\\Firefox Default Browser Agent*",
+              "\\Microsoft\\Office\\Office Background Push Maintenance",
+              "\\Microsoft\\Windows\\GroupPolicy\\GPUpdate"
  )
 ```
 
@@ -1932,7 +2442,7 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0021
+Index: geneve-ut-0039
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -1946,11 +2456,47 @@ process.command_line like~ (
 
 
 
+### AWS EC2 Instance Profile Associated with Running Instance
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-0056
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "ec2.amazonaws.com"
+    and event.action: ("AssociateIamInstanceProfile" or "ReplaceIamInstanceProfile")
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService" 
+    and not aws.cloudtrail.user_identity.invoked_by: "ssm.amazonaws.com"
+```
+
+
+
+### AWS IAM Customer Managed Policy Version Created or Default Version Set
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-0086
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "iam.amazonaws.com"
+    and event.action: ("CreatePolicyVersion" or "SetDefaultPolicyVersion")
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService" 
+    and not aws.cloudtrail.user_identity.arn:arn*/terraform 
+    and not source.as.organization.name:(Amazon* or AMAZON* or "Google LLC" or "MongoDB, Inc.")
+    and not source.address: ( "cloudformation.amazonaws.com" or "servicecatalog.amazonaws.com")
+```
+
+
+
 ### AWS IAM Login Profile Added to User
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0063
+Index: geneve-ut-0093
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
@@ -1959,11 +2505,59 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 
 
+### AWS IAM Sensitive Operations via Lambda Execution Role
+
+Branch count: 22  
+Document count: 22  
+Index: geneve-ut-0103
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "iam.amazonaws.com"
+    and event.outcome: "success"
+    and aws.cloudtrail.user_identity.type: "AssumedRole"
+    and (
+        aws.cloudtrail.user_identity.invoked_by: "lambda.amazonaws.com"
+        or user_agent.original : *AWS_Lambda*
+    )
+    and event.action: (
+        "AddRoleToInstanceProfile" or
+        "AddUserToGroup" or 
+        "AttachGroupPolicy" or 
+        "AttachRolePolicy" or
+        "AttachUserPolicy" or
+        "CreateAccessKey" or
+        "CreateInstanceProfile" or
+        "CreateRole" or
+        "CreateUser" or
+        "PutRolePolicy" or
+        "PutUserPolicy"
+    )
+```
+
+
+
+### AWS KMS Key Policy Updated via PutKeyPolicy
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0110
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "kms.amazonaws.com"
+    and event.action: "PutKeyPolicy"
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService"
+```
+
+
+
 ### AWS Lambda Function Created or Updated
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0075
+Index: geneve-ut-0112
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -1978,7 +2572,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0085
+Index: geneve-ut-0131
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
@@ -1987,11 +2581,27 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 
 
+### AWS STS GetFederationToken with AdministratorAccess in Request
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0165
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "sts.amazonaws.com"
+    and event.action: "GetFederationToken"
+    and event.outcome: "success"
+    and aws.cloudtrail.request_parameters: *AdministratorAccess*
+```
+
+
+
 ### AWS STS GetSessionToken Usage
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0117
+Index: geneve-ut-0166
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -2006,7 +2616,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0126
+Index: geneve-ut-0176
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -2021,7 +2631,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0135
+Index: geneve-ut-0185
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2045,7 +2655,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0136
+Index: geneve-ut-0186
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -2080,7 +2690,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0137
+Index: geneve-ut-0187
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -2097,7 +2707,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0138
+Index: geneve-ut-0188
 
 ```python
 any where host.os.type == "windows" and
@@ -2122,7 +2732,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0140
+Index: geneve-ut-0190
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -2150,7 +2760,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0142
+Index: geneve-ut-0192
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2163,7 +2773,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0144
+Index: geneve-ut-0194
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -2179,7 +2789,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0145
+Index: geneve-ut-0195
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2199,7 +2809,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0146
+Index: geneve-ut-0196
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2220,7 +2830,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0147
+Index: geneve-ut-0197
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -2232,7 +2842,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0150
+Index: geneve-ut-0200
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -2244,7 +2854,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0162
+Index: geneve-ut-0212
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -2261,7 +2871,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0163
+Index: geneve-ut-0213
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -2273,7 +2883,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0165
+Index: geneve-ut-0215
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -2293,7 +2903,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0166
+Index: geneve-ut-0216
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -2307,7 +2917,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0170
+Index: geneve-ut-0220
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -2338,7 +2948,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0171
+Index: geneve-ut-0221
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -2348,14 +2958,14 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 ### Attempt to Clear Kernel Ring Buffer
 
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-0172
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-0222
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
 event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
-process.name == "dmesg" and process.args in ("-c", "--clear")
+process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clear")
 ```
 
 
@@ -2364,7 +2974,7 @@ process.name == "dmesg" and process.args in ("-c", "--clear")
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0173
+Index: geneve-ut-0223
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2379,7 +2989,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0183
+Index: geneve-ut-0233
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -2398,7 +3008,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0184
+Index: geneve-ut-0234
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -2412,7 +3022,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0185
+Index: geneve-ut-0235
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -2443,7 +3053,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0186
+Index: geneve-ut-0236
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2466,7 +3076,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0187
+Index: geneve-ut-0237
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -2480,7 +3090,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0188
+Index: geneve-ut-0238
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2495,11 +3105,25 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Attempt to Install Kali Linux via WSL
+### Attempt to Install Root Certificate
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0239
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and
+  process.name == "security" and process.args like "add-trusted-cert" and
+  (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
+### Attempt to Install or Run Kali Linux via WSL
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0189
+Index: geneve-ut-0240
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2520,25 +3144,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Attempt to Install Root Certificate
-
-Branch count: 16  
-Document count: 16  
-Index: geneve-ut-0190
-
-```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and
-  process.name == "security" and process.args like "add-trusted-cert" and
-  (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
-```
-
-
-
 ### Attempt to Mount SMB Share via Command Line
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0195
+Index: geneve-ut-0245
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -2557,7 +3167,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0198
+Index: geneve-ut-0248
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -2570,7 +3180,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0200
+Index: geneve-ut-0250
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2612,7 +3222,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0203
+Index: geneve-ut-0253
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -2627,7 +3237,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0228
+Index: geneve-ut-0283
 
 ```python
 event.dataset:azure.activitylogs and
@@ -2637,11 +3247,29 @@ event.dataset:azure.activitylogs and
 
 
 
+### Azure Run Command Script Child Process
+
+Branch count: 22  
+Document count: 22  
+Index: geneve-ut-0286
+
+```python
+process where event.type in ("start", "process_started") and
+  (
+    (process.parent.name == "powershell.exe" and
+      process.parent.command_line like "powershell  -ExecutionPolicy Unrestricted -File script?.ps1") or
+    (process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh", "busybox") and
+      process.parent.args like "/var/lib/waagent/run-command/download/*/script.sh")
+  )
+```
+
+
+
 ### BPF Program Tampering via bpftool
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0241
+Index: geneve-ut-0304
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2659,7 +3287,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0242
+Index: geneve-ut-0305
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2677,7 +3305,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0243
+Index: geneve-ut-0306
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2692,7 +3320,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0244
+Index: geneve-ut-0307
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2706,7 +3334,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0245
+Index: geneve-ut-0308
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2721,7 +3349,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0247
+Index: geneve-ut-0310
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -2738,7 +3366,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0248
+Index: geneve-ut-0311
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -2750,7 +3378,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0249
+Index: geneve-ut-0312
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -2762,7 +3390,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0250
+Index: geneve-ut-0313
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2777,7 +3405,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0251
+Index: geneve-ut-0314
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -2797,7 +3425,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0252
+Index: geneve-ut-0315
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2819,7 +3447,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0254
+Index: geneve-ut-0317
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -2865,24 +3493,24 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0255
+Index: geneve-ut-0318
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.name : ("chrome.exe", "msedge.exe") and
-  process.parent.executable != null and process.command_line != null and
+  process.parent.executable != null and
   (
-  process.command_line :
-           ("\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\"",
+    process.command_line : (
+            "\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\"",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\"",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --disable-logging --log-level=3 --v=0",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --log-level=3",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --remote-debugging-port=922? --profile-directory=\"Default\"*",
-            "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --restore-last-session --remote-debugging-port=45452*") or
-
-  (process.args : "--remote-debugging-port=922?" and process.args : "--window-position=-*,-*")
-   ) and
+            "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --restore-last-session --remote-debugging-port=45452*"
+    ) or
+    (process.args : "--remote-debugging-port=922?" and process.args : "--window-position=-*,-*")
+  ) and
   not process.parent.executable :
                          ("C:\\Windows\\explorer.exe",
                           "C:\\Program Files (x86)\\*.exe",
@@ -2899,7 +3527,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0256
+Index: geneve-ut-0319
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2922,7 +3550,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0257
+Index: geneve-ut-0320
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -2940,11 +3568,26 @@ process.executable != null and
 
 
 
+### Chroot Execution in Container Context on Linux
+
+Branch count: 40  
+Document count: 40  
+Index: geneve-ut-0321
+
+```python
+host.os.type:linux and event.category:process and 
+event.type:start and event.action:(executed or exec) and 
+(process.name:"chroot" or process.args:("chroot" or "/bin/chroot" or "/usr/bin/chroot" or "/usr/local/bin/chroot")) and 
+(process.title:"runc init" or process.entry_leader.entry_meta.type:"container" or process.parent.name:("runc" or "containerd-shim-runc-v2"))
+```
+
+
+
 ### Clearing Windows Event Logs
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0259
+Index: geneve-ut-0323
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2965,11 +3608,41 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Cloud Instance Metadata Credential Path HTTP Request
+
+Branch count: 219  
+Document count: 219  
+Index: geneve-ut-0324
+
+```python
+network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
+http.request.method == "GET" and url.path : (
+  "/latest/meta-data/iam/security-credentials/*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*metadata/identity/oauth2/token*"
+) and (
+  ?process.name : (
+    "curl", "wget", "python*", "node", "bun", "php*", "ruby", "perl", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox",
+    "bun.exe", "node.exe", "powershell.exe", "cmd.exe", "curl.exe", "wget.exe", "rundll32.exe", "w3wp.exe", "java*", 
+    "go", "nc", "netcat", "nginx", "apache*", "httpd", "tomcat*", "catalina", "spring*", "dotnet", "gunicorn", "uwsgi", 
+    ".*", "osascript"
+  ) or ?process.executable : (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*", "?:\\ProgramData\\*"
+  ) or user_agent.original : (
+    "curl*", "wget*", "python*", "ruby*", "Go-http-client*", "node*", "axios*", "undici*", "java*", "php*", "Bun*",
+    "Apache-HttpClient*", "okhttp*", "RestTemplate*", "*WindowsPowerShell*", "*roadtools*", "*fasthttp*", "*azurehound*", "*bloodhound*", "*aiohttp*"
+  )
+)
+```
+
+
+
 ### Code Signing Policy Modification Through Built-in tools
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0261
+Index: geneve-ut-0326
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2983,7 +3656,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0262
+Index: geneve-ut-0327
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3005,7 +3678,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0263
+Index: geneve-ut-0328
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -3019,7 +3692,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0264
+Index: geneve-ut-0329
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -3039,7 +3712,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0267
+Index: geneve-ut-0332
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3056,7 +3729,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-0269
+Index: geneve-ut-0334
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3140,7 +3813,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0270
+Index: geneve-ut-0335
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -3170,7 +3843,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0273
+Index: geneve-ut-0338
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -3195,7 +3868,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0275
+Index: geneve-ut-0340
 
 ```python
 sequence by process.entity_id
@@ -3216,7 +3889,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0276
+Index: geneve-ut-0341
 
 ```python
 sequence by process.entity_id
@@ -3233,11 +3906,42 @@ sequence by process.entity_id
 
 
 
+### Container Runtime CLI Execution with Suspicious Arguments
+
+Branch count: 28  
+Document count: 28  
+Index: geneve-ut-0343
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
+(
+  (
+    process.name in ("ctr", "crictl", "nerdctl") and
+    (
+      (process.args == "tasks" and process.args == "exec") or
+      (process.args == "run" and process.args in ("--privileged", "--rm", "--mount", "--net-host", "--pid-host")) or
+      (process.args == "snapshots" and process.args == "mount")
+    )
+  ) or
+  (
+    (process.executable like ("/dev/shm/*", "/tmp/*", "/var/tmp/*") or process.name : ".*") and
+    process.args like ("*containerd.sock*", "k8s.io")
+  )
+) and
+not process.parent.executable in (
+  "/usr/bin/kubelet", "/usr/local/bin/kubelet",
+  "/usr/bin/containerd", "/usr/sbin/containerd",
+  "/lib/systemd/systemd", "/usr/lib/systemd/systemd", "/sbin/init"
+)
+```
+
+
+
 ### Control Panel Process with Unusual Arguments
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0278
+Index: geneve-ut-0344
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3260,7 +3964,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0281
+Index: geneve-ut-0347
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -3273,7 +3977,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0282
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3286,7 +3990,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0284
+Index: geneve-ut-0350
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -3303,7 +4007,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0285
+Index: geneve-ut-0351
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -3314,12 +4018,12 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 ### Creation of a Hidden Local User Account
 
-Branch count: 3  
-Document count: 3  
-Index: geneve-ut-0286
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0352
 
 ```python
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type in ("change", "creation") and
   registry.path : (
     "HKLM\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
     "\\REGISTRY\\MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
@@ -3333,7 +4037,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0287
+Index: geneve-ut-0353
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -3345,7 +4049,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0288
+Index: geneve-ut-0354
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -3413,7 +4117,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0289
+Index: geneve-ut-0355
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -3431,7 +4135,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0290
+Index: geneve-ut-0356
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -3442,15 +4146,18 @@ process.args == "--json" and process.args == "filesystem"
 
 ### Credential Acquisition via Registry Hive Dumping
 
-Branch count: 8  
-Document count: 8  
-Index: geneve-ut-0291
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-0357
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  (?process.pe.original_file_name == "reg.exe" or process.name : "reg.exe") and
  process.args : ("save", "export") and
- process.args : ("hklm\\sam", "hklm\\security")
+ process.args : (
+   "hklm\\sam", "hklm\\security", "hklm\\system",
+   "hkey_local_machine\\sam", "hkey_local_machine\\security", "hkey_local_machine\\system"
+ )
 ```
 
 
@@ -3459,7 +4166,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0292
+Index: geneve-ut-0358
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -3471,7 +4178,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0293
+Index: geneve-ut-0359
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -3483,7 +4190,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0294
+Index: geneve-ut-0360
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -3495,7 +4202,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0295
+Index: geneve-ut-0361
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -3507,7 +4214,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0296
+Index: geneve-ut-0362
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -3552,7 +4259,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0298
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3572,7 +4279,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0299
+Index: geneve-ut-0365
 
 ```python
 sequence with maxspan=10s
@@ -3592,7 +4299,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0300
+Index: geneve-ut-0366
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -3619,7 +4326,7 @@ process.name == "curl" and (
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0302
+Index: geneve-ut-0369
 
 ```python
 process where event.type == "start" and
@@ -3644,7 +4351,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0305
+Index: geneve-ut-0372
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -3688,7 +4395,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0306
+Index: geneve-ut-0373
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3722,7 +4429,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0307
+Index: geneve-ut-0374
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -3734,11 +4441,36 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 
 
+### DNS Request for IP Lookup Service via Unsigned Binary
+
+Branch count: 86  
+Document count: 86  
+Index: geneve-ut-0375
+
+```python
+network where host.os.type == "macos" and event.action == "lookup_result" and 
+  (process.code_signature.trusted == false or process.code_signature.exists == false) and
+  dns.question.name like~ ("*ip-api.com*", "*ipwho.is*", "*checkip.dyndns.org*", "*api.ipify.org*",
+                           "*api.npoint.io*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+                           "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*",
+                           "*ipwhois.app*", "*freeipapi.com*", "*icanhazip.com*", "*curlmyip.com*",
+                           "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*",
+                           "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*", "*api.ip.sb*",
+                           "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*",
+                           "*freegeoip.net*", "*freegeoip.app*", "*myip.ipip.net*", "*geoplugin.net*",
+                           "*myip.dnsomatic.com*", "*www.geoplugin.net*", "*api64.ipify.org*",
+                           "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+                           "*geolocation-db.com*", "*inet-ip.info*", "*httpbin.org*", "*myip.opendns.com*") and
+  not process.executable like "/Users/*/Library/Developer/CoreSimulator/*"
+```
+
+
+
 ### DNS-over-HTTPS Enabled via Registry
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0310
+Index: geneve-ut-0377
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3756,7 +4488,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0312
+Index: geneve-ut-0379
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -3769,7 +4501,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0317
+Index: geneve-ut-0384
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3783,7 +4515,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0318
+Index: geneve-ut-0385
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -3800,23 +4532,11 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
-### Deprecated - EggShell Backdoor Execution
-
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0319
-
-```python
-event.category:process and event.type:(process_started or start) and process.name:espl and process.args:eyJkZWJ1ZyI6*
-```
-
-
-
 ### Deprecated - Encoded Executable Stored in the Registry
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0320
+Index: geneve-ut-0386
 
 ```python
 registry where host.os.type == "windows" and
@@ -3830,7 +4550,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0328
+Index: geneve-ut-0395
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -3854,7 +4574,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0337
+Index: geneve-ut-0404
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3870,7 +4590,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0338
+Index: geneve-ut-0405
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3898,7 +4618,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0339
+Index: geneve-ut-0406
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3915,7 +4635,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0340
+Index: geneve-ut-0407
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3932,7 +4652,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0341
+Index: geneve-ut-0408
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3953,7 +4673,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0343
+Index: geneve-ut-0410
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -3973,7 +4693,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0344
+Index: geneve-ut-0411
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -3988,7 +4708,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0346
+Index: geneve-ut-0413
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -4001,7 +4721,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0347
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4021,7 +4741,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0350
+Index: geneve-ut-0417
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -4034,7 +4754,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0351
+Index: geneve-ut-0418
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4070,13 +4790,20 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 ### Dumping Account Hashes via Built-In Commands
 
-Branch count: 8  
-Document count: 8  
-Index: geneve-ut-0352
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0419
 
 ```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and
- process.name in ("defaults", "mkpassdb") and process.args like~ ("ShadowHashData", "-dump")
+process where host.os.type == "macos" and event.type in ("start","process_started") and (
+  (process.name == "defaults" and process.args like~ "ShadowHashData") or
+  (process.name == "mkpassdb" and process.args == "-dump") or
+  (process.name == "dscl" and process.args like~ "ShadowHashData") or
+  (
+    process.name in ("plutil","cat","strings","xxd","head") and
+    process.args like "/var/db/dslocal/nodes/Default/users/*.plist"
+  )
+)
 ```
 
 
@@ -4085,7 +4812,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0353
+Index: geneve-ut-0420
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -4098,7 +4825,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0354
+Index: geneve-ut-0421
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4121,7 +4848,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0356
+Index: geneve-ut-0423
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4152,7 +4879,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0357
+Index: geneve-ut-0424
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -4171,7 +4898,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0358
+Index: geneve-ut-0425
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -4214,7 +4941,7 @@ not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0359
+Index: geneve-ut-0427
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4229,7 +4956,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0360
+Index: geneve-ut-0428
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4245,7 +4972,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0361
+Index: geneve-ut-0429
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4259,7 +4986,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0362
+Index: geneve-ut-0430
 
 ```python
 sequence by host.id with maxspan=3s
@@ -4285,7 +5012,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0363
+Index: geneve-ut-0431
 
 ```python
 process where event.type == "start" and
@@ -4323,7 +5050,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0368
+Index: geneve-ut-0436
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -4336,7 +5063,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0369
+Index: geneve-ut-0437
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4350,7 +5077,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0370
+Index: geneve-ut-0438
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4385,7 +5112,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0371
+Index: geneve-ut-0439
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -4397,7 +5124,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0402
+Index: geneve-ut-0481
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -4409,7 +5136,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0424
+Index: geneve-ut-0505
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4423,7 +5150,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0427
+Index: geneve-ut-0508
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4450,7 +5177,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0430
+Index: geneve-ut-0511
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4471,7 +5198,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0433
+Index: geneve-ut-0514
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -4504,7 +5231,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0435
+Index: geneve-ut-0516
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -4521,7 +5248,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0436
+Index: geneve-ut-0517
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -4549,7 +5276,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0437
+Index: geneve-ut-0518
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -4562,7 +5289,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0439
+Index: geneve-ut-0520
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -4582,7 +5309,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0440
+Index: geneve-ut-0521
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4608,19 +5335,15 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0441
+Index: geneve-ut-0522
 
 ```python
 sequence with maxspan=2h
   [file where host.os.type == "windows" and event.type != "deletion" and file.extension : "exe" and
-     (process.name : "WINWORD.EXE" or
-      process.name : "EXCEL.EXE" or
-      process.name : "OUTLOOK.EXE" or
-      process.name : "POWERPNT.EXE" or
-      process.name : "eqnedt32.exe" or
-      process.name : "fltldr.exe" or
-      process.name : "MSPUB.EXE" or
-      process.name : "MSACCESS.EXE")
+    process.name : (
+      "WINWORD.EXE", "EXCEL.EXE", "OUTLOOK.EXE", "POWERPNT.EXE",
+      "eqnedt32.exe", "fltldr.exe", "MSPUB.EXE", "MSACCESS.EXE"
+    )
   ] by host.id, file.path
   [process where host.os.type == "windows" and event.type == "start" and 
    not (process.name : "NewOutlookInstaller.exe" and process.code_signature.subject_name : "Microsoft Corporation" and process.code_signature.trusted == true) and 
@@ -4634,7 +5357,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0442
+Index: geneve-ut-0523
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -4663,7 +5386,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0445
+Index: geneve-ut-0526
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -4676,7 +5399,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0449
+Index: geneve-ut-0530
 
 ```python
 sequence by user.id with maxspan=5s
@@ -4691,7 +5414,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0450
+Index: geneve-ut-0531
 
 ```python
 process where event.type == "start" and
@@ -4713,7 +5436,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0451
+Index: geneve-ut-0532
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -4725,7 +5448,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0452
+Index: geneve-ut-0533
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4747,7 +5470,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0454
+Index: geneve-ut-0535
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -4764,7 +5487,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0455
+Index: geneve-ut-0536
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4778,7 +5501,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0456
+Index: geneve-ut-0537
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -4791,7 +5514,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0457
+Index: geneve-ut-0538
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -4803,7 +5526,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0458
+Index: geneve-ut-0539
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -4815,7 +5538,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0459
+Index: geneve-ut-0540
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4829,7 +5552,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0460
+Index: geneve-ut-0541
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -4841,7 +5564,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 304  
 Document count: 304  
-Index: geneve-ut-0461
+Index: geneve-ut-0542
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -4863,7 +5586,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0464
+Index: geneve-ut-0545
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -4912,7 +5635,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0465
+Index: geneve-ut-0546
 
 ```python
 sequence by host.id with maxspan=10s
@@ -4932,7 +5655,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0471
+Index: geneve-ut-0552
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4947,7 +5670,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0472
+Index: geneve-ut-0553
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4961,7 +5684,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0474
+Index: geneve-ut-0555
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4983,7 +5706,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0475
+Index: geneve-ut-0556
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -5004,7 +5727,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0476
+Index: geneve-ut-0557
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5030,7 +5753,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0477
+Index: geneve-ut-0558
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -5054,11 +5777,25 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Finder Sync Plugin Registered and Enabled
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0561
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
+  process.args == "-e" and process.args like~ "use" and process.args == "-i" and
+  (process.parent.name like~ ("python*", "node", "osascript", "bash", "sh", "zsh") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
 ### Full Disk Access Permission Check
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0514
+Index: geneve-ut-0595
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -5075,7 +5812,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0515
+Index: geneve-ut-0596
 
 ```python
 registry where host.os.type == "windows" and
@@ -5093,7 +5830,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0539
+Index: geneve-ut-0633
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -5132,7 +5869,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0540
+Index: geneve-ut-0634
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5159,7 +5896,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0541
+Index: geneve-ut-0635
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -5170,11 +5907,98 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 
 
+### GenAI CLI Started with Unsafe Permission Bypass
+
+Branch count: 267  
+Document count: 267  
+Index: geneve-ut-0636
+
+```python
+process where event.type == "start" and event.action in ("exec", "start") and
+(
+  (
+    process.args in (
+      "--dangerously-skip-permissions",
+      "--allow-dangerously-skip-permissions",
+      "--permission-mode=bypassPermissions"
+    ) or
+    (process.args == "--permission-mode" and process.args == "bypassPermissions")
+  ) and
+  (
+    process.name in ("claude", "claude.exe") or
+    process.executable : (
+      "*/.local/share/claude/versions/*",
+      "*/.claude/downloads/*",
+      "*Caskroom/claude-code/*",
+      "*\\Claude\\versions\\*"
+    ) or
+    (process.name in ("node", "node.exe") and process.args : "*@anthropic-ai/claude-code*")
+  )
+) or
+(
+  (
+    process.args in ("--dangerously-bypass-approvals-and-sandbox", "--full-auto", "--yolo") or
+    process.command_line : (
+      "* -s danger-full-access*",
+      "*--sandbox danger-full-access*",
+      "*--sandbox=danger-full-access*",
+      "*--ask-for-approval never*",
+      "*--ask-for-approval=never*"
+    )
+  ) and
+  (
+    process.name in (
+      "codex", "codex.exe", "codex-exec",
+      "codex-aarch64-apple-darwin", "codex-x86_64-apple-darwin",
+      "codex-linux-arm64", "codex-linux-x64"
+    ) or
+    (process.name in ("node", "node.exe") and process.args : ("*@openai/codex*", "*/codex", "*\\codex*"))
+  )
+) or
+(
+  (
+    process.args in ("--yolo", "-y") or
+    (process.args == "--approval-mode" and process.args == "yolo") or
+    process.args == "--approval-mode=yolo"
+  ) and
+  (
+    process.name in ("gemini", "gemini-cli", "gemini.exe", "gemini-cli.exe") or
+    (process.name in ("node", "node.exe") and process.args : ("*@google/gemini-cli*", "*/gemini", "*\\gemini*"))
+  )
+) or
+(
+  (
+    process.args in (
+      "--yolo",
+      "--autopilot",
+      "--allow-all",
+      "--allow-all-tools",
+      "--allow-all-paths",
+      "--allow-all-urls"
+    )
+  ) and
+  (
+    process.name in ("copilot", "copilot.exe") or
+    (process.name in ("node", "node.exe") and process.args : ("*@github/copilot*", "*/copilot", "*\\copilot*"))
+  )
+) or
+(
+  process.args == "--dangerously-skip-permissions" and
+  (
+    process.name in ("opencode", "opencode.exe", ".opencode") or
+    process.executable : ("*opencode-ai*", "*\\.opencode*") or
+    (process.name in ("node", "node.exe") and process.args : ("*opencode-ai*", "*/opencode", "*\\opencode*"))
+  )
+)
+```
+
+
+
 ### Git Hook Command Execution
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0549
+Index: geneve-ut-0644
 
 ```python
 sequence by host.id with maxspan=3s
@@ -5192,7 +6016,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0550
+Index: geneve-ut-0645
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -5223,7 +6047,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0551
+Index: geneve-ut-0646
 
 ```python
 sequence by host.id with maxspan=3s
@@ -5250,7 +6074,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0552
+Index: geneve-ut-0647
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -5270,7 +6094,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0556
+Index: geneve-ut-0651
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -5283,7 +6107,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0559
+Index: geneve-ut-0654
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -5295,7 +6119,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0562
+Index: geneve-ut-0657
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -5307,7 +6131,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0566
+Index: geneve-ut-0661
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -5319,7 +6143,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0568
+Index: geneve-ut-0663
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -5336,7 +6160,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0587
+Index: geneve-ut-0687
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5349,7 +6173,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0589
+Index: geneve-ut-0689
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -5373,7 +6197,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0590
+Index: geneve-ut-0690
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -5385,7 +6209,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0603
+Index: geneve-ut-0703
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -5394,9 +6218,7 @@ sequence by process.entity_id with maxspan=5m
   /* Plan9FileSystem CLSID - WSL Host File System Worker */
  process.command_line : "*{DFB65C4C-B34F-435D-AFE9-A86218684AA8}*"]
 [file where host.os.type == "windows" and process.name : "dllhost.exe" and
-  not file.path : (
-        "?:\\Users\\*\\Downloads\\*",
-        "?:\\Windows\\Prefetch\\DLLHOST.exe-????????.pf")]
+  not file.path : "?:\\Windows\\Prefetch\\DLLHOST.exe-????????.pf"]
 ```
 
 
@@ -5405,7 +6227,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0604
+Index: geneve-ut-0704
 
 ```python
 any where process.executable != null and
@@ -5454,7 +6276,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0605
+Index: geneve-ut-0705
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5468,7 +6290,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0607
+Index: geneve-ut-0709
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5483,7 +6305,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0612
+Index: geneve-ut-0714
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5500,7 +6322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0614
+Index: geneve-ut-0716
 
 ```python
 sequence with maxspan=1m
@@ -5519,12 +6341,12 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0615
+Index: geneve-ut-0717
 
 ```python
 sequence by host.id with maxspan=1m
  [network where host.os.type == "windows" and event.type == "start" and process.name : "mmc.exe" and source.port >= 49152 and
- destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
+  destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
   network.direction : ("incoming", "ingress") and network.transport == "tcp"
  ] by process.entity_id
  [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "mmc.exe"
@@ -5537,7 +6359,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0616
+Index: geneve-ut-0718
 
 ```python
 sequence by host.id with maxspan=5s
@@ -5556,7 +6378,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0617
+Index: geneve-ut-0719
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -5572,7 +6394,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0618
+Index: geneve-ut-0720
 
 ```python
 sequence by host.id with maxspan=30s
@@ -5588,7 +6410,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0619
+Index: geneve-ut-0721
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5601,7 +6423,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0623
+Index: geneve-ut-0725
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5618,7 +6440,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0625
+Index: geneve-ut-0727
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5631,7 +6453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0626
+Index: geneve-ut-0728
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -5647,7 +6469,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0627
+Index: geneve-ut-0729
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5674,7 +6496,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0628
+Index: geneve-ut-0730
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5698,7 +6520,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0632
+Index: geneve-ut-0734
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -5722,7 +6544,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0633
+Index: geneve-ut-0736
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5758,7 +6580,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0634
+Index: geneve-ut-0737
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -5770,7 +6592,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0635
+Index: geneve-ut-0738
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5784,7 +6606,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0636
+Index: geneve-ut-0739
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -5797,7 +6619,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0637
+Index: geneve-ut-0740
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -5856,7 +6678,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0638
+Index: geneve-ut-0741
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -5869,7 +6691,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0639
+Index: geneve-ut-0742
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -5882,7 +6704,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0640
+Index: geneve-ut-0743
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5903,7 +6725,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0641
+Index: geneve-ut-0744
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5921,7 +6743,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0642
+Index: geneve-ut-0745
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5955,7 +6777,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0643
+Index: geneve-ut-0746
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5973,7 +6795,15 @@ not (
     "/usr/bin/kcarectl", "/usr/share/ksplice/ksplice-apply", "/opt/commvault/Base/linux_drv", "/usr/sbin/veeamsnap-loader",
     "/bin/falcoctl"
   ) or
-  (?process.parent.name like ("python*", "platform-python*") and ?process.parent.args in ("--smart-update", "--auto-update"))
+  (?process.parent.name like ("python*", "platform-python*") and ?process.parent.args in ("--smart-update", "--auto-update")) or
+  (
+    process.name == "modprobe" and process.args == "-q" and process.args == "--" and process.args in ("net-pf-10", "netdev-", "binfmt-464c")
+  ) or
+  (
+    process.name == "modprobe" and process.args == "-n" and process.args == "-v" and process.args in ("usb-storage", "dccp", "squashfs", "udf", "sctp", "cramfs", "hfsplus")
+  ) or
+  ?process.parent.executable like ("/sbin/iptables-multi*", "/var/ossec/bin/wazuh-modulesd", "/usr/sbin/mkinitramfs", "/usr/share/initramfs-tools/hooks/lvm2") or
+  ?process.parent.args like "/usr/share/initramfs-tools/hooks/*"
 )
 ```
 
@@ -5983,7 +6813,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0644
+Index: geneve-ut-0747
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6005,7 +6835,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0646
+Index: geneve-ut-0749
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6032,7 +6862,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0647
+Index: geneve-ut-0750
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6058,7 +6888,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0648
+Index: geneve-ut-0751
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -6074,7 +6904,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0649
+Index: geneve-ut-0752
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -6090,7 +6920,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0651
+Index: geneve-ut-0754
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -6102,7 +6932,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0652
+Index: geneve-ut-0755
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -6130,7 +6960,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0654
+Index: geneve-ut-0757
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6146,7 +6976,7 @@ not process.command_line like ("*download.elastic.co*", "*github.com/kubernetes-
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0656
+Index: geneve-ut-0759
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6169,7 +6999,7 @@ process.name == "kubectl" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0657
+Index: geneve-ut-0760
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6183,7 +7013,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0658
+Index: geneve-ut-0761
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6202,11 +7032,92 @@ process.name == "kubectl" and (
 
 
 
+### Kubelet API Connection Attempt to Internal IP
+
+Branch count: 204  
+Document count: 204  
+Index: geneve-ut-0762
+
+```python
+network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
+  event.action in ("connected-to", "connection_attempted") and (destination.port == 10250 or destination.port == 10255) and
+  cidrmatch(
+    destination.ip,
+    "127.0.0.0/8",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "169.254.0.0/16",
+    "100.64.0.0/10",
+    "::1/128",
+    "fc00::/7",
+    "fe80::/10"
+  ) and
+  (
+    process.name in ("curl", "wget", "nc", "ncat", "netcat", "socat", "openssl", "perl", "busybox") or 
+    process.name like ".*" or process.executable like "/*/.*" or 
+    process.name like ("python*", "ruby*", "node*", "java*", "lua*", "apache*", "php*", "nginx", "httpd*", "lighttpd", "caddy", "mongrel_rails", "gunicorn", 
+                       "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn", 
+                       "daphne", "twistd", "yaws", "webfsd", "flask", "rails", "mongrel", "catalina.sh", "hiawatha", "lswsctrl") or
+    process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/var/run/*", "/home/*", "/run/user/*", "/busybox/*")
+  )
+```
+
+
+
+### Kubernetes API Server Proxying Request to Kubelet
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0764
+
+```python
+kubernetes.audit.objectRef.subresource:"proxy" and
+kubernetes.audit.objectRef.resource:"nodes" and
+not kubernetes.audit.requestURI:(*metrics* or *healthz* or *stats/summary* or *elastic-agent* or *configz*) and
+not user.name:(
+  system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:serviceaccount\:kube-system\:* or
+  system\:node\:* or
+  eks\:* or aksService
+)
+```
+
+
+
+### Kubernetes Admission Webhook Created or Modified
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0765
+
+```python
+kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
+kubernetes.audit.verb:("create" or "update" or "patch" or "delete") and
+kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" and 
+user.name:(* and not 
+  (system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:serviceaccount\:kube-system\:* or
+  eks\:* or aksService or masterclient or nodeclient or
+  system\:serviceaccount\:gke-managed-system\:* or
+  system\:serviceaccount\:cert-manager\:* or
+  system\:serviceaccount\:gatekeeper-system\:* or
+  system\:serviceaccount\:kyverno\:* or
+  system\:serviceaccount\:*\:*-operator)
+) and
+kubernetes.audit.objectRef.name:(* and not (pod-identity-webhook or vpc-resource-mutating-webhook or eks-* or gke-*)) and 
+not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kubernetes.audit.objectRef.name:"k8tz")
+```
+
+
+
 ### Kubernetes Direct API Request via Curl or Wget
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-0666
+Index: geneve-ut-0775
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6228,7 +7139,7 @@ process.name in ("curl", "wget") and process.args like~ (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0680
+Index: geneve-ut-0801
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -6247,7 +7158,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0683
+Index: geneve-ut-0804
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6287,11 +7198,36 @@ not (
 
 
 
+### Kubernetes Static Pod Manifest File Access
+
+Branch count: 116  
+Document count: 116  
+Index: geneve-ut-0806
+
+```python
+host.os.type:linux and event.category:process and event.action:(exec or executed) and 
+process.name:(
+  bash or sh or dash or zsh or 
+  cat or cp or mv or touch or tee or dd or
+  sed or awk or 
+  curl or wget or scp or
+  vi or vim or nano or echo or
+  busybox or
+  python* or perl* or ruby* or node or lua* or
+  openssl or base64 or xxd or
+  .*) and 
+  process.args:(*/etc/kubernetes/manifests/* and not (/etc/kubernetes/manifests/etcd* or /etc/kubernetes/manifests/kube-apiserver* or /etc/kubernetes/manifests/kube-scheduler* or /etc/kubernetes/manifests/kube-controller-manager*)) and 
+  not (process.args :printf* and process.working_directory :/home/*-svc-nessus) and 
+  not process.parent.executable :("/opt/nessus/sbin/nessusd" or "/opt/nessus_agent/sbin/nessus-agent-module")
+```
+
+
+
 ### LSASS Memory Dump Creation
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0688
+Index: geneve-ut-0812
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6329,7 +7265,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0693
+Index: geneve-ut-0817
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6347,7 +7283,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0694
+Index: geneve-ut-0818
 
 ```python
 sequence by host.id with maxspan=30s
@@ -6361,7 +7297,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0698
+Index: geneve-ut-0823
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -6372,72 +7308,11 @@ process.args != "1"
 
 
 
-### Linux Restricted Shell Breakout via Linux Binary(s)
-
-Branch count: 303  
-Document count: 303  
-Index: geneve-ut-0699
-
-```python
-process where host.os.type == "linux" and event.type == "start" and process.executable != null and
-(
-  /* launching shell from capsh */
-  (process.name == "capsh" and process.args == "--" and not process.parent.executable == "/usr/bin/log4j-cve-2021-44228-hotpatch") or
-
-  /* launching shells from unusual parents or parent+arg combos */
-  (process.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
-    (process.parent.name : "*awk" and process.parent.args : "BEGIN {system(*)}") or
-    (process.parent.name == "git" and process.parent.args : ("!*sh", "exec *sh") and not process.name == "ssh" ) or
-    (process.parent.name : ("byebug", "ftp", "strace", "zip", "tar") and
-    (
-      process.parent.args : "BEGIN {system(*)}" or
-      (
-        (process.parent.args : "exec=*sh" or (process.parent.args : "-I" and process.parent.args : "*sh")) or
-        (process.args : "exec=*sh" or (process.args : "-I" and process.args : "*sh"))
-        )
-      )
-    ) or
-
-    /* shells specified in parent args */
-    /* nice rule is broken in 8.2 */
-    (process.parent.args : "*sh" and
-      (
-        (process.parent.name == "nice") or
-        (process.parent.name == "cpulimit" and process.parent.args == "-f") or
-        (process.parent.name == "find" and process.parent.args == "." and process.parent.args == "-exec" and
-         process.parent.args == ";" and process.parent.args : "/bin/*sh") or
-        (process.parent.name == "flock" and process.parent.args == "-u" and process.parent.args == "/")
-      )
-    )
-  )) or
-
-  /* shells specified in args */
-  (process.args : "*sh" and (
-    (process.parent.name == "crash" and process.parent.args == "-h") or
-    (process.name == "sensible-pager" and process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog")
-    /* scope to include more sensible-pager invoked shells with different parent process to reduce noise and remove false positives */
-
-  )) or
-  (process.name == "busybox" and event.action == "exec" and process.args_count == 2 and process.args : "*sh" and not
-   process.executable : "/var/lib/docker/overlay2/*/merged/bin/busybox" and not (process.parent.args == "init" and
-   process.parent.args == "runc") and not process.parent.args in ("ls-remote", "push", "fetch") and not process.parent.name == "mkinitramfs" and
-   not process.parent.executable == "/bin/busybox") or
-  (process.name == "env" and process.args_count == 2 and process.args : "*sh") or
-  (process.parent.name in ("vi", "vim") and process.parent.args == "-c" and process.parent.args : ":!*sh") or
-  (process.parent.name in ("c89", "c99", "gcc") and process.parent.args : "*sh,-s" and process.parent.args == "-wrapper") or
-  (process.parent.name == "expect" and process.parent.args == "-c" and process.parent.args : "spawn *sh;interact") or
-  (process.parent.name == "mysql" and process.parent.args == "-e" and process.parent.args : "\\!*sh") or
-  (process.parent.name == "ssh" and process.parent.args == "-o" and process.parent.args : "ProxyCommand=;*sh 0<&2 1>&2")
-)
-```
-
-
-
 ### Linux SSH X11 Forwarding
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0700
+Index: geneve-ut-0824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6451,7 +7326,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0703
+Index: geneve-ut-0827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6465,7 +7340,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0705
+Index: geneve-ut-0829
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6484,9 +7359,9 @@ not (
 
 ### Linux User Added to Privileged Group
 
-Branch count: 360  
-Document count: 360  
-Index: geneve-ut-0706
+Branch count: 720  
+Document count: 720  
+Index: geneve-ut-0830
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6497,6 +7372,16 @@ process.executable != null and process.args in (
 (
   process.name in ("usermod", "adduser") or
   (process.name == "gpasswd" and process.args in ("-a", "--add", "-M", "--members"))
+) and
+not (
+  ?process.parent.executable like (
+    "/usr/lib/google/guest_agent/core_plugin", "/usr/libexec/platform-python*", "/usr/lib/google/guest_agent/GuestAgentCorePlugin/core_plugin",
+    "/usr/bin/google_guest_agent"
+  ) or
+  (
+    ?process.entry_leader.executable == "/usr/lib/venv-salt-minion/bin/python.original" and
+    ?process.entry_leader.args == "/usr/lib/venv-salt-minion/bin/salt-minion"
+  )
 )
 ```
 
@@ -6506,7 +7391,7 @@ process.executable != null and process.args in (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0710
+Index: geneve-ut-0834
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -6553,7 +7438,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0711
+Index: geneve-ut-0835
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6584,7 +7469,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 600  
 Document count: 1200  
-Index: geneve-ut-0712
+Index: geneve-ut-0836
 
 ```python
 sequence with maxspan=1m
@@ -6609,7 +7494,7 @@ sequence with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0714
+Index: geneve-ut-0838
 
 ```python
 event.dataset:o365.audit and
@@ -6622,7 +7507,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0716
+Index: geneve-ut-0840
 
 ```python
 event.dataset:o365.audit and
@@ -6635,7 +7520,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0717
+Index: geneve-ut-0841
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -6647,7 +7532,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0748
+Index: geneve-ut-0876
 
 ```python
 event.dataset:o365.audit and
@@ -6660,7 +7545,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0749
+Index: geneve-ut-0877
 
 ```python
 event.dataset:o365.audit and
@@ -6673,7 +7558,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0750
+Index: geneve-ut-0878
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -6685,7 +7570,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0751
+Index: geneve-ut-0879
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -6697,7 +7582,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0752
+Index: geneve-ut-0880
 
 ```python
 event.dataset:o365.audit and
@@ -6710,7 +7595,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0759
+Index: geneve-ut-0888
 
 ```python
 event.dataset: "o365.audit" and
@@ -6723,7 +7608,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0763
+Index: geneve-ut-0891
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6743,7 +7628,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0764
+Index: geneve-ut-0892
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -6755,7 +7640,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0765
+Index: geneve-ut-0893
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -6767,7 +7652,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0769
+Index: geneve-ut-0897
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -6779,7 +7664,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0770
+Index: geneve-ut-0898
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -6791,7 +7676,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0771
+Index: geneve-ut-0899
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -6803,7 +7688,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0772
+Index: geneve-ut-0900
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -6815,7 +7700,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0773
+Index: geneve-ut-0901
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6840,7 +7725,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0774
+Index: geneve-ut-0902
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -6860,7 +7745,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0775
+Index: geneve-ut-0903
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -6873,7 +7758,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-0776
+Index: geneve-ut-0904
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6888,7 +7773,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0778
+Index: geneve-ut-0906
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -6900,7 +7785,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0781
+Index: geneve-ut-0909
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -6912,7 +7797,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0782
+Index: geneve-ut-0910
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -6924,7 +7809,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0783
+Index: geneve-ut-0911
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -6958,7 +7843,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0786
+Index: geneve-ut-0914
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6972,7 +7857,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0787
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6993,7 +7878,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0788
+Index: geneve-ut-0916
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7007,7 +7892,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0790
+Index: geneve-ut-0918
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7042,7 +7927,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0791
+Index: geneve-ut-0919
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7067,7 +7952,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0792
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7082,14 +7967,14 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### Microsoft IIS Connection Strings Decryption
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0795
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-0924
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   (process.name : "aspnet_regiis.exe" or ?process.pe.original_file_name == "aspnet_regiis.exe") and
-  process.args : "connectionStrings" and process.args : "-pdf"
+  process.args : "connectionStrings" and process.args : ("-pdf", "-pd")
 ```
 
 
@@ -7098,7 +7983,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0797
+Index: geneve-ut-0926
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7129,7 +8014,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0799
+Index: geneve-ut-0928
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -7183,7 +8068,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0800
+Index: geneve-ut-0929
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -7193,12 +8078,12 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 ### Modification of AmsiEnable Registry Key
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0801
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-0930
 
 ```python
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type in ("creation", "change") and
   registry.value : "AmsiEnable" and registry.data.strings: ("0", "0x00000000")
 
   /*
@@ -7213,7 +8098,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0802
+Index: geneve-ut-0931
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7230,7 +8115,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0804
+Index: geneve-ut-0933
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -7245,7 +8130,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0806
+Index: geneve-ut-0935
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -7261,7 +8146,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0807
+Index: geneve-ut-0936
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -7275,7 +8160,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0809
+Index: geneve-ut-0938
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7298,7 +8183,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0810
+Index: geneve-ut-0939
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7320,7 +8205,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0811
+Index: geneve-ut-0940
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7337,9 +8222,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### MsBuild Making Network Connections
 
-Branch count: 8  
-Document count: 16  
-Index: geneve-ut-0812
+Branch count: 4  
+Document count: 8  
+Index: geneve-ut-0941
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -7357,10 +8242,6 @@ sequence by process.entity_id with maxspan=30s
   /* Exclude domains that are known to be benign */
   [network where host.os.type == "windows" and
     event.action: ("connection_attempted", "lookup_requested") and
-    (
-      process.pe.original_file_name: "MSBuild.exe" or
-      process.name: "MSBuild.exe"
-    ) and
     not user.id == "S-1-5-18" and
     not cidrmatch(destination.ip, "127.0.0.1", "::1") and
     not dns.question.name : (
@@ -7376,7 +8257,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0813
+Index: geneve-ut-0942
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -7394,7 +8275,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-0814
+Index: geneve-ut-0943
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -7435,7 +8316,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-0825
+Index: geneve-ut-0956
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -7461,7 +8342,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0832
+Index: geneve-ut-0963
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -7485,7 +8366,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0835
+Index: geneve-ut-0966
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7497,9 +8378,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### NTDS or SAM Database File Copied
 
-Branch count: 210  
-Document count: 210  
-Index: geneve-ut-0836
+Branch count: 168  
+Document count: 168  
+Index: geneve-ut-0967
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7509,23 +8390,23 @@ process where host.os.type == "windows" and event.type == "start" and
     ) or
     ((?process.pe.original_file_name : "esentutl.exe" or process.name : "esentutl.exe") and process.args : ("*/y*", "*/vss*", "*/d*"))
   ) and
-  process.command_line : ("*\\ntds.dit*", "*\\config\\SAM*", "*\\*\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\*", "*/system32/config/SAM*", "*\\User Data\\*")
+  process.command_line : ("*\\ntds.dit*", "*\\config\\SAM*", "*\\*\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\*", "*/system32/config/SAM*")
 ```
 
 
 
 ### Namespace Manipulation Using Unshare
 
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-0837
+Branch count: 12  
+Document count: 12  
+Index: geneve-ut-0968
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action : ("exec", "exec_event", "start") and
-process.executable: "/usr/bin/unshare" and not (
-  process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
-  process.args == "/usr/bin/snap" and not process.parent.name in ("zz-proxmox-boot", "java") or
-  process.parent.args like (
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
+process.name: "unshare" and not (
+  ?process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
+  ?process.args == "/usr/bin/snap" and not ?process.parent.name in ("zz-proxmox-boot", "java") or
+  ?process.parent.args like (
     "/etc/kernel/postinst.d/zz-proxmox-boot", "/opt/openssh/sbin/sshd", "/usr/sbin/sshd",
     "/snap/*", "/home/*/.local/share/JetBrains/Toolbox/*"
   )
@@ -7538,7 +8419,7 @@ process.executable: "/usr/bin/unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0838
+Index: geneve-ut-0969
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7559,7 +8440,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0839
+Index: geneve-ut-0970
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7574,7 +8455,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0840
+Index: geneve-ut-0971
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7591,7 +8472,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0842
+Index: geneve-ut-0973
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -7611,11 +8492,57 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 
 
+### Network Connection Followed by File Creation
+
+Branch count: 112  
+Document count: 224  
+Index: geneve-ut-0975
+
+```python
+sequence by host.id, process.entity_id with maxspan=5s
+  [network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and
+  process.executable like (
+    "/boot/*", "/dev/shm/*", "/tmp/*", "/var/tmp/*", "/var/log/*", "/var/run/user/*", "/run/user/*"
+  ) and
+  not (
+    destination.ip == null or
+    destination.ip == "0.0.0.0" or 
+    cidrmatch(
+      destination.ip, "10.0.0.0/8", "127.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12",
+      "192.0.0.0/24", "192.0.0.0/29","192.0.0.8/32", "192.0.0.9/32", "192.0.0.10/32",
+      "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24",
+      "192.168.0.0/16", "192.88.99.0/24", "224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24",
+      "198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4", "::1", "FE80::/10",
+      "FF00::/8", "FC00::/7"
+    )
+  )]
+  [file where host.os.type == "linux" and event.type == "creation" and process.executable like (
+    "/boot/*", "/dev/shm/*", "/tmp/*", "/var/tmp/*", "/var/log/*", "/boot/*", "/var/run/user/*", "/run/user/*"
+  ) and
+  not (
+    file.name like "tmp*" or file.extension in ("sqlite-journal", "db-journal", "lockfile", "tmp") or
+    file.path like (
+      "/loki/wal/*", "/dev/shm/.org.chromium.Chromium.*", "/opt/rapid7/nexpose/*",
+      "/usr/local/ltechagent*", "/var/lib/cloudendure/agent_keystore_temp", "/var/cache/yum/*",
+      "/run/aws-node/ipam.json.tmp*", "/run/systemd/journal/streams/.*"
+    ) or
+    (process.executable == "/tmp/terraform" and file.path like "/tmp/terraform-provider*") or 
+    process.name in ("podman", "minikube", "logrotate", "java", "aws-k8s-agent", "grafana", "postman") or
+    process.executable : (
+      "/etc/cron.daily/logrotate", "/etc/update-motd.d/50-motd-news", "/etc/cron.hourly/0yum-hourly.cron",
+      "/etc/cron.hourly/BitdefenderRedline", "/tmp/token_handler", "/tmp/.sentry-cli*.exe", 
+      "/etc/cron.daily/0yum-daily.cron", "/etc/init.d/fortiedr"
+    )
+  )]
+```
+
+
+
 ### Network Connection Initiated by Suspicious SSHD Child Process
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-0844
+Index: geneve-ut-0976
 
 ```python
 sequence by host.id with maxspan=1s
@@ -7657,7 +8584,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-0845
+Index: geneve-ut-0977
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7674,7 +8601,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0847
+Index: geneve-ut-0979
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -7689,7 +8616,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0848
+Index: geneve-ut-0980
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -7708,7 +8635,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0849
+Index: geneve-ut-0981
 
 ```python
 sequence by process.entity_id
@@ -7728,7 +8655,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0850
+Index: geneve-ut-0982
 
 ```python
 sequence by process.entity_id
@@ -7747,7 +8674,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-0851
+Index: geneve-ut-0983
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7776,7 +8703,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-0852
+Index: geneve-ut-0984
 
 ```python
 sequence by process.entity_id
@@ -7801,7 +8728,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0853
+Index: geneve-ut-0985
 
 ```python
 sequence by process.entity_id
@@ -7823,7 +8750,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0854
+Index: geneve-ut-0986
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -7856,7 +8783,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0855
+Index: geneve-ut-0987
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7886,7 +8813,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0858
+Index: geneve-ut-0990
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -7903,7 +8830,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0859
+Index: geneve-ut-0991
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -7940,7 +8867,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0860
+Index: geneve-ut-0992
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7953,7 +8880,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0865
+Index: geneve-ut-0997
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -7965,7 +8892,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0867
+Index: geneve-ut-0999
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -7977,7 +8904,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-0875
+Index: geneve-ut-1007
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7991,7 +8918,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0876
+Index: geneve-ut-1008
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8001,11 +8928,26 @@ process where host.os.type == "linux" and event.type == "start" and
 
 
 
+### Nsenter to PID Namespace via Auditd
+
+Branch count: 32  
+Document count: 32  
+Index: geneve-ut-1009
+
+```python
+host.os.type:linux and 
+event.category:process and event.action:(executed or exec) and 
+(process.name:nsenter or process.args:nsenter) and 
+process.args:((--target* or -t) and not --net=/run/netns/* and not (--assertion and snap) and not (is-active and snap.*))
+```
+
+
+
 ### Office Test Registry Persistence
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0878
+Index: geneve-ut-1011
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -8018,7 +8960,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0879
+Index: geneve-ut-1012
 
 ```python
 event.dataset: "okta.system"
@@ -8033,7 +8975,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0881
+Index: geneve-ut-1014
 
 ```python
 sequence by user.name with maxspan=30m
@@ -8055,7 +8997,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0890
+Index: geneve-ut-1023
 
 ```python
 network where event.action == "connection_accepted" and
@@ -8082,7 +9024,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0891
+Index: geneve-ut-1024
 
 ```python
 network where event.action == "lookup_requested" and
@@ -8102,7 +9044,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0892
+Index: geneve-ut-1025
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8117,7 +9059,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-0893
+Index: geneve-ut-1026
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -8144,7 +9086,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-0894
+Index: geneve-ut-1027
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -8159,7 +9101,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0895
+Index: geneve-ut-1028
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -8175,7 +9117,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0896
+Index: geneve-ut-1029
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -8189,7 +9131,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0899
+Index: geneve-ut-1034
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -8204,7 +9146,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0900
+Index: geneve-ut-1035
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8218,7 +9160,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0901
+Index: geneve-ut-1036
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -8237,7 +9179,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0902
+Index: geneve-ut-1037
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -8249,7 +9191,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0903
+Index: geneve-ut-1038
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -8261,7 +9203,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0904
+Index: geneve-ut-1039
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8279,7 +9221,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0905
+Index: geneve-ut-1040
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -8292,7 +9234,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0906
+Index: geneve-ut-1041
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -8307,7 +9249,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0907
+Index: geneve-ut-1042
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -8322,7 +9264,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0909
+Index: geneve-ut-1044
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -8340,9 +9282,9 @@ process where host.os.type == "macos" and event.type == "start" and
 
 ### Persistence via Microsoft Office AddIns
 
-Branch count: 36  
-Document count: 36  
-Index: geneve-ut-0910
+Branch count: 108  
+Document count: 108  
+Index: geneve-ut-1045
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -8356,7 +9298,8 @@ file where host.os.type == "windows" and event.type != "deletion" and
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Word\\Startup\\*",
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\AddIns\\*",
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*"
- )
+ ) and
+ not (file.name : "~$*" and process.name : "excel.exe" and ?file.size in (0, 165))
 ```
 
 
@@ -8365,7 +9308,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0911
+Index: geneve-ut-1046
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -8379,7 +9322,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0912
+Index: geneve-ut-1047
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -8398,7 +9341,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0913
+Index: geneve-ut-1048
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -8422,9 +9365,9 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 ### Persistence via Suspicious Launch Agent or Launch Daemon
 
-Branch count: 190  
-Document count: 190  
-Index: geneve-ut-0914
+Branch count: 380  
+Document count: 380  
+Index: geneve-ut-1049
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -8439,7 +9382,12 @@ file where host.os.type == "macos" and event.type != "deletion" and
   not process.executable like ("/System/*", "/Library/PrivilegedHelperTools/*") and
   not (process.code_signature.signing_id in ("com.apple.vim", "com.apple.cat", "com.apple.cfprefsd",
                                             "com.jetbrains.toolbox", "com.apple.pico", "com.apple.shove",
-                                            "com.sublimetext.4", "com.apple.ditto") and process.code_signature.trusted == true)
+                                            "com.sublimetext.4", "com.apple.ditto") and process.code_signature.trusted == true) and
+  not (file.path like ("/Library/LaunchDaemons/com.jumpcloud.*",
+                       "/Library/LaunchAgents/com.jumpcloud.*",
+                       "/Library/LaunchDaemons/com.wazuh.*",
+                       "/Library/LaunchDaemons/com.zscaler.service.plist") and
+       process.executable == "/bin/bash")
 ```
 
 
@@ -8448,7 +9396,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0915
+Index: geneve-ut-1050
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8467,7 +9415,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0916
+Index: geneve-ut-1051
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8495,7 +9443,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0917
+Index: geneve-ut-1052
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8510,7 +9458,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0918
+Index: geneve-ut-1053
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8573,7 +9521,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0919
+Index: geneve-ut-1054
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -8594,7 +9542,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0920
+Index: geneve-ut-1055
 
 ```python
 any where host.os.type == "windows" and
@@ -8656,7 +9604,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0922
+Index: geneve-ut-1057
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -8685,7 +9633,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0923
+Index: geneve-ut-1058
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -8697,9 +9645,9 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 ### Pluggable Authentication Module (PAM) Version Discovery
 
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-0924
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1059
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8711,10 +9659,17 @@ process where host.os.type == "linux" and event.type == "start" and
 not (
   ?process.parent.name in ("dcservice", "inspectorssmplugin") or
   ?process.working_directory in ("/var/ossec", "/opt/msp-agent") or
+  ?process.entry_leader.executable in("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/usr/sbin/ScanAssistant") or
   ?process.parent.executable in (
     "/opt/CyberCNSAgent/cybercnsagent_linux", "/usr/local/manageengine/uems_agent/bin/dcpatchscan",
     "/usr/local/manageengine/uems_agent/bin/dcconfig", "/usr/share/vicarius/topiad",
-    "/etc/rc.d/init.d/sshd-chroot"
+    "/etc/rc.d/init.d/sshd-chroot", "/var/ossec/bin/wazuh-modulesd",
+    "/usr/lib/venv-salt-minion/bin/python.original"
+  ) or
+  (
+    process.executable == "/usr/bin/rpm" and
+    ?process.parent.name == "systemd" and
+    ?process.env_vars == "LD_LIBRARY_PATH=/usr/lib/venv-salt-minion/lib"
   )
 )
 ```
@@ -8725,7 +9680,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0927
+Index: geneve-ut-1062
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -8770,9 +9725,9 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 ### Polkit Version Discovery
 
-Branch count: 24  
-Document count: 24  
-Index: geneve-ut-0928
+Branch count: 48  
+Document count: 48  
+Index: geneve-ut-1063
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8784,7 +9739,12 @@ event.action in ("exec", "exec_event", "start", "ProcessRollup2", "process_start
 ) and
 not (
   ?process.working_directory in ("/opt/msp-agent", "/opt/CyberCNSAgent") or
-  ?process.parent.executable like ("/usr/local/cpanel/3rdparty/perl/*/bin/perl", "/usr/share/vicarius/topiad")
+  ?process.parent.executable like ("/usr/local/cpanel/3rdparty/perl/*/bin/perl", "/usr/share/vicarius/topiad") or
+  ?process.entry_leader.executable in ("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/sf/edr/agent/bin/edr_monitor") or
+  (
+    ?process.parent.args == "/usr/lib/venv-salt-minion/bin/python.original" and
+    ?process.parent.args == "/usr/lib/venv-salt-minion/bin/salt-minion"
+  )
 )
 ```
 
@@ -8794,7 +9754,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0929
+Index: geneve-ut-1064
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -8807,7 +9767,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0938
+Index: geneve-ut-1074
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8824,7 +9784,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0940
+Index: geneve-ut-1076
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -8849,7 +9809,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0944
+Index: geneve-ut-1080
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/*/etc/nsswitch.conf" and
@@ -8866,7 +9826,7 @@ not file.path like (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0945
+Index: geneve-ut-1081
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8882,7 +9842,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0946
+Index: geneve-ut-1082
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8903,7 +9863,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-0947
+Index: geneve-ut-1083
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8944,7 +9904,7 @@ event.action in ("exec", "exec_event", "start", "executed", "process_started", "
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0948
+Index: geneve-ut-1084
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -8961,7 +9921,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0949
+Index: geneve-ut-1085
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8985,7 +9945,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-0951
+Index: geneve-ut-1087
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -9014,7 +9974,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0953
+Index: geneve-ut-1089
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -9038,7 +9998,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0955
+Index: geneve-ut-1092
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -9054,18 +10014,18 @@ process where host.os.type == "windows" and event.code == "10" and
 
 ### Potential Credential Access via LSASS Memory Dump
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0956
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1093
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
   winlog.event_data.TargetImage : "?:\\WINDOWS\\system32\\lsass.exe" and
 
-   /* DLLs exporting MiniDumpWriteDump API to create an lsass mdmp*/
-  winlog.event_data.CallTrace : ("*dbghelp*", "*dbgcore*") and
+  /* dbgcore.dll hosts MiniDumpWriteDump on modern Windows; dbghelp-only traces are non-dump usage */
+  winlog.event_data.CallTrace : "*dbgcore*" and
 
-   /* case of lsass crashing */
+  /* crash handlers */
   not process.executable : (
         "?:\\Windows\\System32\\WerFault.exe",
         "?:\\Windows\\SysWOW64\\WerFault.exe",
@@ -9079,7 +10039,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0957
+Index: geneve-ut-1094
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9132,17 +10092,33 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
+### Potential Credential Access via Renamed COM+ Services DLL
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1095
+
+```python
+sequence by process.entity_id with maxspan=1m
+ [process where host.os.type == "windows" and event.type == "start" and process.name : "rundll32.exe"]
+ [process where host.os.type == "windows" and event.code == "7" and
+   (file.pe.original_file_name : "COMSVCS.DLL" or file.pe.imphash : "EADBCCBB324829ACB5F2BBE87E5549A8") and
+   /* renamed COMSVCS */
+   not file.name : "COMSVCS.DLL"]
+```
+
+
+
 ### Potential Credential Access via Trusted Developer Utility
 
-Branch count: 16  
-Document count: 32  
-Index: geneve-ut-0959
+Branch count: 4  
+Document count: 8  
+Index: geneve-ut-1096
 
 ```python
 sequence by process.entity_id
  [process where host.os.type == "windows" and event.type == "start" and (process.name : "MSBuild.exe" or process.pe.original_file_name == "MSBuild.exe")]
- [any where host.os.type == "windows" and (event.category == "library" or (event.category == "process" and event.action : "Image loaded*")) and
-  (?dll.name : ("vaultcli.dll", "SAMLib.DLL") or file.name : ("vaultcli.dll", "SAMLib.DLL"))]
+ [library where host.os.type == "windows" and dll.name : ("vaultcli.dll", "SAMLib.DLL")]
 ```
 
 
@@ -9151,7 +10127,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0971
+Index: geneve-ut-1110
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9166,7 +10142,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0972
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9197,7 +10173,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0973
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9211,7 +10187,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0974
+Index: geneve-ut-1113
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9224,7 +10200,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0975
+Index: geneve-ut-1114
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -9236,7 +10212,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0976
+Index: geneve-ut-1115
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -9245,11 +10221,30 @@ process.parent.name == "proot"
 
 
 
+### Potential Direct Kubelet Access via Process Arguments
+
+Branch count: 136  
+Document count: 136  
+Index: geneve-ut-1117
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
+(
+  /* direct utility execution */
+  process.name like ("curl", "wget", "python*", "perl*", "php*", "node*", "java", "ruby*", "lua*", ".*") or
+
+  process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/var/run/*", "/home/*", "/run/user/*", "/busybox/*")
+) and
+process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:10255/*")
+```
+
+
+
 ### Potential Disabling of AppArmor
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0978
+Index: geneve-ut-1118
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9270,7 +10265,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0979
+Index: geneve-ut-1119
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9284,7 +10279,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0982
+Index: geneve-ut-1122
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -9308,7 +10303,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0983
+Index: geneve-ut-1123
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -9324,7 +10319,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-0984
+Index: geneve-ut-1124
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -9341,7 +10336,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0985
+Index: geneve-ut-1125
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9362,7 +10357,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0987
+Index: geneve-ut-1127
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -9375,7 +10370,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-0989
+Index: geneve-ut-1129
 
 ```python
 sequence by host.id with maxspan=1m
@@ -9403,7 +10398,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-0992
+Index: geneve-ut-1132
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9419,7 +10414,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-0993
+Index: geneve-ut-1133
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9442,7 +10437,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0994
+Index: geneve-ut-1134
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9455,7 +10450,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0996
+Index: geneve-ut-1136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9468,7 +10463,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1001
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9482,7 +10477,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1002
+Index: geneve-ut-1142
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9497,7 +10492,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 375  
 Document count: 375  
-Index: geneve-ut-1003
+Index: geneve-ut-1144
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9518,7 +10513,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1006
+Index: geneve-ut-1147
 
 ```python
 sequence by host.id with maxspan=1m
@@ -9561,7 +10556,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1007
+Index: geneve-ut-1148
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9579,7 +10574,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1008
+Index: geneve-ut-1149
 
 ```python
 host.os.type:"windows" and
@@ -9595,10 +10590,26 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1010
+Index: geneve-ut-1151
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
+```
+
+
+
+### Potential Kubeletctl Execution
+
+Branch count: 38  
+Document count: 38  
+Index: geneve-ut-1153
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
+(
+  process.name == "kubeletctl" or
+  (process.args in ("run", "exec", "scan", "pods", "runningpods", "attach", "portForward", "cri", "pid2pod") and process.args:("*:10250*", "*:10255*"))
+)
 ```
 
 
@@ -9607,7 +10618,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1012
+Index: geneve-ut-1154
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9625,7 +10636,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1013
+Index: geneve-ut-1155
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -9639,7 +10650,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1015
+Index: geneve-ut-1157
 
 ```python
 sequence by host.id with maxspan=30s
@@ -9658,7 +10669,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1017
+Index: geneve-ut-1159
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -9674,7 +10685,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1018
+Index: geneve-ut-1160
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -9687,7 +10698,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1019
+Index: geneve-ut-1161
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9717,7 +10728,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1024
+Index: geneve-ut-1166
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -9740,7 +10751,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1025
+Index: geneve-ut-1167
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9759,7 +10770,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1030
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "windows" and 
@@ -9901,7 +10912,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1031
+Index: geneve-ut-1173
 
 ```python
 process where host.os.type == "windows" and
@@ -9978,7 +10989,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1034
+Index: geneve-ut-1176
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -9995,7 +11006,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1035
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -10029,7 +11040,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1037
+Index: geneve-ut-1179
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -10041,7 +11052,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1038
+Index: geneve-ut-1180
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10080,7 +11091,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1040
+Index: geneve-ut-1182
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10093,7 +11104,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1045
+Index: geneve-ut-1187
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10107,7 +11118,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1052
+Index: geneve-ut-1194
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -10135,7 +11146,8 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
       "/var/run/udev/ud.pid",
       "/var/run/udevd.pid"
     )
-  )
+  ) and
+  not file.path like ("/tmp/krb5cc*", "/tmp/ansible_*", "/storage/*", "/tmp/clearsigned.message.*", "/var/sftp/refinitiv/*", "/tmp/fileutil.message.*")
 ```
 
 
@@ -10144,7 +11156,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1053
+Index: geneve-ut-1195
 
 ```python
 network where host.os.type == "windows" and
@@ -10170,7 +11182,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1056
+Index: geneve-ut-1198
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10185,7 +11197,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1058
+Index: geneve-ut-1200
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -10199,7 +11211,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1059
+Index: geneve-ut-1201
 
 ```python
 file where host.os.type == "windows" and
@@ -10213,7 +11225,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1060
+Index: geneve-ut-1202
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10226,7 +11238,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1061
+Index: geneve-ut-1203
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10246,7 +11258,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1062
+Index: geneve-ut-1204
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10264,9 +11276,9 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 ### Potential PowerShell HackTool Script by Author
 
-Branch count: 45  
-Document count: 45  
-Index: geneve-ut-1064
+Branch count: 48  
+Document count: 48  
+Index: geneve-ut-1206
 
 ```python
 host.os.type:windows and event.category:process and
@@ -10293,7 +11305,8 @@ host.os.type:windows and event.category:process and
       "_nullbind" or "_tmenochet" or
       "jaredcatkinson" or "ChrisTruncer" or
       "monoxgas" or "TheRealWover" or
-      "splinter_code"
+      "splinter_code" or "samratashok" or
+      "leechristensen" or "nikhil_mitt"
   ) and
   not powershell.file.script_block_text : ("Get-UEFIDatabaseSigner" or "Posh-SSH")
 ```
@@ -10304,7 +11317,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1065
+Index: geneve-ut-1207
 
 ```python
 event.category:process and host.os.type:windows and
@@ -10499,7 +11512,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1078
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10511,11 +11524,39 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 
 
+### Potential Privacy Control Bypass via TCCDB Modification
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-1221
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
+ process.args like "/*/Application Support/com.apple.TCC/TCC.db" and
+ (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
+### Potential Privilege Escalation in Container via Runc Init
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1222
+
+```python
+host.os.type:linux and event.category:process and 
+event.action:(executed or exec) and 
+process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
+```
+
+
+
 ### Potential Privilege Escalation through Writable Docker Socket
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1080
+Index: geneve-ut-1223
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -10532,7 +11573,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1081
+Index: geneve-ut-1224
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -10546,7 +11587,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1082
+Index: geneve-ut-1225
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -10558,27 +11599,11 @@ process.interactive == true and process.parent.interactive == true
 
 
 
-### Potential Privilege Escalation via OverlayFS
-
-Branch count: 3  
-Document count: 6  
-Index: geneve-ut-1086
-
-```python
-sequence by process.parent.entity_id, host.id with maxspan=5s
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-    process.name == "unshare" and process.args : ("-r", "-rm", "m") and process.args : "*cap_setuid*"  and user.id != "0"]
-  [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
-    user.id == "0"]
-```
-
-
-
 ### Potential Privilege Escalation via PKEXEC
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1087
+Index: geneve-ut-1229
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -10590,7 +11615,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1088
+Index: geneve-ut-1230
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10606,7 +11631,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1089
+Index: geneve-ut-1231
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10626,7 +11651,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1090
+Index: geneve-ut-1233
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -10663,10 +11688,115 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1092
+Index: geneve-ut-1235
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
+```
+
+
+
+### Potential Privilege Escalation via a Parent Process Sequence
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1236
+
+```python
+sequence by host.id, process.parent.entity_id with maxspan=15s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )]
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")]
+```
+
+
+
+### Potential Privilege Escalation via a Parent/Child Process Sequence
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1237
+
+```python
+sequence by host.id with maxspan=15s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )] by process.entity_id
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")] by process.parent.entity_id
+```
+
+
+
+### Potential Privilege Escalation via a Suspicious UID Change
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1238
+
+```python
+sequence by host.id, process.entity_id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )]
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")]
+```
+
+
+
+### Potential Privilege Escalation via unshare Followed by Root Process
+
+Branch count: 341  
+Document count: 682  
+Index: geneve-ut-1239
+
+```python
+sequence by host.id, process.parent.pid with maxspan=30s
+ [process where host.os.type == "linux" and 
+  (
+   (auditd.data.syscall == "unshare" and auditd.data.class == "namespace" and auditd.data.a0 in ("10000000", "50000000", "70000000", "10020000", "50020000", "70020000")) or 
+
+   (process.name == "unshare" and  
+    (process.args in ("--user", "--map-root-user", "--map-current-user") or process.args like ("-*U*", "-*r*")))
+   ) and user.id != "0" and user.id != null]
+ [process where host.os.type == "linux" and 
+  user.id == "0" and user.id != null and 
+  (
+   process.name in ("su", "sudo", "pkexec", "passwd", "chsh", "newgrp", "doas", "run0", "sg", "dash", "sh", "bash", "zsh", "fish", 
+                    "ksh", "csh", "tcsh", "ash", "mksh", "busybox", "rbash", "rzsh", "rksh", "tmux", "screen", "node") or 
+   process.name like ("python*", "perl*", "ruby*", "php*", "lua*")
+  )]
+```
+
+
+
+### Potential Privilege Escalation via unshare and UID Change
+
+Branch count: 5  
+Document count: 10  
+Index: geneve-ut-1240
+
+```python
+sequence by process.parent.entity_id, host.id with maxspan=60s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+    process.name == "unshare" and process.args : ("-r", "-rm", "-m", "-U", "--user") and user.id != "0"]
+  [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
+    user.id == "0"]
 ```
 
 
@@ -10675,7 +11805,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1093
+Index: geneve-ut-1241
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -10689,7 +11819,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1094
+Index: geneve-ut-1242
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -10712,7 +11842,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1096
+Index: geneve-ut-1244
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -10729,7 +11859,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1097
+Index: geneve-ut-1245
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -10752,7 +11882,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1098
+Index: geneve-ut-1246
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10765,7 +11895,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1099
+Index: geneve-ut-1247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10779,7 +11909,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1100
+Index: geneve-ut-1248
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10792,11 +11922,65 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Potential Proxy Execution via Systemd-run
+
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-1249
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started", "start", "ProcessRollup2") and
+process.name == "systemd-run" and ?process.parent.executable != null and
+not (
+  ?process.parent.executable in (
+    "/usr/lib/systemd", "/lib/systemd/systemd", "/opt/saltstack/salt/run/run", "/etc/update-motd.d/70-available-updates",
+    "/tmp/newroot/usr/libexec/ptyxis-agent", "/usr/local/sbin/clamscan.sh", "/opt/sentinelone/bin/sentinelone-agent",
+    "/usr/local/bin/salt-minion", "/var/vanta/launcher", "/opt/traps/bin/pmd", "/usr/sbin/gdm", "/usr/bin/salt-minion",
+    "/opt/GC_Ext/GC/gc_linux_service", "/usr/lib/plesk-task-manager", "/opt/forticlient/epctrl", "/usr/lib/snapd/snap-exec",
+    "/usr/bin/yay", "/usr/local/bin/hexnode_agent", "/opt/halcyon/halcyonar/agent", "/usr/local/bin/qsetup", "/usr/bin/pamac",
+    "/usr/bin/elephant", "/usr/bin/Hyprland"
+  ) or
+  ?process.parent.executable like (
+    "/opt/tableau/tableau_server/packages/scripts.*/after-install", "/opt/acronis/bin/acp-update-controller", "/snap/*",
+    "/var/lib/amagent/*", "/opt/msp-agent/msp-agent-core", "/opt/beyondtrust/*", "/var/lib/rancher/k3s/*/bin/k3s"
+  ) or
+  ?process.parent.name like "platform-python*" or
+  ?process.parent.name in (
+    "udevadm", "daemon.start", "snap", "systemd", "ptyxis-agent", "run-slack", "run-firefox", "dbus.service", "k3s-server",
+    "systemd-udevd", "kubelet", "hyperkube", "kthreadd", "gnome-shell", "xdg-desktop-portal", "firefox", "picus_updater",
+    "rpm-ostree", "prompt-agent"
+  ) or
+  ?process.command_line in (
+    "/usr/bin/systemd-run /usr/bin/systemctl start man-db-cache-update", "systemd-run env",
+    "systemd-run --user dnf-automatic-notifyonly.timer", "systemd-run --user systemctl suspend", "systemd-run /var/lib/aws-replication-agent/uninstall-agent.sh",
+    "systemd-run --on-active=10 --timer-property=AccuracySec=100ms --slice=system.slice systemctl start gc-agent",
+    "systemd-run --user --scope --unit=tmux-server -- tmux", "systemd-run bash -c sleep 60 && reboot"
+  ) or
+  ?process.command_line like~ (
+    "systemd-run --scope -p CPUQuota=10% rpm -qa*", "systemd-run --scope -p CPUQuota=10% dpkg -l*"
+  ) or
+  ?process.parent.command_line in ("runc init", "/usr/local/bin/main") or
+  ?process.parent.command_line like ("*/var/lib/waagent/*", "bash ./run.sh") or
+  process.args in (
+    "--help", "list-timers", "/usr/lib/udev/kdump-udev-throttler", "kubectl", "--unit=ngt_guest_agent_upgrade", "i3-zoom", "google-chrome",
+    "thunar", "/usr/bin/google-chrome-stable", "snap.lxd.workaround", "--unit=firefox", "--unit=slack", "--slice=zoom.slice",
+    "autorandr-launcher", "--unit=restart-dbus", "--unit=autorandr-debounce"
+  ) or
+  process.args like ("--unit=app-Hyprland-wezterm-*.scope", "--unit=app-Hyprland-swaybg-*.scope", "--unit=rmf_sim_*") or
+  ?process.working_directory == "/opt/Tychon/Endpoint/bin" or
+  (process.args in ("rpm", "dpkg") and process.args like~ "CPUQuota=*") or
+  (process.args == "--slice=app-graphical.slice" and process.args == "--description=xdg-terminal-exec")
+)
+```
+
+
+
 ### Potential REMCOS Trojan Execution
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1101
+Index: geneve-ut-1250
 
 ```python
 any where host.os.type == "windows" and
@@ -10823,7 +12007,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1104
+Index: geneve-ut-1256
 
 ```python
 file where host.os.type == "windows" and
@@ -10838,7 +12022,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1105
+Index: geneve-ut-1257
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -10855,8 +12039,10 @@ any where host.os.type == "windows" and
 
   ) or
   (event.category == "process" and event.type == "start" and
-     (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
-     (?process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
+    (
+      (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
+      (?process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
+    )
   )
 )
 ```
@@ -10867,7 +12053,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1106
+Index: geneve-ut-1258
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10881,7 +12067,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1107
+Index: geneve-ut-1259
 
 ```python
 sequence with maxspan=1m
@@ -10921,18 +12107,25 @@ sequence with maxspan=1m
 
 ### Potential Remote Install via MsiExec
 
-Branch count: 200  
-Document count: 200  
-Index: geneve-ut-1108
+Branch count: 400  
+Document count: 400  
+Index: geneve-ut-1260
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
-  process.name : "msiexec.exe" and process.args : ("-i*", "/i*", "-p*", "/p*") and process.command_line : "*http*" and
+  process.name : "msiexec.exe" and process.args : ("-i*", "/i*", "-p*", "/p*") and
+  process.command_line : ("*http:*", "*https:*") and
   process.args : ("/qn", "-qn", "-q", "/q", "/quiet") and
-  process.parent.name : ("sihost.exe", "explorer.exe", "cmd.exe", "wscript.exe", "mshta.exe", "powershell.exe", "wmiprvse.exe", "pcalua.exe", "forfiles.exe", "conhost.exe") and
-  not process.command_line : ("*--set-server=*", "*UPGRADEADD=*" , "*--url=*",
-                              "*USESERVERCONFIG=*", "*RCTENTERPRISESERVER=*", "*app.ninjarmm.com*", "*zoom.us/client*",
-                              "*SUPPORTSERVERSTSURI=*", "*START_URL=*", "*AUTOCONFIG=*", "*awscli.amazonaws.com*")
+  process.parent.name : (
+    "sihost.exe", "explorer.exe", "cmd.exe", "wscript.exe", "mshta.exe",
+    "powershell.exe", "wmiprvse.exe", "pcalua.exe", "forfiles.exe", "conhost.exe"
+  ) and
+
+  not process.command_line : (
+        "*--set-server=*", "*UPGRADEADD=*" , "*--url=*", "*USESERVERCONFIG=*", "*RCTENTERPRISESERVER=*",
+        "*app.ninjarmm.com*", "*zoom.us/client*", "*SUPPORTSERVERSTSURI=*", "*START_URL=*", "*AUTOCONFIG=*",
+        "*awscli.amazonaws.com*", "*/i \"C:*", "*/i C:\\*"
+  )
 ```
 
 
@@ -10941,7 +12134,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1109
+Index: geneve-ut-1261
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10995,7 +12188,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1110
+Index: geneve-ut-1262
 
 ```python
 sequence by host.id with maxspan=5s
@@ -11015,7 +12208,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1111
+Index: geneve-ut-1263
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -11036,7 +12229,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1112
+Index: geneve-ut-1264
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11051,7 +12244,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1113
+Index: geneve-ut-1265
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -11071,7 +12264,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1114
+Index: geneve-ut-1266
 
 ```python
 sequence by host.id with maxspan=5s
@@ -11091,7 +12284,7 @@ sequence by host.id with maxspan=5s
    and not (
      process.parent.args in (
        "/usr/lib/jenkins/jenkins.war", "/etc/remote-iot/services/remoteiot.jar", "/opt/pentaho/data-integration/launcher/launcher.jar",
-       "/usr/share/java/jenkins.war", "/opt//tomcat/statistics/statistics.jar", "/usr/lib64/NetExtender.jar",
+       "/usr/share/java/jenkins.war", "/opt/tomcat/statistics/statistics.jar", "/usr/lib64/NetExtender.jar",
        "/var/lib/jenkins/workspace/MP-QA/tc_certified_copy*/tc_certified_copy_web_ui_test/target/surefire/surefirebooter*.jar",
        "-javaagent:/opt/opentelemetry/opentelemetry-javaagent-all.jar", "./lib/pipeline-job-executor*SNAPSHOT.jar",
        "./lib/worker-launcher-agent*SNAPSHOT.jar", "/opt/Seqrite_EndPoint_Security/wildfly/jboss-modules.jar",
@@ -11109,11 +12302,26 @@ sequence by host.id with maxspan=5s
 
 
 
+### Potential Root Effective Shell from Non-Standard Path via Auditd
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1270
+
+```python
+host.os.type:linux and event.category:process and 
+event.action:(exec or executed) and user.id:(* and not 0) and 
+process.executable:(* and not (/bin/* or /nix/store/*/bin/sudo or /run/wrappers/wrappers*/sudo or /sbin/* or /usr/bin/* or /usr/sbin/*)) and 
+user.effective.id:0 and process.args:-p
+```
+
+
+
 ### Potential SAP NetWeaver Exploitation
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1118
+Index: geneve-ut-1271
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -11148,7 +12356,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1119
+Index: geneve-ut-1272
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -11165,7 +12373,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1120
+Index: geneve-ut-1274
 
 ```python
 sequence by host.id with maxspan=3s
@@ -11179,7 +12387,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1122
+Index: geneve-ut-1277
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -11192,7 +12400,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1123
+Index: geneve-ut-1278
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -11204,12 +12412,13 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1124
+Index: geneve-ut-1279
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
   winlog.event_data.AttributeValue :B\:828* and
-  not winlog.event_data.SubjectUserName: MSOL_*
+  not winlog.event_data.SubjectUserName: MSOL_* and
+  not winlog.event_data.ObjectClass: "msDS-Device"
 ```
 
 
@@ -11218,7 +12427,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1126
+Index: geneve-ut-1281
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -11246,7 +12455,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1127
+Index: geneve-ut-1282
 
 ```python
 sequence by host.id with maxspan=1s
@@ -11271,7 +12480,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1131
+Index: geneve-ut-1286
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -11305,7 +12514,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1132
+Index: geneve-ut-1287
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11319,7 +12528,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1133
+Index: geneve-ut-1288
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -11335,7 +12544,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1134
+Index: geneve-ut-1289
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11349,7 +12558,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1135
+Index: geneve-ut-1290
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -11379,15 +12588,16 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1136
+Index: geneve-ut-1291
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
-  file.name : ("winload.exe", "winlod.efi", "ntoskrnl.exe", "bootmgr") and
+  file.name : ("winload.exe", "winload.efi", "ntoskrnl.exe", "bootmgr") and
   file.path : ("?:\\Windows\\*", "\\Device\\HarddiskVolume*\\Windows\\*") and
   not process.executable : (
     "?:\\Windows\\System32\\poqexec.exe",
-    "?:\\Windows\\WinSxS\\amd64_microsoft-windows-servicingstack_*\\tiworker.exe"
+    "?:\\Windows\\System32\\wbengine.exe",
+    "?:\\Windows\\WinSxS\\???64_microsoft-windows-servicingstack_*\\tiworker.exe"
   ) and
   not file.path : (
     "?:\\Windows\\WinSxS\\Temp\\InFlight\\*",
@@ -11395,7 +12605,9 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
     "?:\\Windows\\WinSxS\\amd64_microsoft-windows*",
     "?:\\Windows\\SystemTemp\\*",
     "?:\\Windows\\Temp\\????????.???\\*",
-    "?:\\Windows\\Temp\\*\\amd64_microsoft-windows-*"
+    "?:\\Windows\\Temp\\*\\amd64_microsoft-windows-*",
+    "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download*",
+    "?:\\Windows\\Temp\\BootImages\\{*}\\mount\\Windows\\*"
   )
 ```
 
@@ -11405,7 +12617,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1137
+Index: geneve-ut-1292
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11421,7 +12633,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1138
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11435,7 +12647,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1139
+Index: geneve-ut-1294
 
 ```python
 file where host.os.type == "windows" and
@@ -11471,7 +12683,7 @@ file where host.os.type == "windows" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1142
+Index: geneve-ut-1297
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11485,7 +12697,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1143
+Index: geneve-ut-1298
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11505,7 +12717,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1145
+Index: geneve-ut-1300
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11522,7 +12734,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1146
+Index: geneve-ut-1301
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -11534,7 +12746,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1147
+Index: geneve-ut-1302
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -11551,7 +12763,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1148
+Index: geneve-ut-1303
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -11569,7 +12781,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1154
+Index: geneve-ut-1310
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -11596,7 +12808,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1155
+Index: geneve-ut-1311
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -11610,7 +12822,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1157
+Index: geneve-ut-1313
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11625,9 +12837,9 @@ process where host.os.type == "linux" and event.type == "start" and
 
 ### PowerShell Invoke-NinjaCopy script
 
-Branch count: 21  
-Document count: 21  
-Index: geneve-ut-1158
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-1314
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11637,11 +12849,9 @@ event.category:process and host.os.type:windows and
     "StealthCloseFileDelegate" or
     "StealthOpenFile" or
     "StealthCloseFile" or
-    "StealthReadFile" or
     "Invoke-NinjaCopy"
-   )
-  and not user.id : "S-1-5-18"
-  and not powershell.file.script_block_text : (
+   ) and
+  not powershell.file.script_block_text : (
     "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
   )
 ```
@@ -11652,13 +12862,11 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1160
+Index: geneve-ut-1316
 
 ```python
 event.category:process and host.os.type:windows and
-  powershell.file.script_block_text : (
-    KerberosRequestorSecurityToken
-  ) and not user.id : ("S-1-5-18" or "S-1-5-20") and
+  powershell.file.script_block_text : "KerberosRequestorSecurityToken" and
   not powershell.file.script_block_text : (
     ("sentinelbreakpoints" and ("Set-PSBreakpoint" or "Set-HookFunctionTabs")) or
     ("function global" and "\\windows\\sentinel\\4")
@@ -11671,10 +12879,11 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1163
+Index: geneve-ut-1319
 
 ```python
-event.category:process and host.os.type:windows and powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory or pmuDetirWpmuDiniM) and not user.id : "S-1-5-18"
+event.category:process and host.os.type:windows and
+powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory or pmuDetirWpmuDiniM)
 ```
 
 
@@ -11683,7 +12892,7 @@ event.category:process and host.os.type:windows and powershell.file.script_block
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1165
+Index: geneve-ut-1321
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11707,7 +12916,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1166
+Index: geneve-ut-1322
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11735,7 +12944,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1181
+Index: geneve-ut-1337
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11756,7 +12965,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1184
+Index: geneve-ut-1340
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -11793,7 +13002,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1185
+Index: geneve-ut-1341
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -11810,7 +13019,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1186
+Index: geneve-ut-1342
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11824,7 +13033,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1187
+Index: geneve-ut-1343
 
 ```python
 file where host.os.type == "windows" and
@@ -11843,7 +13052,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1188
+Index: geneve-ut-1344
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11855,9 +13064,9 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 ### Privilege Escalation via SUID/SGID
 
-Branch count: 434  
-Document count: 434  
-Index: geneve-ut-1189
+Branch count: 450  
+Document count: 450  
+Index: geneve-ut-1345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11888,9 +13097,11 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     "wc", "wget", "whiptail", "xargs", "xdotool", "xmodmap", "xmore", "xxd", "xz", "yash", "zsh",
     "zsoelim"
   ) or
+  (process.name like ".*" or process.executable like ("/tmp/.*", "/var/tmp/.*", "/dev/shm/.*", "/home/*"))  or 
   (process.name == "ip" and ((process.args == "-force" and process.args in ("-batch", "-b")) or (process.args == "exec"))) or
   (process.name == "find" and process.args in ("-exec", "-execdir")) or
-  (process.name in ("bash", "csh", "dash") and process.args in ("-p", "-b"))
+  (process.name in ("bash", "csh", "dash") and process.args in ("-p", "-b")) or
+  (process.name in ("su", "sudo", "pkexec") and process.args_count == 1)
 ) and not (
   process.parent.name == "spine" or
   process.parent.executable in (
@@ -11908,7 +13119,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1190
+Index: geneve-ut-1346
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11926,7 +13137,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1192
+Index: geneve-ut-1348
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -11944,7 +13155,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1195
+Index: geneve-ut-1351
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11958,7 +13169,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1197
+Index: geneve-ut-1353
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11973,7 +13184,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1198
+Index: geneve-ut-1354
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -11996,7 +13207,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1200
+Index: geneve-ut-1356
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -12040,7 +13251,6 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
                             "?:\\Windows\\Microsoft.NET\\Framework*\\*\\ngen.exe",
                             "?:\\Windows\\Microsoft.NET\\Framework*\\*\\aspnet_regiis.exe")) and
 
-
 /* Ignores additional parent executables that run with elevated privileges */
  not process.parent.executable :
                ("?:\\Windows\\System32\\AtBroker.exe",
@@ -12079,7 +13289,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1201
+Index: geneve-ut-1357
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -12100,7 +13310,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1202
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and
@@ -12119,7 +13329,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1204
+Index: geneve-ut-1360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12172,7 +13382,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1205
+Index: geneve-ut-1361
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -12184,7 +13394,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1206
+Index: geneve-ut-1362
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -12196,7 +13406,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1207
+Index: geneve-ut-1363
 
 ```python
 process where host.os.type == "windows" and
@@ -12211,7 +13421,7 @@ process where host.os.type == "windows" and
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1208
+Index: geneve-ut-1364
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -12271,7 +13481,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1211
+Index: geneve-ut-1367
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -12284,7 +13494,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1212
+Index: geneve-ut-1368
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12316,7 +13526,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1213
+Index: geneve-ut-1369
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -12338,14 +13548,33 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 ### Proxy Execution via Console Window Host
 
-Branch count: 17  
-Document count: 17  
-Index: geneve-ut-1214
+Branch count: 68  
+Document count: 68  
+Index: geneve-ut-1371
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  process.name : "conhost.exe" and process.args : "--headless" and
-  process.command_line : ("*powershell*", "*cmd *", "*cmd.exe *", "*script*", "*mshta*", "*curl *", "*curl.exe *", "*^*^*^*", "*.bat*", "*.cmd*", "*schtasks*", "*@SSL*", "*http*", "* \\\\*", "*.vbs*", "*.js*", "*mhsta*")
+  process.command_line : (
+    "*powershell*", "*cmd *", "*cmd.exe *", "*script*", "*mshta*", "*curl *", "*curl.exe *", "*^*^*^*",
+    "*.bat*", "*.cmd*", "*schtasks*", "*@SSL*", "*http*", "* \\\\*", "*.vbs*", "*.js*", "*mhsta*"
+  ) and
+  not (
+    /* Winget-AutoUpdate via ServiceUI */
+    process.parent.executable : "?:\\Program Files\\winget-autoupdate*\\serviceui.exe" or
+    /* Winget-AutoUpdate notification via Task Scheduler */
+    (
+      process.parent.executable : "?:\\Windows\\System32\\svchost.exe" and process.parent.args : "-s" and
+      process.parent.args : "Schedule" and process.command_line : "*WAU-Notify.ps1*"
+    ) or
+    /* Windows OpenSSH console host — SSH-specific detection handled by 8cd49fbc-a35a-4418-8688-133cc3a1e548 */
+    process.parent.executable : (
+      "?:\\Windows\\System32\\OpenSSH\\sshd.exe",
+      "?:\\Windows\\System32\\OpenSSH\\sshd-session.exe",
+      "?:\\Program Files\\OpenSSH*\\sshd.exe",
+      "?:\\Program Files\\OpenSSH*\\sshd-session.exe"
+    )
+  )
 ```
 
 
@@ -12354,12 +13583,15 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1215
+Index: geneve-ut-1372
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
- process.command_line : ("*Command=*powershell*", "*schtasks*", "*Command=*@echo off*", "*Command=*http*", "*Command=*mshta*",  "*Command=*msiexec*",
-                          "*Command=*cmd /c*", "*Command=*cmd.exe*", "*Command=\"cmd /c*", "*LocalCommand=scp*&&*", "*LocalCommand=?scp*&&*", "*Command=*script*")
+  process.command_line : (
+    "*Command=*powershell*", "*schtasks*", "*Command=*@echo off*", "*Command=*http*",
+    "*Command=*mshta*", "*Command=*msiexec*", "*Command=*cmd /c*", "*Command=*cmd.exe*",
+    "*Command=\"cmd /c*", "*LocalCommand=scp*&&*", "*LocalCommand=?scp*&&*", "*Command=*script*"
+  )
 ```
 
 
@@ -12368,7 +13600,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1216
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -12397,7 +13629,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1217
+Index: geneve-ut-1374
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12411,7 +13643,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1218
+Index: geneve-ut-1375
 
 ```python
 sequence by process.entity_id
@@ -12436,7 +13668,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1219
+Index: geneve-ut-1376
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -12470,7 +13702,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1220
+Index: geneve-ut-1377
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -12498,7 +13730,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1221
+Index: geneve-ut-1378
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -12517,7 +13749,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1224
+Index: geneve-ut-1382
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12545,7 +13777,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1225
+Index: geneve-ut-1383
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -12564,7 +13796,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1229
+Index: geneve-ut-1387
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -12576,7 +13808,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1230
+Index: geneve-ut-1388
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -12588,7 +13820,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1231
+Index: geneve-ut-1389
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -12600,7 +13832,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1232
+Index: geneve-ut-1390
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -12612,7 +13844,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1240
+Index: geneve-ut-1398
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12625,7 +13857,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1241
+Index: geneve-ut-1399
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12663,7 +13895,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1243
+Index: geneve-ut-1401
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12678,7 +13910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1244
+Index: geneve-ut-1402
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12697,7 +13929,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1245
+Index: geneve-ut-1403
 
 ```python
 sequence with maxspan=1m
@@ -12716,18 +13948,23 @@ sequence with maxspan=1m
               "ZOHO Corporation Private Limited",
               "BeyondTrust Corporation", 
               "CyberArk Software Ltd.", 
-              "Sophos Ltd"
+              "Sophos Ltd",
+              "AO Kaspersky Lab",
+              "Anthropic, PBC",
+              "Adobe Inc.",
+              "Netwrix Corporation"
         )
       ) or
       (
         process.executable : (
           "?:\\Windows\\ccmsetup\\ccmsetup.exe",
-          "?:\\Windows\\SoftwareDistribution\\Download\\Install\\AM_Delta*.exe",
-          "?:\\Windows\\CAInvokerService.exe"
+          "?:\\Windows\\SoftwareDistribution\\Download\\Install\\*.exe",
+          "?:\\Windows\\CAInvokerService.exe",
+          "?:\\Users\\*\\AppData\\Local\\Microsoft\\OneDrive\\*\\OneDriveSetup.exe"
         ) and process.code_signature.trusted == true
       ) or
       (
-        process.executable : "G:\\SMS_*\\srvboot.exe" and 
+        process.executable : "?:\\SMS_*\\srvboot.exe" and 
         process.code_signature.trusted == true and process.code_signature.subject_name : "Microsoft Corporation"
       )
     )
@@ -12740,7 +13977,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1247
+Index: geneve-ut-1405
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -12763,7 +14000,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1249
+Index: geneve-ut-1407
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12777,7 +14014,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1250
+Index: geneve-ut-1408
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12791,7 +14028,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1252
+Index: geneve-ut-1410
 
 ```python
 sequence by host.id, process.entity_id
@@ -12808,7 +14045,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1253
+Index: geneve-ut-1411
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -12822,7 +14059,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1254
+Index: geneve-ut-1412
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12840,17 +14077,29 @@ sequence by host.id with maxspan=1m
 
 ### Remote SSH Login Enabled via systemsetup Command
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1255
+Branch count: 10  
+Document count: 10  
+Index: geneve-ut-1413
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
- process.name == "systemsetup" and
- process.args like~ "-setremotelogin" and 
- process.args like~ "on" and
- process.parent.executable != null and
- not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xpcproxy", "/usr/bin/sudo")
+(
+  (
+    process.name == "systemsetup" and
+    process.args like~ "-setremotelogin" and
+    process.args like~ "on"
+  ) or
+  (
+    process.name == "launchctl" and
+    process.args in ("load", "bootstrap") and
+    (
+      process.command_line like~ "*/System/Library/LaunchDaemons/ssh.plist*" or
+      process.command_line like~ "*com.openssh.sshd*"
+    )
+  )
+) and
+process.parent.executable != null and
+not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xpcproxy", "/usr/bin/sudo")
 ```
 
 
@@ -12859,7 +14108,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1256
+Index: geneve-ut-1414
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -12879,7 +14128,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1257
+Index: geneve-ut-1415
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -12892,7 +14141,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1259
+Index: geneve-ut-1417
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -12934,7 +14183,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1260
+Index: geneve-ut-1418
 
 ```python
 sequence with maxspan=1m
@@ -12957,7 +14206,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1261
+Index: geneve-ut-1419
 
 ```python
 sequence with maxspan=1s
@@ -13005,7 +14254,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1262
+Index: geneve-ut-1420
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13022,7 +14271,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1264
+Index: geneve-ut-1422
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -13051,7 +14300,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1265
+Index: geneve-ut-1423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -13079,7 +14328,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1266
+Index: geneve-ut-1424
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -13096,7 +14345,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1268
+Index: geneve-ut-1426
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -13115,7 +14364,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1269
+Index: geneve-ut-1427
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -13136,7 +14385,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1274
+Index: geneve-ut-1433
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -13155,7 +14404,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1275
+Index: geneve-ut-1434
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -13169,7 +14418,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1276
+Index: geneve-ut-1435
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -13189,7 +14438,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1278
+Index: geneve-ut-1437
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13207,7 +14456,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1279
+Index: geneve-ut-1438
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -13228,7 +14477,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1281
+Index: geneve-ut-1440
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13240,15 +14489,15 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 ### ScreenConnect Server Spawning Suspicious Processes
 
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-1282
+Branch count: 10  
+Document count: 10  
+Index: geneve-ut-1441
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.parent.name : "ScreenConnect.Service.exe" and
   (process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "powershell_ise.exe", "csc.exe") or
-  ?process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE", "pwsh.dll", "powershell_ise.EXE"))
+  ?process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE", "pwsh.dll", "powershell_ise.EXE", "csc.exe"))
 ```
 
 
@@ -13257,7 +14506,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1283
+Index: geneve-ut-1442
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -13298,7 +14547,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1285
+Index: geneve-ut-1444
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -13323,7 +14572,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1286
+Index: geneve-ut-1445
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -13362,7 +14611,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1287
+Index: geneve-ut-1446
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13376,7 +14625,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1288
+Index: geneve-ut-1447
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13400,7 +14649,12 @@ process.args like (
   ?process.parent.args in ("/opt/imperva/ragent/bin/get_sys_resources.sh", "/usr/sbin/lynis", "./terra_linux.sh") or
   process.args == "/usr/bin/coreutils" or
   (process.parent.name == "pwsh" and process.parent.command_line like "*Evaluate-STIG*") or
-  ?process.parent.executable == "/usr/sap/audit_scripts/auto_audit_gral.sh"
+  ?process.parent.executable like (
+    "/usr/sap/audit_scripts/auto_audit_gral.sh", "/opt/saltstack/salt/bin/python3*", "/opt/puppetlabs/puppet/bin/ruby"
+  ) or
+  ?process.entry_leader.executable like (
+    "/usr/sbin/ScanAssistant", "/opt/Tanium/TaniumClient/TaniumClient", "/tmp/CVU_*resource/exectask", "/opt/nessus/sbin/nessus-service"
+  )
 )
 ```
 
@@ -13410,7 +14664,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1289
+Index: geneve-ut-1448
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13424,7 +14678,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1290
+Index: geneve-ut-1449
 
 ```python
 process where event.type == "start" and
@@ -13496,7 +14750,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1292
+Index: geneve-ut-1452
 
 ```python
 event.code : "4719" and host.os.type : "windows" and
@@ -13517,7 +14771,7 @@ event.code : "4719" and host.os.type : "windows" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1293
+Index: geneve-ut-1453
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -13538,7 +14792,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1295
+Index: geneve-ut-1455
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13555,7 +14809,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1296
+Index: geneve-ut-1457
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13569,11 +14823,11 @@ process.command_line like~ (
 
 
 
-### Sensitive Privilege SeEnableDelegationPrivilege assigned to a User
+### Sensitive Privilege SeEnableDelegationPrivilege assigned to a Principal
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1297
+Index: geneve-ut-1458
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -13585,19 +14839,31 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1298
+Index: geneve-ut-1459
 
 ```python
-file where host.os.type == "windows" and 
- event.action == "open" and event.outcome == "success" and process.executable != null and 
+file where host.os.type == "windows" and
+ event.action == "open" and event.outcome == "success" and process.executable != null and
  file.path :
       ("?:\\Windows\\System32\\config\\RegBack\\SAM",
        "?:\\Windows\\System32\\config\\RegBack\\SECURITY",
-       "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and 
+       "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and
  not (
     user.id == "S-1-5-18" and process.executable : (
-        "?:\\Windows\\system32\\taskhostw.exe", "?:\\Windows\\system32\\taskhost.exe"
-    ))
+        "?:\\Windows\\system32\\taskhostw.exe",
+        "?:\\Windows\\system32\\taskhost.exe",
+        "?:\\Program Files\\Sophos\\Endpoint Defense\\SophosScanCoordinator.exe",
+        "?:\\Program Files\\Sophos\\Endpoint Defense\\SSPService.exe",
+        "?:\\Program Files\\Windows Defender Advanced Threat Protection\\MsSense.exe",
+        "?:\\Program Files\\Trend Micro\\AMSP\\coreServiceShell.exe",
+        "?:\\Program Files\\Symantec\\Symantec Endpoint Protection\\*\\Bin64\\ccSvcHst.exe",
+        "?:\\Program Files\\Bitdefender\\Endpoint Security\\EPSecurityService.exe",
+        "?:\\Program Files\\N-able Technologies\\AVDefender\\EPSecurityService.exe",
+        "?:\\Program Files\\Cylance\\Optics\\CyOptics.exe",
+        "?:\\Program Files\\Common Files\\McAfee\\AVSolution\\mcshield.exe",
+        "?:\\Program Files (x86)\\Padvish AV\\APCcSvc.exe"
+    )
+ )
 ```
 
 
@@ -13606,7 +14872,7 @@ file where host.os.type == "windows" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1301
+Index: geneve-ut-1462
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -13623,7 +14889,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1302
+Index: geneve-ut-1463
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -13643,7 +14909,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1304
+Index: geneve-ut-1465
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13658,7 +14924,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1305
+Index: geneve-ut-1466
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13679,7 +14945,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1306
+Index: geneve-ut-1467
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13702,7 +14968,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1307
+Index: geneve-ut-1468
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -13715,7 +14981,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1308
+Index: geneve-ut-1469
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13732,7 +14998,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1310
+Index: geneve-ut-1471
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -13757,7 +15023,7 @@ not (
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1312
+Index: geneve-ut-1474
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -13806,7 +15072,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1313
+Index: geneve-ut-1475
 
 ```python
 sequence by host.id with maxspan=10s
@@ -13816,11 +15082,26 @@ sequence by host.id with maxspan=10s
 
 
 
+### Shell Execution via Elastic Endpoint
+
+Branch count: 64  
+Document count: 64  
+Index: geneve-ut-1476
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.parent.executable == "/opt/Elastic/Endpoint/elastic-endpoint" and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+process.args in ("-c", "-cl", "-lc", "--command")
+```
+
+
+
 ### Shell History Clearing via Environment Variables
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1314
+Index: geneve-ut-1477
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13835,7 +15116,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1315
+Index: geneve-ut-1478
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -13857,7 +15138,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1316
+Index: geneve-ut-1479
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13878,7 +15159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1319
+Index: geneve-ut-1482
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13892,7 +15173,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1320
+Index: geneve-ut-1483
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -13915,7 +15196,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1346
+Index: geneve-ut-1511
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13940,7 +15221,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1347
+Index: geneve-ut-1512
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -13973,7 +15254,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1348
+Index: geneve-ut-1513
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -14032,7 +15313,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1350
+Index: geneve-ut-1515
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -14050,7 +15331,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1351
+Index: geneve-ut-1516
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -14062,7 +15343,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1353
+Index: geneve-ut-1518
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -14087,7 +15368,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1358
+Index: geneve-ut-1523
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14102,7 +15383,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1359
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -14125,7 +15406,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1362
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14139,7 +15420,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1364
+Index: geneve-ut-1529
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14161,7 +15442,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1366
+Index: geneve-ut-1531
 
 ```python
 sequence by host.id with maxspan=5s
@@ -14188,7 +15469,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1370
+Index: geneve-ut-1535
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -14200,6 +15481,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
     "?:\\Windows\\Syswow64\\amsi.dll",
     "?:\\$WINDOWS.~BT\\*\\amsi.dll",
     "?:\\Windows\\CbsTemp\\*\\amsi.dll",
+    "?:\\Windows\\SystemTemp\\*\\amsi.dll",
     "?:\\Windows\\SoftwareDistribution\\Download\\*",
     "?:\\Windows\\WinSxS\\*\\amsi.dll", 
     "?:\\Windows\\servicing\\*\\amsi.dll",
@@ -14214,7 +15496,8 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
     "\\Device\\HarddiskVolume*\\$SysReset\\CloudImage\\Package_for_RollupFix*\\amsi.dll",
     "\\Device\\HarddiskVolume*\\$WINDOWS.~BT\\*\\amsi.dll", 
     "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download\\*\\amsi.dll", 
-    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll", 
+    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll",
+    "\\Device\\HarddiskVolume*\\Windows\\SystemTemp\\*\\amsi.dll", 
     "\\Device\\HarddiskVolume*\\Windows\\servicing\\*\\amsi.dll"
   )
 ```
@@ -14225,7 +15508,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1371
+Index: geneve-ut-1536
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -14248,7 +15531,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1372
+Index: geneve-ut-1537
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -14262,7 +15545,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1373
+Index: geneve-ut-1538
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14278,7 +15561,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1374
+Index: geneve-ut-1539
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14294,7 +15577,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1375
+Index: geneve-ut-1540
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14308,7 +15591,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1377
+Index: geneve-ut-1542
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14331,7 +15614,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1378
+Index: geneve-ut-1543
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14346,7 +15629,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1379
+Index: geneve-ut-1546
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -14373,7 +15656,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1381
+Index: geneve-ut-1548
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -14389,7 +15672,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1382
+Index: geneve-ut-1549
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -14402,7 +15685,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1384
+Index: geneve-ut-1551
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -14418,7 +15701,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1385
+Index: geneve-ut-1552
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -14434,7 +15717,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1386
+Index: geneve-ut-1553
 
 ```python
 any where host.os.type == "windows" and 
@@ -14501,7 +15784,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1388
+Index: geneve-ut-1555
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -14517,7 +15800,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1389
+Index: geneve-ut-1556
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14553,7 +15836,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1390
+Index: geneve-ut-1557
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14591,7 +15874,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1391
+Index: geneve-ut-1558
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -14626,7 +15909,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1392
+Index: geneve-ut-1559
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14660,7 +15943,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1394
+Index: geneve-ut-1561
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -14681,7 +15964,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1399
+Index: geneve-ut-1566
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -14709,7 +15992,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1400
+Index: geneve-ut-1567
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14717,7 +16000,7 @@ process where host.os.type == "windows" and event.type == "start" and
 (process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or ?process.code_signature.subject_name : "OpenJS Foundation") and
 
 (
-  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume?\\\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
+  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
 
   (process.args : "-r" and process.parent.name : "powershell.exe") or
 
@@ -14731,7 +16014,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1401
+Index: geneve-ut-1568
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14755,7 +16038,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1402
+Index: geneve-ut-1569
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -14776,7 +16059,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1405
+Index: geneve-ut-1572
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14791,7 +16074,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1408
+Index: geneve-ut-1575
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14804,7 +16087,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1409
+Index: geneve-ut-1576
 
 ```python
 any where host.os.type == "windows" and
@@ -14819,7 +16102,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1410
+Index: geneve-ut-1577
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14835,7 +16118,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1411
+Index: geneve-ut-1578
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -14849,7 +16132,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1413
+Index: geneve-ut-1582
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14863,19 +16146,28 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1415
+Index: geneve-ut-1584
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
  [network where host.os.type == "windows" and destination.port == 88 and
   process.executable != null and process.pid != 4 and 
-  not process.executable : 
-              ("?:\\Windows\\system32\\lsass.exe", 
-               "\\device\\harddiskvolume*\\windows\\system32\\lsass.exe", 
-               "\\device\\harddiskvolume*\\windows\\system32\\svchost.exe") and
-  not (process.executable : ("C:\\Windows\\System32\\svchost.exe", 
-                             "C:\\Program Files\\VMware\\VMware View\\Server\\bin\\ws_TomcatService.exe", 
-                             "F:\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe") and user.id in ("S-1-5-20", "S-1-5-18")) and   
+  not process.executable : (
+        "?:\\Windows\\system32\\lsass.exe",
+        "\\device\\harddiskvolume*\\windows\\system32\\lsass.exe",
+        "\\device\\harddiskvolume*\\windows\\system32\\svchost.exe"
+  ) and
+  not (
+    process.executable : (
+      "C:\\Windows\\System32\\svchost.exe",
+      "C:\\Program Files\\VMware\\VMware View\\Server\\bin\\ws_TomcatService.exe",
+      "C:\\Program Files\\Omnissa\\Horizon\\Server\\bin\\ws_TomcatService.exe",
+      "C:\\Program Files\\SysAidServer\\root\\WEB-INF\\domains\\NetworkDiscovery.exe",
+      "C:\\Program Files (x86)\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe",
+      "F:\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe"
+    ) and
+    user.id in ("S-1-5-20", "S-1-5-18")
+  ) and
   source.ip != "127.0.0.1" and destination.ip != "::1" and destination.ip != "127.0.0.1"]
  [authentication where host.os.type == "windows" and event.code in ("4768", "4769")]
 ```
@@ -14886,7 +16178,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1417
+Index: geneve-ut-1586
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -14899,7 +16191,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1418
+Index: geneve-ut-1587
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -14908,7 +16200,7 @@ process where host.os.type == "windows" and event.code == "10" and
    /* seclogon service accessing lsass */
   winlog.event_data.CallTrace : "*seclogon.dll*" and process.name : "svchost.exe" and
 
-   /* PROCESS_CREATE_PROCESS & PROCESS_DUP_HANDLE & PROCESS_QUERY_INFORMATION */
+   /* PROCESS_CREATE_PROCESS & PROCESS_DUP_HANDLE & PROCESS_QUERY_INFORMATION & PROCESS_QUERY_LIMITED_INFORMATION */
   winlog.event_data.GrantedAccess == "0x14c0"
 ```
 
@@ -14918,7 +16210,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1419
+Index: geneve-ut-1588
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -14964,7 +16256,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1421
+Index: geneve-ut-1590
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14985,7 +16277,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1422
+Index: geneve-ut-1591
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -15005,7 +16297,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1423
+Index: geneve-ut-1592
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15019,7 +16311,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1424
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15047,28 +16339,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Suspicious Microsoft HTML Application Child Process
-
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-1426
-
-```python
-process where host.os.type == "windows" and event.type == "start" and
- process.parent.name : "mshta.exe" and
- (
-  process.name : ("cmd.exe", "powershell.exe", "certutil.exe", "bitsadmin.exe", "curl.exe", "msiexec.exe", "schtasks.exe", "reg.exe", "wscript.exe", "rundll32.exe") or
-  process.executable : ("C:\\Users\\*\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\*.exe")
-  )
-```
-
-
-
 ### Suspicious Mining Process Creation Event
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1427
+Index: geneve-ut-1596
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -15087,80 +16362,101 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 ### Suspicious Module Loaded by LSASS
 
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-1429
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1598
 
 ```python
-any where event.category in ("library", "driver") and host.os.type == "windows" and
+library where host.os.type == "windows" and event.action == "load" and
   process.executable : "?:\\Windows\\System32\\lsass.exe" and
-  not (dll.code_signature.subject_name :
-               ("Microsoft Windows",
-                "Microsoft Corporation",
-                "Microsoft Windows Publisher",
-                "Microsoft Windows Software Compatibility Publisher",
-                "Microsoft Windows Hardware Compatibility Publisher",
-                "McAfee, Inc.",
-                "SecMaker AB",
-                "HID Global Corporation",
-                "HID Global",
-                "Apple Inc.",
-                "Citrix Systems, Inc.",
-                "Dell Inc",
-                "Hewlett-Packard Company",
-                "Symantec Corporation",
-                "National Instruments Corporation",
-                "DigitalPersona, Inc.",
-                "Novell, Inc.",
-                "gemalto",
-                "EasyAntiCheat Oy",
-                "Entrust Datacard Corporation",
-                "AuriStor, Inc.",
-                "LogMeIn, Inc.",
-                "VMware, Inc.",
-                "Istituto Poligrafico e Zecca dello Stato S.p.A.",
-                "Nubeva Technologies Ltd",
-                "Micro Focus (US), Inc.",
-                "Yubico AB",
-                "GEMALTO SA",
-                "Secure Endpoints, Inc.",
-                "Sophos Ltd",
-                "Morphisec Information Security 2014 Ltd",
-                "Entrust, Inc.",
-                "Nubeva Technologies Ltd",
-                "Micro Focus (US), Inc.",
-                "F5 Networks Inc",
-                "Bit4id",
-                "Thales DIS CPL USA, Inc.",
-                "Micro Focus International plc",
-                "HYPR Corp",
-                "Intel(R) Software Development Products",
-                "PGP Corporation",
-                "Parallels International GmbH",
-                "FrontRange Solutions Deutschland GmbH",
-                "SecureLink, Inc.",
-                "Tidexa OU",
-                "Amazon Web Services, Inc.",
-                "SentryBay Limited",
-                "Audinate Pty Ltd",
-                "CyberArk Software Ltd.",
-                "McAfeeSysPrep",
-                "NVIDIA Corporation PE Sign v2016",
-                "Trend Micro, Inc.",
-                "Fortinet Technologies (Canada) Inc.",
-                "Carbon Black, Inc.") and
-       dll.code_signature.status : ("trusted", "errorExpired", "errorCode_endpoint*", "errorChaining")) and
+  not (
+        dll.code_signature.subject_name : (
+            "Algorithmic Research LTD.",
+            "Amazon Web Services, Inc.",
+            "Apple Inc.",
+            "Audinate Pty Ltd",
+            "AuriStor, Inc.",
+            "Bit4id",
+            "Carbon Black, Inc.",
+            "Check Point Software Technologies Ltd.",
+            "Citrix Systems, Inc.",
+            "CyberArk Software Ltd.",
+            "Dell Inc",
+            "DigitalPersona, Inc.",
+            "EasyAntiCheat Oy",
+            "Entrust Corporation",
+            "Entrust Datacard Corporation",
+            "Entrust, Inc.",
+            "F5 Networks Inc",
+            "Fortinet, Inc.",
+            "Fortinet Technologies (Canada) Inc.",
+            "FrontRange Solutions Deutschland GmbH",
+            "GEMALTO SA",
+            "gemalto",
+            "Hewlett-Packard Company",
+            "HID Global",
+            "HID Global Corporation",
+            "HYPR Corp",
+            "IDEMIA IDENTITY & SECURITY FRANCE SAS",
+            "IDEMIA France SAS",
+            "Intel(R) Software Development Products",
+            "Istituto Poligrafico e Zecca dello Stato S.p.A.",
+            "LogMeIn, Inc.",
+            "McAfee, Inc.",
+            "McAfeeSysPrep",
+            "Micro Focus (US), Inc.",
+            "Micro Focus International plc",
+            "Microsoft Corporation",
+            "Microsoft Windows",
+            "Microsoft Windows Hardware Compatibility Publisher",
+            "Microsoft Windows Publisher",
+            "Microsoft Windows Software Compatibility Publisher",
+            "Morphisec Information Security 2014 Ltd",
+            "Musarubra US LLC",
+            "National Instruments Corporation",
+            "Novell, Inc.",
+            "Nubeva Technologies Ltd",
+            "NVIDIA Corporation PE Sign v2016",
+            "Palo Alto Networks (Netherlands) B.V.",
+            "Parallels International GmbH",
+            "PGP Corporation",
+            "QUEST SOFTWARE INC.",
+            "SecMaker AB",
+            "Secure Endpoints, Inc.",
+            "SecureLink, Inc.",
+            "SentinelOne Inc.",
+            "SentryBay Limited",
+            "Sophos Ltd",
+            "Symantec Corporation",
+            "Thales DIS CPL USA, Inc.",
+            "Tidexa OU",
+            "Trend Micro, Inc.",
+            "VMware, Inc.",
+            "Yubico AB"
+        ) and
+        dll.code_signature.status : ("trusted", "errorExpired", "errorCode_endpoint*", "errorChaining")
+  ) and
 
-     not dll.hash.sha256 :
-                ("811a03a5d7c03802676d2613d741be690b3461022ea925eb6b2651a5be740a4c",
-                 "1181542d9cfd63fb00c76242567446513e6773ea37db6211545629ba2ecf26a1",
-                 "ed6e735aa6233ed262f50f67585949712f1622751035db256811b4088c214ce3",
-                 "26be2e4383728eebe191c0ab19706188f0e9592add2e0bf86b37442083ae5e12",
-                 "9367e78b84ef30cf38ab27776605f2645e52e3f6e93369c674972b668a444faa",
-                 "d46cc934765c5ecd53867070f540e8d6f7701e834831c51c2b0552aba871921b",
-                 "0f77a3826d7a5cd0533990be0269d951a88a5c277bc47cff94553330b715ec61",
-                 "4aca034d3d85a9e9127b5d7a10882c2ef4c3e0daa3329ae2ac1d0797398695fb",
-                 "86031e69914d9d33c34c2f4ac4ae523cef855254d411f88ac26684265c981d95")
+  not dll.hash.sha256 : (
+          "811a03a5d7c03802676d2613d741be690b3461022ea925eb6b2651a5be740a4c",
+          "1181542d9cfd63fb00c76242567446513e6773ea37db6211545629ba2ecf26a1",
+          "ed6e735aa6233ed262f50f67585949712f1622751035db256811b4088c214ce3",
+          "26be2e4383728eebe191c0ab19706188f0e9592add2e0bf86b37442083ae5e12",
+          "9367e78b84ef30cf38ab27776605f2645e52e3f6e93369c674972b668a444faa",
+          "d46cc934765c5ecd53867070f540e8d6f7701e834831c51c2b0552aba871921b",
+          "0f77a3826d7a5cd0533990be0269d951a88a5c277bc47cff94553330b715ec61",
+          "4aca034d3d85a9e9127b5d7a10882c2ef4c3e0daa3329ae2ac1d0797398695fb",
+          "86031e69914d9d33c34c2f4ac4ae523cef855254d411f88ac26684265c981d95",
+          "4af1fee3369d9a993a84f54eafb72a661633c33e9e12fb3dd151a6a2cddbd404"
+  ) and
+  not dll.path : (
+        "C:\\Windows\\System32\\CertPolEng.dll",
+        "C:\\Windows\\System32\\FWPUCLNT.DLL",
+        "C:\\Windows\\System32\\keyiso.dll",
+        "C:\\Windows\\System32\\ngcpopkeysrv.dll",
+        "C:\\Windows\\System32\\SecureTimeAggregator.dll",
+        "C:\\Windows\\System32\\vaultsvc.dll"
+  )
 ```
 
 
@@ -15169,7 +16465,7 @@ any where event.category in ("library", "driver") and host.os.type == "windows" 
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1432
+Index: geneve-ut-1601
 
 ```python
 sequence by host.id with maxspan=5s
@@ -15217,7 +16513,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1434
+Index: geneve-ut-1603
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15243,7 +16539,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1435
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15288,7 +16584,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1436
+Index: geneve-ut-1605
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15312,7 +16608,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1437
+Index: geneve-ut-1606
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -15328,7 +16624,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1439
+Index: geneve-ut-1608
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -15353,7 +16649,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1440
+Index: geneve-ut-1609
 
 ```python
 event.category:process and host.os.type:windows and
@@ -15368,7 +16664,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1443
+Index: geneve-ut-1612
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -15382,7 +16678,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1444
+Index: geneve-ut-1613
 
 ```python
 sequence by host.id with maxspan=30s
@@ -15402,7 +16698,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1445
+Index: geneve-ut-1614
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -15437,7 +16733,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1449
+Index: geneve-ut-1618
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15450,7 +16746,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1451
+Index: geneve-ut-1620
 
 ```python
 any where host.os.type == "windows" and
@@ -15483,7 +16779,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1453
+Index: geneve-ut-1622
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -15501,7 +16797,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1454
+Index: geneve-ut-1623
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -15519,11 +16815,50 @@ and not (
 
 
 
+### Suspicious SUID Binary Execution (Auditd Sequence)
+
+Branch count: 414  
+Document count: 828  
+Index: geneve-ut-1626
+
+```python
+sequence by host.id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action == "executed" and
+   user.id != "0" and user.effective.id != "0" and
+   (
+     process.name like ("python*", "perl*", "ruby*", "php*", "lua*", ".*") or
+     process.name in ("node", "bun", "java") or
+     process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+     (
+       process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+       process.args in ("-c", "--command", "-ic", "-ci", "-cl", "-lc")
+     )
+   )
+  ] by process.pid
+
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action == "executed" and
+   user.effective.id == "0" and user.id != "0" and
+   (
+     (process.name in ("sudo", "pkexec") and
+      not process.args like "-*" and
+      not process.args : ("/usr/*", "/bin/*", "/sbin/*", "/opt/*")) or
+     (process.name == "su" and
+      not process.args in ("--command", "-c", "--shell", "-s")) or
+     (process.name in ("passwd", "chsh", "newgrp") and
+      not process.args in ("--shell", "-s", "--help"))
+   )
+  ] by process.parent.pid
+```
+
+
+
 ### Suspicious ScreenConnect Client Child Process
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1456
+Index: geneve-ut-1627
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15542,7 +16877,7 @@ process where host.os.type == "windows" and event.type == "start" and
    (process.name : "rundll32.exe" and not process.args : "url.dll,FileProtocolHandler") or
    (process.name : "msiexec.exe" and process.args : ("/i", "-i") and
     process.args : ("/q", "/quiet", "/qn", "-q", "-quiet", "-qn", "-Q+")) or
-   process.name : ("mshta.exe", "certutil.exe", "bistadmin.exe", "certreq.exe", "wscript.exe", "cscript.exe", "curl.exe",
+   process.name : ("mshta.exe", "certutil.exe", "bitsadmin.exe", "certreq.exe", "wscript.exe", "cscript.exe", "curl.exe",
                    "ssh.exe", "scp.exe", "wevtutil.exe", "wget.exe", "wmic.exe")
    )
 ```
@@ -15553,7 +16888,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1457
+Index: geneve-ut-1628
 
 ```python
 any where host.os.type == "windows" and
@@ -15587,7 +16922,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1458
+Index: geneve-ut-1629
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -15601,7 +16936,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1461
+Index: geneve-ut-1632
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15632,13 +16967,13 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1462
+Index: geneve-ut-1633
 
 ```python
 any where host.os.type == "windows" and
 (
  (event.category == "library" and
-  process.executable : ("C:\\Program Files\\WebHelpDesk\\*\\java.exe", "C:\\Program Files (x86)\\WebHelpDesk\\*\\java.exe") and
+  process.executable : ("C:\\Program Files\\WebHelpDesk\\*\\java*.exe", "C:\\Program Files (x86)\\WebHelpDesk\\*\\java*.exe") and
   (dll.path : "\\Device\\Mup\\*" or dll.code_signature.trusted == false or ?dll.code_signature.exists == false)) or
 
  (event.category == "process" and process.name : ("cmd.exe", "powershell.exe", "rundll32.exe") and
@@ -15652,7 +16987,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1463
+Index: geneve-ut-1634
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15693,7 +17028,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1464
+Index: geneve-ut-1635
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -15709,7 +17044,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1465
+Index: geneve-ut-1636
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15739,7 +17074,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1469
+Index: geneve-ut-1640
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -15752,7 +17087,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1470
+Index: geneve-ut-1641
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -15776,7 +17111,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1472
+Index: geneve-ut-1643
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15794,7 +17129,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1474
+Index: geneve-ut-1645
 
 ```python
 any where host.os.type == "windows" and
@@ -15809,7 +17144,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1475
+Index: geneve-ut-1646
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -15827,7 +17162,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1476
+Index: geneve-ut-1647
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -15839,7 +17174,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
                   "Login Data") and
  ((process.code_signature.trusted == false or process.code_signature.exists == false) or process.name == "osascript") and
  not process.code_signature.signing_id == "org.mozilla.firefox" and
- not Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
+not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
 ```
 
 
@@ -15848,7 +17183,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1477
+Index: geneve-ut-1648
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15867,7 +17202,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1480
+Index: geneve-ut-1651
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15892,7 +17227,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1481
+Index: geneve-ut-1652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15905,7 +17240,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1483
+Index: geneve-ut-1654
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -15918,7 +17253,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1485
+Index: geneve-ut-1656
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15941,7 +17276,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1487
+Index: geneve-ut-1658
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15960,7 +17295,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1488
+Index: geneve-ut-1659
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -15982,7 +17317,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1489
+Index: geneve-ut-1660
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -16015,7 +17350,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1491
+Index: geneve-ut-1662
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16033,7 +17368,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1492
+Index: geneve-ut-1663
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -16047,7 +17382,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1493
+Index: geneve-ut-1664
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16071,7 +17406,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1494
+Index: geneve-ut-1665
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -16094,7 +17429,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1495
+Index: geneve-ut-1666
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -16113,7 +17448,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1499
+Index: geneve-ut-1670
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -16148,7 +17483,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1500
+Index: geneve-ut-1671
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16165,7 +17500,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1501
+Index: geneve-ut-1672
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16185,7 +17520,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1502
+Index: geneve-ut-1673
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16225,7 +17560,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1503
+Index: geneve-ut-1674
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -16241,7 +17576,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1504
+Index: geneve-ut-1675
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16255,7 +17590,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1505
+Index: geneve-ut-1676
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -16293,7 +17628,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1506
+Index: geneve-ut-1677
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -16343,11 +17678,39 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 
 
+### Systemd Service Override Configuration File Created
+
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-1678
+
+```python
+file where host.os.type == "linux" and event.action in ("rename", "creation") and
+file.extension == "conf" and file.path like (
+  "/etc/systemd/system/*.d/*.conf", "/etc/systemd/user/*.d/*.conf", "/usr/local/lib/systemd/system/*.d/*.conf",
+  "/lib/systemd/system/*.d/*.conf", "/usr/lib/systemd/system/*.d/*.conf", "/usr/lib/systemd/user/*.d/*.conf",
+  "/home/*/.config/systemd/user/*.d/*.conf", "/home/*/.local/share/systemd/user/*.d/*.conf",
+  "/root/.config/systemd/user/*.d/*.conf", "/root/.local/share/systemd/user/*.d/*.conf",
+  "/run/systemd/system/*.d/*.conf", "/var/run/systemd/system/*.d/*.conf"
+) and
+not process.executable in (
+  "/bin/dpkg", "/usr/bin/dpkg", "/bin/dockerd", "/usr/bin/dockerd", "/usr/sbin/dockerd", "/bin/microdnf",
+  "/usr/bin/microdnf", "/bin/rpm", "/usr/bin/rpm", "/bin/snapd", "/usr/bin/snapd", "/bin/yum", "/usr/bin/yum",
+  "/bin/dnf", "/usr/bin/dnf", "/bin/podman", "/usr/bin/podman", "/bin/dnf-automatic", "/usr/bin/dnf-automatic",
+  "/usr/bin/dpkg-divert", "/bin/dpkg-divert", "/sbin/apk", "/usr/sbin/apk", "/usr/local/sbin/apk", "/usr/bin/dnf5",
+  "/usr/bin/apt", "/usr/bin/puppet", "/bin/puppet", "/opt/puppetlabs/puppet/bin/puppet", "/usr/bin/pacman",
+  "/usr/bin/chef-client", "/bin/chef-client", "/usr/bin/pamac-daemon", "/bin/pamac-daemon", "/usr/local/bin/dockerd",
+  "/usr/bin/crio", "/usr/bin/podman", "/usr/bin/tdnf", "/usr/bin/apk"
+)
+```
+
+
+
 ### Systemd Shell Execution During Boot
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1508
+Index: geneve-ut-1680
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -16361,7 +17724,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1509
+Index: geneve-ut-1681
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -16407,7 +17770,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1510
+Index: geneve-ut-1682
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -16446,7 +17809,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1511
+Index: geneve-ut-1683
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -16459,7 +17822,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1514
+Index: geneve-ut-1686
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -16492,7 +17855,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1515
+Index: geneve-ut-1687
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -16506,7 +17869,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1516
+Index: geneve-ut-1688
 
 ```python
 sequence by host.id with maxspan=1s
@@ -16520,7 +17883,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1517
+Index: geneve-ut-1689
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -16534,7 +17897,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1518
+Index: geneve-ut-1690
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -16573,7 +17936,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1524
+Index: geneve-ut-1696
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -16615,7 +17978,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1525
+Index: geneve-ut-1697
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -16628,7 +17991,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1526
+Index: geneve-ut-1698
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16645,7 +18008,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1527
+Index: geneve-ut-1699
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -16661,7 +18024,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1528
+Index: geneve-ut-1700
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16674,7 +18037,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1529
+Index: geneve-ut-1701
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -16689,7 +18052,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1530
+Index: geneve-ut-1702
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16710,15 +18073,16 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### UAC Bypass via ICMLuaUtil Elevated COM Interface
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1531
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1703
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  process.parent.name == "dllhost.exe" and
  process.parent.args in ("/Processid:{3E5FC7F9-9A51-4367-9063-A120244FBEC7}", "/Processid:{D2E7041B-2927-42FB-8E9F-7CE93B6DC937}") and
- process.pe.original_file_name != "WerFault.exe"
+ process.pe.original_file_name != "WerFault.exe" and
+ not (process.executable : "?:\\Program Files\\WireGuard\\wireguard.exe" and process.args : "/installmanagerservice")
 ```
 
 
@@ -16727,7 +18091,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1532
+Index: geneve-ut-1704
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16739,38 +18103,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Uncommon Destination Port Connection by Web Server
-
-Branch count: 45  
-Document count: 45  
-Index: geneve-ut-1536
-
-```python
-network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and (
-  process.name like (
-    "apache", "nginx", "apache2", "httpd", "lighttpd", "caddy", "mongrel_rails", "gunicorn",
-    "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn",
-    "daphne", "twistd", "yaws", "webfsd", "httpd.worker", "flask", "rails", "mongrel", "php-fpm*", "php-cgi",
-    "php-fcgi", "php-cgi.cagefs", "catalina.sh", "hiawatha", "lswsctrl"
-  ) or
-  user.name in ("apache", "www-data", "httpd", "nginx", "lighttpd", "tomcat", "tomcat8", "tomcat9") or
-  user.id in ("33", "498", "48") or
-  (process.name == "java" and process.working_directory like "/u0?/*")
-) and
-network.direction == "egress" and destination.ip != null and
-not destination.port in (80, 443, 8080, 8443, 8000, 8888, 3128, 3306, 5432, 8220, 8082) and
-not cidrmatch(destination.ip, "127.0.0.0/8", "::1","FE80::/10", "FF00::/8", "10.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.0.0.0/24", "192.0.0.0/29", "192.0.0.8/32", "192.0.0.9/32",
-"192.0.0.10/32", "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24", "192.168.0.0/16", "192.88.99.0/24",
-"224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24","198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "224.0.0.0/4", "240.0.0.0/4")
-```
-
-
-
 ### Unexpected Child Process of macOS Screensaver Engine
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1538
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -16782,7 +18119,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1539
+Index: geneve-ut-1710
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16811,7 +18148,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1541
+Index: geneve-ut-1712
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -16821,36 +18158,22 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 
 
-### Untrusted DLL Loaded by Azure AD Sync Service
+### Untrusted DLL Loaded by Azure AD Connect Authentication Agent
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1546
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1717
 
 ```python
-any where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
-(
- (event.category == "library" and event.action == "load") or
- (event.category == "process" and event.action : "Image loaded*")
-) and
+library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
 
-not (?dll.code_signature.trusted == true or file.code_signature.status == "Valid") and not
-
-  (
-   /* Elastic defend DLL path */
-   ?dll.path :
-         ("?:\\Windows\\assembly\\NativeImages*",
-          "?:\\Windows\\Microsoft.NET\\*",
-          "?:\\Windows\\WinSxS\\*",
-          "?:\\Windows\\System32\\DriverStore\\FileRepository\\*") or
-
-   /* Sysmon DLL path is mapped to file.path */
-   file.path :
-         ("?:\\Windows\\assembly\\NativeImages*",
-          "?:\\Windows\\Microsoft.NET\\*",
-          "?:\\Windows\\WinSxS\\*",
-          "?:\\Windows\\System32\\DriverStore\\FileRepository\\*")
-  )
+not dll.code_signature.trusted == true and
+not dll.path : (
+    "?:\\Windows\\assembly\\NativeImages*",
+    "?:\\Windows\\Microsoft.NET\\*",
+    "?:\\Windows\\WinSxS\\*",
+    "?:\\Windows\\System32\\DriverStore\\FileRepository\\*"
+)
 ```
 
 
@@ -16859,12 +18182,23 @@ not (?dll.code_signature.trusted == true or file.code_signature.status == "Valid
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1547
+Index: geneve-ut-1718
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
   (dll.code_signature.trusted == false or dll.code_signature.exists == false) and
-  not dll.code_signature.status : ("errorExpired", "errorRevoked", "errorCode_endpoint:*")
+  /* errorExpired and errorRevoked are handled by d12bac54-ab2a-4159-933f-d7bcefa7b61d */
+  not dll.code_signature.status : ("errorExpired", "errorRevoked", "errorCode_endpoint:*") and
+
+  not dll.hash.sha256 : (
+        /* HP DOT4 printer driver family FPs (Dot4.sys, Dot4Prt.sys, Dot4usb.sys, Dot4Scan.sys) */
+        "f21c1d478180bc5e932bb2c2e4618e3ed463ca87acedeb139682d218435f82f1",
+        "7e2f2a139e897eae56038b920bda9381094bc0ae9e626f6634e6b444b8b0c91f",
+        "12ffdf5f48a79b1b4adbb88ba2cb6c59dd6719554e8ea6beefe99b3e3c66f1ac",
+        "dbc6afaf80141e2480e19878f581edfe9c2b018da2ec527c4025ff04d5587afd",
+        /* (dc3d.sys, test-signed) */
+        "ca8f9564733ded4c3895cf7150bb254995d66889e6be08d6654e4f897e4ff7a4"
+  )
 ```
 
 
@@ -16873,7 +18207,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1551
+Index: geneve-ut-1723
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16887,16 +18221,18 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1552
+Index: geneve-ut-1724
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.parent.name : "dns.exe" and
   not process.executable : (
     "?:\\Windows\\System32\\conhost.exe",
+    "?:\\Windows\\System32\\dns.exe",
 
     /* Crowdstrike specific exclusion as it uses NT Object paths */
     "\\Device\\HarddiskVolume*\\Windows\\System32\\conhost.exe",
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\dns.exe",
     "\\Device\\HarddiskVolume*\\Program Files\\ReasonLabs\\*"
   ) and
   not ?process.parent.executable : "?:\\Program Files\\ReasonLabs\\DNS\\ui\\DNS.exe"
@@ -16908,7 +18244,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1557
+Index: geneve-ut-1729
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -16942,7 +18278,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1559
+Index: geneve-ut-1731
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16957,37 +18293,15 @@ process.group_leader.name != null and not (
 
 
 
-### Unusual Executable File Creation by a System Critical Process
-
-Branch count: 18  
-Document count: 18  
-Index: geneve-ut-1562
-
-```python
-file where host.os.type == "windows" and event.type != "deletion" and
-  file.extension : ("exe", "dll") and
-  process.name : ("smss.exe",
-                  "autochk.exe",
-                  "csrss.exe",
-                  "wininit.exe",
-                  "services.exe",
-                  "lsass.exe",
-                  "winlogon.exe",
-                  "userinit.exe",
-                  "LogonUI.exe")
-```
-
-
-
 ### Unusual File Creation - Alternate Data Stream
 
-Branch count: 186  
-Document count: 186  
-Index: geneve-ut-1566
+Branch count: 248  
+Document count: 248  
+Index: geneve-ut-1738
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
-   process.name : ("cmd.exe", "powershell.exe", "mshta.exe", "wscript.exe", "node.exe", "python*.exe") and
+   process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "mshta.exe", "wscript.exe", "cscript.exe", "node.exe", "python*.exe") and
    file.extension in~ (
     "pdf", "dll", "exe", "dat", "com", "bat", "cmd", "sys", "vbs", "vbe", "ps1", "hta", "txt", "js", "jse",
     "wsh", "wsf", "sct", "docx", "doc", "xlsx", "xls", "pptx", "ppt", "rtf", "gif", "jpg", "png", "bmp", "img", "iso"
@@ -16998,128 +18312,11 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
-### Unusual Instance Metadata Service (IMDS) API Request
-
-Branch count: 141  
-Document count: 282  
-Index: geneve-ut-1577
-
-```python
-sequence by host.id, process.parent.entity_id with maxspan=3s
-[
-    process
-    where host.os.type == "linux"
-        and event.type == "start"
-        and event.action == "exec"
-        and process.parent.executable != null
-
-        // common tooling / suspicious names (keep broad)
-        and (
-            process.name : (
-                "curl", "wget", "python*", "perl*", "php*", "ruby*", "lua*", "telnet", "pwsh",
-                "openssl", "nc", "ncat", "netcat", "awk", "gawk", "mawk", "nawk", "socat", "node",
-                "bash", "sh"
-            )
-            or
-            // suspicious execution locations (dropped binaries / temp execution)
-            process.executable : (
-                "./*", "/tmp/*", "/var/tmp/*", "/var/www/*", "/dev/shm/*", "/etc/init.d/*", "/etc/rc*.d/*",
-                "/etc/cron*", "/etc/update-motd.d/*", "/boot/*", "/srv/*", "/run/*", "/etc/rc.local"
-            )
-            or
-            // threat-relevant IMDS / metadata endpoints (inclusion list)
-            process.command_line : (
-                "*169.254.169.254/latest/api/token*",
-                "*169.254.169.254/latest/meta-data/iam/security-credentials*",
-                "*169.254.169.254/latest/meta-data/local-ipv4*",
-                "*169.254.169.254/latest/meta-data/local-hostname*",
-                "*169.254.169.254/latest/meta-data/public-ipv4*",
-                "*169.254.169.254/latest/user-data*",
-                "*169.254.169.254/latest/dynamic/instance-identity/document*",
-                "*169.254.169.254/latest/meta-data/instance-id*",
-                "*169.254.169.254/latest/meta-data/public-keys*",
-                "*computeMetadata/v1/instance/service-accounts/*/token*",
-                "*/metadata/identity/oauth2/token*",
-                "*169.254.169.254/opc/v*/instance*",
-                "*169.254.169.254/opc/v*/vnics*"
-            )
-        )
-
-        // global working-dir / executable / parent exclusions for known benign agents
-        and not process.working_directory : (
-            "/opt/rapid7*",
-            "/opt/nessus*",
-            "/snap/amazon-ssm-agent*",
-            "/var/snap/amazon-ssm-agent/*",
-            "/var/log/amazon/ssm/*",
-            "/srv/snp/docker/overlay2*",
-            "/opt/nessus_agent/var/nessus/*"
-        )
-
-        and not process.executable : (
-            "/opt/rumble/bin/rumble-agent*",
-            "/opt/aws/inspector/bin/inspectorssmplugin",
-            "/snap/oracle-cloud-agent/*",
-            "/lusr/libexec/oracle-cloud-agent/*"
-        )
-
-        and not process.parent.executable : (
-            "/usr/bin/setup-policy-routes",
-            "/usr/share/ec2-instance-connect/*",
-            "/var/lib/amazon/ssm/*",
-            "/etc/update-motd.d/30-banner",
-            "/usr/sbin/dhclient-script",
-            "/usr/local/bin/uwsgi",
-            "/usr/lib/skylight/al-extras",
-            "/usr/bin/cloud-init",
-            "/usr/sbin/waagent",
-            "/usr/bin/google_osconfig_agent",
-            "/usr/bin/docker",
-            "/usr/bin/containerd-shim",
-            "/usr/bin/runc"
-        )
-
-        and not process.entry_leader.executable : (
-            "/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent",
-            "/opt/Elastic/Agent/data/elastic-agent-*/elastic-agent",
-            "/opt/nessus_agent/sbin/nessus-service"
-        )
-
-        // carve-out: safe /usr/bin/curl usage (suppress noisy, legitimate agent patterns)
-        and not (
-            process.executable == "/usr/bin/curl"
-            and (
-                // AWS IMDSv2 token PUT that includes ttl header
-                (process.command_line : "*-X PUT*169.254.169.254/latest/api/token*" and process.command_line : "*X-aws-ec2-metadata-token-ttl-seconds*")
-                or
-                // Any IMDSv2 GET that includes token header for any /latest/* path
-                process.command_line : "*-H X-aws-ec2-metadata-token:*169.254.169.254/latest/*"
-                or
-                // Common amazon tooling UA
-                process.command_line : "*-A amazon-ec2-net-utils/*"
-                or
-                // Azure metadata legitimate header
-                process.command_line : "*-H Metadata:true*169.254.169.254/metadata/*"
-                or
-                // Oracle IMDS legitimate header
-                process.command_line : "*-H Authorization:*Oracle*169.254.169.254/opc/*"
-            )
-        )
-]
-[
-    network where host.os.type == "linux"
-        and event.action == "connection_attempted"
-        and destination.ip == "169.254.169.254"
-]
-```
-
-
-
 ### Unusual Kill Signal
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1580
+Index: geneve-ut-1751
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -17136,7 +18333,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1583
+Index: geneve-ut-1754
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -17153,7 +18350,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1599
+Index: geneve-ut-1770
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -17170,13 +18367,13 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 ### Unusual Parent-Child Relationship
 
-Branch count: 32  
-Document count: 32  
-Index: geneve-ut-1603
+Branch count: 66  
+Document count: 66  
+Index: geneve-ut-1774
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
-process.parent.name != null and
+process.parent.name != null and process.parent.executable like ("?:\\*", "\\Device\\*") and
  (
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
@@ -17199,11 +18396,12 @@ process.parent.name != null and
    (process.name:"userinit.exe" and not process.parent.name:("dwm.exe", "winlogon.exe", "KUsrInit.exe")) or
    (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
    /* suspicious child processes */
-   (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe")) or
+   (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
-   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe"))
+   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
+     not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe"))
   )
 ```
 
@@ -17213,7 +18411,7 @@ process.parent.name != null and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1604
+Index: geneve-ut-1775
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17258,7 +18456,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1607
+Index: geneve-ut-1778
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17296,11 +18494,39 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Unusual Process Connection to Docker or Containerd Socket
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1780
+
+```python
+host.os.type:"linux" and 
+event.category:"network" and
+event.action:"connected-to" and network.direction:"egress" and 
+destination.address:("/run/containerd/containerd.sock" or "/var/run/containerd/containerd.sock" or "/var/run/docker.sock" or "/run/docker.sock") and
+process.executable:(* and not 
+  ("/usr/bin/kubelet" or
+  "/usr/local/bin/kubelet" or
+  "/usr/bin/containerd" or
+  "/usr/sbin/containerd" or
+  "/usr/bin/containerd-shim" or
+  "/usr/bin/containerd-shim-runc-v2" or
+  "/usr/local/bin/containerd-shim-runc-v2" or
+  "/usr/bin/dockerd" or
+  "/usr/sbin/dockerd" or  
+   /var/lib/*/usr/bin/dockerd or 
+  "/usr/bin/docker-proxy")
+)
+```
+
+
+
 ### Unusual Process Execution on WBEM Path
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1611
+Index: geneve-ut-1783
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17324,7 +18550,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1612
+Index: geneve-ut-1784
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17364,7 +18590,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1613
+Index: geneve-ut-1785
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -17411,7 +18637,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1617
+Index: geneve-ut-1789
 
 ```python
 sequence by process.entity_id
@@ -17448,7 +18674,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1651
+Index: geneve-ut-1821
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17462,7 +18688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1652
+Index: geneve-ut-1822
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -17505,7 +18731,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1653
+Index: geneve-ut-1823
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -17518,7 +18744,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1655
+Index: geneve-ut-1825
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -17532,7 +18758,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1656
+Index: geneve-ut-1826
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -17541,29 +18767,11 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 
 
-### Veeam Backup Library Loaded by Unusual Process
-
-Branch count: 10  
-Document count: 10  
-Index: geneve-ut-1659
-
-```python
-library where host.os.type == "windows" and event.action == "load" and
-  (dll.name : "Veeam.Backup.Common.dll" or dll.pe.original_file_name : "Veeam.Backup.Common.dll") and
-  (
-    process.code_signature.trusted == false or
-    process.code_signature.exists == false or
-    process.name : ("powershell.exe", "pwsh.exe", "powershell_ise.exe")
-  )
-```
-
-
-
 ### Virtual Machine Fingerprinting
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1660
+Index: geneve-ut-1830
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -17588,7 +18796,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1661
+Index: geneve-ut-1831
 
 ```python
 process where event.type == "start" and
@@ -17603,7 +18811,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1662
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17620,7 +18828,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1663
+Index: geneve-ut-1833
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17634,7 +18842,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1664
+Index: geneve-ut-1834
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17650,7 +18858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1665
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +18872,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1666
+Index: geneve-ut-1836
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -17677,8 +18885,12 @@ file where host.os.type == "windows" and event.action != "deletion" and
   ) and
   not process.executable : (
     "C:\\Windows\\System32\\poqexec.exe",
-    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe"
-  )
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe",
+    "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+    "?:\\Windows\\System32\\omadmclient.exe"
+  ) and
+  /* System / ntoskrnl.exe (PID 4) */
+  not process.pid == 4
 ```
 
 
@@ -17687,7 +18899,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1668
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -17699,7 +18911,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1669
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17715,7 +18927,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1670
+Index: geneve-ut-1840
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -17738,7 +18950,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1671
+Index: geneve-ut-1841
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -17751,7 +18963,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1672
+Index: geneve-ut-1842
 
 ```python
 http.response.status_code:403 and http.request.method:post
@@ -17763,7 +18975,7 @@ http.response.status_code:403 and http.request.method:post
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1673
+Index: geneve-ut-1843
 
 ```python
 http.response.status_code:405
@@ -17775,7 +18987,7 @@ http.response.status_code:405
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1674
+Index: geneve-ut-1844
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -17783,22 +18995,101 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 
 
-### Web Server Potential SQL Injection Request
+### Web Server Cloud Metadata SSRF Request
 
-Branch count: 61  
-Document count: 61  
-Index: geneve-ut-1677
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1845
 
 ```python
-any where url.original like~ (
-  "*%20order%20by%*", "*dbms_pipe.receive_message%28chr%*", "*waitfor%20delay%20*", "*%28select%20*from%20pg_sleep%285*", "*%28select%28sleep%285*", "*%3bselect%20pg_sleep%285*",
-  "*select%20concat%28concat*", "*xp_cmdshell*", "*select*case*when*", "*and*extractvalue*select*", "*from*information_schema.tables*", "*boolean*mode*having*", "*extractvalue*concat*",
-  "*case*when*sleep*", "*select*sleep*", "*dbms_lock.sleep*", "*and*sleep*", "*like*sleep*", "*csleep*", "*pgsleep*", "*char*char*char*", "*union*select*", "*concat*select*",
-  "*select*else*drop*", "*having*like*", "*case*else*end*", "*if*sleep*", "*where*and*select*", "*or*1=1*", "*\"1\"=\"1\"*", "*or*'a'='a*", "*into*outfile*", "*pga_sleep*",
-  "*into%20outfile*", "*into*dumpfile*", "*load_file%28*", "*load%5ffile%28*", "*cast%28*", "*convert%28*", "*cast%28%*", "*convert%28%*", "*@@version*", "*@@version_comment*",
-  "*version%28*", "*user%28*", "*current_user%28*", "*database%28*", "*schema_name%28*", "*information_schema.columns*", "*information_schema.columns*", "*table_schema*",
-  "*column_name*", "*dbms_pipe*", "*dbms_lock%2e*sleep*", "*dbms_lock.sleep*", "*sp_executesql*", "*sp_executesql*", "*load%20data*", "*information_schema*",  "*pg_slp*",
-  "*information_schema.tables*"
+web where (
+  url.original : (
+    "*169.254.169.254*", "*169%2e254%2e169%2e254*", "*0xa9fea9fe*", "*0xa9.0xfe.0xa9.0xfe*", 
+    "*2852039166*", "*0251.0376.0251.0376*", "*::ffff:169.254.169.254*", "*::ffff:a9fe:a9fe*", "*fd00:ec2::254*",
+    "*100.100.100.200*", "*169.254.170.2*", "*metadata.google.internal*", "*metadata.goog*", "*computeMetadata/v1*",
+    "*meta-data/iam/security-credentials*", "*meta-data%2Fiam%2Fsecurity-credentials*",
+    "*latest/meta-data*", "*latest/api/token*"
+  )
+  or
+  url.query : (
+    "*169.254.169.254*", "*169%2e254%2e169%2e254*", "*0xa9fea9fe*", "*0xa9.0xfe.0xa9.0xfe*", 
+    "*2852039166*", "*0251.0376.0251.0376*", "*::ffff:169.254.169.254*", "*::ffff:a9fe:a9fe*", "*fd00:ec2::254*",
+    "*100.100.100.200*", "*169.254.170.2*", "*metadata.google.internal*", "*metadata.goog*", "*computeMetadata/v1*",
+    "*meta-data/iam/security-credentials*", "*meta-data%2Fiam%2Fsecurity-credentials*",
+    "*latest/meta-data*", "*latest/api/token*"
+  )
+)
+```
+
+
+
+### Web Server Potential SQL Injection Request
+
+Branch count: 91  
+Document count: 91  
+Index: geneve-ut-1848
+
+```python
+any where (
+url.original like~ (
+    "*dbms_pipe.receive_message%28chr%*",
+    "*waitfor%20delay%20%270%3a0%3a*",
+    "*%28select%28sleep%285*", "*%28select%20*from%20pg_sleep%285*", "*%3bselect%20pg_sleep%285*",
+    "*and%20sleep%28*%29*", "*or%20sleep%28*%29*", "*case%20when*then%20sleep%28*", "*if%28sleep%28*%29*",
+    "*benchmark%28*%2c*md5%28*",
+    "*convert%28int%2c%28select%20char%28*",
+    "*char%28*char%28*char%28*char%28*",
+    "*concat%28concat%28char%28*",
+    "*case%20when%20%28*%3d*%29%20then*else*end*",
+    "*elt%28*%3d*%2c1%29%29*",
+    "*union%20select%20null%2cnull*", "*union%20all%20select%20null*",
+    "*union%20all%20select%20*concat%28md5%28*",
+    "*extractvalue%28*concat%280x*", "*updatexml%28*concat%280x*",
+    "*procedure%2f%2a%2a%2fanalyse%28extractvalue%28*",
+    "*gtid_subset%28concat%280x*", "*gtid_subtract%28concat%280x*",
+    "*mid%28ifnull%28session_user%28%29*",
+    "*'qq'%2b%28%28select%20@@version%29%29%2b'qq'*",
+    "*%27%20or%20%271%27%3d%271*", "*%22%20or%20%221%22%3d%221*", "*%27%20or%20%27a%27%3d%27a*",
+    "*and%201%3d1--*", "*and%201%3d2--*",
+    "*%29%3bselect*if%28%28ord%28mid%28*",
+    "*xp_cmdshell*",
+    "*select%20*into%20outfile*", "*select%20*into%20dumpfile*",
+    "*load_file%28*", "*load%5ffile%28*",
+    "*select%20*from%20information_schema.tables*", "*from%20information_schema.columns%20where%20table_schema*",
+    "*dbms_pipe%2ereceive_message*", "*dbms_lock%2esleep*",
+    "*select%20@@version*", "*select%20user%28%29*", "*select%20current_user%28%29*", "*select%20database%28%29*",
+    "*sp_executesql%20*exec%20*", "*xp_dirtree*"
+  )
+  or
+  url.query like~ (
+    "*dbms_pipe.receive_message(chr*",
+    "*waitfor delay '0:0:*",
+    "*(select(sleep(5*", "*(select*from pg_sleep(5*", "*;select pg_sleep(5*",
+    "*and sleep(*)*", "*or sleep(*)*", "*case when*then sleep(*", "*if(sleep(*)*",
+    "*benchmark(*,*md5(*",
+    "*convert(int,(select char(*",
+    "*char(*char(*char(*char(*",
+    "*concat(concat(char(*",
+    "*case when (*=*) then*else*end*",
+    "*elt(*=*,1))*",
+    "*union select null,null*", "*union all select null*",
+    "*union all select*concat(md5(*",
+    "*extractvalue(*concat(0x*", "*updatexml(*concat(0x*",
+    "*procedure/**/analyse(extractvalue(*",
+    "*gtid_subset(concat(0x*", "*gtid_subtract(concat(0x*",
+    "*mid(ifnull(session_user()*",
+    "*'qq'+((select @@version))+'qq'*",
+    "*' or '1'='1*", "*\" or \"1\"=\"1*", "*' or 'a'='a*",
+    "*and 1=1--*", "*and 1=2--*",
+    "*);select*if((ord(mid(*",
+    "*xp_cmdshell*",
+    "*select*into outfile*", "*select*into dumpfile*",
+    "*load_file(*",
+    "*select*from information_schema.tables*", "*from information_schema.columns where table_schema*",
+    "*dbms_pipe.receive_message*", "*dbms_lock.sleep*",
+    "*select @@version*", "*select user()*", "*select current_user()*", "*select database()*",
+    "*sp_executesql*exec*", "*xp_dirtree*"
+  )
 )
 ```
 
@@ -17808,7 +19099,7 @@ any where url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1679
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17829,7 +19120,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1682
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -17843,7 +19134,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1683
+Index: geneve-ut-1854
 
 ```python
 file where event.type == "deletion" and
@@ -17860,7 +19151,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1684
+Index: geneve-ut-1855
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17878,7 +19169,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1686
+Index: geneve-ut-1857
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17916,7 +19207,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1688
+Index: geneve-ut-1859
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17953,7 +19244,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1689
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17968,7 +19259,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1690
+Index: geneve-ut-1861
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -17981,7 +19272,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1691
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18000,7 +19291,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-1692
+Index: geneve-ut-1863
 
 ```python
 sequence with maxspan=1m
@@ -18025,7 +19316,7 @@ sequence with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1693
+Index: geneve-ut-1864
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18051,7 +19342,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1694
+Index: geneve-ut-1865
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -18073,7 +19364,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1695
+Index: geneve-ut-1866
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18090,7 +19381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-1697
+Index: geneve-ut-1868
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -18109,7 +19400,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-1698
+Index: geneve-ut-1869
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -18149,7 +19440,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1699
+Index: geneve-ut-1870
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18166,7 +19457,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1701
+Index: geneve-ut-1872
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -18179,7 +19470,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1702
+Index: geneve-ut-1873
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -18193,7 +19484,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1703
+Index: geneve-ut-1874
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18221,7 +19512,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1704
+Index: geneve-ut-1875
 
 ```python
 process where event.type == "start" and
@@ -18246,7 +19537,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1705
+Index: geneve-ut-1876
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18256,11 +19547,27 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### XDG-Open Command Execution
+
+Branch count: 25  
+Document count: 25  
+Index: geneve-ut-1877
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2") and (
+  process.name == "xdg-open" or
+  process.args in ("/bin/xdg-open", "/usr/bin/xdg-open", "/usr/local/bin/xdg-open", "xdg-open")
+)
+```
+
+
+
 ### Yum Package Manager Plugin File Creation
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1706
+Index: geneve-ut-1878
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -18295,7 +19602,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1707
+Index: geneve-ut-1879
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18313,7 +19620,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1710
+Index: geneve-ut-1882
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.2.md
+++ b/tests/reports/alerts_from_rules-9.2.md
@@ -5,22 +5,22 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.2.14
+Rules version: 9.2.19
 
 ## Table of contents
-   1. [Failed rules (13)](#failed-rules-13)
-   1. [Unsuccessful rules with signals (13)](#unsuccessful-rules-with-signals-13)
+   1. [Failed rules (17)](#failed-rules-17)
+   1. [Unsuccessful rules with signals (17)](#unsuccessful-rules-with-signals-17)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
-   1. [Rules with too few signals (16)](#rules-with-too-few-signals-16)
-   1. [Rules with the correct signals (742)](#rules-with-the-correct-signals-742)
+   1. [Rules with too few signals (21)](#rules-with-too-few-signals-21)
+   1. [Rules with the correct signals (770)](#rules-with-the-correct-signals-770)
 
-## Failed rules (13)
+## Failed rules (17)
 
 ### Execution via GitHub Actions Runner
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0450  
+Index: geneve-ut-0531  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -89,7 +89,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0472  
+Index: geneve-ut-0553  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -118,7 +118,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0552  
+Index: geneve-ut-0647  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -145,11 +145,64 @@ not process.name in ("git", "dirname")
 
 
 
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0825  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Multi-Base64 Decoding Attempt from Suspicious Location
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0818  
+Index: geneve-ut-0947  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -182,7 +235,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-0930  
+Index: geneve-ut-1065  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -208,7 +261,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-0946  
+Index: geneve-ut-1082  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -246,7 +299,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1001  
+Index: geneve-ut-1141  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -268,7 +321,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1015  
+Index: geneve-ut-1156  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -307,7 +360,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1096  
+Index: geneve-ut-1239  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -370,7 +423,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1370  
+Index: geneve-ut-1535  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -414,11 +467,46 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1549  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Execution via Scheduled Task
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1403  
+Index: geneve-ut-1570  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -481,7 +569,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1408  
+Index: geneve-ut-1575  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -505,11 +593,82 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1584  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1630  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1503  
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1674  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -519,13 +678,16 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -555,7 +717,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -563,23 +724,28 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
 
-## Unsuccessful rules with signals (13)
+## Unsuccessful rules with signals (17)
 
 ### Execution via GitHub Actions Runner
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0450
+Index: geneve-ut-0531
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -645,7 +811,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0472
+Index: geneve-ut-0553
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -671,7 +837,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0552
+Index: geneve-ut-0647
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -695,11 +861,61 @@ not process.name in ("git", "dirname")
 
 
 
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0825
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Multi-Base64 Decoding Attempt from Suspicious Location
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0818
+Index: geneve-ut-0947
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -729,7 +945,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-0930
+Index: geneve-ut-1065
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -752,7 +968,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-0946
+Index: geneve-ut-1082
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -787,7 +1003,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1001
+Index: geneve-ut-1141
 
 ```python
 sequence by host.id with maxspan=1m
@@ -806,7 +1022,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1015
+Index: geneve-ut-1156
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -842,7 +1058,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1096
+Index: geneve-ut-1239
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -902,7 +1118,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1370
+Index: geneve-ut-1535
 
 ```python
 sequence by host.id with maxspan=5s
@@ -943,11 +1159,43 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1549
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Execution via Scheduled Task
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1403
+Index: geneve-ut-1570
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1007,7 +1255,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1408
+Index: geneve-ut-1575
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1028,24 +1276,92 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1584
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1630
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1503
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1674
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -1075,7 +1391,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -1083,12 +1398,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -1099,7 +1419,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0167
+Index: geneve-ut-0217
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1113,7 +1433,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0701
+Index: geneve-ut-0826
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1125,7 +1445,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0708
+Index: geneve-ut-0832
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1137,7 +1457,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1048
+Index: geneve-ut-1190
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1151,27 +1471,28 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 
 
-### Potential Privacy Control Bypass via TCCDB Modification
+### Protected Storage Service Access via SMB
 
-Branch count: 16  
-Document count: 16  
-Index: geneve-ut-1084
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1375
 
 ```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "sqlite*" and
- process.args like "/*/Application Support/com.apple.TCC/TCC.db" and
- (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+host.os.type:windows and event.category:file and event.code:5145 and
+  winlog.event_data.ShareName:"\\\\*\\IPC$" and
+  winlog.event_data.RelativeTargetName:"protected_storage" and
+  not source.ip:("::" or "::1" or "0.0.0.0" or "127.0.0.1")
 ```
 
 
 
-## Rules with too few signals (16)
+## Rules with too few signals (21)
 
 ### Execution via GitHub Actions Runner
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0450  
+Index: geneve-ut-0531  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -1239,7 +1560,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0472  
+Index: geneve-ut-0553  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -1267,7 +1588,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0552  
+Index: geneve-ut-0647  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -1293,11 +1614,82 @@ not process.name in ("git", "dirname")
 
 
 
+### Kubernetes Secrets List Across Cluster or Sensitive Namespaces
+
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0804  
+Failure message(s):  
+  got 3 signals, expected 6  
+
+```python
+event.dataset:"kubernetes.audit_logs" and event.action:list and 
+kubernetes.audit.objectRef.resource:secrets and 
+kubernetes.audit.requestURI :(/api/v1/secrets or /api/v1/secrets?limit* or /api/v1/namespaces/kube-system/secrets or /api/v1/namespaces/kube-system/secrets?limit* or /api/v1/namespaces/default/secrets or /api/v1/namespaces/default/secrets?limit*) and 
+source.ip:(* and not ("::1" or "127.0.0.1")) and 
+not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator) and 
+not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
+```
+
+
+
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0825  
+Failure message(s):  
+  got 1000 signals, expected 6552  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Microsoft IIS Service Account Password Dumped
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0799  
+Index: geneve-ut-0928  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -1317,7 +1709,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0818  
+Index: geneve-ut-0947  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -1349,7 +1741,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-0930  
+Index: geneve-ut-1065  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -1374,7 +1766,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-0946  
+Index: geneve-ut-1082  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -1411,7 +1803,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1001  
+Index: geneve-ut-1141  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -1432,7 +1824,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1015  
+Index: geneve-ut-1156  
 Failure message(s):  
   got 1000 signals, expected 1085  
 
@@ -1470,7 +1862,7 @@ process.command_line like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1088  
+Index: geneve-ut-1231  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -1487,7 +1879,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1096  
+Index: geneve-ut-1239  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -1549,7 +1941,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1188  
+Index: geneve-ut-1344  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -1574,7 +1966,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1370  
+Index: geneve-ut-1535  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -1617,11 +2009,45 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1549  
+Failure message(s):  
+  got 1000 signals, expected 5280  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Execution via Scheduled Task
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1403  
+Index: geneve-ut-1570  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -1683,7 +2109,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1408  
+Index: geneve-ut-1575  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -1706,26 +2132,98 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1584  
+Failure message(s):  
+  got 1000 signals, expected 2457  
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1630  
+Failure message(s):  
+  got 1000 signals, expected 8576  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1503  
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1674  
 Failure message(s):  
-  got 1000 signals, expected 1053  
+  got 1000 signals, expected 2442  
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -1755,7 +2253,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -1763,17 +2260,22 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
 
-## Rules with the correct signals (742)
+## Rules with the correct signals (770)
 
 ### A scheduled task was created
 
@@ -1796,7 +2298,15 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
               "\\Hewlett-Packard\\HP Web Products Detection",
               "\\Microsoft\\VisualStudio\\Updates\\BackgroundDownload",
               "\\OneDrive Standalone Update Task-S-1-5-21*",
-              "\\OneDrive Standalone Update Task-S-1-12-1-*"
+              "\\OneDrive Standalone Update Task-S-1-12-1-*",
+              "\\SoftLanding\\S-1-5-21-*\\SoftLanding*",
+              "\\SoftLanding\\S-1-12-*\\SoftLanding*",
+              "\\OneDrive Reporting Task-S-1-5-21-*",
+              "\\OneDrive Reporting Task-S-1-12-1-*",
+              "\\GoogleUserPEH\\RunPlatformExperienceHelper*",
+              "\\Mozilla\\Firefox Default Browser Agent*",
+              "\\Microsoft\\Office\\Office Background Push Maintenance",
+              "\\Microsoft\\Windows\\GroupPolicy\\GPUpdate"
  )
 ```
 
@@ -1858,7 +2368,7 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0022
+Index: geneve-ut-0040
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -1872,11 +2382,47 @@ process.command_line like~ (
 
 
 
+### AWS EC2 Instance Profile Associated with Running Instance
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-0057
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "ec2.amazonaws.com"
+    and event.action: ("AssociateIamInstanceProfile" or "ReplaceIamInstanceProfile")
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService" 
+    and not aws.cloudtrail.user_identity.invoked_by: "ssm.amazonaws.com"
+```
+
+
+
+### AWS IAM Customer Managed Policy Version Created or Default Version Set
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-0087
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "iam.amazonaws.com"
+    and event.action: ("CreatePolicyVersion" or "SetDefaultPolicyVersion")
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService" 
+    and not aws.cloudtrail.user_identity.arn:arn*/terraform 
+    and not source.as.organization.name:(Amazon* or AMAZON* or "Google LLC" or "MongoDB, Inc.")
+    and not source.address: ( "cloudformation.amazonaws.com" or "servicecatalog.amazonaws.com")
+```
+
+
+
 ### AWS IAM Login Profile Added to User
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0064
+Index: geneve-ut-0094
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
@@ -1885,11 +2431,59 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 
 
+### AWS IAM Sensitive Operations via Lambda Execution Role
+
+Branch count: 22  
+Document count: 22  
+Index: geneve-ut-0105
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "iam.amazonaws.com"
+    and event.outcome: "success"
+    and aws.cloudtrail.user_identity.type: "AssumedRole"
+    and (
+        aws.cloudtrail.user_identity.invoked_by: "lambda.amazonaws.com"
+        or user_agent.original : *AWS_Lambda*
+    )
+    and event.action: (
+        "AddRoleToInstanceProfile" or
+        "AddUserToGroup" or 
+        "AttachGroupPolicy" or 
+        "AttachRolePolicy" or
+        "AttachUserPolicy" or
+        "CreateAccessKey" or
+        "CreateInstanceProfile" or
+        "CreateRole" or
+        "CreateUser" or
+        "PutRolePolicy" or
+        "PutUserPolicy"
+    )
+```
+
+
+
+### AWS KMS Key Policy Updated via PutKeyPolicy
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0112
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "kms.amazonaws.com"
+    and event.action: "PutKeyPolicy"
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService"
+```
+
+
+
 ### AWS Lambda Function Created or Updated
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0077
+Index: geneve-ut-0114
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -1904,7 +2498,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0087
+Index: geneve-ut-0133
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
@@ -1913,11 +2507,27 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 
 
+### AWS STS GetFederationToken with AdministratorAccess in Request
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0168
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "sts.amazonaws.com"
+    and event.action: "GetFederationToken"
+    and event.outcome: "success"
+    and aws.cloudtrail.request_parameters: *AdministratorAccess*
+```
+
+
+
 ### AWS STS GetSessionToken Usage
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0120
+Index: geneve-ut-0169
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -1932,7 +2542,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0129
+Index: geneve-ut-0179
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -1947,7 +2557,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0138
+Index: geneve-ut-0188
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1971,7 +2581,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0139
+Index: geneve-ut-0189
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -2006,7 +2616,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0140
+Index: geneve-ut-0190
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -2023,7 +2633,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0141
+Index: geneve-ut-0191
 
 ```python
 any where host.os.type == "windows" and
@@ -2048,7 +2658,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0143
+Index: geneve-ut-0193
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -2076,7 +2686,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0145
+Index: geneve-ut-0195
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2089,7 +2699,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0147
+Index: geneve-ut-0197
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -2105,7 +2715,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0148
+Index: geneve-ut-0198
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2125,7 +2735,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0149
+Index: geneve-ut-0199
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2146,7 +2756,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0150
+Index: geneve-ut-0200
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -2158,7 +2768,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0153
+Index: geneve-ut-0203
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -2170,7 +2780,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0165
+Index: geneve-ut-0215
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -2187,7 +2797,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0166
+Index: geneve-ut-0216
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -2199,7 +2809,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0168
+Index: geneve-ut-0218
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -2219,7 +2829,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0169
+Index: geneve-ut-0219
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -2233,7 +2843,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0173
+Index: geneve-ut-0223
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -2264,7 +2874,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0174
+Index: geneve-ut-0224
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -2274,14 +2884,14 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 ### Attempt to Clear Kernel Ring Buffer
 
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-0175
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-0225
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
 event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
-process.name == "dmesg" and process.args in ("-c", "--clear")
+process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clear")
 ```
 
 
@@ -2290,7 +2900,7 @@ process.name == "dmesg" and process.args in ("-c", "--clear")
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0176
+Index: geneve-ut-0226
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2305,7 +2915,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0186
+Index: geneve-ut-0236
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -2324,7 +2934,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0187
+Index: geneve-ut-0237
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -2338,7 +2948,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0188
+Index: geneve-ut-0238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -2369,7 +2979,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0189
+Index: geneve-ut-0239
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2392,7 +3002,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0190
+Index: geneve-ut-0240
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -2406,7 +3016,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0191
+Index: geneve-ut-0241
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2421,11 +3031,25 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Attempt to Install Kali Linux via WSL
+### Attempt to Install Root Certificate
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0242
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and
+  process.name == "security" and process.args like "add-trusted-cert" and
+  (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
+### Attempt to Install or Run Kali Linux via WSL
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0192
+Index: geneve-ut-0243
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2446,25 +3070,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Attempt to Install Root Certificate
-
-Branch count: 16  
-Document count: 16  
-Index: geneve-ut-0193
-
-```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and
-  process.name == "security" and process.args like "add-trusted-cert" and
-  (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
-```
-
-
-
 ### Attempt to Mount SMB Share via Command Line
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0198
+Index: geneve-ut-0248
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -2483,7 +3093,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0201
+Index: geneve-ut-0251
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -2496,7 +3106,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0203
+Index: geneve-ut-0253
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2538,7 +3148,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0206
+Index: geneve-ut-0256
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -2553,7 +3163,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0231
+Index: geneve-ut-0286
 
 ```python
 event.dataset:azure.activitylogs and
@@ -2563,11 +3173,29 @@ event.dataset:azure.activitylogs and
 
 
 
+### Azure Run Command Script Child Process
+
+Branch count: 22  
+Document count: 22  
+Index: geneve-ut-0289
+
+```python
+process where event.type in ("start", "process_started") and
+  (
+    (process.parent.name == "powershell.exe" and
+      process.parent.command_line like "powershell  -ExecutionPolicy Unrestricted -File script?.ps1") or
+    (process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh", "busybox") and
+      process.parent.args like "/var/lib/waagent/run-command/download/*/script.sh")
+  )
+```
+
+
+
 ### BPF Program Tampering via bpftool
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0244
+Index: geneve-ut-0307
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2585,7 +3213,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0245
+Index: geneve-ut-0308
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2603,7 +3231,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0246
+Index: geneve-ut-0309
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2618,7 +3246,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0247
+Index: geneve-ut-0310
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2632,7 +3260,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0248
+Index: geneve-ut-0311
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2647,7 +3275,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0250
+Index: geneve-ut-0313
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -2664,7 +3292,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0251
+Index: geneve-ut-0314
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -2676,7 +3304,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0252
+Index: geneve-ut-0315
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -2688,7 +3316,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0253
+Index: geneve-ut-0316
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2703,7 +3331,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0254
+Index: geneve-ut-0317
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -2723,7 +3351,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0255
+Index: geneve-ut-0318
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2745,7 +3373,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0257
+Index: geneve-ut-0320
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -2791,24 +3419,24 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0258
+Index: geneve-ut-0321
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.name : ("chrome.exe", "msedge.exe") and
-  process.parent.executable != null and process.command_line != null and
+  process.parent.executable != null and
   (
-  process.command_line :
-           ("\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\"",
+    process.command_line : (
+            "\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\"",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\"",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --disable-logging --log-level=3 --v=0",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --log-level=3",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --remote-debugging-port=922? --profile-directory=\"Default\"*",
-            "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --restore-last-session --remote-debugging-port=45452*") or
-
-  (process.args : "--remote-debugging-port=922?" and process.args : "--window-position=-*,-*")
-   ) and
+            "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --restore-last-session --remote-debugging-port=45452*"
+    ) or
+    (process.args : "--remote-debugging-port=922?" and process.args : "--window-position=-*,-*")
+  ) and
   not process.parent.executable :
                          ("C:\\Windows\\explorer.exe",
                           "C:\\Program Files (x86)\\*.exe",
@@ -2825,7 +3453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0259
+Index: geneve-ut-0322
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2848,7 +3476,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0260
+Index: geneve-ut-0323
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -2866,11 +3494,26 @@ process.executable != null and
 
 
 
+### Chroot Execution in Container Context on Linux
+
+Branch count: 40  
+Document count: 40  
+Index: geneve-ut-0324
+
+```python
+host.os.type:linux and event.category:process and 
+event.type:start and event.action:(executed or exec) and 
+(process.name:"chroot" or process.args:("chroot" or "/bin/chroot" or "/usr/bin/chroot" or "/usr/local/bin/chroot")) and 
+(process.title:"runc init" or process.entry_leader.entry_meta.type:"container" or process.parent.name:("runc" or "containerd-shim-runc-v2"))
+```
+
+
+
 ### Clearing Windows Event Logs
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0262
+Index: geneve-ut-0326
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2891,11 +3534,41 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Cloud Instance Metadata Credential Path HTTP Request
+
+Branch count: 219  
+Document count: 219  
+Index: geneve-ut-0327
+
+```python
+network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
+http.request.method == "GET" and url.path : (
+  "/latest/meta-data/iam/security-credentials/*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*metadata/identity/oauth2/token*"
+) and (
+  ?process.name : (
+    "curl", "wget", "python*", "node", "bun", "php*", "ruby", "perl", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox",
+    "bun.exe", "node.exe", "powershell.exe", "cmd.exe", "curl.exe", "wget.exe", "rundll32.exe", "w3wp.exe", "java*", 
+    "go", "nc", "netcat", "nginx", "apache*", "httpd", "tomcat*", "catalina", "spring*", "dotnet", "gunicorn", "uwsgi", 
+    ".*", "osascript"
+  ) or ?process.executable : (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*", "?:\\ProgramData\\*"
+  ) or user_agent.original : (
+    "curl*", "wget*", "python*", "ruby*", "Go-http-client*", "node*", "axios*", "undici*", "java*", "php*", "Bun*",
+    "Apache-HttpClient*", "okhttp*", "RestTemplate*", "*WindowsPowerShell*", "*roadtools*", "*fasthttp*", "*azurehound*", "*bloodhound*", "*aiohttp*"
+  )
+)
+```
+
+
+
 ### Code Signing Policy Modification Through Built-in tools
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0264
+Index: geneve-ut-0329
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2909,7 +3582,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0265
+Index: geneve-ut-0330
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -2931,7 +3604,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0266
+Index: geneve-ut-0331
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -2945,7 +3618,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0267
+Index: geneve-ut-0332
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -2965,7 +3638,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0270
+Index: geneve-ut-0335
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2982,7 +3655,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-0272
+Index: geneve-ut-0337
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3066,7 +3739,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0273
+Index: geneve-ut-0338
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -3096,7 +3769,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0276
+Index: geneve-ut-0341
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -3121,7 +3794,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0278
+Index: geneve-ut-0343
 
 ```python
 sequence by process.entity_id
@@ -3142,7 +3815,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0279
+Index: geneve-ut-0344
 
 ```python
 sequence by process.entity_id
@@ -3159,11 +3832,42 @@ sequence by process.entity_id
 
 
 
+### Container Runtime CLI Execution with Suspicious Arguments
+
+Branch count: 28  
+Document count: 28  
+Index: geneve-ut-0346
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
+(
+  (
+    process.name in ("ctr", "crictl", "nerdctl") and
+    (
+      (process.args == "tasks" and process.args == "exec") or
+      (process.args == "run" and process.args in ("--privileged", "--rm", "--mount", "--net-host", "--pid-host")) or
+      (process.args == "snapshots" and process.args == "mount")
+    )
+  ) or
+  (
+    (process.executable like ("/dev/shm/*", "/tmp/*", "/var/tmp/*") or process.name : ".*") and
+    process.args like ("*containerd.sock*", "k8s.io")
+  )
+) and
+not process.parent.executable in (
+  "/usr/bin/kubelet", "/usr/local/bin/kubelet",
+  "/usr/bin/containerd", "/usr/sbin/containerd",
+  "/lib/systemd/systemd", "/usr/lib/systemd/systemd", "/sbin/init"
+)
+```
+
+
+
 ### Control Panel Process with Unusual Arguments
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0281
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3186,7 +3890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0284
+Index: geneve-ut-0350
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -3199,7 +3903,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0285
+Index: geneve-ut-0351
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3212,7 +3916,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0287
+Index: geneve-ut-0353
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -3229,7 +3933,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0288
+Index: geneve-ut-0354
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -3240,12 +3944,12 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 ### Creation of a Hidden Local User Account
 
-Branch count: 3  
-Document count: 3  
-Index: geneve-ut-0289
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0355
 
 ```python
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type in ("change", "creation") and
   registry.path : (
     "HKLM\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
     "\\REGISTRY\\MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
@@ -3259,7 +3963,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0290
+Index: geneve-ut-0356
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -3271,7 +3975,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0291
+Index: geneve-ut-0357
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -3339,7 +4043,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0292
+Index: geneve-ut-0358
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -3357,7 +4061,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0293
+Index: geneve-ut-0359
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -3368,15 +4072,18 @@ process.args == "--json" and process.args == "filesystem"
 
 ### Credential Acquisition via Registry Hive Dumping
 
-Branch count: 8  
-Document count: 8  
-Index: geneve-ut-0294
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  (?process.pe.original_file_name == "reg.exe" or process.name : "reg.exe") and
  process.args : ("save", "export") and
- process.args : ("hklm\\sam", "hklm\\security")
+ process.args : (
+   "hklm\\sam", "hklm\\security", "hklm\\system",
+   "hkey_local_machine\\sam", "hkey_local_machine\\security", "hkey_local_machine\\system"
+ )
 ```
 
 
@@ -3385,7 +4092,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0295
+Index: geneve-ut-0361
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -3397,7 +4104,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0296
+Index: geneve-ut-0362
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -3409,7 +4116,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0297
+Index: geneve-ut-0363
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -3421,7 +4128,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0298
+Index: geneve-ut-0364
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -3433,7 +4140,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0299
+Index: geneve-ut-0365
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -3478,7 +4185,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0301
+Index: geneve-ut-0367
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3498,7 +4205,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0302
+Index: geneve-ut-0368
 
 ```python
 sequence with maxspan=10s
@@ -3518,7 +4225,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0303
+Index: geneve-ut-0369
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -3545,7 +4252,7 @@ process.name == "curl" and (
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0305
+Index: geneve-ut-0372
 
 ```python
 process where event.type == "start" and
@@ -3570,7 +4277,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0308
+Index: geneve-ut-0375
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -3614,7 +4321,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0309
+Index: geneve-ut-0376
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3648,7 +4355,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0310
+Index: geneve-ut-0377
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -3660,11 +4367,36 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 
 
+### DNS Request for IP Lookup Service via Unsigned Binary
+
+Branch count: 86  
+Document count: 86  
+Index: geneve-ut-0378
+
+```python
+network where host.os.type == "macos" and event.action == "lookup_result" and 
+  (process.code_signature.trusted == false or process.code_signature.exists == false) and
+  dns.question.name like~ ("*ip-api.com*", "*ipwho.is*", "*checkip.dyndns.org*", "*api.ipify.org*",
+                           "*api.npoint.io*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+                           "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*",
+                           "*ipwhois.app*", "*freeipapi.com*", "*icanhazip.com*", "*curlmyip.com*",
+                           "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*",
+                           "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*", "*api.ip.sb*",
+                           "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*",
+                           "*freegeoip.net*", "*freegeoip.app*", "*myip.ipip.net*", "*geoplugin.net*",
+                           "*myip.dnsomatic.com*", "*www.geoplugin.net*", "*api64.ipify.org*",
+                           "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+                           "*geolocation-db.com*", "*inet-ip.info*", "*httpbin.org*", "*myip.opendns.com*") and
+  not process.executable like "/Users/*/Library/Developer/CoreSimulator/*"
+```
+
+
+
 ### DNS-over-HTTPS Enabled via Registry
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0313
+Index: geneve-ut-0380
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3682,7 +4414,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0315
+Index: geneve-ut-0382
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -3695,7 +4427,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0320
+Index: geneve-ut-0387
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3709,7 +4441,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0321
+Index: geneve-ut-0388
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -3726,23 +4458,11 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
-### Deprecated - EggShell Backdoor Execution
-
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0322
-
-```python
-event.category:process and event.type:(process_started or start) and process.name:espl and process.args:eyJkZWJ1ZyI6*
-```
-
-
-
 ### Deprecated - Encoded Executable Stored in the Registry
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0323
+Index: geneve-ut-0389
 
 ```python
 registry where host.os.type == "windows" and
@@ -3756,7 +4476,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0331
+Index: geneve-ut-0398
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -3780,7 +4500,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0340
+Index: geneve-ut-0407
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3796,7 +4516,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0341
+Index: geneve-ut-0408
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3824,7 +4544,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0342
+Index: geneve-ut-0409
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3841,7 +4561,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0343
+Index: geneve-ut-0410
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3858,7 +4578,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0344
+Index: geneve-ut-0411
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3879,7 +4599,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0346
+Index: geneve-ut-0413
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -3899,7 +4619,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0347
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -3914,7 +4634,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0349
+Index: geneve-ut-0416
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -3927,7 +4647,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0350
+Index: geneve-ut-0417
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3947,7 +4667,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0353
+Index: geneve-ut-0420
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -3960,7 +4680,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0354
+Index: geneve-ut-0421
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -3996,13 +4716,20 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 ### Dumping Account Hashes via Built-In Commands
 
-Branch count: 8  
-Document count: 8  
-Index: geneve-ut-0355
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0422
 
 ```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and
- process.name in ("defaults", "mkpassdb") and process.args like~ ("ShadowHashData", "-dump")
+process where host.os.type == "macos" and event.type in ("start","process_started") and (
+  (process.name == "defaults" and process.args like~ "ShadowHashData") or
+  (process.name == "mkpassdb" and process.args == "-dump") or
+  (process.name == "dscl" and process.args like~ "ShadowHashData") or
+  (
+    process.name in ("plutil","cat","strings","xxd","head") and
+    process.args like "/var/db/dslocal/nodes/Default/users/*.plist"
+  )
+)
 ```
 
 
@@ -4011,7 +4738,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0356
+Index: geneve-ut-0423
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -4024,7 +4751,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0357
+Index: geneve-ut-0424
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4047,7 +4774,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0359
+Index: geneve-ut-0426
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4078,7 +4805,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0360
+Index: geneve-ut-0427
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -4097,7 +4824,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0361
+Index: geneve-ut-0428
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -4140,7 +4867,7 @@ not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0362
+Index: geneve-ut-0430
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4155,7 +4882,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0363
+Index: geneve-ut-0431
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4171,7 +4898,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0364
+Index: geneve-ut-0432
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4185,7 +4912,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0365
+Index: geneve-ut-0433
 
 ```python
 sequence by host.id with maxspan=3s
@@ -4211,7 +4938,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0366
+Index: geneve-ut-0434
 
 ```python
 process where event.type == "start" and
@@ -4249,7 +4976,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0371
+Index: geneve-ut-0439
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -4262,7 +4989,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0372
+Index: geneve-ut-0440
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4276,7 +5003,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0373
+Index: geneve-ut-0441
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4311,7 +5038,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0374
+Index: geneve-ut-0442
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -4323,7 +5050,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0406
+Index: geneve-ut-0485
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -4335,7 +5062,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0428
+Index: geneve-ut-0509
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4349,7 +5076,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0431
+Index: geneve-ut-0512
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4376,7 +5103,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0434
+Index: geneve-ut-0515
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4397,7 +5124,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0437
+Index: geneve-ut-0518
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -4430,7 +5157,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0439
+Index: geneve-ut-0520
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -4447,7 +5174,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0440
+Index: geneve-ut-0521
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -4475,7 +5202,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0441
+Index: geneve-ut-0522
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -4488,7 +5215,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0443
+Index: geneve-ut-0524
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -4508,7 +5235,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0444
+Index: geneve-ut-0525
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4534,19 +5261,15 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0445
+Index: geneve-ut-0526
 
 ```python
 sequence with maxspan=2h
   [file where host.os.type == "windows" and event.type != "deletion" and file.extension : "exe" and
-     (process.name : "WINWORD.EXE" or
-      process.name : "EXCEL.EXE" or
-      process.name : "OUTLOOK.EXE" or
-      process.name : "POWERPNT.EXE" or
-      process.name : "eqnedt32.exe" or
-      process.name : "fltldr.exe" or
-      process.name : "MSPUB.EXE" or
-      process.name : "MSACCESS.EXE")
+    process.name : (
+      "WINWORD.EXE", "EXCEL.EXE", "OUTLOOK.EXE", "POWERPNT.EXE",
+      "eqnedt32.exe", "fltldr.exe", "MSPUB.EXE", "MSACCESS.EXE"
+    )
   ] by host.id, file.path
   [process where host.os.type == "windows" and event.type == "start" and 
    not (process.name : "NewOutlookInstaller.exe" and process.code_signature.subject_name : "Microsoft Corporation" and process.code_signature.trusted == true) and 
@@ -4560,7 +5283,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0446
+Index: geneve-ut-0527
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -4589,7 +5312,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0449
+Index: geneve-ut-0530
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -4602,7 +5325,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0453
+Index: geneve-ut-0534
 
 ```python
 sequence by user.id with maxspan=5s
@@ -4617,7 +5340,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0454
+Index: geneve-ut-0535
 
 ```python
 process where event.type == "start" and
@@ -4639,7 +5362,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0455
+Index: geneve-ut-0536
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -4651,7 +5374,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0456
+Index: geneve-ut-0537
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4673,7 +5396,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0458
+Index: geneve-ut-0539
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -4690,7 +5413,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0459
+Index: geneve-ut-0540
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4704,7 +5427,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0460
+Index: geneve-ut-0541
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -4717,7 +5440,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0461
+Index: geneve-ut-0542
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -4729,7 +5452,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0462
+Index: geneve-ut-0543
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -4741,7 +5464,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0463
+Index: geneve-ut-0544
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4755,7 +5478,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0464
+Index: geneve-ut-0545
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -4767,7 +5490,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 304  
 Document count: 304  
-Index: geneve-ut-0465
+Index: geneve-ut-0546
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -4789,7 +5512,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0468
+Index: geneve-ut-0549
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -4838,7 +5561,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0469
+Index: geneve-ut-0550
 
 ```python
 sequence by host.id with maxspan=10s
@@ -4858,7 +5581,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0475
+Index: geneve-ut-0556
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4873,7 +5596,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0476
+Index: geneve-ut-0557
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4887,7 +5610,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0478
+Index: geneve-ut-0559
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4909,7 +5632,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0479
+Index: geneve-ut-0560
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -4930,7 +5653,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0480
+Index: geneve-ut-0561
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4956,7 +5679,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0481
+Index: geneve-ut-0562
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -4980,11 +5703,25 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Finder Sync Plugin Registered and Enabled
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0565
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
+  process.args == "-e" and process.args like~ "use" and process.args == "-i" and
+  (process.parent.name like~ ("python*", "node", "osascript", "bash", "sh", "zsh") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
 ### Full Disk Access Permission Check
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0518
+Index: geneve-ut-0599
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -5001,7 +5738,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0519
+Index: geneve-ut-0600
 
 ```python
 registry where host.os.type == "windows" and
@@ -5019,7 +5756,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0543
+Index: geneve-ut-0637
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -5058,7 +5795,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0544
+Index: geneve-ut-0638
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5085,7 +5822,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0545
+Index: geneve-ut-0639
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -5096,11 +5833,98 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 
 
+### GenAI CLI Started with Unsafe Permission Bypass
+
+Branch count: 267  
+Document count: 267  
+Index: geneve-ut-0640
+
+```python
+process where event.type == "start" and event.action in ("exec", "start") and
+(
+  (
+    process.args in (
+      "--dangerously-skip-permissions",
+      "--allow-dangerously-skip-permissions",
+      "--permission-mode=bypassPermissions"
+    ) or
+    (process.args == "--permission-mode" and process.args == "bypassPermissions")
+  ) and
+  (
+    process.name in ("claude", "claude.exe") or
+    process.executable : (
+      "*/.local/share/claude/versions/*",
+      "*/.claude/downloads/*",
+      "*Caskroom/claude-code/*",
+      "*\\Claude\\versions\\*"
+    ) or
+    (process.name in ("node", "node.exe") and process.args : "*@anthropic-ai/claude-code*")
+  )
+) or
+(
+  (
+    process.args in ("--dangerously-bypass-approvals-and-sandbox", "--full-auto", "--yolo") or
+    process.command_line : (
+      "* -s danger-full-access*",
+      "*--sandbox danger-full-access*",
+      "*--sandbox=danger-full-access*",
+      "*--ask-for-approval never*",
+      "*--ask-for-approval=never*"
+    )
+  ) and
+  (
+    process.name in (
+      "codex", "codex.exe", "codex-exec",
+      "codex-aarch64-apple-darwin", "codex-x86_64-apple-darwin",
+      "codex-linux-arm64", "codex-linux-x64"
+    ) or
+    (process.name in ("node", "node.exe") and process.args : ("*@openai/codex*", "*/codex", "*\\codex*"))
+  )
+) or
+(
+  (
+    process.args in ("--yolo", "-y") or
+    (process.args == "--approval-mode" and process.args == "yolo") or
+    process.args == "--approval-mode=yolo"
+  ) and
+  (
+    process.name in ("gemini", "gemini-cli", "gemini.exe", "gemini-cli.exe") or
+    (process.name in ("node", "node.exe") and process.args : ("*@google/gemini-cli*", "*/gemini", "*\\gemini*"))
+  )
+) or
+(
+  (
+    process.args in (
+      "--yolo",
+      "--autopilot",
+      "--allow-all",
+      "--allow-all-tools",
+      "--allow-all-paths",
+      "--allow-all-urls"
+    )
+  ) and
+  (
+    process.name in ("copilot", "copilot.exe") or
+    (process.name in ("node", "node.exe") and process.args : ("*@github/copilot*", "*/copilot", "*\\copilot*"))
+  )
+) or
+(
+  process.args == "--dangerously-skip-permissions" and
+  (
+    process.name in ("opencode", "opencode.exe", ".opencode") or
+    process.executable : ("*opencode-ai*", "*\\.opencode*") or
+    (process.name in ("node", "node.exe") and process.args : ("*opencode-ai*", "*/opencode", "*\\opencode*"))
+  )
+)
+```
+
+
+
 ### Git Hook Command Execution
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0553
+Index: geneve-ut-0648
 
 ```python
 sequence by host.id with maxspan=3s
@@ -5118,7 +5942,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0554
+Index: geneve-ut-0649
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -5149,7 +5973,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0555
+Index: geneve-ut-0650
 
 ```python
 sequence by host.id with maxspan=3s
@@ -5176,7 +6000,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0556
+Index: geneve-ut-0651
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -5196,7 +6020,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0560
+Index: geneve-ut-0655
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -5209,7 +6033,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0563
+Index: geneve-ut-0658
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -5221,7 +6045,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0566
+Index: geneve-ut-0661
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -5233,7 +6057,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0570
+Index: geneve-ut-0665
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -5245,7 +6069,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0572
+Index: geneve-ut-0667
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -5262,7 +6086,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0591
+Index: geneve-ut-0691
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5275,7 +6099,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0593
+Index: geneve-ut-0693
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -5299,7 +6123,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0594
+Index: geneve-ut-0694
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -5311,7 +6135,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0607
+Index: geneve-ut-0707
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -5320,9 +6144,7 @@ sequence by process.entity_id with maxspan=5m
   /* Plan9FileSystem CLSID - WSL Host File System Worker */
  process.command_line : "*{DFB65C4C-B34F-435D-AFE9-A86218684AA8}*"]
 [file where host.os.type == "windows" and process.name : "dllhost.exe" and
-  not file.path : (
-        "?:\\Users\\*\\Downloads\\*",
-        "?:\\Windows\\Prefetch\\DLLHOST.exe-????????.pf")]
+  not file.path : "?:\\Windows\\Prefetch\\DLLHOST.exe-????????.pf"]
 ```
 
 
@@ -5331,7 +6153,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0608
+Index: geneve-ut-0708
 
 ```python
 any where process.executable != null and
@@ -5380,7 +6202,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0609
+Index: geneve-ut-0709
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5394,7 +6216,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0611
+Index: geneve-ut-0713
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5409,7 +6231,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0616
+Index: geneve-ut-0718
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5426,7 +6248,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0618
+Index: geneve-ut-0720
 
 ```python
 sequence with maxspan=1m
@@ -5445,12 +6267,12 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0619
+Index: geneve-ut-0721
 
 ```python
 sequence by host.id with maxspan=1m
  [network where host.os.type == "windows" and event.type == "start" and process.name : "mmc.exe" and source.port >= 49152 and
- destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
+  destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
   network.direction : ("incoming", "ingress") and network.transport == "tcp"
  ] by process.entity_id
  [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "mmc.exe"
@@ -5463,7 +6285,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0620
+Index: geneve-ut-0722
 
 ```python
 sequence by host.id with maxspan=5s
@@ -5482,7 +6304,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0621
+Index: geneve-ut-0723
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -5498,7 +6320,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0622
+Index: geneve-ut-0724
 
 ```python
 sequence by host.id with maxspan=30s
@@ -5514,7 +6336,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0623
+Index: geneve-ut-0725
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5527,7 +6349,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0627
+Index: geneve-ut-0729
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5544,7 +6366,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0629
+Index: geneve-ut-0731
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5557,7 +6379,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0630
+Index: geneve-ut-0732
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -5573,7 +6395,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0631
+Index: geneve-ut-0733
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5600,7 +6422,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0632
+Index: geneve-ut-0734
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5624,7 +6446,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0636
+Index: geneve-ut-0738
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -5648,7 +6470,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0637
+Index: geneve-ut-0740
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5684,7 +6506,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0638
+Index: geneve-ut-0741
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -5696,7 +6518,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0639
+Index: geneve-ut-0742
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5710,7 +6532,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0640
+Index: geneve-ut-0743
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -5723,7 +6545,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0641
+Index: geneve-ut-0744
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -5782,7 +6604,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0642
+Index: geneve-ut-0745
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -5795,7 +6617,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0643
+Index: geneve-ut-0746
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -5808,7 +6630,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0644
+Index: geneve-ut-0747
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5829,7 +6651,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0645
+Index: geneve-ut-0748
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5847,7 +6669,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0646
+Index: geneve-ut-0749
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5881,7 +6703,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0647
+Index: geneve-ut-0750
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5899,7 +6721,15 @@ not (
     "/usr/bin/kcarectl", "/usr/share/ksplice/ksplice-apply", "/opt/commvault/Base/linux_drv", "/usr/sbin/veeamsnap-loader",
     "/bin/falcoctl"
   ) or
-  (?process.parent.name like ("python*", "platform-python*") and ?process.parent.args in ("--smart-update", "--auto-update"))
+  (?process.parent.name like ("python*", "platform-python*") and ?process.parent.args in ("--smart-update", "--auto-update")) or
+  (
+    process.name == "modprobe" and process.args == "-q" and process.args == "--" and process.args in ("net-pf-10", "netdev-", "binfmt-464c")
+  ) or
+  (
+    process.name == "modprobe" and process.args == "-n" and process.args == "-v" and process.args in ("usb-storage", "dccp", "squashfs", "udf", "sctp", "cramfs", "hfsplus")
+  ) or
+  ?process.parent.executable like ("/sbin/iptables-multi*", "/var/ossec/bin/wazuh-modulesd", "/usr/sbin/mkinitramfs", "/usr/share/initramfs-tools/hooks/lvm2") or
+  ?process.parent.args like "/usr/share/initramfs-tools/hooks/*"
 )
 ```
 
@@ -5909,7 +6739,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0648
+Index: geneve-ut-0751
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5931,7 +6761,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0650
+Index: geneve-ut-0753
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5958,7 +6788,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0651
+Index: geneve-ut-0754
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5984,7 +6814,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0652
+Index: geneve-ut-0755
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -6000,7 +6830,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0653
+Index: geneve-ut-0756
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -6016,7 +6846,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0655
+Index: geneve-ut-0758
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -6028,7 +6858,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0656
+Index: geneve-ut-0759
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -6056,7 +6886,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0658
+Index: geneve-ut-0761
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6072,7 +6902,7 @@ not process.command_line like ("*download.elastic.co*", "*github.com/kubernetes-
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0660
+Index: geneve-ut-0763
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6095,7 +6925,7 @@ process.name == "kubectl" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0661
+Index: geneve-ut-0764
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6109,7 +6939,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0662
+Index: geneve-ut-0765
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6128,11 +6958,92 @@ process.name == "kubectl" and (
 
 
 
+### Kubelet API Connection Attempt to Internal IP
+
+Branch count: 204  
+Document count: 204  
+Index: geneve-ut-0766
+
+```python
+network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
+  event.action in ("connected-to", "connection_attempted") and (destination.port == 10250 or destination.port == 10255) and
+  cidrmatch(
+    destination.ip,
+    "127.0.0.0/8",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "169.254.0.0/16",
+    "100.64.0.0/10",
+    "::1/128",
+    "fc00::/7",
+    "fe80::/10"
+  ) and
+  (
+    process.name in ("curl", "wget", "nc", "ncat", "netcat", "socat", "openssl", "perl", "busybox") or 
+    process.name like ".*" or process.executable like "/*/.*" or 
+    process.name like ("python*", "ruby*", "node*", "java*", "lua*", "apache*", "php*", "nginx", "httpd*", "lighttpd", "caddy", "mongrel_rails", "gunicorn", 
+                       "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn", 
+                       "daphne", "twistd", "yaws", "webfsd", "flask", "rails", "mongrel", "catalina.sh", "hiawatha", "lswsctrl") or
+    process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/var/run/*", "/home/*", "/run/user/*", "/busybox/*")
+  )
+```
+
+
+
+### Kubernetes API Server Proxying Request to Kubelet
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0768
+
+```python
+kubernetes.audit.objectRef.subresource:"proxy" and
+kubernetes.audit.objectRef.resource:"nodes" and
+not kubernetes.audit.requestURI:(*metrics* or *healthz* or *stats/summary* or *elastic-agent* or *configz*) and
+not user.name:(
+  system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:serviceaccount\:kube-system\:* or
+  system\:node\:* or
+  eks\:* or aksService
+)
+```
+
+
+
+### Kubernetes Admission Webhook Created or Modified
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0769
+
+```python
+kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
+kubernetes.audit.verb:("create" or "update" or "patch" or "delete") and
+kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" and 
+user.name:(* and not 
+  (system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:serviceaccount\:kube-system\:* or
+  eks\:* or aksService or masterclient or nodeclient or
+  system\:serviceaccount\:gke-managed-system\:* or
+  system\:serviceaccount\:cert-manager\:* or
+  system\:serviceaccount\:gatekeeper-system\:* or
+  system\:serviceaccount\:kyverno\:* or
+  system\:serviceaccount\:*\:*-operator)
+) and
+kubernetes.audit.objectRef.name:(* and not (pod-identity-webhook or vpc-resource-mutating-webhook or eks-* or gke-*)) and 
+not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kubernetes.audit.objectRef.name:"k8tz")
+```
+
+
+
 ### Kubernetes Direct API Request via Curl or Wget
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-0670
+Index: geneve-ut-0779
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6154,7 +7065,7 @@ process.name in ("curl", "wget") and process.args like~ (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0684
+Index: geneve-ut-0805
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -6173,7 +7084,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0687
+Index: geneve-ut-0808
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6213,11 +7124,36 @@ not (
 
 
 
+### Kubernetes Static Pod Manifest File Access
+
+Branch count: 116  
+Document count: 116  
+Index: geneve-ut-0810
+
+```python
+host.os.type:linux and event.category:process and event.action:(exec or executed) and 
+process.name:(
+  bash or sh or dash or zsh or 
+  cat or cp or mv or touch or tee or dd or
+  sed or awk or 
+  curl or wget or scp or
+  vi or vim or nano or echo or
+  busybox or
+  python* or perl* or ruby* or node or lua* or
+  openssl or base64 or xxd or
+  .*) and 
+  process.args:(*/etc/kubernetes/manifests/* and not (/etc/kubernetes/manifests/etcd* or /etc/kubernetes/manifests/kube-apiserver* or /etc/kubernetes/manifests/kube-scheduler* or /etc/kubernetes/manifests/kube-controller-manager*)) and 
+  not (process.args :printf* and process.working_directory :/home/*-svc-nessus) and 
+  not process.parent.executable :("/opt/nessus/sbin/nessusd" or "/opt/nessus_agent/sbin/nessus-agent-module")
+```
+
+
+
 ### LSASS Memory Dump Creation
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0692
+Index: geneve-ut-0816
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6255,7 +7191,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0697
+Index: geneve-ut-0821
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6273,7 +7209,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0698
+Index: geneve-ut-0822
 
 ```python
 sequence by host.id with maxspan=30s
@@ -6287,7 +7223,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0702
+Index: geneve-ut-0827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -6298,72 +7234,11 @@ process.args != "1"
 
 
 
-### Linux Restricted Shell Breakout via Linux Binary(s)
-
-Branch count: 303  
-Document count: 303  
-Index: geneve-ut-0703
-
-```python
-process where host.os.type == "linux" and event.type == "start" and process.executable != null and
-(
-  /* launching shell from capsh */
-  (process.name == "capsh" and process.args == "--" and not process.parent.executable == "/usr/bin/log4j-cve-2021-44228-hotpatch") or
-
-  /* launching shells from unusual parents or parent+arg combos */
-  (process.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
-    (process.parent.name : "*awk" and process.parent.args : "BEGIN {system(*)}") or
-    (process.parent.name == "git" and process.parent.args : ("!*sh", "exec *sh") and not process.name == "ssh" ) or
-    (process.parent.name : ("byebug", "ftp", "strace", "zip", "tar") and
-    (
-      process.parent.args : "BEGIN {system(*)}" or
-      (
-        (process.parent.args : "exec=*sh" or (process.parent.args : "-I" and process.parent.args : "*sh")) or
-        (process.args : "exec=*sh" or (process.args : "-I" and process.args : "*sh"))
-        )
-      )
-    ) or
-
-    /* shells specified in parent args */
-    /* nice rule is broken in 8.2 */
-    (process.parent.args : "*sh" and
-      (
-        (process.parent.name == "nice") or
-        (process.parent.name == "cpulimit" and process.parent.args == "-f") or
-        (process.parent.name == "find" and process.parent.args == "." and process.parent.args == "-exec" and
-         process.parent.args == ";" and process.parent.args : "/bin/*sh") or
-        (process.parent.name == "flock" and process.parent.args == "-u" and process.parent.args == "/")
-      )
-    )
-  )) or
-
-  /* shells specified in args */
-  (process.args : "*sh" and (
-    (process.parent.name == "crash" and process.parent.args == "-h") or
-    (process.name == "sensible-pager" and process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog")
-    /* scope to include more sensible-pager invoked shells with different parent process to reduce noise and remove false positives */
-
-  )) or
-  (process.name == "busybox" and event.action == "exec" and process.args_count == 2 and process.args : "*sh" and not
-   process.executable : "/var/lib/docker/overlay2/*/merged/bin/busybox" and not (process.parent.args == "init" and
-   process.parent.args == "runc") and not process.parent.args in ("ls-remote", "push", "fetch") and not process.parent.name == "mkinitramfs" and
-   not process.parent.executable == "/bin/busybox") or
-  (process.name == "env" and process.args_count == 2 and process.args : "*sh") or
-  (process.parent.name in ("vi", "vim") and process.parent.args == "-c" and process.parent.args : ":!*sh") or
-  (process.parent.name in ("c89", "c99", "gcc") and process.parent.args : "*sh,-s" and process.parent.args == "-wrapper") or
-  (process.parent.name == "expect" and process.parent.args == "-c" and process.parent.args : "spawn *sh;interact") or
-  (process.parent.name == "mysql" and process.parent.args == "-e" and process.parent.args : "\\!*sh") or
-  (process.parent.name == "ssh" and process.parent.args == "-o" and process.parent.args : "ProxyCommand=;*sh 0<&2 1>&2")
-)
-```
-
-
-
 ### Linux SSH X11 Forwarding
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0704
+Index: geneve-ut-0828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6377,7 +7252,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0707
+Index: geneve-ut-0831
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6391,7 +7266,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0709
+Index: geneve-ut-0833
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6410,9 +7285,9 @@ not (
 
 ### Linux User Added to Privileged Group
 
-Branch count: 360  
-Document count: 360  
-Index: geneve-ut-0710
+Branch count: 720  
+Document count: 720  
+Index: geneve-ut-0834
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6423,6 +7298,16 @@ process.executable != null and process.args in (
 (
   process.name in ("usermod", "adduser") or
   (process.name == "gpasswd" and process.args in ("-a", "--add", "-M", "--members"))
+) and
+not (
+  ?process.parent.executable like (
+    "/usr/lib/google/guest_agent/core_plugin", "/usr/libexec/platform-python*", "/usr/lib/google/guest_agent/GuestAgentCorePlugin/core_plugin",
+    "/usr/bin/google_guest_agent"
+  ) or
+  (
+    ?process.entry_leader.executable == "/usr/lib/venv-salt-minion/bin/python.original" and
+    ?process.entry_leader.args == "/usr/lib/venv-salt-minion/bin/salt-minion"
+  )
 )
 ```
 
@@ -6432,7 +7317,7 @@ process.executable != null and process.args in (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0714
+Index: geneve-ut-0838
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -6479,7 +7364,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0715
+Index: geneve-ut-0839
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6510,7 +7395,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 600  
 Document count: 1200  
-Index: geneve-ut-0716
+Index: geneve-ut-0840
 
 ```python
 sequence with maxspan=1m
@@ -6535,7 +7420,7 @@ sequence with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0718
+Index: geneve-ut-0842
 
 ```python
 event.dataset:o365.audit and
@@ -6548,7 +7433,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0720
+Index: geneve-ut-0844
 
 ```python
 event.dataset:o365.audit and
@@ -6561,7 +7446,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0721
+Index: geneve-ut-0845
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -6573,7 +7458,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0752
+Index: geneve-ut-0880
 
 ```python
 event.dataset:o365.audit and
@@ -6586,7 +7471,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0753
+Index: geneve-ut-0881
 
 ```python
 event.dataset:o365.audit and
@@ -6599,7 +7484,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0754
+Index: geneve-ut-0882
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -6611,7 +7496,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0755
+Index: geneve-ut-0883
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -6623,7 +7508,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0756
+Index: geneve-ut-0884
 
 ```python
 event.dataset:o365.audit and
@@ -6636,7 +7521,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0763
+Index: geneve-ut-0892
 
 ```python
 event.dataset: "o365.audit" and
@@ -6649,7 +7534,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0767
+Index: geneve-ut-0895
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6669,7 +7554,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0768
+Index: geneve-ut-0896
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -6681,7 +7566,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0769
+Index: geneve-ut-0897
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -6693,7 +7578,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0773
+Index: geneve-ut-0901
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -6705,7 +7590,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0774
+Index: geneve-ut-0902
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -6717,7 +7602,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0775
+Index: geneve-ut-0903
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -6729,7 +7614,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0776
+Index: geneve-ut-0904
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -6741,7 +7626,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0777
+Index: geneve-ut-0905
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6766,7 +7651,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0778
+Index: geneve-ut-0906
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -6786,7 +7671,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0779
+Index: geneve-ut-0907
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -6799,7 +7684,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-0780
+Index: geneve-ut-0908
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6814,7 +7699,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0782
+Index: geneve-ut-0910
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -6826,7 +7711,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0785
+Index: geneve-ut-0913
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -6838,7 +7723,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0786
+Index: geneve-ut-0914
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -6850,7 +7735,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0787
+Index: geneve-ut-0915
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -6884,7 +7769,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0790
+Index: geneve-ut-0918
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6898,7 +7783,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0791
+Index: geneve-ut-0919
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6919,7 +7804,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0792
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6933,7 +7818,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0793
+Index: geneve-ut-0921
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6968,7 +7853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0794
+Index: geneve-ut-0922
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -6993,7 +7878,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0795
+Index: geneve-ut-0923
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7008,14 +7893,14 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### Microsoft IIS Connection Strings Decryption
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0798
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-0927
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   (process.name : "aspnet_regiis.exe" or ?process.pe.original_file_name == "aspnet_regiis.exe") and
-  process.args : "connectionStrings" and process.args : "-pdf"
+  process.args : "connectionStrings" and process.args : ("-pdf", "-pd")
 ```
 
 
@@ -7024,7 +7909,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0800
+Index: geneve-ut-0929
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7055,7 +7940,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0802
+Index: geneve-ut-0931
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -7109,7 +7994,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0803
+Index: geneve-ut-0932
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -7119,12 +8004,12 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 ### Modification of AmsiEnable Registry Key
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0804
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-0933
 
 ```python
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type in ("creation", "change") and
   registry.value : "AmsiEnable" and registry.data.strings: ("0", "0x00000000")
 
   /*
@@ -7139,7 +8024,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0805
+Index: geneve-ut-0934
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7156,7 +8041,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0807
+Index: geneve-ut-0936
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -7171,7 +8056,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0809
+Index: geneve-ut-0938
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -7187,7 +8072,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0810
+Index: geneve-ut-0939
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -7201,7 +8086,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0812
+Index: geneve-ut-0941
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7224,7 +8109,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0813
+Index: geneve-ut-0942
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7246,7 +8131,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0814
+Index: geneve-ut-0943
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7263,9 +8148,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### MsBuild Making Network Connections
 
-Branch count: 8  
-Document count: 16  
-Index: geneve-ut-0815
+Branch count: 4  
+Document count: 8  
+Index: geneve-ut-0944
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -7283,10 +8168,6 @@ sequence by process.entity_id with maxspan=30s
   /* Exclude domains that are known to be benign */
   [network where host.os.type == "windows" and
     event.action: ("connection_attempted", "lookup_requested") and
-    (
-      process.pe.original_file_name: "MSBuild.exe" or
-      process.name: "MSBuild.exe"
-    ) and
     not user.id == "S-1-5-18" and
     not cidrmatch(destination.ip, "127.0.0.1", "::1") and
     not dns.question.name : (
@@ -7302,7 +8183,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0816
+Index: geneve-ut-0945
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -7320,7 +8201,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-0817
+Index: geneve-ut-0946
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -7361,7 +8242,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-0828
+Index: geneve-ut-0959
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -7387,7 +8268,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0835
+Index: geneve-ut-0966
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -7411,7 +8292,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0838
+Index: geneve-ut-0969
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7423,9 +8304,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### NTDS or SAM Database File Copied
 
-Branch count: 210  
-Document count: 210  
-Index: geneve-ut-0839
+Branch count: 168  
+Document count: 168  
+Index: geneve-ut-0970
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7435,23 +8316,23 @@ process where host.os.type == "windows" and event.type == "start" and
     ) or
     ((?process.pe.original_file_name : "esentutl.exe" or process.name : "esentutl.exe") and process.args : ("*/y*", "*/vss*", "*/d*"))
   ) and
-  process.command_line : ("*\\ntds.dit*", "*\\config\\SAM*", "*\\*\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\*", "*/system32/config/SAM*", "*\\User Data\\*")
+  process.command_line : ("*\\ntds.dit*", "*\\config\\SAM*", "*\\*\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\*", "*/system32/config/SAM*")
 ```
 
 
 
 ### Namespace Manipulation Using Unshare
 
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-0840
+Branch count: 12  
+Document count: 12  
+Index: geneve-ut-0971
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action : ("exec", "exec_event", "start") and
-process.executable: "/usr/bin/unshare" and not (
-  process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
-  process.args == "/usr/bin/snap" and not process.parent.name in ("zz-proxmox-boot", "java") or
-  process.parent.args like (
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
+process.name: "unshare" and not (
+  ?process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
+  ?process.args == "/usr/bin/snap" and not ?process.parent.name in ("zz-proxmox-boot", "java") or
+  ?process.parent.args like (
     "/etc/kernel/postinst.d/zz-proxmox-boot", "/opt/openssh/sbin/sshd", "/usr/sbin/sshd",
     "/snap/*", "/home/*/.local/share/JetBrains/Toolbox/*"
   )
@@ -7464,7 +8345,7 @@ process.executable: "/usr/bin/unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0841
+Index: geneve-ut-0972
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7485,7 +8366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0842
+Index: geneve-ut-0973
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7500,7 +8381,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0843
+Index: geneve-ut-0974
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7517,7 +8398,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0845
+Index: geneve-ut-0976
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -7537,11 +8418,57 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 
 
+### Network Connection Followed by File Creation
+
+Branch count: 112  
+Document count: 224  
+Index: geneve-ut-0978
+
+```python
+sequence by host.id, process.entity_id with maxspan=5s
+  [network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and
+  process.executable like (
+    "/boot/*", "/dev/shm/*", "/tmp/*", "/var/tmp/*", "/var/log/*", "/var/run/user/*", "/run/user/*"
+  ) and
+  not (
+    destination.ip == null or
+    destination.ip == "0.0.0.0" or 
+    cidrmatch(
+      destination.ip, "10.0.0.0/8", "127.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12",
+      "192.0.0.0/24", "192.0.0.0/29","192.0.0.8/32", "192.0.0.9/32", "192.0.0.10/32",
+      "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24",
+      "192.168.0.0/16", "192.88.99.0/24", "224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24",
+      "198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4", "::1", "FE80::/10",
+      "FF00::/8", "FC00::/7"
+    )
+  )]
+  [file where host.os.type == "linux" and event.type == "creation" and process.executable like (
+    "/boot/*", "/dev/shm/*", "/tmp/*", "/var/tmp/*", "/var/log/*", "/boot/*", "/var/run/user/*", "/run/user/*"
+  ) and
+  not (
+    file.name like "tmp*" or file.extension in ("sqlite-journal", "db-journal", "lockfile", "tmp") or
+    file.path like (
+      "/loki/wal/*", "/dev/shm/.org.chromium.Chromium.*", "/opt/rapid7/nexpose/*",
+      "/usr/local/ltechagent*", "/var/lib/cloudendure/agent_keystore_temp", "/var/cache/yum/*",
+      "/run/aws-node/ipam.json.tmp*", "/run/systemd/journal/streams/.*"
+    ) or
+    (process.executable == "/tmp/terraform" and file.path like "/tmp/terraform-provider*") or 
+    process.name in ("podman", "minikube", "logrotate", "java", "aws-k8s-agent", "grafana", "postman") or
+    process.executable : (
+      "/etc/cron.daily/logrotate", "/etc/update-motd.d/50-motd-news", "/etc/cron.hourly/0yum-hourly.cron",
+      "/etc/cron.hourly/BitdefenderRedline", "/tmp/token_handler", "/tmp/.sentry-cli*.exe", 
+      "/etc/cron.daily/0yum-daily.cron", "/etc/init.d/fortiedr"
+    )
+  )]
+```
+
+
+
 ### Network Connection Initiated by Suspicious SSHD Child Process
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-0847
+Index: geneve-ut-0979
 
 ```python
 sequence by host.id with maxspan=1s
@@ -7583,7 +8510,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-0848
+Index: geneve-ut-0980
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7600,7 +8527,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0850
+Index: geneve-ut-0982
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -7615,7 +8542,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0851
+Index: geneve-ut-0983
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -7634,7 +8561,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0852
+Index: geneve-ut-0984
 
 ```python
 sequence by process.entity_id
@@ -7654,7 +8581,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0853
+Index: geneve-ut-0985
 
 ```python
 sequence by process.entity_id
@@ -7673,7 +8600,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-0854
+Index: geneve-ut-0986
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7702,7 +8629,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-0855
+Index: geneve-ut-0987
 
 ```python
 sequence by process.entity_id
@@ -7727,7 +8654,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0856
+Index: geneve-ut-0988
 
 ```python
 sequence by process.entity_id
@@ -7749,7 +8676,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0857
+Index: geneve-ut-0989
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -7782,7 +8709,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0858
+Index: geneve-ut-0990
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7812,7 +8739,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0861
+Index: geneve-ut-0993
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -7829,7 +8756,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0862
+Index: geneve-ut-0994
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -7866,7 +8793,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0863
+Index: geneve-ut-0995
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7879,7 +8806,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0868
+Index: geneve-ut-1000
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -7891,7 +8818,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0871
+Index: geneve-ut-1003
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -7903,7 +8830,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-0879
+Index: geneve-ut-1011
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7917,7 +8844,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0880
+Index: geneve-ut-1012
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7927,11 +8854,26 @@ process where host.os.type == "linux" and event.type == "start" and
 
 
 
+### Nsenter to PID Namespace via Auditd
+
+Branch count: 32  
+Document count: 32  
+Index: geneve-ut-1013
+
+```python
+host.os.type:linux and 
+event.category:process and event.action:(executed or exec) and 
+(process.name:nsenter or process.args:nsenter) and 
+process.args:((--target* or -t) and not --net=/run/netns/* and not (--assertion and snap) and not (is-active and snap.*))
+```
+
+
+
 ### Office Test Registry Persistence
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0882
+Index: geneve-ut-1015
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -7944,7 +8886,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0883
+Index: geneve-ut-1016
 
 ```python
 event.dataset: "okta.system"
@@ -7959,7 +8901,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0885
+Index: geneve-ut-1018
 
 ```python
 sequence by user.name with maxspan=30m
@@ -7981,7 +8923,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0894
+Index: geneve-ut-1027
 
 ```python
 network where event.action == "connection_accepted" and
@@ -8008,7 +8950,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0895
+Index: geneve-ut-1028
 
 ```python
 network where event.action == "lookup_requested" and
@@ -8028,7 +8970,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0896
+Index: geneve-ut-1029
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8043,7 +8985,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-0897
+Index: geneve-ut-1030
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -8070,7 +9012,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-0898
+Index: geneve-ut-1031
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -8085,7 +9027,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0899
+Index: geneve-ut-1032
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -8101,7 +9043,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0900
+Index: geneve-ut-1033
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -8115,7 +9057,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0903
+Index: geneve-ut-1038
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -8130,7 +9072,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0904
+Index: geneve-ut-1039
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8144,7 +9086,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0905
+Index: geneve-ut-1040
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -8163,7 +9105,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0906
+Index: geneve-ut-1041
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -8175,7 +9117,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0907
+Index: geneve-ut-1042
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -8187,7 +9129,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0908
+Index: geneve-ut-1043
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8205,7 +9147,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0909
+Index: geneve-ut-1044
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -8218,7 +9160,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0910
+Index: geneve-ut-1045
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -8233,7 +9175,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0911
+Index: geneve-ut-1046
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -8248,7 +9190,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0913
+Index: geneve-ut-1048
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -8266,9 +9208,9 @@ process where host.os.type == "macos" and event.type == "start" and
 
 ### Persistence via Microsoft Office AddIns
 
-Branch count: 36  
-Document count: 36  
-Index: geneve-ut-0914
+Branch count: 108  
+Document count: 108  
+Index: geneve-ut-1049
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -8282,7 +9224,8 @@ file where host.os.type == "windows" and event.type != "deletion" and
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Word\\Startup\\*",
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\AddIns\\*",
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*"
- )
+ ) and
+ not (file.name : "~$*" and process.name : "excel.exe" and ?file.size in (0, 165))
 ```
 
 
@@ -8291,7 +9234,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0915
+Index: geneve-ut-1050
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -8305,7 +9248,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0916
+Index: geneve-ut-1051
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -8324,7 +9267,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0917
+Index: geneve-ut-1052
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -8348,9 +9291,9 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 ### Persistence via Suspicious Launch Agent or Launch Daemon
 
-Branch count: 190  
-Document count: 190  
-Index: geneve-ut-0918
+Branch count: 380  
+Document count: 380  
+Index: geneve-ut-1053
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -8365,7 +9308,12 @@ file where host.os.type == "macos" and event.type != "deletion" and
   not process.executable like ("/System/*", "/Library/PrivilegedHelperTools/*") and
   not (process.code_signature.signing_id in ("com.apple.vim", "com.apple.cat", "com.apple.cfprefsd",
                                             "com.jetbrains.toolbox", "com.apple.pico", "com.apple.shove",
-                                            "com.sublimetext.4", "com.apple.ditto") and process.code_signature.trusted == true)
+                                            "com.sublimetext.4", "com.apple.ditto") and process.code_signature.trusted == true) and
+  not (file.path like ("/Library/LaunchDaemons/com.jumpcloud.*",
+                       "/Library/LaunchAgents/com.jumpcloud.*",
+                       "/Library/LaunchDaemons/com.wazuh.*",
+                       "/Library/LaunchDaemons/com.zscaler.service.plist") and
+       process.executable == "/bin/bash")
 ```
 
 
@@ -8374,7 +9322,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0919
+Index: geneve-ut-1054
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8393,7 +9341,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0920
+Index: geneve-ut-1055
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8421,7 +9369,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0921
+Index: geneve-ut-1056
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8436,7 +9384,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0922
+Index: geneve-ut-1057
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8499,7 +9447,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0923
+Index: geneve-ut-1058
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -8520,7 +9468,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0924
+Index: geneve-ut-1059
 
 ```python
 any where host.os.type == "windows" and
@@ -8582,7 +9530,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0926
+Index: geneve-ut-1061
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -8611,7 +9559,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0927
+Index: geneve-ut-1062
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -8623,9 +9571,9 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 ### Pluggable Authentication Module (PAM) Version Discovery
 
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-0928
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1063
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8637,10 +9585,17 @@ process where host.os.type == "linux" and event.type == "start" and
 not (
   ?process.parent.name in ("dcservice", "inspectorssmplugin") or
   ?process.working_directory in ("/var/ossec", "/opt/msp-agent") or
+  ?process.entry_leader.executable in("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/usr/sbin/ScanAssistant") or
   ?process.parent.executable in (
     "/opt/CyberCNSAgent/cybercnsagent_linux", "/usr/local/manageengine/uems_agent/bin/dcpatchscan",
     "/usr/local/manageengine/uems_agent/bin/dcconfig", "/usr/share/vicarius/topiad",
-    "/etc/rc.d/init.d/sshd-chroot"
+    "/etc/rc.d/init.d/sshd-chroot", "/var/ossec/bin/wazuh-modulesd",
+    "/usr/lib/venv-salt-minion/bin/python.original"
+  ) or
+  (
+    process.executable == "/usr/bin/rpm" and
+    ?process.parent.name == "systemd" and
+    ?process.env_vars == "LD_LIBRARY_PATH=/usr/lib/venv-salt-minion/lib"
   )
 )
 ```
@@ -8651,7 +9606,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0931
+Index: geneve-ut-1066
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -8696,9 +9651,9 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 ### Polkit Version Discovery
 
-Branch count: 24  
-Document count: 24  
-Index: geneve-ut-0932
+Branch count: 48  
+Document count: 48  
+Index: geneve-ut-1067
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8710,7 +9665,12 @@ event.action in ("exec", "exec_event", "start", "ProcessRollup2", "process_start
 ) and
 not (
   ?process.working_directory in ("/opt/msp-agent", "/opt/CyberCNSAgent") or
-  ?process.parent.executable like ("/usr/local/cpanel/3rdparty/perl/*/bin/perl", "/usr/share/vicarius/topiad")
+  ?process.parent.executable like ("/usr/local/cpanel/3rdparty/perl/*/bin/perl", "/usr/share/vicarius/topiad") or
+  ?process.entry_leader.executable in ("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/sf/edr/agent/bin/edr_monitor") or
+  (
+    ?process.parent.args == "/usr/lib/venv-salt-minion/bin/python.original" and
+    ?process.parent.args == "/usr/lib/venv-salt-minion/bin/salt-minion"
+  )
 )
 ```
 
@@ -8720,7 +9680,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0933
+Index: geneve-ut-1068
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -8733,7 +9693,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0942
+Index: geneve-ut-1078
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8750,7 +9710,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0944
+Index: geneve-ut-1080
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -8775,7 +9735,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0948
+Index: geneve-ut-1084
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/*/etc/nsswitch.conf" and
@@ -8792,7 +9752,7 @@ not file.path like (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0949
+Index: geneve-ut-1085
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8808,7 +9768,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0950
+Index: geneve-ut-1086
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8829,7 +9789,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-0951
+Index: geneve-ut-1087
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8870,7 +9830,7 @@ event.action in ("exec", "exec_event", "start", "executed", "process_started", "
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0952
+Index: geneve-ut-1088
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -8887,7 +9847,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0953
+Index: geneve-ut-1089
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8911,7 +9871,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-0955
+Index: geneve-ut-1091
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -8940,7 +9900,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0957
+Index: geneve-ut-1093
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -8964,7 +9924,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0959
+Index: geneve-ut-1096
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -8980,18 +9940,18 @@ process where host.os.type == "windows" and event.code == "10" and
 
 ### Potential Credential Access via LSASS Memory Dump
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0960
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
   winlog.event_data.TargetImage : "?:\\WINDOWS\\system32\\lsass.exe" and
 
-   /* DLLs exporting MiniDumpWriteDump API to create an lsass mdmp*/
-  winlog.event_data.CallTrace : ("*dbghelp*", "*dbgcore*") and
+  /* dbgcore.dll hosts MiniDumpWriteDump on modern Windows; dbghelp-only traces are non-dump usage */
+  winlog.event_data.CallTrace : "*dbgcore*" and
 
-   /* case of lsass crashing */
+  /* crash handlers */
   not process.executable : (
         "?:\\Windows\\System32\\WerFault.exe",
         "?:\\Windows\\SysWOW64\\WerFault.exe",
@@ -9005,7 +9965,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0961
+Index: geneve-ut-1098
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9058,17 +10018,33 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
+### Potential Credential Access via Renamed COM+ Services DLL
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1099
+
+```python
+sequence by process.entity_id with maxspan=1m
+ [process where host.os.type == "windows" and event.type == "start" and process.name : "rundll32.exe"]
+ [process where host.os.type == "windows" and event.code == "7" and
+   (file.pe.original_file_name : "COMSVCS.DLL" or file.pe.imphash : "EADBCCBB324829ACB5F2BBE87E5549A8") and
+   /* renamed COMSVCS */
+   not file.name : "COMSVCS.DLL"]
+```
+
+
+
 ### Potential Credential Access via Trusted Developer Utility
 
-Branch count: 16  
-Document count: 32  
-Index: geneve-ut-0963
+Branch count: 4  
+Document count: 8  
+Index: geneve-ut-1100
 
 ```python
 sequence by process.entity_id
  [process where host.os.type == "windows" and event.type == "start" and (process.name : "MSBuild.exe" or process.pe.original_file_name == "MSBuild.exe")]
- [any where host.os.type == "windows" and (event.category == "library" or (event.category == "process" and event.action : "Image loaded*")) and
-  (?dll.name : ("vaultcli.dll", "SAMLib.DLL") or file.name : ("vaultcli.dll", "SAMLib.DLL"))]
+ [library where host.os.type == "windows" and dll.name : ("vaultcli.dll", "SAMLib.DLL")]
 ```
 
 
@@ -9077,7 +10053,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0975
+Index: geneve-ut-1114
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9092,7 +10068,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0976
+Index: geneve-ut-1115
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9123,7 +10099,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0977
+Index: geneve-ut-1116
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9137,7 +10113,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0978
+Index: geneve-ut-1117
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9150,7 +10126,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0979
+Index: geneve-ut-1118
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -9162,7 +10138,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0980
+Index: geneve-ut-1119
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -9171,11 +10147,30 @@ process.parent.name == "proot"
 
 
 
+### Potential Direct Kubelet Access via Process Arguments
+
+Branch count: 136  
+Document count: 136  
+Index: geneve-ut-1121
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
+(
+  /* direct utility execution */
+  process.name like ("curl", "wget", "python*", "perl*", "php*", "node*", "java", "ruby*", "lua*", ".*") or
+
+  process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/var/run/*", "/home/*", "/run/user/*", "/busybox/*")
+) and
+process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:10255/*")
+```
+
+
+
 ### Potential Disabling of AppArmor
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0982
+Index: geneve-ut-1122
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9196,7 +10191,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0983
+Index: geneve-ut-1123
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9210,7 +10205,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0986
+Index: geneve-ut-1126
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -9234,7 +10229,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0987
+Index: geneve-ut-1127
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -9250,7 +10245,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-0988
+Index: geneve-ut-1128
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -9267,7 +10262,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0989
+Index: geneve-ut-1129
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9288,7 +10283,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0991
+Index: geneve-ut-1131
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -9301,7 +10296,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-0993
+Index: geneve-ut-1133
 
 ```python
 sequence by host.id with maxspan=1m
@@ -9329,7 +10324,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-0996
+Index: geneve-ut-1136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9345,7 +10340,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-0997
+Index: geneve-ut-1137
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9368,7 +10363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0998
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9381,7 +10376,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1000
+Index: geneve-ut-1140
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9394,7 +10389,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1005
+Index: geneve-ut-1145
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9408,7 +10403,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1006
+Index: geneve-ut-1146
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9423,7 +10418,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 375  
 Document count: 375  
-Index: geneve-ut-1007
+Index: geneve-ut-1148
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9444,7 +10439,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1010
+Index: geneve-ut-1151
 
 ```python
 sequence by host.id with maxspan=1m
@@ -9487,7 +10482,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1011
+Index: geneve-ut-1152
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9505,7 +10500,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1012
+Index: geneve-ut-1153
 
 ```python
 host.os.type:"windows" and
@@ -9521,10 +10516,26 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1014
+Index: geneve-ut-1155
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
+```
+
+
+
+### Potential Kubeletctl Execution
+
+Branch count: 38  
+Document count: 38  
+Index: geneve-ut-1157
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
+(
+  process.name == "kubeletctl" or
+  (process.args in ("run", "exec", "scan", "pods", "runningpods", "attach", "portForward", "cri", "pid2pod") and process.args:("*:10250*", "*:10255*"))
+)
 ```
 
 
@@ -9533,7 +10544,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1016
+Index: geneve-ut-1158
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9551,7 +10562,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1017
+Index: geneve-ut-1159
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -9565,7 +10576,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1019
+Index: geneve-ut-1161
 
 ```python
 sequence by host.id with maxspan=30s
@@ -9584,7 +10595,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1021
+Index: geneve-ut-1163
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -9600,7 +10611,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1022
+Index: geneve-ut-1164
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -9613,7 +10624,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1023
+Index: geneve-ut-1165
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9643,7 +10654,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1028
+Index: geneve-ut-1170
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -9666,7 +10677,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1029
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9685,7 +10696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1034
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "windows" and 
@@ -9827,7 +10838,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1035
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "windows" and
@@ -9904,7 +10915,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1039
+Index: geneve-ut-1181
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -9921,7 +10932,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1040
+Index: geneve-ut-1182
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -9955,7 +10966,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1042
+Index: geneve-ut-1184
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -9967,7 +10978,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1043
+Index: geneve-ut-1185
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10006,7 +11017,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1045
+Index: geneve-ut-1187
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10019,7 +11030,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1050
+Index: geneve-ut-1192
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10033,7 +11044,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1057
+Index: geneve-ut-1199
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -10061,7 +11072,8 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
       "/var/run/udev/ud.pid",
       "/var/run/udevd.pid"
     )
-  )
+  ) and
+  not file.path like ("/tmp/krb5cc*", "/tmp/ansible_*", "/storage/*", "/tmp/clearsigned.message.*", "/var/sftp/refinitiv/*", "/tmp/fileutil.message.*")
 ```
 
 
@@ -10070,7 +11082,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1058
+Index: geneve-ut-1200
 
 ```python
 network where host.os.type == "windows" and
@@ -10096,7 +11108,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1061
+Index: geneve-ut-1203
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10111,7 +11123,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1063
+Index: geneve-ut-1205
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -10125,7 +11137,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1064
+Index: geneve-ut-1206
 
 ```python
 file where host.os.type == "windows" and
@@ -10139,7 +11151,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1065
+Index: geneve-ut-1207
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10152,7 +11164,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1066
+Index: geneve-ut-1208
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10172,7 +11184,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1067
+Index: geneve-ut-1209
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10190,9 +11202,9 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 ### Potential PowerShell HackTool Script by Author
 
-Branch count: 45  
-Document count: 45  
-Index: geneve-ut-1069
+Branch count: 48  
+Document count: 48  
+Index: geneve-ut-1211
 
 ```python
 host.os.type:windows and event.category:process and
@@ -10219,7 +11231,8 @@ host.os.type:windows and event.category:process and
       "_nullbind" or "_tmenochet" or
       "jaredcatkinson" or "ChrisTruncer" or
       "monoxgas" or "TheRealWover" or
-      "splinter_code"
+      "splinter_code" or "samratashok" or
+      "leechristensen" or "nikhil_mitt"
   ) and
   not powershell.file.script_block_text : ("Get-UEFIDatabaseSigner" or "Posh-SSH")
 ```
@@ -10230,7 +11243,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1070
+Index: geneve-ut-1212
 
 ```python
 event.category:process and host.os.type:windows and
@@ -10425,7 +11438,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1083
+Index: geneve-ut-1225
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10437,11 +11450,39 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 
 
+### Potential Privacy Control Bypass via TCCDB Modification
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-1226
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
+ process.args like "/*/Application Support/com.apple.TCC/TCC.db" and
+ (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
+### Potential Privilege Escalation in Container via Runc Init
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1227
+
+```python
+host.os.type:linux and event.category:process and 
+event.action:(executed or exec) and 
+process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
+```
+
+
+
 ### Potential Privilege Escalation through Writable Docker Socket
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1085
+Index: geneve-ut-1228
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -10458,7 +11499,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1086
+Index: geneve-ut-1229
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -10472,7 +11513,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1087
+Index: geneve-ut-1230
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -10484,27 +11525,11 @@ process.interactive == true and process.parent.interactive == true
 
 
 
-### Potential Privilege Escalation via OverlayFS
-
-Branch count: 3  
-Document count: 6  
-Index: geneve-ut-1091
-
-```python
-sequence by process.parent.entity_id, host.id with maxspan=5s
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-    process.name == "unshare" and process.args : ("-r", "-rm", "m") and process.args : "*cap_setuid*"  and user.id != "0"]
-  [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
-    user.id == "0"]
-```
-
-
-
 ### Potential Privilege Escalation via PKEXEC
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1092
+Index: geneve-ut-1234
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -10516,7 +11541,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1093
+Index: geneve-ut-1235
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10532,7 +11557,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1094
+Index: geneve-ut-1236
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10552,7 +11577,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1095
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -10589,10 +11614,115 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1097
+Index: geneve-ut-1240
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
+```
+
+
+
+### Potential Privilege Escalation via a Parent Process Sequence
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1241
+
+```python
+sequence by host.id, process.parent.entity_id with maxspan=15s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )]
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")]
+```
+
+
+
+### Potential Privilege Escalation via a Parent/Child Process Sequence
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1242
+
+```python
+sequence by host.id with maxspan=15s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )] by process.entity_id
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")] by process.parent.entity_id
+```
+
+
+
+### Potential Privilege Escalation via a Suspicious UID Change
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1243
+
+```python
+sequence by host.id, process.entity_id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )]
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")]
+```
+
+
+
+### Potential Privilege Escalation via unshare Followed by Root Process
+
+Branch count: 341  
+Document count: 682  
+Index: geneve-ut-1244
+
+```python
+sequence by host.id, process.parent.pid with maxspan=30s
+ [process where host.os.type == "linux" and 
+  (
+   (auditd.data.syscall == "unshare" and auditd.data.class == "namespace" and auditd.data.a0 in ("10000000", "50000000", "70000000", "10020000", "50020000", "70020000")) or 
+
+   (process.name == "unshare" and  
+    (process.args in ("--user", "--map-root-user", "--map-current-user") or process.args like ("-*U*", "-*r*")))
+   ) and user.id != "0" and user.id != null]
+ [process where host.os.type == "linux" and 
+  user.id == "0" and user.id != null and 
+  (
+   process.name in ("su", "sudo", "pkexec", "passwd", "chsh", "newgrp", "doas", "run0", "sg", "dash", "sh", "bash", "zsh", "fish", 
+                    "ksh", "csh", "tcsh", "ash", "mksh", "busybox", "rbash", "rzsh", "rksh", "tmux", "screen", "node") or 
+   process.name like ("python*", "perl*", "ruby*", "php*", "lua*")
+  )]
+```
+
+
+
+### Potential Privilege Escalation via unshare and UID Change
+
+Branch count: 5  
+Document count: 10  
+Index: geneve-ut-1245
+
+```python
+sequence by process.parent.entity_id, host.id with maxspan=60s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+    process.name == "unshare" and process.args : ("-r", "-rm", "-m", "-U", "--user") and user.id != "0"]
+  [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
+    user.id == "0"]
 ```
 
 
@@ -10601,7 +11731,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1098
+Index: geneve-ut-1246
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -10615,7 +11745,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1099
+Index: geneve-ut-1247
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -10638,7 +11768,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1101
+Index: geneve-ut-1249
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -10655,7 +11785,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1102
+Index: geneve-ut-1250
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -10678,7 +11808,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1103
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10691,7 +11821,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1104
+Index: geneve-ut-1252
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10705,7 +11835,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1105
+Index: geneve-ut-1253
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10718,11 +11848,65 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Potential Proxy Execution via Systemd-run
+
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-1254
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started", "start", "ProcessRollup2") and
+process.name == "systemd-run" and ?process.parent.executable != null and
+not (
+  ?process.parent.executable in (
+    "/usr/lib/systemd", "/lib/systemd/systemd", "/opt/saltstack/salt/run/run", "/etc/update-motd.d/70-available-updates",
+    "/tmp/newroot/usr/libexec/ptyxis-agent", "/usr/local/sbin/clamscan.sh", "/opt/sentinelone/bin/sentinelone-agent",
+    "/usr/local/bin/salt-minion", "/var/vanta/launcher", "/opt/traps/bin/pmd", "/usr/sbin/gdm", "/usr/bin/salt-minion",
+    "/opt/GC_Ext/GC/gc_linux_service", "/usr/lib/plesk-task-manager", "/opt/forticlient/epctrl", "/usr/lib/snapd/snap-exec",
+    "/usr/bin/yay", "/usr/local/bin/hexnode_agent", "/opt/halcyon/halcyonar/agent", "/usr/local/bin/qsetup", "/usr/bin/pamac",
+    "/usr/bin/elephant", "/usr/bin/Hyprland"
+  ) or
+  ?process.parent.executable like (
+    "/opt/tableau/tableau_server/packages/scripts.*/after-install", "/opt/acronis/bin/acp-update-controller", "/snap/*",
+    "/var/lib/amagent/*", "/opt/msp-agent/msp-agent-core", "/opt/beyondtrust/*", "/var/lib/rancher/k3s/*/bin/k3s"
+  ) or
+  ?process.parent.name like "platform-python*" or
+  ?process.parent.name in (
+    "udevadm", "daemon.start", "snap", "systemd", "ptyxis-agent", "run-slack", "run-firefox", "dbus.service", "k3s-server",
+    "systemd-udevd", "kubelet", "hyperkube", "kthreadd", "gnome-shell", "xdg-desktop-portal", "firefox", "picus_updater",
+    "rpm-ostree", "prompt-agent"
+  ) or
+  ?process.command_line in (
+    "/usr/bin/systemd-run /usr/bin/systemctl start man-db-cache-update", "systemd-run env",
+    "systemd-run --user dnf-automatic-notifyonly.timer", "systemd-run --user systemctl suspend", "systemd-run /var/lib/aws-replication-agent/uninstall-agent.sh",
+    "systemd-run --on-active=10 --timer-property=AccuracySec=100ms --slice=system.slice systemctl start gc-agent",
+    "systemd-run --user --scope --unit=tmux-server -- tmux", "systemd-run bash -c sleep 60 && reboot"
+  ) or
+  ?process.command_line like~ (
+    "systemd-run --scope -p CPUQuota=10% rpm -qa*", "systemd-run --scope -p CPUQuota=10% dpkg -l*"
+  ) or
+  ?process.parent.command_line in ("runc init", "/usr/local/bin/main") or
+  ?process.parent.command_line like ("*/var/lib/waagent/*", "bash ./run.sh") or
+  process.args in (
+    "--help", "list-timers", "/usr/lib/udev/kdump-udev-throttler", "kubectl", "--unit=ngt_guest_agent_upgrade", "i3-zoom", "google-chrome",
+    "thunar", "/usr/bin/google-chrome-stable", "snap.lxd.workaround", "--unit=firefox", "--unit=slack", "--slice=zoom.slice",
+    "autorandr-launcher", "--unit=restart-dbus", "--unit=autorandr-debounce"
+  ) or
+  process.args like ("--unit=app-Hyprland-wezterm-*.scope", "--unit=app-Hyprland-swaybg-*.scope", "--unit=rmf_sim_*") or
+  ?process.working_directory == "/opt/Tychon/Endpoint/bin" or
+  (process.args in ("rpm", "dpkg") and process.args like~ "CPUQuota=*") or
+  (process.args == "--slice=app-graphical.slice" and process.args == "--description=xdg-terminal-exec")
+)
+```
+
+
+
 ### Potential REMCOS Trojan Execution
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1106
+Index: geneve-ut-1255
 
 ```python
 any where host.os.type == "windows" and
@@ -10749,7 +11933,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1109
+Index: geneve-ut-1261
 
 ```python
 file where host.os.type == "windows" and
@@ -10764,7 +11948,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1110
+Index: geneve-ut-1262
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -10781,8 +11965,10 @@ any where host.os.type == "windows" and
 
   ) or
   (event.category == "process" and event.type == "start" and
-     (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
-     (?process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
+    (
+      (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
+      (?process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
+    )
   )
 )
 ```
@@ -10793,7 +11979,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1111
+Index: geneve-ut-1263
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10807,7 +11993,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1112
+Index: geneve-ut-1264
 
 ```python
 sequence with maxspan=1m
@@ -10847,18 +12033,25 @@ sequence with maxspan=1m
 
 ### Potential Remote Install via MsiExec
 
-Branch count: 200  
-Document count: 200  
-Index: geneve-ut-1113
+Branch count: 400  
+Document count: 400  
+Index: geneve-ut-1265
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
-  process.name : "msiexec.exe" and process.args : ("-i*", "/i*", "-p*", "/p*") and process.command_line : "*http*" and
+  process.name : "msiexec.exe" and process.args : ("-i*", "/i*", "-p*", "/p*") and
+  process.command_line : ("*http:*", "*https:*") and
   process.args : ("/qn", "-qn", "-q", "/q", "/quiet") and
-  process.parent.name : ("sihost.exe", "explorer.exe", "cmd.exe", "wscript.exe", "mshta.exe", "powershell.exe", "wmiprvse.exe", "pcalua.exe", "forfiles.exe", "conhost.exe") and
-  not process.command_line : ("*--set-server=*", "*UPGRADEADD=*" , "*--url=*",
-                              "*USESERVERCONFIG=*", "*RCTENTERPRISESERVER=*", "*app.ninjarmm.com*", "*zoom.us/client*",
-                              "*SUPPORTSERVERSTSURI=*", "*START_URL=*", "*AUTOCONFIG=*", "*awscli.amazonaws.com*")
+  process.parent.name : (
+    "sihost.exe", "explorer.exe", "cmd.exe", "wscript.exe", "mshta.exe",
+    "powershell.exe", "wmiprvse.exe", "pcalua.exe", "forfiles.exe", "conhost.exe"
+  ) and
+
+  not process.command_line : (
+        "*--set-server=*", "*UPGRADEADD=*" , "*--url=*", "*USESERVERCONFIG=*", "*RCTENTERPRISESERVER=*",
+        "*app.ninjarmm.com*", "*zoom.us/client*", "*SUPPORTSERVERSTSURI=*", "*START_URL=*", "*AUTOCONFIG=*",
+        "*awscli.amazonaws.com*", "*/i \"C:*", "*/i C:\\*"
+  )
 ```
 
 
@@ -10867,7 +12060,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1114
+Index: geneve-ut-1266
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10921,7 +12114,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1115
+Index: geneve-ut-1267
 
 ```python
 sequence by host.id with maxspan=5s
@@ -10941,7 +12134,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1116
+Index: geneve-ut-1268
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -10962,7 +12155,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1117
+Index: geneve-ut-1269
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10977,7 +12170,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1118
+Index: geneve-ut-1270
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10997,7 +12190,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1119
+Index: geneve-ut-1271
 
 ```python
 sequence by host.id with maxspan=5s
@@ -11017,7 +12210,7 @@ sequence by host.id with maxspan=5s
    and not (
      process.parent.args in (
        "/usr/lib/jenkins/jenkins.war", "/etc/remote-iot/services/remoteiot.jar", "/opt/pentaho/data-integration/launcher/launcher.jar",
-       "/usr/share/java/jenkins.war", "/opt//tomcat/statistics/statistics.jar", "/usr/lib64/NetExtender.jar",
+       "/usr/share/java/jenkins.war", "/opt/tomcat/statistics/statistics.jar", "/usr/lib64/NetExtender.jar",
        "/var/lib/jenkins/workspace/MP-QA/tc_certified_copy*/tc_certified_copy_web_ui_test/target/surefire/surefirebooter*.jar",
        "-javaagent:/opt/opentelemetry/opentelemetry-javaagent-all.jar", "./lib/pipeline-job-executor*SNAPSHOT.jar",
        "./lib/worker-launcher-agent*SNAPSHOT.jar", "/opt/Seqrite_EndPoint_Security/wildfly/jboss-modules.jar",
@@ -11035,11 +12228,26 @@ sequence by host.id with maxspan=5s
 
 
 
+### Potential Root Effective Shell from Non-Standard Path via Auditd
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1275
+
+```python
+host.os.type:linux and event.category:process and 
+event.action:(exec or executed) and user.id:(* and not 0) and 
+process.executable:(* and not (/bin/* or /nix/store/*/bin/sudo or /run/wrappers/wrappers*/sudo or /sbin/* or /usr/bin/* or /usr/sbin/*)) and 
+user.effective.id:0 and process.args:-p
+```
+
+
+
 ### Potential SAP NetWeaver Exploitation
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1123
+Index: geneve-ut-1276
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -11074,7 +12282,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1124
+Index: geneve-ut-1277
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -11091,7 +12299,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1125
+Index: geneve-ut-1279
 
 ```python
 sequence by host.id with maxspan=3s
@@ -11105,7 +12313,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1127
+Index: geneve-ut-1282
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -11118,7 +12326,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1128
+Index: geneve-ut-1283
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -11130,12 +12338,13 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1129
+Index: geneve-ut-1284
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
   winlog.event_data.AttributeValue :B\:828* and
-  not winlog.event_data.SubjectUserName: MSOL_*
+  not winlog.event_data.SubjectUserName: MSOL_* and
+  not winlog.event_data.ObjectClass: "msDS-Device"
 ```
 
 
@@ -11144,7 +12353,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1131
+Index: geneve-ut-1286
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -11172,7 +12381,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1132
+Index: geneve-ut-1287
 
 ```python
 sequence by host.id with maxspan=1s
@@ -11197,7 +12406,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1136
+Index: geneve-ut-1291
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -11231,7 +12440,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1137
+Index: geneve-ut-1292
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11245,7 +12454,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1138
+Index: geneve-ut-1293
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -11261,7 +12470,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1139
+Index: geneve-ut-1294
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11275,7 +12484,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1140
+Index: geneve-ut-1295
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -11305,15 +12514,16 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1141
+Index: geneve-ut-1296
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
-  file.name : ("winload.exe", "winlod.efi", "ntoskrnl.exe", "bootmgr") and
+  file.name : ("winload.exe", "winload.efi", "ntoskrnl.exe", "bootmgr") and
   file.path : ("?:\\Windows\\*", "\\Device\\HarddiskVolume*\\Windows\\*") and
   not process.executable : (
     "?:\\Windows\\System32\\poqexec.exe",
-    "?:\\Windows\\WinSxS\\amd64_microsoft-windows-servicingstack_*\\tiworker.exe"
+    "?:\\Windows\\System32\\wbengine.exe",
+    "?:\\Windows\\WinSxS\\???64_microsoft-windows-servicingstack_*\\tiworker.exe"
   ) and
   not file.path : (
     "?:\\Windows\\WinSxS\\Temp\\InFlight\\*",
@@ -11321,7 +12531,9 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
     "?:\\Windows\\WinSxS\\amd64_microsoft-windows*",
     "?:\\Windows\\SystemTemp\\*",
     "?:\\Windows\\Temp\\????????.???\\*",
-    "?:\\Windows\\Temp\\*\\amd64_microsoft-windows-*"
+    "?:\\Windows\\Temp\\*\\amd64_microsoft-windows-*",
+    "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download*",
+    "?:\\Windows\\Temp\\BootImages\\{*}\\mount\\Windows\\*"
   )
 ```
 
@@ -11331,7 +12543,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1142
+Index: geneve-ut-1297
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11347,7 +12559,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1143
+Index: geneve-ut-1298
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11361,7 +12573,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1144
+Index: geneve-ut-1299
 
 ```python
 file where host.os.type == "windows" and
@@ -11397,7 +12609,7 @@ file where host.os.type == "windows" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1147
+Index: geneve-ut-1302
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11411,7 +12623,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1148
+Index: geneve-ut-1303
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11431,7 +12643,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1150
+Index: geneve-ut-1305
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11448,7 +12660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1151
+Index: geneve-ut-1306
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -11460,7 +12672,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1152
+Index: geneve-ut-1307
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -11477,7 +12689,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1153
+Index: geneve-ut-1308
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -11495,7 +12707,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1159
+Index: geneve-ut-1315
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -11522,7 +12734,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1160
+Index: geneve-ut-1316
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -11536,7 +12748,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1162
+Index: geneve-ut-1318
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11551,9 +12763,9 @@ process where host.os.type == "linux" and event.type == "start" and
 
 ### PowerShell Invoke-NinjaCopy script
 
-Branch count: 21  
-Document count: 21  
-Index: geneve-ut-1163
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-1319
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11563,11 +12775,9 @@ event.category:process and host.os.type:windows and
     "StealthCloseFileDelegate" or
     "StealthOpenFile" or
     "StealthCloseFile" or
-    "StealthReadFile" or
     "Invoke-NinjaCopy"
-   )
-  and not user.id : "S-1-5-18"
-  and not powershell.file.script_block_text : (
+   ) and
+  not powershell.file.script_block_text : (
     "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
   )
 ```
@@ -11578,13 +12788,11 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1165
+Index: geneve-ut-1321
 
 ```python
 event.category:process and host.os.type:windows and
-  powershell.file.script_block_text : (
-    KerberosRequestorSecurityToken
-  ) and not user.id : ("S-1-5-18" or "S-1-5-20") and
+  powershell.file.script_block_text : "KerberosRequestorSecurityToken" and
   not powershell.file.script_block_text : (
     ("sentinelbreakpoints" and ("Set-PSBreakpoint" or "Set-HookFunctionTabs")) or
     ("function global" and "\\windows\\sentinel\\4")
@@ -11597,10 +12805,11 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1168
+Index: geneve-ut-1324
 
 ```python
-event.category:process and host.os.type:windows and powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory or pmuDetirWpmuDiniM) and not user.id : "S-1-5-18"
+event.category:process and host.os.type:windows and
+powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory or pmuDetirWpmuDiniM)
 ```
 
 
@@ -11609,7 +12818,7 @@ event.category:process and host.os.type:windows and powershell.file.script_block
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1170
+Index: geneve-ut-1326
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11633,7 +12842,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1171
+Index: geneve-ut-1327
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11661,7 +12870,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1186
+Index: geneve-ut-1342
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11682,7 +12891,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1189
+Index: geneve-ut-1345
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -11719,7 +12928,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1190
+Index: geneve-ut-1346
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -11736,7 +12945,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1191
+Index: geneve-ut-1347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11750,7 +12959,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1192
+Index: geneve-ut-1348
 
 ```python
 file where host.os.type == "windows" and
@@ -11769,7 +12978,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1193
+Index: geneve-ut-1349
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11781,9 +12990,9 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 ### Privilege Escalation via SUID/SGID
 
-Branch count: 434  
-Document count: 434  
-Index: geneve-ut-1194
+Branch count: 450  
+Document count: 450  
+Index: geneve-ut-1350
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11814,9 +13023,11 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     "wc", "wget", "whiptail", "xargs", "xdotool", "xmodmap", "xmore", "xxd", "xz", "yash", "zsh",
     "zsoelim"
   ) or
+  (process.name like ".*" or process.executable like ("/tmp/.*", "/var/tmp/.*", "/dev/shm/.*", "/home/*"))  or 
   (process.name == "ip" and ((process.args == "-force" and process.args in ("-batch", "-b")) or (process.args == "exec"))) or
   (process.name == "find" and process.args in ("-exec", "-execdir")) or
-  (process.name in ("bash", "csh", "dash") and process.args in ("-p", "-b"))
+  (process.name in ("bash", "csh", "dash") and process.args in ("-p", "-b")) or
+  (process.name in ("su", "sudo", "pkexec") and process.args_count == 1)
 ) and not (
   process.parent.name == "spine" or
   process.parent.executable in (
@@ -11834,7 +13045,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1195
+Index: geneve-ut-1351
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11852,7 +13063,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1197
+Index: geneve-ut-1353
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -11870,7 +13081,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1200
+Index: geneve-ut-1356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11884,7 +13095,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1202
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11899,7 +13110,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1203
+Index: geneve-ut-1359
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -11922,7 +13133,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1205
+Index: geneve-ut-1361
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -11966,7 +13177,6 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
                             "?:\\Windows\\Microsoft.NET\\Framework*\\*\\ngen.exe",
                             "?:\\Windows\\Microsoft.NET\\Framework*\\*\\aspnet_regiis.exe")) and
 
-
 /* Ignores additional parent executables that run with elevated privileges */
  not process.parent.executable :
                ("?:\\Windows\\System32\\AtBroker.exe",
@@ -12005,7 +13215,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1206
+Index: geneve-ut-1362
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -12026,7 +13236,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1207
+Index: geneve-ut-1363
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and
@@ -12045,7 +13255,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1209
+Index: geneve-ut-1365
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12098,7 +13308,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1210
+Index: geneve-ut-1366
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -12110,7 +13320,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1211
+Index: geneve-ut-1367
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -12122,7 +13332,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1212
+Index: geneve-ut-1368
 
 ```python
 process where host.os.type == "windows" and
@@ -12137,7 +13347,7 @@ process where host.os.type == "windows" and
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1213
+Index: geneve-ut-1369
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -12197,7 +13407,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1216
+Index: geneve-ut-1372
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -12210,7 +13420,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1217
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12242,7 +13452,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1218
+Index: geneve-ut-1374
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -12264,14 +13474,33 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 ### Proxy Execution via Console Window Host
 
-Branch count: 17  
-Document count: 17  
-Index: geneve-ut-1219
+Branch count: 68  
+Document count: 68  
+Index: geneve-ut-1376
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  process.name : "conhost.exe" and process.args : "--headless" and
-  process.command_line : ("*powershell*", "*cmd *", "*cmd.exe *", "*script*", "*mshta*", "*curl *", "*curl.exe *", "*^*^*^*", "*.bat*", "*.cmd*", "*schtasks*", "*@SSL*", "*http*", "* \\\\*", "*.vbs*", "*.js*", "*mhsta*")
+  process.command_line : (
+    "*powershell*", "*cmd *", "*cmd.exe *", "*script*", "*mshta*", "*curl *", "*curl.exe *", "*^*^*^*",
+    "*.bat*", "*.cmd*", "*schtasks*", "*@SSL*", "*http*", "* \\\\*", "*.vbs*", "*.js*", "*mhsta*"
+  ) and
+  not (
+    /* Winget-AutoUpdate via ServiceUI */
+    process.parent.executable : "?:\\Program Files\\winget-autoupdate*\\serviceui.exe" or
+    /* Winget-AutoUpdate notification via Task Scheduler */
+    (
+      process.parent.executable : "?:\\Windows\\System32\\svchost.exe" and process.parent.args : "-s" and
+      process.parent.args : "Schedule" and process.command_line : "*WAU-Notify.ps1*"
+    ) or
+    /* Windows OpenSSH console host — SSH-specific detection handled by 8cd49fbc-a35a-4418-8688-133cc3a1e548 */
+    process.parent.executable : (
+      "?:\\Windows\\System32\\OpenSSH\\sshd.exe",
+      "?:\\Windows\\System32\\OpenSSH\\sshd-session.exe",
+      "?:\\Program Files\\OpenSSH*\\sshd.exe",
+      "?:\\Program Files\\OpenSSH*\\sshd-session.exe"
+    )
+  )
 ```
 
 
@@ -12280,12 +13509,15 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1220
+Index: geneve-ut-1377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
- process.command_line : ("*Command=*powershell*", "*schtasks*", "*Command=*@echo off*", "*Command=*http*", "*Command=*mshta*",  "*Command=*msiexec*",
-                          "*Command=*cmd /c*", "*Command=*cmd.exe*", "*Command=\"cmd /c*", "*LocalCommand=scp*&&*", "*LocalCommand=?scp*&&*", "*Command=*script*")
+  process.command_line : (
+    "*Command=*powershell*", "*schtasks*", "*Command=*@echo off*", "*Command=*http*",
+    "*Command=*mshta*", "*Command=*msiexec*", "*Command=*cmd /c*", "*Command=*cmd.exe*",
+    "*Command=\"cmd /c*", "*LocalCommand=scp*&&*", "*LocalCommand=?scp*&&*", "*Command=*script*"
+  )
 ```
 
 
@@ -12294,7 +13526,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1221
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -12323,7 +13555,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1222
+Index: geneve-ut-1379
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12337,7 +13569,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1223
+Index: geneve-ut-1380
 
 ```python
 sequence by process.entity_id
@@ -12362,7 +13594,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1224
+Index: geneve-ut-1381
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -12396,7 +13628,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1225
+Index: geneve-ut-1382
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -12424,7 +13656,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1226
+Index: geneve-ut-1383
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -12443,7 +13675,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1229
+Index: geneve-ut-1387
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12471,7 +13703,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1230
+Index: geneve-ut-1388
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -12490,7 +13722,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1234
+Index: geneve-ut-1392
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -12502,7 +13734,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1235
+Index: geneve-ut-1393
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -12514,7 +13746,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1236
+Index: geneve-ut-1394
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -12526,7 +13758,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1237
+Index: geneve-ut-1395
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -12538,7 +13770,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1245
+Index: geneve-ut-1403
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12551,7 +13783,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1246
+Index: geneve-ut-1404
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12589,7 +13821,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1248
+Index: geneve-ut-1406
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12604,7 +13836,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1249
+Index: geneve-ut-1407
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12623,7 +13855,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1250
+Index: geneve-ut-1408
 
 ```python
 sequence with maxspan=1m
@@ -12642,18 +13874,23 @@ sequence with maxspan=1m
               "ZOHO Corporation Private Limited",
               "BeyondTrust Corporation", 
               "CyberArk Software Ltd.", 
-              "Sophos Ltd"
+              "Sophos Ltd",
+              "AO Kaspersky Lab",
+              "Anthropic, PBC",
+              "Adobe Inc.",
+              "Netwrix Corporation"
         )
       ) or
       (
         process.executable : (
           "?:\\Windows\\ccmsetup\\ccmsetup.exe",
-          "?:\\Windows\\SoftwareDistribution\\Download\\Install\\AM_Delta*.exe",
-          "?:\\Windows\\CAInvokerService.exe"
+          "?:\\Windows\\SoftwareDistribution\\Download\\Install\\*.exe",
+          "?:\\Windows\\CAInvokerService.exe",
+          "?:\\Users\\*\\AppData\\Local\\Microsoft\\OneDrive\\*\\OneDriveSetup.exe"
         ) and process.code_signature.trusted == true
       ) or
       (
-        process.executable : "G:\\SMS_*\\srvboot.exe" and 
+        process.executable : "?:\\SMS_*\\srvboot.exe" and 
         process.code_signature.trusted == true and process.code_signature.subject_name : "Microsoft Corporation"
       )
     )
@@ -12666,7 +13903,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1252
+Index: geneve-ut-1410
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -12689,7 +13926,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1254
+Index: geneve-ut-1412
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12703,7 +13940,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1255
+Index: geneve-ut-1413
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12717,7 +13954,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1257
+Index: geneve-ut-1415
 
 ```python
 sequence by host.id, process.entity_id
@@ -12734,7 +13971,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1258
+Index: geneve-ut-1416
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -12748,7 +13985,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1259
+Index: geneve-ut-1417
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12766,17 +14003,29 @@ sequence by host.id with maxspan=1m
 
 ### Remote SSH Login Enabled via systemsetup Command
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1260
+Branch count: 10  
+Document count: 10  
+Index: geneve-ut-1418
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
- process.name == "systemsetup" and
- process.args like~ "-setremotelogin" and 
- process.args like~ "on" and
- process.parent.executable != null and
- not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xpcproxy", "/usr/bin/sudo")
+(
+  (
+    process.name == "systemsetup" and
+    process.args like~ "-setremotelogin" and
+    process.args like~ "on"
+  ) or
+  (
+    process.name == "launchctl" and
+    process.args in ("load", "bootstrap") and
+    (
+      process.command_line like~ "*/System/Library/LaunchDaemons/ssh.plist*" or
+      process.command_line like~ "*com.openssh.sshd*"
+    )
+  )
+) and
+process.parent.executable != null and
+not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xpcproxy", "/usr/bin/sudo")
 ```
 
 
@@ -12785,7 +14034,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1261
+Index: geneve-ut-1419
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -12805,7 +14054,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1262
+Index: geneve-ut-1420
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -12818,7 +14067,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1264
+Index: geneve-ut-1422
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -12860,7 +14109,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1265
+Index: geneve-ut-1423
 
 ```python
 sequence with maxspan=1m
@@ -12883,7 +14132,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1266
+Index: geneve-ut-1424
 
 ```python
 sequence with maxspan=1s
@@ -12931,7 +14180,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1267
+Index: geneve-ut-1425
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12948,7 +14197,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1269
+Index: geneve-ut-1427
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -12977,7 +14226,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1270
+Index: geneve-ut-1428
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -13005,7 +14254,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1271
+Index: geneve-ut-1429
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -13022,7 +14271,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1273
+Index: geneve-ut-1431
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -13041,7 +14290,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1274
+Index: geneve-ut-1432
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -13062,7 +14311,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1279
+Index: geneve-ut-1438
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -13081,7 +14330,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1280
+Index: geneve-ut-1439
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -13095,7 +14344,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1281
+Index: geneve-ut-1440
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -13115,7 +14364,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1283
+Index: geneve-ut-1442
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13133,7 +14382,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1284
+Index: geneve-ut-1443
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -13154,7 +14403,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1286
+Index: geneve-ut-1445
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13166,15 +14415,15 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 ### ScreenConnect Server Spawning Suspicious Processes
 
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-1287
+Branch count: 10  
+Document count: 10  
+Index: geneve-ut-1446
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.parent.name : "ScreenConnect.Service.exe" and
   (process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "powershell_ise.exe", "csc.exe") or
-  ?process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE", "pwsh.dll", "powershell_ise.EXE"))
+  ?process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE", "pwsh.dll", "powershell_ise.EXE", "csc.exe"))
 ```
 
 
@@ -13183,7 +14432,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1288
+Index: geneve-ut-1447
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -13224,7 +14473,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1290
+Index: geneve-ut-1449
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -13249,7 +14498,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1291
+Index: geneve-ut-1450
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -13288,7 +14537,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1292
+Index: geneve-ut-1451
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13302,7 +14551,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1293
+Index: geneve-ut-1452
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13326,7 +14575,12 @@ process.args like (
   ?process.parent.args in ("/opt/imperva/ragent/bin/get_sys_resources.sh", "/usr/sbin/lynis", "./terra_linux.sh") or
   process.args == "/usr/bin/coreutils" or
   (process.parent.name == "pwsh" and process.parent.command_line like "*Evaluate-STIG*") or
-  ?process.parent.executable == "/usr/sap/audit_scripts/auto_audit_gral.sh"
+  ?process.parent.executable like (
+    "/usr/sap/audit_scripts/auto_audit_gral.sh", "/opt/saltstack/salt/bin/python3*", "/opt/puppetlabs/puppet/bin/ruby"
+  ) or
+  ?process.entry_leader.executable like (
+    "/usr/sbin/ScanAssistant", "/opt/Tanium/TaniumClient/TaniumClient", "/tmp/CVU_*resource/exectask", "/opt/nessus/sbin/nessus-service"
+  )
 )
 ```
 
@@ -13336,7 +14590,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1294
+Index: geneve-ut-1453
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13350,7 +14604,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1295
+Index: geneve-ut-1454
 
 ```python
 process where event.type == "start" and
@@ -13422,7 +14676,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1297
+Index: geneve-ut-1457
 
 ```python
 event.code : "4719" and host.os.type : "windows" and
@@ -13443,7 +14697,7 @@ event.code : "4719" and host.os.type : "windows" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1298
+Index: geneve-ut-1458
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -13464,7 +14718,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1300
+Index: geneve-ut-1460
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13481,7 +14735,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1301
+Index: geneve-ut-1462
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13495,11 +14749,11 @@ process.command_line like~ (
 
 
 
-### Sensitive Privilege SeEnableDelegationPrivilege assigned to a User
+### Sensitive Privilege SeEnableDelegationPrivilege assigned to a Principal
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1302
+Index: geneve-ut-1463
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -13511,19 +14765,31 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1303
+Index: geneve-ut-1464
 
 ```python
-file where host.os.type == "windows" and 
- event.action == "open" and event.outcome == "success" and process.executable != null and 
+file where host.os.type == "windows" and
+ event.action == "open" and event.outcome == "success" and process.executable != null and
  file.path :
       ("?:\\Windows\\System32\\config\\RegBack\\SAM",
        "?:\\Windows\\System32\\config\\RegBack\\SECURITY",
-       "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and 
+       "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and
  not (
     user.id == "S-1-5-18" and process.executable : (
-        "?:\\Windows\\system32\\taskhostw.exe", "?:\\Windows\\system32\\taskhost.exe"
-    ))
+        "?:\\Windows\\system32\\taskhostw.exe",
+        "?:\\Windows\\system32\\taskhost.exe",
+        "?:\\Program Files\\Sophos\\Endpoint Defense\\SophosScanCoordinator.exe",
+        "?:\\Program Files\\Sophos\\Endpoint Defense\\SSPService.exe",
+        "?:\\Program Files\\Windows Defender Advanced Threat Protection\\MsSense.exe",
+        "?:\\Program Files\\Trend Micro\\AMSP\\coreServiceShell.exe",
+        "?:\\Program Files\\Symantec\\Symantec Endpoint Protection\\*\\Bin64\\ccSvcHst.exe",
+        "?:\\Program Files\\Bitdefender\\Endpoint Security\\EPSecurityService.exe",
+        "?:\\Program Files\\N-able Technologies\\AVDefender\\EPSecurityService.exe",
+        "?:\\Program Files\\Cylance\\Optics\\CyOptics.exe",
+        "?:\\Program Files\\Common Files\\McAfee\\AVSolution\\mcshield.exe",
+        "?:\\Program Files (x86)\\Padvish AV\\APCcSvc.exe"
+    )
+ )
 ```
 
 
@@ -13532,7 +14798,7 @@ file where host.os.type == "windows" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1306
+Index: geneve-ut-1467
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -13549,7 +14815,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1307
+Index: geneve-ut-1468
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -13569,7 +14835,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1309
+Index: geneve-ut-1470
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13584,7 +14850,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1310
+Index: geneve-ut-1471
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13605,7 +14871,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1311
+Index: geneve-ut-1472
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13628,7 +14894,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1312
+Index: geneve-ut-1473
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -13641,7 +14907,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1313
+Index: geneve-ut-1474
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13658,7 +14924,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1315
+Index: geneve-ut-1476
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -13683,7 +14949,7 @@ not (
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1317
+Index: geneve-ut-1479
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -13732,7 +14998,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1318
+Index: geneve-ut-1480
 
 ```python
 sequence by host.id with maxspan=10s
@@ -13742,11 +15008,26 @@ sequence by host.id with maxspan=10s
 
 
 
+### Shell Execution via Elastic Endpoint
+
+Branch count: 64  
+Document count: 64  
+Index: geneve-ut-1481
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.parent.executable == "/opt/Elastic/Endpoint/elastic-endpoint" and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+process.args in ("-c", "-cl", "-lc", "--command")
+```
+
+
+
 ### Shell History Clearing via Environment Variables
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1319
+Index: geneve-ut-1482
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13761,7 +15042,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1320
+Index: geneve-ut-1483
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -13783,7 +15064,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1321
+Index: geneve-ut-1484
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13804,7 +15085,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1324
+Index: geneve-ut-1487
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13818,7 +15099,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1325
+Index: geneve-ut-1488
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -13841,7 +15122,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1351
+Index: geneve-ut-1516
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13866,7 +15147,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1352
+Index: geneve-ut-1517
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -13899,7 +15180,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1353
+Index: geneve-ut-1518
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -13958,7 +15239,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1355
+Index: geneve-ut-1520
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -13976,7 +15257,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1356
+Index: geneve-ut-1521
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -13988,7 +15269,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1358
+Index: geneve-ut-1523
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -14013,7 +15294,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1363
+Index: geneve-ut-1528
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14028,7 +15309,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1364
+Index: geneve-ut-1529
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -14051,7 +15332,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1367
+Index: geneve-ut-1532
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14065,7 +15346,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1369
+Index: geneve-ut-1534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14087,7 +15368,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1371
+Index: geneve-ut-1536
 
 ```python
 sequence by host.id with maxspan=5s
@@ -14114,7 +15395,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1375
+Index: geneve-ut-1540
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -14126,6 +15407,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
     "?:\\Windows\\Syswow64\\amsi.dll",
     "?:\\$WINDOWS.~BT\\*\\amsi.dll",
     "?:\\Windows\\CbsTemp\\*\\amsi.dll",
+    "?:\\Windows\\SystemTemp\\*\\amsi.dll",
     "?:\\Windows\\SoftwareDistribution\\Download\\*",
     "?:\\Windows\\WinSxS\\*\\amsi.dll", 
     "?:\\Windows\\servicing\\*\\amsi.dll",
@@ -14140,7 +15422,8 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
     "\\Device\\HarddiskVolume*\\$SysReset\\CloudImage\\Package_for_RollupFix*\\amsi.dll",
     "\\Device\\HarddiskVolume*\\$WINDOWS.~BT\\*\\amsi.dll", 
     "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download\\*\\amsi.dll", 
-    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll", 
+    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll",
+    "\\Device\\HarddiskVolume*\\Windows\\SystemTemp\\*\\amsi.dll", 
     "\\Device\\HarddiskVolume*\\Windows\\servicing\\*\\amsi.dll"
   )
 ```
@@ -14151,7 +15434,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1376
+Index: geneve-ut-1541
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -14174,7 +15457,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1377
+Index: geneve-ut-1542
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -14188,7 +15471,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1378
+Index: geneve-ut-1543
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14204,7 +15487,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1379
+Index: geneve-ut-1544
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14220,7 +15503,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1380
+Index: geneve-ut-1545
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14234,7 +15517,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1382
+Index: geneve-ut-1547
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14257,7 +15540,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1383
+Index: geneve-ut-1548
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14272,7 +15555,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1384
+Index: geneve-ut-1551
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -14299,7 +15582,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1386
+Index: geneve-ut-1553
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -14315,7 +15598,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1387
+Index: geneve-ut-1554
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -14328,7 +15611,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1389
+Index: geneve-ut-1556
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -14344,7 +15627,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1390
+Index: geneve-ut-1557
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -14360,7 +15643,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1391
+Index: geneve-ut-1558
 
 ```python
 any where host.os.type == "windows" and 
@@ -14427,7 +15710,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1393
+Index: geneve-ut-1560
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -14443,7 +15726,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1394
+Index: geneve-ut-1561
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14479,7 +15762,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1395
+Index: geneve-ut-1562
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14517,7 +15800,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1396
+Index: geneve-ut-1563
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -14552,7 +15835,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1397
+Index: geneve-ut-1564
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14586,7 +15869,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1399
+Index: geneve-ut-1566
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -14607,7 +15890,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1404
+Index: geneve-ut-1571
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -14635,7 +15918,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1405
+Index: geneve-ut-1572
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14643,7 +15926,7 @@ process where host.os.type == "windows" and event.type == "start" and
 (process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or ?process.code_signature.subject_name : "OpenJS Foundation") and
 
 (
-  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume?\\\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
+  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
 
   (process.args : "-r" and process.parent.name : "powershell.exe") or
 
@@ -14657,7 +15940,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1406
+Index: geneve-ut-1573
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14681,7 +15964,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1407
+Index: geneve-ut-1574
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -14702,7 +15985,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1410
+Index: geneve-ut-1577
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14717,7 +16000,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1413
+Index: geneve-ut-1580
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14730,7 +16013,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1414
+Index: geneve-ut-1581
 
 ```python
 any where host.os.type == "windows" and
@@ -14745,7 +16028,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1415
+Index: geneve-ut-1582
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14761,7 +16044,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1416
+Index: geneve-ut-1583
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -14775,7 +16058,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1418
+Index: geneve-ut-1587
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14789,19 +16072,28 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1420
+Index: geneve-ut-1589
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
  [network where host.os.type == "windows" and destination.port == 88 and
   process.executable != null and process.pid != 4 and 
-  not process.executable : 
-              ("?:\\Windows\\system32\\lsass.exe", 
-               "\\device\\harddiskvolume*\\windows\\system32\\lsass.exe", 
-               "\\device\\harddiskvolume*\\windows\\system32\\svchost.exe") and
-  not (process.executable : ("C:\\Windows\\System32\\svchost.exe", 
-                             "C:\\Program Files\\VMware\\VMware View\\Server\\bin\\ws_TomcatService.exe", 
-                             "F:\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe") and user.id in ("S-1-5-20", "S-1-5-18")) and   
+  not process.executable : (
+        "?:\\Windows\\system32\\lsass.exe",
+        "\\device\\harddiskvolume*\\windows\\system32\\lsass.exe",
+        "\\device\\harddiskvolume*\\windows\\system32\\svchost.exe"
+  ) and
+  not (
+    process.executable : (
+      "C:\\Windows\\System32\\svchost.exe",
+      "C:\\Program Files\\VMware\\VMware View\\Server\\bin\\ws_TomcatService.exe",
+      "C:\\Program Files\\Omnissa\\Horizon\\Server\\bin\\ws_TomcatService.exe",
+      "C:\\Program Files\\SysAidServer\\root\\WEB-INF\\domains\\NetworkDiscovery.exe",
+      "C:\\Program Files (x86)\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe",
+      "F:\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe"
+    ) and
+    user.id in ("S-1-5-20", "S-1-5-18")
+  ) and
   source.ip != "127.0.0.1" and destination.ip != "::1" and destination.ip != "127.0.0.1"]
  [authentication where host.os.type == "windows" and event.code in ("4768", "4769")]
 ```
@@ -14812,7 +16104,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1422
+Index: geneve-ut-1591
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -14825,7 +16117,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1423
+Index: geneve-ut-1592
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -14834,7 +16126,7 @@ process where host.os.type == "windows" and event.code == "10" and
    /* seclogon service accessing lsass */
   winlog.event_data.CallTrace : "*seclogon.dll*" and process.name : "svchost.exe" and
 
-   /* PROCESS_CREATE_PROCESS & PROCESS_DUP_HANDLE & PROCESS_QUERY_INFORMATION */
+   /* PROCESS_CREATE_PROCESS & PROCESS_DUP_HANDLE & PROCESS_QUERY_INFORMATION & PROCESS_QUERY_LIMITED_INFORMATION */
   winlog.event_data.GrantedAccess == "0x14c0"
 ```
 
@@ -14844,7 +16136,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1424
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -14890,7 +16182,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1426
+Index: geneve-ut-1595
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14911,7 +16203,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1427
+Index: geneve-ut-1596
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14931,7 +16223,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1428
+Index: geneve-ut-1597
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14945,7 +16237,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1429
+Index: geneve-ut-1598
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14973,28 +16265,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Suspicious Microsoft HTML Application Child Process
-
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-1431
-
-```python
-process where host.os.type == "windows" and event.type == "start" and
- process.parent.name : "mshta.exe" and
- (
-  process.name : ("cmd.exe", "powershell.exe", "certutil.exe", "bitsadmin.exe", "curl.exe", "msiexec.exe", "schtasks.exe", "reg.exe", "wscript.exe", "rundll32.exe") or
-  process.executable : ("C:\\Users\\*\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\*.exe")
-  )
-```
-
-
-
 ### Suspicious Mining Process Creation Event
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1432
+Index: geneve-ut-1601
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -15013,80 +16288,101 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 ### Suspicious Module Loaded by LSASS
 
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-1434
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1603
 
 ```python
-any where event.category in ("library", "driver") and host.os.type == "windows" and
+library where host.os.type == "windows" and event.action == "load" and
   process.executable : "?:\\Windows\\System32\\lsass.exe" and
-  not (dll.code_signature.subject_name :
-               ("Microsoft Windows",
-                "Microsoft Corporation",
-                "Microsoft Windows Publisher",
-                "Microsoft Windows Software Compatibility Publisher",
-                "Microsoft Windows Hardware Compatibility Publisher",
-                "McAfee, Inc.",
-                "SecMaker AB",
-                "HID Global Corporation",
-                "HID Global",
-                "Apple Inc.",
-                "Citrix Systems, Inc.",
-                "Dell Inc",
-                "Hewlett-Packard Company",
-                "Symantec Corporation",
-                "National Instruments Corporation",
-                "DigitalPersona, Inc.",
-                "Novell, Inc.",
-                "gemalto",
-                "EasyAntiCheat Oy",
-                "Entrust Datacard Corporation",
-                "AuriStor, Inc.",
-                "LogMeIn, Inc.",
-                "VMware, Inc.",
-                "Istituto Poligrafico e Zecca dello Stato S.p.A.",
-                "Nubeva Technologies Ltd",
-                "Micro Focus (US), Inc.",
-                "Yubico AB",
-                "GEMALTO SA",
-                "Secure Endpoints, Inc.",
-                "Sophos Ltd",
-                "Morphisec Information Security 2014 Ltd",
-                "Entrust, Inc.",
-                "Nubeva Technologies Ltd",
-                "Micro Focus (US), Inc.",
-                "F5 Networks Inc",
-                "Bit4id",
-                "Thales DIS CPL USA, Inc.",
-                "Micro Focus International plc",
-                "HYPR Corp",
-                "Intel(R) Software Development Products",
-                "PGP Corporation",
-                "Parallels International GmbH",
-                "FrontRange Solutions Deutschland GmbH",
-                "SecureLink, Inc.",
-                "Tidexa OU",
-                "Amazon Web Services, Inc.",
-                "SentryBay Limited",
-                "Audinate Pty Ltd",
-                "CyberArk Software Ltd.",
-                "McAfeeSysPrep",
-                "NVIDIA Corporation PE Sign v2016",
-                "Trend Micro, Inc.",
-                "Fortinet Technologies (Canada) Inc.",
-                "Carbon Black, Inc.") and
-       dll.code_signature.status : ("trusted", "errorExpired", "errorCode_endpoint*", "errorChaining")) and
+  not (
+        dll.code_signature.subject_name : (
+            "Algorithmic Research LTD.",
+            "Amazon Web Services, Inc.",
+            "Apple Inc.",
+            "Audinate Pty Ltd",
+            "AuriStor, Inc.",
+            "Bit4id",
+            "Carbon Black, Inc.",
+            "Check Point Software Technologies Ltd.",
+            "Citrix Systems, Inc.",
+            "CyberArk Software Ltd.",
+            "Dell Inc",
+            "DigitalPersona, Inc.",
+            "EasyAntiCheat Oy",
+            "Entrust Corporation",
+            "Entrust Datacard Corporation",
+            "Entrust, Inc.",
+            "F5 Networks Inc",
+            "Fortinet, Inc.",
+            "Fortinet Technologies (Canada) Inc.",
+            "FrontRange Solutions Deutschland GmbH",
+            "GEMALTO SA",
+            "gemalto",
+            "Hewlett-Packard Company",
+            "HID Global",
+            "HID Global Corporation",
+            "HYPR Corp",
+            "IDEMIA IDENTITY & SECURITY FRANCE SAS",
+            "IDEMIA France SAS",
+            "Intel(R) Software Development Products",
+            "Istituto Poligrafico e Zecca dello Stato S.p.A.",
+            "LogMeIn, Inc.",
+            "McAfee, Inc.",
+            "McAfeeSysPrep",
+            "Micro Focus (US), Inc.",
+            "Micro Focus International plc",
+            "Microsoft Corporation",
+            "Microsoft Windows",
+            "Microsoft Windows Hardware Compatibility Publisher",
+            "Microsoft Windows Publisher",
+            "Microsoft Windows Software Compatibility Publisher",
+            "Morphisec Information Security 2014 Ltd",
+            "Musarubra US LLC",
+            "National Instruments Corporation",
+            "Novell, Inc.",
+            "Nubeva Technologies Ltd",
+            "NVIDIA Corporation PE Sign v2016",
+            "Palo Alto Networks (Netherlands) B.V.",
+            "Parallels International GmbH",
+            "PGP Corporation",
+            "QUEST SOFTWARE INC.",
+            "SecMaker AB",
+            "Secure Endpoints, Inc.",
+            "SecureLink, Inc.",
+            "SentinelOne Inc.",
+            "SentryBay Limited",
+            "Sophos Ltd",
+            "Symantec Corporation",
+            "Thales DIS CPL USA, Inc.",
+            "Tidexa OU",
+            "Trend Micro, Inc.",
+            "VMware, Inc.",
+            "Yubico AB"
+        ) and
+        dll.code_signature.status : ("trusted", "errorExpired", "errorCode_endpoint*", "errorChaining")
+  ) and
 
-     not dll.hash.sha256 :
-                ("811a03a5d7c03802676d2613d741be690b3461022ea925eb6b2651a5be740a4c",
-                 "1181542d9cfd63fb00c76242567446513e6773ea37db6211545629ba2ecf26a1",
-                 "ed6e735aa6233ed262f50f67585949712f1622751035db256811b4088c214ce3",
-                 "26be2e4383728eebe191c0ab19706188f0e9592add2e0bf86b37442083ae5e12",
-                 "9367e78b84ef30cf38ab27776605f2645e52e3f6e93369c674972b668a444faa",
-                 "d46cc934765c5ecd53867070f540e8d6f7701e834831c51c2b0552aba871921b",
-                 "0f77a3826d7a5cd0533990be0269d951a88a5c277bc47cff94553330b715ec61",
-                 "4aca034d3d85a9e9127b5d7a10882c2ef4c3e0daa3329ae2ac1d0797398695fb",
-                 "86031e69914d9d33c34c2f4ac4ae523cef855254d411f88ac26684265c981d95")
+  not dll.hash.sha256 : (
+          "811a03a5d7c03802676d2613d741be690b3461022ea925eb6b2651a5be740a4c",
+          "1181542d9cfd63fb00c76242567446513e6773ea37db6211545629ba2ecf26a1",
+          "ed6e735aa6233ed262f50f67585949712f1622751035db256811b4088c214ce3",
+          "26be2e4383728eebe191c0ab19706188f0e9592add2e0bf86b37442083ae5e12",
+          "9367e78b84ef30cf38ab27776605f2645e52e3f6e93369c674972b668a444faa",
+          "d46cc934765c5ecd53867070f540e8d6f7701e834831c51c2b0552aba871921b",
+          "0f77a3826d7a5cd0533990be0269d951a88a5c277bc47cff94553330b715ec61",
+          "4aca034d3d85a9e9127b5d7a10882c2ef4c3e0daa3329ae2ac1d0797398695fb",
+          "86031e69914d9d33c34c2f4ac4ae523cef855254d411f88ac26684265c981d95",
+          "4af1fee3369d9a993a84f54eafb72a661633c33e9e12fb3dd151a6a2cddbd404"
+  ) and
+  not dll.path : (
+        "C:\\Windows\\System32\\CertPolEng.dll",
+        "C:\\Windows\\System32\\FWPUCLNT.DLL",
+        "C:\\Windows\\System32\\keyiso.dll",
+        "C:\\Windows\\System32\\ngcpopkeysrv.dll",
+        "C:\\Windows\\System32\\SecureTimeAggregator.dll",
+        "C:\\Windows\\System32\\vaultsvc.dll"
+  )
 ```
 
 
@@ -15095,7 +16391,7 @@ any where event.category in ("library", "driver") and host.os.type == "windows" 
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1437
+Index: geneve-ut-1606
 
 ```python
 sequence by host.id with maxspan=5s
@@ -15143,7 +16439,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1439
+Index: geneve-ut-1608
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15169,7 +16465,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1440
+Index: geneve-ut-1609
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15214,7 +16510,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1441
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15238,7 +16534,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1442
+Index: geneve-ut-1611
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -15254,7 +16550,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1444
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -15279,7 +16575,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1445
+Index: geneve-ut-1614
 
 ```python
 event.category:process and host.os.type:windows and
@@ -15294,7 +16590,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1448
+Index: geneve-ut-1617
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -15308,7 +16604,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1449
+Index: geneve-ut-1618
 
 ```python
 sequence by host.id with maxspan=30s
@@ -15328,7 +16624,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1450
+Index: geneve-ut-1619
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -15363,7 +16659,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1454
+Index: geneve-ut-1623
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15376,7 +16672,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1456
+Index: geneve-ut-1625
 
 ```python
 any where host.os.type == "windows" and
@@ -15409,7 +16705,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1458
+Index: geneve-ut-1627
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -15427,7 +16723,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1459
+Index: geneve-ut-1628
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -15445,11 +16741,50 @@ and not (
 
 
 
+### Suspicious SUID Binary Execution (Auditd Sequence)
+
+Branch count: 414  
+Document count: 828  
+Index: geneve-ut-1631
+
+```python
+sequence by host.id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action == "executed" and
+   user.id != "0" and user.effective.id != "0" and
+   (
+     process.name like ("python*", "perl*", "ruby*", "php*", "lua*", ".*") or
+     process.name in ("node", "bun", "java") or
+     process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+     (
+       process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+       process.args in ("-c", "--command", "-ic", "-ci", "-cl", "-lc")
+     )
+   )
+  ] by process.pid
+
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action == "executed" and
+   user.effective.id == "0" and user.id != "0" and
+   (
+     (process.name in ("sudo", "pkexec") and
+      not process.args like "-*" and
+      not process.args : ("/usr/*", "/bin/*", "/sbin/*", "/opt/*")) or
+     (process.name == "su" and
+      not process.args in ("--command", "-c", "--shell", "-s")) or
+     (process.name in ("passwd", "chsh", "newgrp") and
+      not process.args in ("--shell", "-s", "--help"))
+   )
+  ] by process.parent.pid
+```
+
+
+
 ### Suspicious ScreenConnect Client Child Process
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1461
+Index: geneve-ut-1632
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15468,7 +16803,7 @@ process where host.os.type == "windows" and event.type == "start" and
    (process.name : "rundll32.exe" and not process.args : "url.dll,FileProtocolHandler") or
    (process.name : "msiexec.exe" and process.args : ("/i", "-i") and
     process.args : ("/q", "/quiet", "/qn", "-q", "-quiet", "-qn", "-Q+")) or
-   process.name : ("mshta.exe", "certutil.exe", "bistadmin.exe", "certreq.exe", "wscript.exe", "cscript.exe", "curl.exe",
+   process.name : ("mshta.exe", "certutil.exe", "bitsadmin.exe", "certreq.exe", "wscript.exe", "cscript.exe", "curl.exe",
                    "ssh.exe", "scp.exe", "wevtutil.exe", "wget.exe", "wmic.exe")
    )
 ```
@@ -15479,7 +16814,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1462
+Index: geneve-ut-1633
 
 ```python
 any where host.os.type == "windows" and
@@ -15513,7 +16848,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1463
+Index: geneve-ut-1634
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -15527,7 +16862,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1466
+Index: geneve-ut-1637
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15558,13 +16893,13 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1467
+Index: geneve-ut-1638
 
 ```python
 any where host.os.type == "windows" and
 (
  (event.category == "library" and
-  process.executable : ("C:\\Program Files\\WebHelpDesk\\*\\java.exe", "C:\\Program Files (x86)\\WebHelpDesk\\*\\java.exe") and
+  process.executable : ("C:\\Program Files\\WebHelpDesk\\*\\java*.exe", "C:\\Program Files (x86)\\WebHelpDesk\\*\\java*.exe") and
   (dll.path : "\\Device\\Mup\\*" or dll.code_signature.trusted == false or ?dll.code_signature.exists == false)) or
 
  (event.category == "process" and process.name : ("cmd.exe", "powershell.exe", "rundll32.exe") and
@@ -15578,7 +16913,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1468
+Index: geneve-ut-1639
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15619,7 +16954,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1469
+Index: geneve-ut-1640
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -15635,7 +16970,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1470
+Index: geneve-ut-1641
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15665,7 +17000,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1474
+Index: geneve-ut-1645
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -15678,7 +17013,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1475
+Index: geneve-ut-1646
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -15702,7 +17037,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1477
+Index: geneve-ut-1648
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15720,7 +17055,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1479
+Index: geneve-ut-1650
 
 ```python
 any where host.os.type == "windows" and
@@ -15735,7 +17070,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1480
+Index: geneve-ut-1651
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -15753,7 +17088,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1481
+Index: geneve-ut-1652
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -15765,7 +17100,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
                   "Login Data") and
  ((process.code_signature.trusted == false or process.code_signature.exists == false) or process.name == "osascript") and
  not process.code_signature.signing_id == "org.mozilla.firefox" and
- not Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
+not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
 ```
 
 
@@ -15774,7 +17109,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1482
+Index: geneve-ut-1653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15793,7 +17128,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1485
+Index: geneve-ut-1656
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15818,7 +17153,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1486
+Index: geneve-ut-1657
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15831,7 +17166,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1488
+Index: geneve-ut-1659
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -15844,7 +17179,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1490
+Index: geneve-ut-1661
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15867,7 +17202,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1492
+Index: geneve-ut-1663
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15886,7 +17221,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1493
+Index: geneve-ut-1664
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -15908,7 +17243,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1494
+Index: geneve-ut-1665
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -15941,7 +17276,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1496
+Index: geneve-ut-1667
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15959,7 +17294,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1497
+Index: geneve-ut-1668
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15973,7 +17308,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1498
+Index: geneve-ut-1669
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15997,7 +17332,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1499
+Index: geneve-ut-1670
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -16020,7 +17355,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1500
+Index: geneve-ut-1671
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -16039,7 +17374,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1504
+Index: geneve-ut-1675
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -16074,7 +17409,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1505
+Index: geneve-ut-1676
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16091,7 +17426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1506
+Index: geneve-ut-1677
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16111,7 +17446,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1507
+Index: geneve-ut-1678
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16151,7 +17486,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1508
+Index: geneve-ut-1679
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -16167,7 +17502,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1509
+Index: geneve-ut-1680
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16181,7 +17516,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1510
+Index: geneve-ut-1681
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -16219,7 +17554,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1511
+Index: geneve-ut-1682
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -16269,11 +17604,39 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 
 
+### Systemd Service Override Configuration File Created
+
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-1683
+
+```python
+file where host.os.type == "linux" and event.action in ("rename", "creation") and
+file.extension == "conf" and file.path like (
+  "/etc/systemd/system/*.d/*.conf", "/etc/systemd/user/*.d/*.conf", "/usr/local/lib/systemd/system/*.d/*.conf",
+  "/lib/systemd/system/*.d/*.conf", "/usr/lib/systemd/system/*.d/*.conf", "/usr/lib/systemd/user/*.d/*.conf",
+  "/home/*/.config/systemd/user/*.d/*.conf", "/home/*/.local/share/systemd/user/*.d/*.conf",
+  "/root/.config/systemd/user/*.d/*.conf", "/root/.local/share/systemd/user/*.d/*.conf",
+  "/run/systemd/system/*.d/*.conf", "/var/run/systemd/system/*.d/*.conf"
+) and
+not process.executable in (
+  "/bin/dpkg", "/usr/bin/dpkg", "/bin/dockerd", "/usr/bin/dockerd", "/usr/sbin/dockerd", "/bin/microdnf",
+  "/usr/bin/microdnf", "/bin/rpm", "/usr/bin/rpm", "/bin/snapd", "/usr/bin/snapd", "/bin/yum", "/usr/bin/yum",
+  "/bin/dnf", "/usr/bin/dnf", "/bin/podman", "/usr/bin/podman", "/bin/dnf-automatic", "/usr/bin/dnf-automatic",
+  "/usr/bin/dpkg-divert", "/bin/dpkg-divert", "/sbin/apk", "/usr/sbin/apk", "/usr/local/sbin/apk", "/usr/bin/dnf5",
+  "/usr/bin/apt", "/usr/bin/puppet", "/bin/puppet", "/opt/puppetlabs/puppet/bin/puppet", "/usr/bin/pacman",
+  "/usr/bin/chef-client", "/bin/chef-client", "/usr/bin/pamac-daemon", "/bin/pamac-daemon", "/usr/local/bin/dockerd",
+  "/usr/bin/crio", "/usr/bin/podman", "/usr/bin/tdnf", "/usr/bin/apk"
+)
+```
+
+
+
 ### Systemd Shell Execution During Boot
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1513
+Index: geneve-ut-1685
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -16287,7 +17650,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1514
+Index: geneve-ut-1686
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -16333,7 +17696,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1515
+Index: geneve-ut-1687
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -16372,7 +17735,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1516
+Index: geneve-ut-1688
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -16385,7 +17748,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1519
+Index: geneve-ut-1691
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -16418,7 +17781,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1520
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -16432,7 +17795,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1521
+Index: geneve-ut-1693
 
 ```python
 sequence by host.id with maxspan=1s
@@ -16446,7 +17809,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1522
+Index: geneve-ut-1694
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -16460,7 +17823,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1523
+Index: geneve-ut-1695
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -16499,7 +17862,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1529
+Index: geneve-ut-1701
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -16541,7 +17904,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1530
+Index: geneve-ut-1702
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -16554,7 +17917,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1531
+Index: geneve-ut-1703
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16571,7 +17934,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1532
+Index: geneve-ut-1704
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -16587,7 +17950,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1533
+Index: geneve-ut-1705
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16600,7 +17963,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1534
+Index: geneve-ut-1706
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -16615,7 +17978,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1535
+Index: geneve-ut-1707
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16636,15 +17999,16 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### UAC Bypass via ICMLuaUtil Elevated COM Interface
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1536
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1708
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  process.parent.name == "dllhost.exe" and
  process.parent.args in ("/Processid:{3E5FC7F9-9A51-4367-9063-A120244FBEC7}", "/Processid:{D2E7041B-2927-42FB-8E9F-7CE93B6DC937}") and
- process.pe.original_file_name != "WerFault.exe"
+ process.pe.original_file_name != "WerFault.exe" and
+ not (process.executable : "?:\\Program Files\\WireGuard\\wireguard.exe" and process.args : "/installmanagerservice")
 ```
 
 
@@ -16653,7 +18017,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1537
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16665,38 +18029,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Uncommon Destination Port Connection by Web Server
-
-Branch count: 45  
-Document count: 45  
-Index: geneve-ut-1541
-
-```python
-network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and (
-  process.name like (
-    "apache", "nginx", "apache2", "httpd", "lighttpd", "caddy", "mongrel_rails", "gunicorn",
-    "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn",
-    "daphne", "twistd", "yaws", "webfsd", "httpd.worker", "flask", "rails", "mongrel", "php-fpm*", "php-cgi",
-    "php-fcgi", "php-cgi.cagefs", "catalina.sh", "hiawatha", "lswsctrl"
-  ) or
-  user.name in ("apache", "www-data", "httpd", "nginx", "lighttpd", "tomcat", "tomcat8", "tomcat9") or
-  user.id in ("33", "498", "48") or
-  (process.name == "java" and process.working_directory like "/u0?/*")
-) and
-network.direction == "egress" and destination.ip != null and
-not destination.port in (80, 443, 8080, 8443, 8000, 8888, 3128, 3306, 5432, 8220, 8082) and
-not cidrmatch(destination.ip, "127.0.0.0/8", "::1","FE80::/10", "FF00::/8", "10.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.0.0.0/24", "192.0.0.0/29", "192.0.0.8/32", "192.0.0.9/32",
-"192.0.0.10/32", "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24", "192.168.0.0/16", "192.88.99.0/24",
-"224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24","198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "224.0.0.0/4", "240.0.0.0/4")
-```
-
-
-
 ### Unexpected Child Process of macOS Screensaver Engine
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1543
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -16708,7 +18045,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1544
+Index: geneve-ut-1715
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16737,7 +18074,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1546
+Index: geneve-ut-1717
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -16747,36 +18084,22 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 
 
-### Untrusted DLL Loaded by Azure AD Sync Service
+### Untrusted DLL Loaded by Azure AD Connect Authentication Agent
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1551
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1722
 
 ```python
-any where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
-(
- (event.category == "library" and event.action == "load") or
- (event.category == "process" and event.action : "Image loaded*")
-) and
+library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
 
-not (?dll.code_signature.trusted == true or file.code_signature.status == "Valid") and not
-
-  (
-   /* Elastic defend DLL path */
-   ?dll.path :
-         ("?:\\Windows\\assembly\\NativeImages*",
-          "?:\\Windows\\Microsoft.NET\\*",
-          "?:\\Windows\\WinSxS\\*",
-          "?:\\Windows\\System32\\DriverStore\\FileRepository\\*") or
-
-   /* Sysmon DLL path is mapped to file.path */
-   file.path :
-         ("?:\\Windows\\assembly\\NativeImages*",
-          "?:\\Windows\\Microsoft.NET\\*",
-          "?:\\Windows\\WinSxS\\*",
-          "?:\\Windows\\System32\\DriverStore\\FileRepository\\*")
-  )
+not dll.code_signature.trusted == true and
+not dll.path : (
+    "?:\\Windows\\assembly\\NativeImages*",
+    "?:\\Windows\\Microsoft.NET\\*",
+    "?:\\Windows\\WinSxS\\*",
+    "?:\\Windows\\System32\\DriverStore\\FileRepository\\*"
+)
 ```
 
 
@@ -16785,12 +18108,23 @@ not (?dll.code_signature.trusted == true or file.code_signature.status == "Valid
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1552
+Index: geneve-ut-1723
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
   (dll.code_signature.trusted == false or dll.code_signature.exists == false) and
-  not dll.code_signature.status : ("errorExpired", "errorRevoked", "errorCode_endpoint:*")
+  /* errorExpired and errorRevoked are handled by d12bac54-ab2a-4159-933f-d7bcefa7b61d */
+  not dll.code_signature.status : ("errorExpired", "errorRevoked", "errorCode_endpoint:*") and
+
+  not dll.hash.sha256 : (
+        /* HP DOT4 printer driver family FPs (Dot4.sys, Dot4Prt.sys, Dot4usb.sys, Dot4Scan.sys) */
+        "f21c1d478180bc5e932bb2c2e4618e3ed463ca87acedeb139682d218435f82f1",
+        "7e2f2a139e897eae56038b920bda9381094bc0ae9e626f6634e6b444b8b0c91f",
+        "12ffdf5f48a79b1b4adbb88ba2cb6c59dd6719554e8ea6beefe99b3e3c66f1ac",
+        "dbc6afaf80141e2480e19878f581edfe9c2b018da2ec527c4025ff04d5587afd",
+        /* (dc3d.sys, test-signed) */
+        "ca8f9564733ded4c3895cf7150bb254995d66889e6be08d6654e4f897e4ff7a4"
+  )
 ```
 
 
@@ -16799,7 +18133,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1556
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16813,16 +18147,18 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1557
+Index: geneve-ut-1729
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.parent.name : "dns.exe" and
   not process.executable : (
     "?:\\Windows\\System32\\conhost.exe",
+    "?:\\Windows\\System32\\dns.exe",
 
     /* Crowdstrike specific exclusion as it uses NT Object paths */
     "\\Device\\HarddiskVolume*\\Windows\\System32\\conhost.exe",
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\dns.exe",
     "\\Device\\HarddiskVolume*\\Program Files\\ReasonLabs\\*"
   ) and
   not ?process.parent.executable : "?:\\Program Files\\ReasonLabs\\DNS\\ui\\DNS.exe"
@@ -16834,7 +18170,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1562
+Index: geneve-ut-1734
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -16868,7 +18204,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1564
+Index: geneve-ut-1736
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16883,37 +18219,15 @@ process.group_leader.name != null and not (
 
 
 
-### Unusual Executable File Creation by a System Critical Process
-
-Branch count: 18  
-Document count: 18  
-Index: geneve-ut-1567
-
-```python
-file where host.os.type == "windows" and event.type != "deletion" and
-  file.extension : ("exe", "dll") and
-  process.name : ("smss.exe",
-                  "autochk.exe",
-                  "csrss.exe",
-                  "wininit.exe",
-                  "services.exe",
-                  "lsass.exe",
-                  "winlogon.exe",
-                  "userinit.exe",
-                  "LogonUI.exe")
-```
-
-
-
 ### Unusual File Creation - Alternate Data Stream
 
-Branch count: 186  
-Document count: 186  
-Index: geneve-ut-1571
+Branch count: 248  
+Document count: 248  
+Index: geneve-ut-1743
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
-   process.name : ("cmd.exe", "powershell.exe", "mshta.exe", "wscript.exe", "node.exe", "python*.exe") and
+   process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "mshta.exe", "wscript.exe", "cscript.exe", "node.exe", "python*.exe") and
    file.extension in~ (
     "pdf", "dll", "exe", "dat", "com", "bat", "cmd", "sys", "vbs", "vbe", "ps1", "hta", "txt", "js", "jse",
     "wsh", "wsf", "sct", "docx", "doc", "xlsx", "xls", "pptx", "ppt", "rtf", "gif", "jpg", "png", "bmp", "img", "iso"
@@ -16924,128 +18238,11 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
-### Unusual Instance Metadata Service (IMDS) API Request
-
-Branch count: 141  
-Document count: 282  
-Index: geneve-ut-1582
-
-```python
-sequence by host.id, process.parent.entity_id with maxspan=3s
-[
-    process
-    where host.os.type == "linux"
-        and event.type == "start"
-        and event.action == "exec"
-        and process.parent.executable != null
-
-        // common tooling / suspicious names (keep broad)
-        and (
-            process.name : (
-                "curl", "wget", "python*", "perl*", "php*", "ruby*", "lua*", "telnet", "pwsh",
-                "openssl", "nc", "ncat", "netcat", "awk", "gawk", "mawk", "nawk", "socat", "node",
-                "bash", "sh"
-            )
-            or
-            // suspicious execution locations (dropped binaries / temp execution)
-            process.executable : (
-                "./*", "/tmp/*", "/var/tmp/*", "/var/www/*", "/dev/shm/*", "/etc/init.d/*", "/etc/rc*.d/*",
-                "/etc/cron*", "/etc/update-motd.d/*", "/boot/*", "/srv/*", "/run/*", "/etc/rc.local"
-            )
-            or
-            // threat-relevant IMDS / metadata endpoints (inclusion list)
-            process.command_line : (
-                "*169.254.169.254/latest/api/token*",
-                "*169.254.169.254/latest/meta-data/iam/security-credentials*",
-                "*169.254.169.254/latest/meta-data/local-ipv4*",
-                "*169.254.169.254/latest/meta-data/local-hostname*",
-                "*169.254.169.254/latest/meta-data/public-ipv4*",
-                "*169.254.169.254/latest/user-data*",
-                "*169.254.169.254/latest/dynamic/instance-identity/document*",
-                "*169.254.169.254/latest/meta-data/instance-id*",
-                "*169.254.169.254/latest/meta-data/public-keys*",
-                "*computeMetadata/v1/instance/service-accounts/*/token*",
-                "*/metadata/identity/oauth2/token*",
-                "*169.254.169.254/opc/v*/instance*",
-                "*169.254.169.254/opc/v*/vnics*"
-            )
-        )
-
-        // global working-dir / executable / parent exclusions for known benign agents
-        and not process.working_directory : (
-            "/opt/rapid7*",
-            "/opt/nessus*",
-            "/snap/amazon-ssm-agent*",
-            "/var/snap/amazon-ssm-agent/*",
-            "/var/log/amazon/ssm/*",
-            "/srv/snp/docker/overlay2*",
-            "/opt/nessus_agent/var/nessus/*"
-        )
-
-        and not process.executable : (
-            "/opt/rumble/bin/rumble-agent*",
-            "/opt/aws/inspector/bin/inspectorssmplugin",
-            "/snap/oracle-cloud-agent/*",
-            "/lusr/libexec/oracle-cloud-agent/*"
-        )
-
-        and not process.parent.executable : (
-            "/usr/bin/setup-policy-routes",
-            "/usr/share/ec2-instance-connect/*",
-            "/var/lib/amazon/ssm/*",
-            "/etc/update-motd.d/30-banner",
-            "/usr/sbin/dhclient-script",
-            "/usr/local/bin/uwsgi",
-            "/usr/lib/skylight/al-extras",
-            "/usr/bin/cloud-init",
-            "/usr/sbin/waagent",
-            "/usr/bin/google_osconfig_agent",
-            "/usr/bin/docker",
-            "/usr/bin/containerd-shim",
-            "/usr/bin/runc"
-        )
-
-        and not process.entry_leader.executable : (
-            "/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent",
-            "/opt/Elastic/Agent/data/elastic-agent-*/elastic-agent",
-            "/opt/nessus_agent/sbin/nessus-service"
-        )
-
-        // carve-out: safe /usr/bin/curl usage (suppress noisy, legitimate agent patterns)
-        and not (
-            process.executable == "/usr/bin/curl"
-            and (
-                // AWS IMDSv2 token PUT that includes ttl header
-                (process.command_line : "*-X PUT*169.254.169.254/latest/api/token*" and process.command_line : "*X-aws-ec2-metadata-token-ttl-seconds*")
-                or
-                // Any IMDSv2 GET that includes token header for any /latest/* path
-                process.command_line : "*-H X-aws-ec2-metadata-token:*169.254.169.254/latest/*"
-                or
-                // Common amazon tooling UA
-                process.command_line : "*-A amazon-ec2-net-utils/*"
-                or
-                // Azure metadata legitimate header
-                process.command_line : "*-H Metadata:true*169.254.169.254/metadata/*"
-                or
-                // Oracle IMDS legitimate header
-                process.command_line : "*-H Authorization:*Oracle*169.254.169.254/opc/*"
-            )
-        )
-]
-[
-    network where host.os.type == "linux"
-        and event.action == "connection_attempted"
-        and destination.ip == "169.254.169.254"
-]
-```
-
-
-
 ### Unusual Kill Signal
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1585
+Index: geneve-ut-1756
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -17062,7 +18259,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1588
+Index: geneve-ut-1759
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -17079,7 +18276,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1604
+Index: geneve-ut-1775
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -17096,13 +18293,13 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 ### Unusual Parent-Child Relationship
 
-Branch count: 32  
-Document count: 32  
-Index: geneve-ut-1608
+Branch count: 66  
+Document count: 66  
+Index: geneve-ut-1779
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
-process.parent.name != null and
+process.parent.name != null and process.parent.executable like ("?:\\*", "\\Device\\*") and
  (
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
@@ -17125,11 +18322,12 @@ process.parent.name != null and
    (process.name:"userinit.exe" and not process.parent.name:("dwm.exe", "winlogon.exe", "KUsrInit.exe")) or
    (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
    /* suspicious child processes */
-   (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe")) or
+   (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
-   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe"))
+   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
+     not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe"))
   )
 ```
 
@@ -17139,7 +18337,7 @@ process.parent.name != null and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1609
+Index: geneve-ut-1780
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17184,7 +18382,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1612
+Index: geneve-ut-1783
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17222,11 +18420,39 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Unusual Process Connection to Docker or Containerd Socket
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1785
+
+```python
+host.os.type:"linux" and 
+event.category:"network" and
+event.action:"connected-to" and network.direction:"egress" and 
+destination.address:("/run/containerd/containerd.sock" or "/var/run/containerd/containerd.sock" or "/var/run/docker.sock" or "/run/docker.sock") and
+process.executable:(* and not 
+  ("/usr/bin/kubelet" or
+  "/usr/local/bin/kubelet" or
+  "/usr/bin/containerd" or
+  "/usr/sbin/containerd" or
+  "/usr/bin/containerd-shim" or
+  "/usr/bin/containerd-shim-runc-v2" or
+  "/usr/local/bin/containerd-shim-runc-v2" or
+  "/usr/bin/dockerd" or
+  "/usr/sbin/dockerd" or  
+   /var/lib/*/usr/bin/dockerd or 
+  "/usr/bin/docker-proxy")
+)
+```
+
+
+
 ### Unusual Process Execution on WBEM Path
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1616
+Index: geneve-ut-1788
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17250,7 +18476,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1617
+Index: geneve-ut-1789
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17290,7 +18516,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1618
+Index: geneve-ut-1790
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -17337,7 +18563,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1622
+Index: geneve-ut-1794
 
 ```python
 sequence by process.entity_id
@@ -17374,7 +18600,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1656
+Index: geneve-ut-1826
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +18614,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1657
+Index: geneve-ut-1827
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -17431,7 +18657,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1658
+Index: geneve-ut-1828
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -17444,7 +18670,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1660
+Index: geneve-ut-1830
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -17458,7 +18684,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1661
+Index: geneve-ut-1831
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -17467,29 +18693,11 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 
 
-### Veeam Backup Library Loaded by Unusual Process
-
-Branch count: 10  
-Document count: 10  
-Index: geneve-ut-1664
-
-```python
-library where host.os.type == "windows" and event.action == "load" and
-  (dll.name : "Veeam.Backup.Common.dll" or dll.pe.original_file_name : "Veeam.Backup.Common.dll") and
-  (
-    process.code_signature.trusted == false or
-    process.code_signature.exists == false or
-    process.name : ("powershell.exe", "pwsh.exe", "powershell_ise.exe")
-  )
-```
-
-
-
 ### Virtual Machine Fingerprinting
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1665
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -17514,7 +18722,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1666
+Index: geneve-ut-1836
 
 ```python
 process where event.type == "start" and
@@ -17529,7 +18737,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1667
+Index: geneve-ut-1837
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17546,7 +18754,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1668
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17560,7 +18768,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1669
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17576,7 +18784,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1670
+Index: geneve-ut-1840
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17590,7 +18798,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1671
+Index: geneve-ut-1841
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -17603,8 +18811,12 @@ file where host.os.type == "windows" and event.action != "deletion" and
   ) and
   not process.executable : (
     "C:\\Windows\\System32\\poqexec.exe",
-    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe"
-  )
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe",
+    "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+    "?:\\Windows\\System32\\omadmclient.exe"
+  ) and
+  /* System / ntoskrnl.exe (PID 4) */
+  not process.pid == 4
 ```
 
 
@@ -17613,7 +18825,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1673
+Index: geneve-ut-1843
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -17625,7 +18837,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1674
+Index: geneve-ut-1844
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17641,7 +18853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1675
+Index: geneve-ut-1845
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -17664,7 +18876,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1676
+Index: geneve-ut-1846
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -17677,7 +18889,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1677
+Index: geneve-ut-1847
 
 ```python
 http.response.status_code:403 and http.request.method:post
@@ -17689,7 +18901,7 @@ http.response.status_code:403 and http.request.method:post
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1678
+Index: geneve-ut-1848
 
 ```python
 http.response.status_code:405
@@ -17701,7 +18913,7 @@ http.response.status_code:405
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1679
+Index: geneve-ut-1849
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -17709,22 +18921,101 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 
 
-### Web Server Potential SQL Injection Request
+### Web Server Cloud Metadata SSRF Request
 
-Branch count: 61  
-Document count: 61  
-Index: geneve-ut-1684
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1850
 
 ```python
-any where url.original like~ (
-  "*%20order%20by%*", "*dbms_pipe.receive_message%28chr%*", "*waitfor%20delay%20*", "*%28select%20*from%20pg_sleep%285*", "*%28select%28sleep%285*", "*%3bselect%20pg_sleep%285*",
-  "*select%20concat%28concat*", "*xp_cmdshell*", "*select*case*when*", "*and*extractvalue*select*", "*from*information_schema.tables*", "*boolean*mode*having*", "*extractvalue*concat*",
-  "*case*when*sleep*", "*select*sleep*", "*dbms_lock.sleep*", "*and*sleep*", "*like*sleep*", "*csleep*", "*pgsleep*", "*char*char*char*", "*union*select*", "*concat*select*",
-  "*select*else*drop*", "*having*like*", "*case*else*end*", "*if*sleep*", "*where*and*select*", "*or*1=1*", "*\"1\"=\"1\"*", "*or*'a'='a*", "*into*outfile*", "*pga_sleep*",
-  "*into%20outfile*", "*into*dumpfile*", "*load_file%28*", "*load%5ffile%28*", "*cast%28*", "*convert%28*", "*cast%28%*", "*convert%28%*", "*@@version*", "*@@version_comment*",
-  "*version%28*", "*user%28*", "*current_user%28*", "*database%28*", "*schema_name%28*", "*information_schema.columns*", "*information_schema.columns*", "*table_schema*",
-  "*column_name*", "*dbms_pipe*", "*dbms_lock%2e*sleep*", "*dbms_lock.sleep*", "*sp_executesql*", "*sp_executesql*", "*load%20data*", "*information_schema*",  "*pg_slp*",
-  "*information_schema.tables*"
+web where (
+  url.original : (
+    "*169.254.169.254*", "*169%2e254%2e169%2e254*", "*0xa9fea9fe*", "*0xa9.0xfe.0xa9.0xfe*", 
+    "*2852039166*", "*0251.0376.0251.0376*", "*::ffff:169.254.169.254*", "*::ffff:a9fe:a9fe*", "*fd00:ec2::254*",
+    "*100.100.100.200*", "*169.254.170.2*", "*metadata.google.internal*", "*metadata.goog*", "*computeMetadata/v1*",
+    "*meta-data/iam/security-credentials*", "*meta-data%2Fiam%2Fsecurity-credentials*",
+    "*latest/meta-data*", "*latest/api/token*"
+  )
+  or
+  url.query : (
+    "*169.254.169.254*", "*169%2e254%2e169%2e254*", "*0xa9fea9fe*", "*0xa9.0xfe.0xa9.0xfe*", 
+    "*2852039166*", "*0251.0376.0251.0376*", "*::ffff:169.254.169.254*", "*::ffff:a9fe:a9fe*", "*fd00:ec2::254*",
+    "*100.100.100.200*", "*169.254.170.2*", "*metadata.google.internal*", "*metadata.goog*", "*computeMetadata/v1*",
+    "*meta-data/iam/security-credentials*", "*meta-data%2Fiam%2Fsecurity-credentials*",
+    "*latest/meta-data*", "*latest/api/token*"
+  )
+)
+```
+
+
+
+### Web Server Potential SQL Injection Request
+
+Branch count: 91  
+Document count: 91  
+Index: geneve-ut-1855
+
+```python
+any where (
+url.original like~ (
+    "*dbms_pipe.receive_message%28chr%*",
+    "*waitfor%20delay%20%270%3a0%3a*",
+    "*%28select%28sleep%285*", "*%28select%20*from%20pg_sleep%285*", "*%3bselect%20pg_sleep%285*",
+    "*and%20sleep%28*%29*", "*or%20sleep%28*%29*", "*case%20when*then%20sleep%28*", "*if%28sleep%28*%29*",
+    "*benchmark%28*%2c*md5%28*",
+    "*convert%28int%2c%28select%20char%28*",
+    "*char%28*char%28*char%28*char%28*",
+    "*concat%28concat%28char%28*",
+    "*case%20when%20%28*%3d*%29%20then*else*end*",
+    "*elt%28*%3d*%2c1%29%29*",
+    "*union%20select%20null%2cnull*", "*union%20all%20select%20null*",
+    "*union%20all%20select%20*concat%28md5%28*",
+    "*extractvalue%28*concat%280x*", "*updatexml%28*concat%280x*",
+    "*procedure%2f%2a%2a%2fanalyse%28extractvalue%28*",
+    "*gtid_subset%28concat%280x*", "*gtid_subtract%28concat%280x*",
+    "*mid%28ifnull%28session_user%28%29*",
+    "*'qq'%2b%28%28select%20@@version%29%29%2b'qq'*",
+    "*%27%20or%20%271%27%3d%271*", "*%22%20or%20%221%22%3d%221*", "*%27%20or%20%27a%27%3d%27a*",
+    "*and%201%3d1--*", "*and%201%3d2--*",
+    "*%29%3bselect*if%28%28ord%28mid%28*",
+    "*xp_cmdshell*",
+    "*select%20*into%20outfile*", "*select%20*into%20dumpfile*",
+    "*load_file%28*", "*load%5ffile%28*",
+    "*select%20*from%20information_schema.tables*", "*from%20information_schema.columns%20where%20table_schema*",
+    "*dbms_pipe%2ereceive_message*", "*dbms_lock%2esleep*",
+    "*select%20@@version*", "*select%20user%28%29*", "*select%20current_user%28%29*", "*select%20database%28%29*",
+    "*sp_executesql%20*exec%20*", "*xp_dirtree*"
+  )
+  or
+  url.query like~ (
+    "*dbms_pipe.receive_message(chr*",
+    "*waitfor delay '0:0:*",
+    "*(select(sleep(5*", "*(select*from pg_sleep(5*", "*;select pg_sleep(5*",
+    "*and sleep(*)*", "*or sleep(*)*", "*case when*then sleep(*", "*if(sleep(*)*",
+    "*benchmark(*,*md5(*",
+    "*convert(int,(select char(*",
+    "*char(*char(*char(*char(*",
+    "*concat(concat(char(*",
+    "*case when (*=*) then*else*end*",
+    "*elt(*=*,1))*",
+    "*union select null,null*", "*union all select null*",
+    "*union all select*concat(md5(*",
+    "*extractvalue(*concat(0x*", "*updatexml(*concat(0x*",
+    "*procedure/**/analyse(extractvalue(*",
+    "*gtid_subset(concat(0x*", "*gtid_subtract(concat(0x*",
+    "*mid(ifnull(session_user()*",
+    "*'qq'+((select @@version))+'qq'*",
+    "*' or '1'='1*", "*\" or \"1\"=\"1*", "*' or 'a'='a*",
+    "*and 1=1--*", "*and 1=2--*",
+    "*);select*if((ord(mid(*",
+    "*xp_cmdshell*",
+    "*select*into outfile*", "*select*into dumpfile*",
+    "*load_file(*",
+    "*select*from information_schema.tables*", "*from information_schema.columns where table_schema*",
+    "*dbms_pipe.receive_message*", "*dbms_lock.sleep*",
+    "*select @@version*", "*select user()*", "*select current_user()*", "*select database()*",
+    "*sp_executesql*exec*", "*xp_dirtree*"
+  )
 )
 ```
 
@@ -17734,7 +19025,7 @@ any where url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1686
+Index: geneve-ut-1857
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17755,7 +19046,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1689
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -17769,7 +19060,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1690
+Index: geneve-ut-1861
 
 ```python
 file where event.type == "deletion" and
@@ -17786,7 +19077,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1691
+Index: geneve-ut-1862
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17804,7 +19095,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1693
+Index: geneve-ut-1864
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17842,7 +19133,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1695
+Index: geneve-ut-1866
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17879,7 +19170,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1696
+Index: geneve-ut-1867
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17894,7 +19185,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1697
+Index: geneve-ut-1868
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -17907,7 +19198,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1698
+Index: geneve-ut-1869
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17926,7 +19217,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-1699
+Index: geneve-ut-1870
 
 ```python
 sequence with maxspan=1m
@@ -17951,7 +19242,7 @@ sequence with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1700
+Index: geneve-ut-1871
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17977,7 +19268,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1701
+Index: geneve-ut-1872
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -17999,7 +19290,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1702
+Index: geneve-ut-1873
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18016,7 +19307,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-1704
+Index: geneve-ut-1875
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -18035,7 +19326,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-1705
+Index: geneve-ut-1876
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -18075,7 +19366,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1706
+Index: geneve-ut-1877
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18092,7 +19383,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1708
+Index: geneve-ut-1879
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -18105,7 +19396,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1709
+Index: geneve-ut-1880
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -18119,7 +19410,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1710
+Index: geneve-ut-1881
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18147,7 +19438,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1711
+Index: geneve-ut-1882
 
 ```python
 process where event.type == "start" and
@@ -18172,7 +19463,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1712
+Index: geneve-ut-1883
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18182,11 +19473,27 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### XDG-Open Command Execution
+
+Branch count: 25  
+Document count: 25  
+Index: geneve-ut-1884
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2") and (
+  process.name == "xdg-open" or
+  process.args in ("/bin/xdg-open", "/usr/bin/xdg-open", "/usr/local/bin/xdg-open", "xdg-open")
+)
+```
+
+
+
 ### Yum Package Manager Plugin File Creation
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1713
+Index: geneve-ut-1885
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -18221,7 +19528,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1714
+Index: geneve-ut-1886
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18239,7 +19546,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1717
+Index: geneve-ut-1889
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.3.md
+++ b/tests/reports/alerts_from_rules-9.3.md
@@ -5,22 +5,22 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.10
+Rules version: 9.3.15
 
 ## Table of contents
-   1. [Failed rules (20)](#failed-rules-20)
-   1. [Unsuccessful rules with signals (20)](#unsuccessful-rules-with-signals-20)
+   1. [Failed rules (24)](#failed-rules-24)
+   1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
-   1. [Rules with too few signals (23)](#rules-with-too-few-signals-23)
-   1. [Rules with the correct signals (770)](#rules-with-the-correct-signals-770)
+   1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
+   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
 
-## Failed rules (20)
+## Failed rules (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0264  
+Index: geneve-ut-0328  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0466  
+Index: geneve-ut-0549  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -144,7 +144,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0489  
+Index: geneve-ut-0572  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -173,7 +173,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0572  
+Index: geneve-ut-0669  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -200,11 +200,64 @@ not process.name in ("git", "dirname")
 
 
 
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0856  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Multi-Base64 Decoding Attempt from Suspicious Location
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0849  
+Index: geneve-ut-0980  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -237,7 +290,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-0874  
+Index: geneve-ut-1008  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -280,7 +333,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0936  
+Index: geneve-ut-1075  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -321,7 +374,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-0964  
+Index: geneve-ut-1103  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -347,7 +400,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-0980  
+Index: geneve-ut-1120  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -385,7 +438,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1037  
+Index: geneve-ut-1182  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -407,7 +460,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1051  
+Index: geneve-ut-1197  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +501,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1133  
+Index: geneve-ut-1281  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -511,7 +564,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1342  
+Index: geneve-ut-1507  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -557,7 +610,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1345  
+Index: geneve-ut-1511  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -600,7 +653,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1421  
+Index: geneve-ut-1591  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -644,11 +697,46 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1605  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Echo or Printf Execution Detected via Defend for Containers
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1445  
+Index: geneve-ut-1618  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -673,7 +761,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1455  
+Index: geneve-ut-1628  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -736,7 +824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1460  
+Index: geneve-ut-1633  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -760,11 +848,82 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1642  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1691  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1559  
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1736  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -774,13 +933,16 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -810,7 +972,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -818,12 +979,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -832,7 +998,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1586  
+Index: geneve-ut-1764  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -875,13 +1041,13 @@ process.interactive == true and container.id like "*"
 
 
 
-## Unsuccessful rules with signals (20)
+## Unsuccessful rules with signals (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0264
+Index: geneve-ut-0328
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -933,7 +1099,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0466
+Index: geneve-ut-0549
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -999,7 +1165,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0489
+Index: geneve-ut-0572
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1025,7 +1191,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0572
+Index: geneve-ut-0669
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1049,11 +1215,61 @@ not process.name in ("git", "dirname")
 
 
 
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0856
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Multi-Base64 Decoding Attempt from Suspicious Location
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0849
+Index: geneve-ut-0980
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1083,7 +1299,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-0874
+Index: geneve-ut-1008
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1123,7 +1339,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0936
+Index: geneve-ut-1075
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1161,7 +1377,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-0964
+Index: geneve-ut-1103
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1184,7 +1400,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-0980
+Index: geneve-ut-1120
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1219,7 +1435,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1037
+Index: geneve-ut-1182
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1238,7 +1454,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1051
+Index: geneve-ut-1197
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1276,7 +1492,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1133
+Index: geneve-ut-1281
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1336,7 +1552,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1342
+Index: geneve-ut-1507
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1379,7 +1595,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1345
+Index: geneve-ut-1511
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1419,7 +1635,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1421
+Index: geneve-ut-1591
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1460,11 +1676,43 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1605
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Echo or Printf Execution Detected via Defend for Containers
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1445
+Index: geneve-ut-1618
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.interactive == true and
@@ -1486,7 +1734,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1455
+Index: geneve-ut-1628
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1546,7 +1794,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1460
+Index: geneve-ut-1633
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1567,24 +1815,92 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1642
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1691
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1559
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1736
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -1614,7 +1930,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -1622,12 +1937,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -1636,7 +1956,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1586
+Index: geneve-ut-1764
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1682,7 +2002,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0167
+Index: geneve-ut-0217
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1696,7 +2016,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0730
+Index: geneve-ut-0857
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1708,7 +2028,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0737
+Index: geneve-ut-0863
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1720,7 +2040,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1085
+Index: geneve-ut-1232
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1734,27 +2054,28 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 
 
-### Potential Privacy Control Bypass via TCCDB Modification
+### Protected Storage Service Access via SMB
 
-Branch count: 16  
-Document count: 16  
-Index: geneve-ut-1121
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1420
 
 ```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "sqlite*" and
- process.args like "/*/Application Support/com.apple.TCC/TCC.db" and
- (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+host.os.type:windows and event.category:file and event.code:5145 and
+  winlog.event_data.ShareName:"\\\\*\\IPC$" and
+  winlog.event_data.RelativeTargetName:"protected_storage" and
+  not source.ip:("::" or "::1" or "0.0.0.0" or "127.0.0.1")
 ```
 
 
 
-## Rules with too few signals (23)
+## Rules with too few signals (28)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0264  
+Index: geneve-ut-0328  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -1808,7 +2129,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0466  
+Index: geneve-ut-0549  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -1876,7 +2197,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0489  
+Index: geneve-ut-0572  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -1904,7 +2225,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0572  
+Index: geneve-ut-0669  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -1930,11 +2251,82 @@ not process.name in ("git", "dirname")
 
 
 
+### Kubernetes Secrets List Across Cluster or Sensitive Namespaces
+
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0833  
+Failure message(s):  
+  got 3 signals, expected 6  
+
+```python
+event.dataset:"kubernetes.audit_logs" and event.action:list and 
+kubernetes.audit.objectRef.resource:secrets and 
+kubernetes.audit.requestURI :(/api/v1/secrets or /api/v1/secrets?limit* or /api/v1/namespaces/kube-system/secrets or /api/v1/namespaces/kube-system/secrets?limit* or /api/v1/namespaces/default/secrets or /api/v1/namespaces/default/secrets?limit*) and 
+source.ip:(* and not ("::1" or "127.0.0.1")) and 
+not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator) and 
+not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
+```
+
+
+
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0856  
+Failure message(s):  
+  got 1000 signals, expected 6552  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Microsoft IIS Service Account Password Dumped
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0828  
+Index: geneve-ut-0959  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -1954,7 +2346,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0849  
+Index: geneve-ut-0980  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -1986,7 +2378,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-0874  
+Index: geneve-ut-1008  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2028,7 +2420,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0936  
+Index: geneve-ut-1075  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2068,7 +2460,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-0964  
+Index: geneve-ut-1103  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2093,7 +2485,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-0980  
+Index: geneve-ut-1120  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2130,7 +2522,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1037  
+Index: geneve-ut-1182  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2151,7 +2543,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1051  
+Index: geneve-ut-1197  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2191,7 +2583,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1125  
+Index: geneve-ut-1273  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2208,7 +2600,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1133  
+Index: geneve-ut-1281  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2270,7 +2662,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1227  
+Index: geneve-ut-1388  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2295,7 +2687,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1342  
+Index: geneve-ut-1507  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2340,7 +2732,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1345  
+Index: geneve-ut-1511  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -2382,7 +2774,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1421  
+Index: geneve-ut-1591  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -2425,11 +2817,45 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1605  
+Failure message(s):  
+  got 1000 signals, expected 5280  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Echo or Printf Execution Detected via Defend for Containers
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1445  
+Index: geneve-ut-1618  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -2453,7 +2879,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1455  
+Index: geneve-ut-1628  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -2515,7 +2941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1460  
+Index: geneve-ut-1633  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -2538,26 +2964,98 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1642  
+Failure message(s):  
+  got 1000 signals, expected 2457  
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1691  
+Failure message(s):  
+  got 1000 signals, expected 8576  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1559  
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1736  
 Failure message(s):  
-  got 1000 signals, expected 1053  
+  got 1000 signals, expected 2442  
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -2587,7 +3085,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -2595,12 +3092,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -2609,7 +3111,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1586  
+Index: geneve-ut-1764  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -2651,7 +3153,7 @@ process.interactive == true and container.id like "*"
 
 
 
-## Rules with the correct signals (770)
+## Rules with the correct signals (805)
 
 ### A scheduled task was created
 
@@ -2674,7 +3176,15 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
               "\\Hewlett-Packard\\HP Web Products Detection",
               "\\Microsoft\\VisualStudio\\Updates\\BackgroundDownload",
               "\\OneDrive Standalone Update Task-S-1-5-21*",
-              "\\OneDrive Standalone Update Task-S-1-12-1-*"
+              "\\OneDrive Standalone Update Task-S-1-12-1-*",
+              "\\SoftLanding\\S-1-5-21-*\\SoftLanding*",
+              "\\SoftLanding\\S-1-12-*\\SoftLanding*",
+              "\\OneDrive Reporting Task-S-1-5-21-*",
+              "\\OneDrive Reporting Task-S-1-12-1-*",
+              "\\GoogleUserPEH\\RunPlatformExperienceHelper*",
+              "\\Mozilla\\Firefox Default Browser Agent*",
+              "\\Microsoft\\Office\\Office Background Push Maintenance",
+              "\\Microsoft\\Windows\\GroupPolicy\\GPUpdate"
  )
 ```
 
@@ -2736,7 +3246,7 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0022
+Index: geneve-ut-0040
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -2750,11 +3260,47 @@ process.command_line like~ (
 
 
 
+### AWS EC2 Instance Profile Associated with Running Instance
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-0057
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "ec2.amazonaws.com"
+    and event.action: ("AssociateIamInstanceProfile" or "ReplaceIamInstanceProfile")
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService" 
+    and not aws.cloudtrail.user_identity.invoked_by: "ssm.amazonaws.com"
+```
+
+
+
+### AWS IAM Customer Managed Policy Version Created or Default Version Set
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-0087
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "iam.amazonaws.com"
+    and event.action: ("CreatePolicyVersion" or "SetDefaultPolicyVersion")
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService" 
+    and not aws.cloudtrail.user_identity.arn:arn*/terraform 
+    and not source.as.organization.name:(Amazon* or AMAZON* or "Google LLC" or "MongoDB, Inc.")
+    and not source.address: ( "cloudformation.amazonaws.com" or "servicecatalog.amazonaws.com")
+```
+
+
+
 ### AWS IAM Login Profile Added to User
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0064
+Index: geneve-ut-0094
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
@@ -2763,11 +3309,59 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 
 
+### AWS IAM Sensitive Operations via Lambda Execution Role
+
+Branch count: 22  
+Document count: 22  
+Index: geneve-ut-0105
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "iam.amazonaws.com"
+    and event.outcome: "success"
+    and aws.cloudtrail.user_identity.type: "AssumedRole"
+    and (
+        aws.cloudtrail.user_identity.invoked_by: "lambda.amazonaws.com"
+        or user_agent.original : *AWS_Lambda*
+    )
+    and event.action: (
+        "AddRoleToInstanceProfile" or
+        "AddUserToGroup" or 
+        "AttachGroupPolicy" or 
+        "AttachRolePolicy" or
+        "AttachUserPolicy" or
+        "CreateAccessKey" or
+        "CreateInstanceProfile" or
+        "CreateRole" or
+        "CreateUser" or
+        "PutRolePolicy" or
+        "PutUserPolicy"
+    )
+```
+
+
+
+### AWS KMS Key Policy Updated via PutKeyPolicy
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0112
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "kms.amazonaws.com"
+    and event.action: "PutKeyPolicy"
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService"
+```
+
+
+
 ### AWS Lambda Function Created or Updated
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0077
+Index: geneve-ut-0114
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2782,7 +3376,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0087
+Index: geneve-ut-0133
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
@@ -2791,11 +3385,27 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 
 
+### AWS STS GetFederationToken with AdministratorAccess in Request
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0168
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "sts.amazonaws.com"
+    and event.action: "GetFederationToken"
+    and event.outcome: "success"
+    and aws.cloudtrail.request_parameters: *AdministratorAccess*
+```
+
+
+
 ### AWS STS GetSessionToken Usage
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0120
+Index: geneve-ut-0169
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -2810,7 +3420,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0129
+Index: geneve-ut-0179
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -2825,7 +3435,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0138
+Index: geneve-ut-0188
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2849,7 +3459,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0139
+Index: geneve-ut-0189
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -2884,7 +3494,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0140
+Index: geneve-ut-0190
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -2901,7 +3511,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0141
+Index: geneve-ut-0191
 
 ```python
 any where host.os.type == "windows" and
@@ -2926,7 +3536,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0143
+Index: geneve-ut-0193
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -2954,7 +3564,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0145
+Index: geneve-ut-0195
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2967,7 +3577,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0147
+Index: geneve-ut-0197
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -2983,7 +3593,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0148
+Index: geneve-ut-0198
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3003,7 +3613,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0149
+Index: geneve-ut-0199
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3024,7 +3634,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0150
+Index: geneve-ut-0200
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3036,7 +3646,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0153
+Index: geneve-ut-0203
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3048,7 +3658,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0165
+Index: geneve-ut-0215
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3065,7 +3675,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0166
+Index: geneve-ut-0216
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3077,7 +3687,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0168
+Index: geneve-ut-0218
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3097,7 +3707,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0169
+Index: geneve-ut-0219
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3111,7 +3721,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0173
+Index: geneve-ut-0223
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3142,7 +3752,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0174
+Index: geneve-ut-0224
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3152,14 +3762,14 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 ### Attempt to Clear Kernel Ring Buffer
 
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-0175
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-0225
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
 event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
-process.name == "dmesg" and process.args in ("-c", "--clear")
+process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clear")
 ```
 
 
@@ -3168,7 +3778,7 @@ process.name == "dmesg" and process.args in ("-c", "--clear")
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0176
+Index: geneve-ut-0226
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3183,7 +3793,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0186
+Index: geneve-ut-0236
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -3202,7 +3812,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0187
+Index: geneve-ut-0237
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3216,7 +3826,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0188
+Index: geneve-ut-0238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -3247,7 +3857,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0189
+Index: geneve-ut-0239
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3270,7 +3880,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0190
+Index: geneve-ut-0240
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3284,7 +3894,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0191
+Index: geneve-ut-0241
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3299,11 +3909,25 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Attempt to Install Kali Linux via WSL
+### Attempt to Install Root Certificate
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0242
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and
+  process.name == "security" and process.args like "add-trusted-cert" and
+  (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
+### Attempt to Install or Run Kali Linux via WSL
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0192
+Index: geneve-ut-0243
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3324,25 +3948,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Attempt to Install Root Certificate
-
-Branch count: 16  
-Document count: 16  
-Index: geneve-ut-0193
-
-```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and
-  process.name == "security" and process.args like "add-trusted-cert" and
-  (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
-```
-
-
-
 ### Attempt to Mount SMB Share via Command Line
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0198
+Index: geneve-ut-0248
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3361,7 +3971,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0201
+Index: geneve-ut-0251
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3374,7 +3984,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0203
+Index: geneve-ut-0253
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3416,7 +4026,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0206
+Index: geneve-ut-0256
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -3431,7 +4041,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0231
+Index: geneve-ut-0286
 
 ```python
 event.dataset:azure.activitylogs and
@@ -3441,11 +4051,29 @@ event.dataset:azure.activitylogs and
 
 
 
+### Azure Run Command Script Child Process
+
+Branch count: 22  
+Document count: 22  
+Index: geneve-ut-0289
+
+```python
+process where event.type in ("start", "process_started") and
+  (
+    (process.parent.name == "powershell.exe" and
+      process.parent.command_line like "powershell  -ExecutionPolicy Unrestricted -File script?.ps1") or
+    (process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh", "busybox") and
+      process.parent.args like "/var/lib/waagent/run-command/download/*/script.sh")
+  )
+```
+
+
+
 ### BPF Program Tampering via bpftool
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0244
+Index: geneve-ut-0307
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3463,7 +4091,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0245
+Index: geneve-ut-0308
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3481,7 +4109,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0246
+Index: geneve-ut-0309
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3496,7 +4124,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0247
+Index: geneve-ut-0310
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3510,7 +4138,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0248
+Index: geneve-ut-0311
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3525,7 +4153,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0250
+Index: geneve-ut-0313
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -3542,7 +4170,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0251
+Index: geneve-ut-0314
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -3554,7 +4182,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0252
+Index: geneve-ut-0315
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -3566,7 +4194,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0253
+Index: geneve-ut-0316
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3581,7 +4209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0254
+Index: geneve-ut-0317
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -3601,7 +4229,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0255
+Index: geneve-ut-0318
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3623,7 +4251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0257
+Index: geneve-ut-0320
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -3669,24 +4297,24 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0258
+Index: geneve-ut-0321
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.name : ("chrome.exe", "msedge.exe") and
-  process.parent.executable != null and process.command_line != null and
+  process.parent.executable != null and
   (
-  process.command_line :
-           ("\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\"",
+    process.command_line : (
+            "\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\"",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\"",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --disable-logging --log-level=3 --v=0",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --log-level=3",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --remote-debugging-port=922? --profile-directory=\"Default\"*",
-            "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --restore-last-session --remote-debugging-port=45452*") or
-
-  (process.args : "--remote-debugging-port=922?" and process.args : "--window-position=-*,-*")
-   ) and
+            "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --restore-last-session --remote-debugging-port=45452*"
+    ) or
+    (process.args : "--remote-debugging-port=922?" and process.args : "--window-position=-*,-*")
+  ) and
   not process.parent.executable :
                          ("C:\\Windows\\explorer.exe",
                           "C:\\Program Files (x86)\\*.exe",
@@ -3703,7 +4331,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0259
+Index: geneve-ut-0322
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3726,7 +4354,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0260
+Index: geneve-ut-0323
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -3748,7 +4376,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0261
+Index: geneve-ut-0324
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -3772,11 +4400,26 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 
 
+### Chroot Execution in Container Context on Linux
+
+Branch count: 40  
+Document count: 40  
+Index: geneve-ut-0325
+
+```python
+host.os.type:linux and event.category:process and 
+event.type:start and event.action:(executed or exec) and 
+(process.name:"chroot" or process.args:("chroot" or "/bin/chroot" or "/usr/bin/chroot" or "/usr/local/bin/chroot")) and 
+(process.title:"runc init" or process.entry_leader.entry_meta.type:"container" or process.parent.name:("runc" or "containerd-shim-runc-v2"))
+```
+
+
+
 ### Clearing Windows Event Logs
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0263
+Index: geneve-ut-0327
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3797,11 +4440,41 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Cloud Instance Metadata Credential Path HTTP Request
+
+Branch count: 219  
+Document count: 219  
+Index: geneve-ut-0329
+
+```python
+network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
+http.request.method == "GET" and url.path : (
+  "/latest/meta-data/iam/security-credentials/*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*metadata/identity/oauth2/token*"
+) and (
+  ?process.name : (
+    "curl", "wget", "python*", "node", "bun", "php*", "ruby", "perl", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox",
+    "bun.exe", "node.exe", "powershell.exe", "cmd.exe", "curl.exe", "wget.exe", "rundll32.exe", "w3wp.exe", "java*", 
+    "go", "nc", "netcat", "nginx", "apache*", "httpd", "tomcat*", "catalina", "spring*", "dotnet", "gunicorn", "uwsgi", 
+    ".*", "osascript"
+  ) or ?process.executable : (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*", "?:\\ProgramData\\*"
+  ) or user_agent.original : (
+    "curl*", "wget*", "python*", "ruby*", "Go-http-client*", "node*", "axios*", "undici*", "java*", "php*", "Bun*",
+    "Apache-HttpClient*", "okhttp*", "RestTemplate*", "*WindowsPowerShell*", "*roadtools*", "*fasthttp*", "*azurehound*", "*bloodhound*", "*aiohttp*"
+  )
+)
+```
+
+
+
 ### Code Signing Policy Modification Through Built-in tools
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0266
+Index: geneve-ut-0331
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3815,7 +4488,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0267
+Index: geneve-ut-0332
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3837,7 +4510,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0268
+Index: geneve-ut-0333
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -3851,7 +4524,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0269
+Index: geneve-ut-0334
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -3871,7 +4544,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0272
+Index: geneve-ut-0337
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3888,7 +4561,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-0274
+Index: geneve-ut-0339
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3972,7 +4645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0275
+Index: geneve-ut-0340
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4002,7 +4675,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0278
+Index: geneve-ut-0343
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4027,7 +4700,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0280
+Index: geneve-ut-0345
 
 ```python
 sequence by process.entity_id
@@ -4048,7 +4721,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0281
+Index: geneve-ut-0346
 
 ```python
 sequence by process.entity_id
@@ -4065,11 +4738,42 @@ sequence by process.entity_id
 
 
 
+### Container Runtime CLI Execution with Suspicious Arguments
+
+Branch count: 28  
+Document count: 28  
+Index: geneve-ut-0349
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
+(
+  (
+    process.name in ("ctr", "crictl", "nerdctl") and
+    (
+      (process.args == "tasks" and process.args == "exec") or
+      (process.args == "run" and process.args in ("--privileged", "--rm", "--mount", "--net-host", "--pid-host")) or
+      (process.args == "snapshots" and process.args == "mount")
+    )
+  ) or
+  (
+    (process.executable like ("/dev/shm/*", "/tmp/*", "/var/tmp/*") or process.name : ".*") and
+    process.args like ("*containerd.sock*", "k8s.io")
+  )
+) and
+not process.parent.executable in (
+  "/usr/bin/kubelet", "/usr/local/bin/kubelet",
+  "/usr/bin/containerd", "/usr/sbin/containerd",
+  "/lib/systemd/systemd", "/usr/lib/systemd/systemd", "/sbin/init"
+)
+```
+
+
+
 ### Container Workload Protection
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0284
+Index: geneve-ut-0350
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4081,7 +4785,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0285
+Index: geneve-ut-0351
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4104,7 +4808,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0288
+Index: geneve-ut-0354
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4117,7 +4821,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0289
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4130,7 +4834,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0291
+Index: geneve-ut-0357
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4147,7 +4851,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0292
+Index: geneve-ut-0358
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -4158,12 +4862,12 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 ### Creation of a Hidden Local User Account
 
-Branch count: 3  
-Document count: 3  
-Index: geneve-ut-0293
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0359
 
 ```python
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type in ("change", "creation") and
   registry.path : (
     "HKLM\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
     "\\REGISTRY\\MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
@@ -4177,7 +4881,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0294
+Index: geneve-ut-0360
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -4189,7 +4893,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0295
+Index: geneve-ut-0361
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -4257,7 +4961,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0296
+Index: geneve-ut-0362
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -4275,7 +4979,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0297
+Index: geneve-ut-0363
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -4286,15 +4990,18 @@ process.args == "--json" and process.args == "filesystem"
 
 ### Credential Acquisition via Registry Hive Dumping
 
-Branch count: 8  
-Document count: 8  
-Index: geneve-ut-0298
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  (?process.pe.original_file_name == "reg.exe" or process.name : "reg.exe") and
  process.args : ("save", "export") and
- process.args : ("hklm\\sam", "hklm\\security")
+ process.args : (
+   "hklm\\sam", "hklm\\security", "hklm\\system",
+   "hkey_local_machine\\sam", "hkey_local_machine\\security", "hkey_local_machine\\system"
+ )
 ```
 
 
@@ -4303,7 +5010,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0299
+Index: geneve-ut-0365
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4315,7 +5022,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0300
+Index: geneve-ut-0366
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4327,7 +5034,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0301
+Index: geneve-ut-0367
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4339,7 +5046,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0302
+Index: geneve-ut-0368
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4351,7 +5058,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0303
+Index: geneve-ut-0369
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -4396,7 +5103,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0305
+Index: geneve-ut-0371
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4416,7 +5123,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0306
+Index: geneve-ut-0372
 
 ```python
 sequence with maxspan=10s
@@ -4436,7 +5143,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0307
+Index: geneve-ut-0373
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4463,7 +5170,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0308
+Index: geneve-ut-0374
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4477,7 +5184,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0310
+Index: geneve-ut-0377
 
 ```python
 process where event.type == "start" and
@@ -4502,7 +5209,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0313
+Index: geneve-ut-0380
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4546,7 +5253,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0314
+Index: geneve-ut-0381
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -4580,7 +5287,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0315
+Index: geneve-ut-0382
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4625,7 +5332,7 @@ process.interactive == true and container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0316
+Index: geneve-ut-0383
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -4637,11 +5344,182 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 
 
+### DNS Request for IP Lookup Service via Unsigned Binary
+
+Branch count: 86  
+Document count: 86  
+Index: geneve-ut-0384
+
+```python
+network where host.os.type == "macos" and event.action == "lookup_result" and 
+  (process.code_signature.trusted == false or process.code_signature.exists == false) and
+  dns.question.name like~ ("*ip-api.com*", "*ipwho.is*", "*checkip.dyndns.org*", "*api.ipify.org*",
+                           "*api.npoint.io*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+                           "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*",
+                           "*ipwhois.app*", "*freeipapi.com*", "*icanhazip.com*", "*curlmyip.com*",
+                           "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*",
+                           "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*", "*api.ip.sb*",
+                           "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*",
+                           "*freegeoip.net*", "*freegeoip.app*", "*myip.ipip.net*", "*geoplugin.net*",
+                           "*myip.dnsomatic.com*", "*www.geoplugin.net*", "*api64.ipify.org*",
+                           "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+                           "*geolocation-db.com*", "*inet-ip.info*", "*httpbin.org*", "*myip.opendns.com*") and
+  not process.executable like "/Users/*/Library/Developer/CoreSimulator/*"
+```
+
+
+
+### DNS Request to Suspicious Top Level Domain
+
+Branch count: 50  
+Document count: 50  
+Index: geneve-ut-0385
+
+```python
+network where host.os.type == "linux" and dns.question.name != null and process.name != null and
+dns.question.name like~ (
+  "*.forum", "*.pro", "*.team", "*.lol", "*.kr", "*.ke", "*.nu", "*.space", "*.capital", "*.in", "*.cfd", "*.online",
+  "*.ru", "*.info", "*.top", "*.buzz", "*.xyz", "*.rest", "*.ml", "*.cf", "*.gq", "*.ga", "*.onion", "*.network",
+  "*.monster", "*.marketing", "*.cyou", "*.quest", "*.cc", "*.bar", "*.click", "*.cam", "*.surf", "*.tk", "*.shop",
+  "*.club", "*.icu", "*.pw", "*.ws", "*.fun", "*.life", "*.boats", "*.store", "*.hair", "*.mom",
+  "*.beauty", "*.bond", "*.biz", "*.live", "*.zone"
+)
+```
+
+
+
+### DNS to Commonly Abused Web Services
+
+Branch count: 218  
+Document count: 218  
+Index: geneve-ut-0387
+
+```python
+network where host.os.type == "linux" and dns.question.name != null and process.name != null and
+dns.question.name like~ (
+  /* Google services */
+  "drive.google.com", "docs.google.com", "script.google.com", "script.googleusercontent.com",
+  "*googleapis.com", "calendar.app.google*",
+
+  /* Dropbox */
+  "api.dropboxapi.com", "content.dropboxapi.com", "*dl.dropboxusercontent.com",
+
+  /* Microsoft / OneDrive / SharePoint */
+  "api.onedrive.com", "*.onedrive.org", "onedrive.live.com", "*files.1drv.com", "graph.microsoft.com",
+  "*.sharepoint.com", "login.live.com", "g.live.com",
+
+  /* Slack */
+  "*slack.com", "slack-redir.net", "slack-files.com",
+
+  /* Discord */
+  "discord.com", "cdn.discordapp.com", "discordapp.com",
+
+  /* Telegram */
+  "api.telegram.org", "t.me",
+
+  /* Azure / Cloud storage */
+  "apis.azureedge.net", "*.blob.core.windows.net", "*.blob.storage.azure.net", "*azurewebsites.net",
+
+  /* GitHub / Dev hosting */
+  "api.github.com", "raw.githubusercontent.*", "gist.githubusercontent.com", "rawcdn.githack.*",
+  "*.notabug.org",
+
+  /* Developer tunnels / reverse proxies */
+  "*.devtunnels.ms", "*global.rel.tunnels.api.visualstudio.com", "*.ngrok.io", "*.ngrok-free.app",
+  "*.portmap.*", "serveo.net", "*localtunnel.me", "*pagekite.me", "*.trycloudflare.com",
+
+  /* AWS */
+  "*s3.amazonaws.com",
+
+  /* Paste services */
+  "pastebin.*", "paste4btc.com", "paste.ee", "ghostbin.com", "paste.nrecom.net", "zerobin.net",
+  "controlc.com", "pastecode.dev", "paste.rs", "hastebin.com", "dpaste.org", "dpaste.com", "0bin.net",
+  "paste.ofcode.org", "paste.wakas.org", "nopaste.net",
+
+  /* File sharing / exfiltration */
+  "filebin.net", "file.io", "transfer.sh", "*.gofile.io", "workupload.com", "*upload.ee", "*anonfiles.com",
+  "api.anonfile.com", "*bayfiles.com", "*bublup.com", "*dropfiles.org", "*dropmefiles.com", "*easyupload.io",
+  "*filetransfer.io", "*sendspace.com", "*share.riseup.net", "*temp.sh", "*tempsend.com", "*ufile.io",
+  "*send.now", "*send.cm", "*sendit.sh", "*pixeldrain.com", "*megaupload.com", "*mediafire.com",
+  "*bashupload.com", "*bujang.online", "mediafire.zip", "*.4shared.com", "filecloud.me", "*.pcloud.com",
+  "*catbox.moe",
+
+  /* CDN / hosting / generic file infra */
+  "*cdnmegafiles.com", "www.uplooder.net", "?.top4top.io", "top4top.io", "*.b-cdn.net", "cdn*.space",
+  "i.ibb.co", "i.imgur.com",
+
+  /* Webhooks / testing / bins */
+  "webhook.site", "run.mocky.io", "mockbin.org", "requestbin.net",
+
+  /* Public hosting / misc infra */
+  "*.publicvm.com", "*.blogspot.com", "*infinityfreeapp.com", "free.keep.sh", "*.aternos.me",
+  "*hosting-profi.de",
+
+  /* IP / network utilities */
+  "api.mylnikov.org", "ipbase.com", "*.getmyip.com", "myexternalip.com", "*.geojs.io",
+  "*api.2ip.ua", "*api.db-ip.com", "*api.ip.sb", "*api.ipify.org", "*api.myip.com",
+  "*api.npoint.io", "*api64.ipify.org", "*bot.whatismyipaddress.com", "*checkip.amazonaws.com",
+  "*checkip.dyndns.org", "*curlmyip.com", "*eth0.me", "*freegeoip.app", "*freegeoip.net",
+  "*freeipapi.com", "*geoiptool.com", "*geolocation-db.com", "*httpbin.org",
+  "*icanhazip.com", "*ident.me", "*ifcfg.me", "*ifconfig.me", "*inet-ip.info", "*ip-api.com",
+  "*ip.appspot.com", "*ip.tyk.nu", "*ip4.seeip.org", "*ipecho.net", "*ipinfo.io", "*iplogger.*",
+  "*ipof.in", "*ipwho.is", "*ipwhois.app", "*ipv4.icanhazip.com", "*ipv6.icanhazip.com",
+  "*myip.dnsomatic.com", "*myip.ipip.net", "*myip.opendns.com", "*portmap.io", "*wgetip.com",
+  "*whatismyip.akamai.com", "*wtfismyip.com",
+
+  /* Social / platforms */
+  "mbasic.facebook.com", "*.zulipchat.com", "stackoverflow.com",
+
+  /* Package hosting */
+  "files.pythonhosted.org",
+
+  /* Databases / backend platforms */
+  "*.supabase.co", "*.elastic-cloud.com", "*.cloud.es.io",
+
+  /* Misc / suspicious */
+  "*up.freeo*.space", "*icp0.io", "updates.peer2profit.com", "meacz.gq", "rwrd.org", "lobfile.com",
+  "ftpupload.net", "the.earth.li",
+
+  /* URL shorteners */
+  "*shorturl.at", "*tinyurl.com", "*bit.ly", "*cutt.ly", "*is.gd", "*rebrand.ly", "*rebrandly.com",
+  "*adf.ly", "*rb.gy", "tiny.one", "t.ly", "urlz.fr", "rentry.co",
+
+  /* Crypto mining pools */
+  "*.nicehash.com", "stratum*.nicehash.com",
+  "*.2miners.com", "*.moneroocean.stream", "*.supportxmr.com",
+  "*.nanopool.org", "*.f2pool.com", "*.poolbinance.com",
+  "*.antpool.com", "*.viabtc.com", "*.braiins.com", "*.slushpool.com",
+
+  /* Decentralized */
+  "ipfs.io", "*.ipfs.io", "dweb.link", "*.dweb.link",
+  "*.ipfs.dweb.link", "*.ipns.dweb.link",
+  "gateway.pinata.cloud", "*.mypinata.cloud",
+  "web3.storage", "*.web3.storage",
+  "nftstorage.link", "*.nftstorage.link",
+  "arweave.net", "*.arweave.net",
+  "ar.io", "*.ar.io",
+  "ic0.app", "*.ic0.app",
+  "icp0.io", "*.icp0.io",
+  "*.storjshare.io"
+) and
+not process.executable like (
+  "/opt/google-cloud-ops-agent/subagents/fluent-bit/bin/fluent-bit", "/usr/lib/systemd/systemd-resolved",
+  "/opt/Elastic/Agent/data/elastic-agent-*/components/elastic-otel-collector", "/usr/bin/dockerd",
+  "/usr/bin/google_osconfig_agent", "/snap/firefox/*/usr/lib/firefox/firefox", "/usr/bin/warp-svc",
+  "/var/lib/docker/overlay2/*/merged/usr/local/bin/node", "/snap/chromium/*/usr/lib/chromium-browser/chrome",
+  "/opt/google-cloud-ops-agent/subagents/opentelemetry-collector/otelopscol", "/usr/local/bin/rclone",
+  "/var/lib/elastic-agent/data/elastic-agent-*/components/elastic-otel-collector", "/opt/google/chrome/chrome",
+  "/usr/bin/pihole-FTL"
+)
+```
+
+
+
 ### DNS-over-HTTPS Enabled via Registry
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0319
+Index: geneve-ut-0388
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4659,7 +5537,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0321
+Index: geneve-ut-0390
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -4672,7 +5550,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0322
+Index: geneve-ut-0391
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4702,7 +5580,7 @@ container.security_context.privileged == true and process.interactive == true an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0328
+Index: geneve-ut-0397
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4716,7 +5594,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0329
+Index: geneve-ut-0398
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4733,23 +5611,11 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
-### Deprecated - EggShell Backdoor Execution
-
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0330
-
-```python
-event.category:process and event.type:(process_started or start) and process.name:espl and process.args:eyJkZWJ1ZyI6*
-```
-
-
-
 ### Deprecated - Encoded Executable Stored in the Registry
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0331
+Index: geneve-ut-0399
 
 ```python
 registry where host.os.type == "windows" and
@@ -4763,7 +5629,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0339
+Index: geneve-ut-0408
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -4787,7 +5653,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0348
+Index: geneve-ut-0417
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4841,7 +5707,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0351
+Index: geneve-ut-0420
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4857,7 +5723,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0352
+Index: geneve-ut-0421
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4885,7 +5751,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0353
+Index: geneve-ut-0422
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4902,7 +5768,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0354
+Index: geneve-ut-0423
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4919,7 +5785,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0355
+Index: geneve-ut-0424
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4940,7 +5806,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0357
+Index: geneve-ut-0426
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4960,7 +5826,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0358
+Index: geneve-ut-0427
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -4975,7 +5841,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0360
+Index: geneve-ut-0429
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -4988,7 +5854,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0361
+Index: geneve-ut-0430
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5008,7 +5874,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0364
+Index: geneve-ut-0433
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -5021,7 +5887,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0365
+Index: geneve-ut-0434
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5057,13 +5923,20 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 ### Dumping Account Hashes via Built-In Commands
 
-Branch count: 8  
-Document count: 8  
-Index: geneve-ut-0366
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0435
 
 ```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and
- process.name in ("defaults", "mkpassdb") and process.args like~ ("ShadowHashData", "-dump")
+process where host.os.type == "macos" and event.type in ("start","process_started") and (
+  (process.name == "defaults" and process.args like~ "ShadowHashData") or
+  (process.name == "mkpassdb" and process.args == "-dump") or
+  (process.name == "dscl" and process.args like~ "ShadowHashData") or
+  (
+    process.name in ("plutil","cat","strings","xxd","head") and
+    process.args like "/var/db/dslocal/nodes/Default/users/*.plist"
+  )
+)
 ```
 
 
@@ -5072,7 +5945,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0367
+Index: geneve-ut-0436
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5085,7 +5958,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0368
+Index: geneve-ut-0437
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5108,7 +5981,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0370
+Index: geneve-ut-0439
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5139,7 +6012,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0371
+Index: geneve-ut-0440
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -5158,7 +6031,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0372
+Index: geneve-ut-0441
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -5201,7 +6074,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0373
+Index: geneve-ut-0442
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -5215,7 +6088,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0374
+Index: geneve-ut-0444
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5230,7 +6103,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0375
+Index: geneve-ut-0445
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5246,7 +6119,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0376
+Index: geneve-ut-0446
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5260,7 +6133,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0377
+Index: geneve-ut-0447
 
 ```python
 sequence by host.id with maxspan=3s
@@ -5286,7 +6159,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0378
+Index: geneve-ut-0448
 
 ```python
 process where event.type == "start" and
@@ -5324,7 +6197,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0385
+Index: geneve-ut-0455
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -5337,7 +6210,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0386
+Index: geneve-ut-0456
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5351,7 +6224,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0387
+Index: geneve-ut-0457
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -5373,7 +6246,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0388
+Index: geneve-ut-0458
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5408,7 +6281,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0389
+Index: geneve-ut-0459
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -5420,7 +6293,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0421
+Index: geneve-ut-0502
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -5432,7 +6305,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0443
+Index: geneve-ut-0526
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5446,7 +6319,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0446
+Index: geneve-ut-0529
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5473,7 +6346,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0449
+Index: geneve-ut-0532
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5494,7 +6367,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0450
+Index: geneve-ut-0533
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5524,7 +6397,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0453
+Index: geneve-ut-0536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -5557,7 +6430,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0455
+Index: geneve-ut-0538
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -5574,7 +6447,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0456
+Index: geneve-ut-0539
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -5602,7 +6475,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0457
+Index: geneve-ut-0540
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -5615,7 +6488,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0459
+Index: geneve-ut-0542
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -5635,7 +6508,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0460
+Index: geneve-ut-0543
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5661,19 +6534,15 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0461
+Index: geneve-ut-0544
 
 ```python
 sequence with maxspan=2h
   [file where host.os.type == "windows" and event.type != "deletion" and file.extension : "exe" and
-     (process.name : "WINWORD.EXE" or
-      process.name : "EXCEL.EXE" or
-      process.name : "OUTLOOK.EXE" or
-      process.name : "POWERPNT.EXE" or
-      process.name : "eqnedt32.exe" or
-      process.name : "fltldr.exe" or
-      process.name : "MSPUB.EXE" or
-      process.name : "MSACCESS.EXE")
+    process.name : (
+      "WINWORD.EXE", "EXCEL.EXE", "OUTLOOK.EXE", "POWERPNT.EXE",
+      "eqnedt32.exe", "fltldr.exe", "MSPUB.EXE", "MSACCESS.EXE"
+    )
   ] by host.id, file.path
   [process where host.os.type == "windows" and event.type == "start" and 
    not (process.name : "NewOutlookInstaller.exe" and process.code_signature.subject_name : "Microsoft Corporation" and process.code_signature.trusted == true) and 
@@ -5687,7 +6556,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0462
+Index: geneve-ut-0545
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -5716,7 +6585,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0465
+Index: geneve-ut-0548
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5729,7 +6598,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0469
+Index: geneve-ut-0552
 
 ```python
 sequence by user.id with maxspan=5s
@@ -5744,7 +6613,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0470
+Index: geneve-ut-0553
 
 ```python
 process where event.type == "start" and
@@ -5766,7 +6635,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0471
+Index: geneve-ut-0554
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -5778,7 +6647,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0472
+Index: geneve-ut-0555
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5800,7 +6669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0474
+Index: geneve-ut-0557
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -5817,7 +6686,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0475
+Index: geneve-ut-0558
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5831,7 +6700,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0476
+Index: geneve-ut-0559
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -5844,7 +6713,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0477
+Index: geneve-ut-0560
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5856,7 +6725,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0478
+Index: geneve-ut-0561
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5868,7 +6737,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0479
+Index: geneve-ut-0562
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5882,7 +6751,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0480
+Index: geneve-ut-0563
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -5894,7 +6763,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 304  
 Document count: 304  
-Index: geneve-ut-0481
+Index: geneve-ut-0564
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -5916,7 +6785,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0484
+Index: geneve-ut-0567
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -5965,7 +6834,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0485
+Index: geneve-ut-0568
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -5982,7 +6851,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0486
+Index: geneve-ut-0569
 
 ```python
 sequence by host.id with maxspan=10s
@@ -5998,11 +6867,33 @@ sequence by host.id with maxspan=10s
 
 
 
+### File Download Detected via Defend for Containers
+
+Branch count: 40  
+Document count: 40  
+Index: geneve-ut-0574
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+  (
+    (process.name == "curl" or process.args in ("curl", "/bin/curl", "/usr/bin/curl", "/usr/local/bin/curl")) and
+    process.args in ("-o", "-O", "--output", "--remote-name", "--remote-name-all", "--output-dir")
+  ) or
+  (
+    (process.name == "wget" or process.args in ("wget", "/bin/wget", "/usr/bin/wget", "/usr/local/bin/wget")) and
+    process.args like ("-*O*", "--output-document=*", "--output-file=*")
+  )
+) 
+and container.id like "?*"
+```
+
+
+
 ### File Staged in Root Folder of Recycle Bin
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0494
+Index: geneve-ut-0577
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -6017,7 +6908,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0495
+Index: geneve-ut-0578
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6031,7 +6922,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0497
+Index: geneve-ut-0580
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6053,7 +6944,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0498
+Index: geneve-ut-0581
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -6074,7 +6965,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0499
+Index: geneve-ut-0582
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6100,7 +6991,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0500
+Index: geneve-ut-0583
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -6124,11 +7015,25 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Finder Sync Plugin Registered and Enabled
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0586
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
+  process.args == "-e" and process.args like~ "use" and process.args == "-i" and
+  (process.parent.name like~ ("python*", "node", "osascript", "bash", "sh", "zsh") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
 ### Full Disk Access Permission Check
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0538
+Index: geneve-ut-0621
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -6145,7 +7050,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0539
+Index: geneve-ut-0622
 
 ```python
 registry where host.os.type == "windows" and
@@ -6163,7 +7068,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0563
+Index: geneve-ut-0659
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -6202,7 +7107,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0564
+Index: geneve-ut-0660
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6229,7 +7134,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0565
+Index: geneve-ut-0661
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -6240,11 +7145,98 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 
 
+### GenAI CLI Started with Unsafe Permission Bypass
+
+Branch count: 267  
+Document count: 267  
+Index: geneve-ut-0662
+
+```python
+process where event.type == "start" and event.action in ("exec", "start") and
+(
+  (
+    process.args in (
+      "--dangerously-skip-permissions",
+      "--allow-dangerously-skip-permissions",
+      "--permission-mode=bypassPermissions"
+    ) or
+    (process.args == "--permission-mode" and process.args == "bypassPermissions")
+  ) and
+  (
+    process.name in ("claude", "claude.exe") or
+    process.executable : (
+      "*/.local/share/claude/versions/*",
+      "*/.claude/downloads/*",
+      "*Caskroom/claude-code/*",
+      "*\\Claude\\versions\\*"
+    ) or
+    (process.name in ("node", "node.exe") and process.args : "*@anthropic-ai/claude-code*")
+  )
+) or
+(
+  (
+    process.args in ("--dangerously-bypass-approvals-and-sandbox", "--full-auto", "--yolo") or
+    process.command_line : (
+      "* -s danger-full-access*",
+      "*--sandbox danger-full-access*",
+      "*--sandbox=danger-full-access*",
+      "*--ask-for-approval never*",
+      "*--ask-for-approval=never*"
+    )
+  ) and
+  (
+    process.name in (
+      "codex", "codex.exe", "codex-exec",
+      "codex-aarch64-apple-darwin", "codex-x86_64-apple-darwin",
+      "codex-linux-arm64", "codex-linux-x64"
+    ) or
+    (process.name in ("node", "node.exe") and process.args : ("*@openai/codex*", "*/codex", "*\\codex*"))
+  )
+) or
+(
+  (
+    process.args in ("--yolo", "-y") or
+    (process.args == "--approval-mode" and process.args == "yolo") or
+    process.args == "--approval-mode=yolo"
+  ) and
+  (
+    process.name in ("gemini", "gemini-cli", "gemini.exe", "gemini-cli.exe") or
+    (process.name in ("node", "node.exe") and process.args : ("*@google/gemini-cli*", "*/gemini", "*\\gemini*"))
+  )
+) or
+(
+  (
+    process.args in (
+      "--yolo",
+      "--autopilot",
+      "--allow-all",
+      "--allow-all-tools",
+      "--allow-all-paths",
+      "--allow-all-urls"
+    )
+  ) and
+  (
+    process.name in ("copilot", "copilot.exe") or
+    (process.name in ("node", "node.exe") and process.args : ("*@github/copilot*", "*/copilot", "*\\copilot*"))
+  )
+) or
+(
+  process.args == "--dangerously-skip-permissions" and
+  (
+    process.name in ("opencode", "opencode.exe", ".opencode") or
+    process.executable : ("*opencode-ai*", "*\\.opencode*") or
+    (process.name in ("node", "node.exe") and process.args : ("*opencode-ai*", "*/opencode", "*\\opencode*"))
+  )
+)
+```
+
+
+
 ### Git Hook Command Execution
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0573
+Index: geneve-ut-0670
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6262,7 +7254,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0574
+Index: geneve-ut-0671
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -6293,7 +7285,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0575
+Index: geneve-ut-0672
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6320,7 +7312,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0576
+Index: geneve-ut-0673
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -6340,7 +7332,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0580
+Index: geneve-ut-0677
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -6353,7 +7345,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0583
+Index: geneve-ut-0680
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -6365,7 +7357,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0586
+Index: geneve-ut-0683
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -6377,7 +7369,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0590
+Index: geneve-ut-0687
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -6389,7 +7381,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0592
+Index: geneve-ut-0689
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -6406,7 +7398,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0611
+Index: geneve-ut-0713
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6419,7 +7411,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0613
+Index: geneve-ut-0715
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -6443,7 +7435,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0614
+Index: geneve-ut-0716
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -6455,7 +7447,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0627
+Index: geneve-ut-0729
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6464,9 +7456,7 @@ sequence by process.entity_id with maxspan=5m
   /* Plan9FileSystem CLSID - WSL Host File System Worker */
  process.command_line : "*{DFB65C4C-B34F-435D-AFE9-A86218684AA8}*"]
 [file where host.os.type == "windows" and process.name : "dllhost.exe" and
-  not file.path : (
-        "?:\\Users\\*\\Downloads\\*",
-        "?:\\Windows\\Prefetch\\DLLHOST.exe-????????.pf")]
+  not file.path : "?:\\Windows\\Prefetch\\DLLHOST.exe-????????.pf"]
 ```
 
 
@@ -6475,7 +7465,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0628
+Index: geneve-ut-0730
 
 ```python
 any where process.executable != null and
@@ -6524,7 +7514,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0629
+Index: geneve-ut-0731
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6538,7 +7528,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0631
+Index: geneve-ut-0735
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6553,7 +7543,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0636
+Index: geneve-ut-0740
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6570,7 +7560,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0638
+Index: geneve-ut-0742
 
 ```python
 sequence with maxspan=1m
@@ -6589,12 +7579,12 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0639
+Index: geneve-ut-0743
 
 ```python
 sequence by host.id with maxspan=1m
  [network where host.os.type == "windows" and event.type == "start" and process.name : "mmc.exe" and source.port >= 49152 and
- destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
+  destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
   network.direction : ("incoming", "ingress") and network.transport == "tcp"
  ] by process.entity_id
  [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "mmc.exe"
@@ -6607,7 +7597,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0640
+Index: geneve-ut-0744
 
 ```python
 sequence by host.id with maxspan=5s
@@ -6626,7 +7616,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0641
+Index: geneve-ut-0745
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -6642,7 +7632,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0642
+Index: geneve-ut-0746
 
 ```python
 sequence by host.id with maxspan=30s
@@ -6658,7 +7648,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0643
+Index: geneve-ut-0747
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6671,7 +7661,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0648
+Index: geneve-ut-0752
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6688,7 +7678,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0650
+Index: geneve-ut-0754
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6701,7 +7691,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0651
+Index: geneve-ut-0755
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -6717,7 +7707,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0652
+Index: geneve-ut-0756
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6744,7 +7734,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0653
+Index: geneve-ut-0757
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6768,7 +7758,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0654
+Index: geneve-ut-0758
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6788,7 +7778,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-0656
+Index: geneve-ut-0760
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -6816,7 +7806,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0660
+Index: geneve-ut-0764
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6840,7 +7830,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0661
+Index: geneve-ut-0766
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6876,7 +7866,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0662
+Index: geneve-ut-0767
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -6888,7 +7878,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0663
+Index: geneve-ut-0768
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6902,7 +7892,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0664
+Index: geneve-ut-0769
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -6915,7 +7905,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0665
+Index: geneve-ut-0770
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -6974,7 +7964,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0666
+Index: geneve-ut-0771
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6987,7 +7977,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0667
+Index: geneve-ut-0772
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -7000,7 +7990,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0668
+Index: geneve-ut-0773
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7021,7 +8011,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0669
+Index: geneve-ut-0774
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7039,7 +8029,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0670
+Index: geneve-ut-0775
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7071,27 +8061,35 @@ not (
 
 ### Kernel Module Load via Built-in Utility
 
-Branch count: 48  
-Document count: 48  
-Index: geneve-ut-0671
+Branch count: 8  
+Document count: 8  
+Index: geneve-ut-0776
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and
-event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "load_module" and
+(
   (process.name == "kmod" and process.args == "insmod" and process.args like~ "*.ko*") or
   (process.name == "kmod" and process.args == "modprobe" and not process.args in ("-r", "--remove")) or
   (process.name == "insmod" and process.args like~ "*.ko*") or
   (process.name == "modprobe" and not process.args in ("-r", "--remove"))
 ) and
 not (
-  ?process.parent.executable like ("/opt/ds_agent/*", "/opt/TrendMicro/vls_agent/*", "/opt/intel/oneapi/*") or
-  ?process.working_directory in ("/opt/vinchin/agent", "/var/opt/ds_agent/am", "/opt/ds_agent", "/var/opt/TrendMicro/vls_agent/am") or
-  ?process.parent.executable in (
+  process.parent.executable like ("/opt/ds_agent/*", "/opt/TrendMicro/vls_agent/*", "/opt/intel/oneapi/*") or
+  process.working_directory in ("/opt/vinchin/agent", "/var/opt/ds_agent/am", "/opt/ds_agent", "/var/opt/TrendMicro/vls_agent/am") or
+  process.parent.executable in (
     "/usr/lib/uptrack/ksplice-apply", "/opt/commvault/commvault/Base/linux_drv", "/opt/cisco/amp/bin/cisco-amp-helper",
     "/usr/bin/kcarectl", "/usr/share/ksplice/ksplice-apply", "/opt/commvault/Base/linux_drv", "/usr/sbin/veeamsnap-loader",
     "/bin/falcoctl"
   ) or
-  (?process.parent.name like ("python*", "platform-python*") and ?process.parent.args in ("--smart-update", "--auto-update"))
+  (process.parent.name like ("python*", "platform-python*") and process.parent.args in ("--smart-update", "--auto-update")) or
+  (
+    process.name == "modprobe" and process.args == "-q" and process.args == "--" and process.args in ("net-pf-10", "netdev-", "binfmt-464c")
+  ) or
+  (
+    process.name == "modprobe" and process.args == "-n" and process.args == "-v" and process.args in ("usb-storage", "dccp", "squashfs", "udf", "sctp", "cramfs", "hfsplus")
+  ) or
+  process.parent.executable like ("/sbin/iptables-multi*", "/var/ossec/bin/wazuh-modulesd", "/usr/sbin/mkinitramfs", "/usr/share/initramfs-tools/hooks/lvm2") or
+  process.parent.args like "/usr/share/initramfs-tools/hooks/*"
 )
 ```
 
@@ -7101,7 +8099,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0672
+Index: geneve-ut-0777
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7123,7 +8121,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0674
+Index: geneve-ut-0779
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7150,7 +8148,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0675
+Index: geneve-ut-0780
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7176,7 +8174,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0676
+Index: geneve-ut-0781
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -7192,7 +8190,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0677
+Index: geneve-ut-0782
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -7208,7 +8206,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0679
+Index: geneve-ut-0784
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -7220,7 +8218,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0680
+Index: geneve-ut-0785
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7248,7 +8246,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0682
+Index: geneve-ut-0787
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7264,7 +8262,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0684
+Index: geneve-ut-0789
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -7289,7 +8287,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0685
+Index: geneve-ut-0790
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -7303,7 +8301,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0687
+Index: geneve-ut-0792
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7322,11 +8320,44 @@ process.name == "kubectl" and (
 
 
 
+### Kubelet API Connection Attempt to Internal IP
+
+Branch count: 204  
+Document count: 204  
+Index: geneve-ut-0793
+
+```python
+network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
+  event.action in ("connected-to", "connection_attempted") and (destination.port == 10250 or destination.port == 10255) and
+  cidrmatch(
+    destination.ip,
+    "127.0.0.0/8",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "169.254.0.0/16",
+    "100.64.0.0/10",
+    "::1/128",
+    "fc00::/7",
+    "fe80::/10"
+  ) and
+  (
+    process.name in ("curl", "wget", "nc", "ncat", "netcat", "socat", "openssl", "perl", "busybox") or 
+    process.name like ".*" or process.executable like "/*/.*" or 
+    process.name like ("python*", "ruby*", "node*", "java*", "lua*", "apache*", "php*", "nginx", "httpd*", "lighttpd", "caddy", "mongrel_rails", "gunicorn", 
+                       "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn", 
+                       "daphne", "twistd", "yaws", "webfsd", "flask", "rails", "mongrel", "catalina.sh", "hiawatha", "lswsctrl") or
+    process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/var/run/*", "/home/*", "/run/user/*", "/busybox/*")
+  )
+```
+
+
+
 ### Kubelet Certificate File Access Detected via Defend for Containers
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0688
+Index: geneve-ut-0794
 
 ```python
 any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
@@ -7349,11 +8380,59 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 
 
+### Kubernetes API Server Proxying Request to Kubelet
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0797
+
+```python
+kubernetes.audit.objectRef.subresource:"proxy" and
+kubernetes.audit.objectRef.resource:"nodes" and
+not kubernetes.audit.requestURI:(*metrics* or *healthz* or *stats/summary* or *elastic-agent* or *configz*) and
+not user.name:(
+  system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:serviceaccount\:kube-system\:* or
+  system\:node\:* or
+  eks\:* or aksService
+)
+```
+
+
+
+### Kubernetes Admission Webhook Created or Modified
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0798
+
+```python
+kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
+kubernetes.audit.verb:("create" or "update" or "patch" or "delete") and
+kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" and 
+user.name:(* and not 
+  (system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:serviceaccount\:kube-system\:* or
+  eks\:* or aksService or masterclient or nodeclient or
+  system\:serviceaccount\:gke-managed-system\:* or
+  system\:serviceaccount\:cert-manager\:* or
+  system\:serviceaccount\:gatekeeper-system\:* or
+  system\:serviceaccount\:kyverno\:* or
+  system\:serviceaccount\:*\:*-operator)
+) and
+kubernetes.audit.objectRef.name:(* and not (pod-identity-webhook or vpc-resource-mutating-webhook or eks-* or gke-*)) and 
+not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kubernetes.audit.objectRef.name:"k8tz")
+```
+
+
+
 ### Kubernetes Direct API Request via Curl or Wget
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0697
+Index: geneve-ut-0808
 
 ```python
 process where event.type == "start" and
@@ -7375,7 +8454,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0711
+Index: geneve-ut-0834
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7394,7 +8473,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0714
+Index: geneve-ut-0837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7434,11 +8513,36 @@ not (
 
 
 
+### Kubernetes Static Pod Manifest File Access
+
+Branch count: 116  
+Document count: 116  
+Index: geneve-ut-0839
+
+```python
+host.os.type:linux and event.category:process and event.action:(exec or executed) and 
+process.name:(
+  bash or sh or dash or zsh or 
+  cat or cp or mv or touch or tee or dd or
+  sed or awk or 
+  curl or wget or scp or
+  vi or vim or nano or echo or
+  busybox or
+  python* or perl* or ruby* or node or lua* or
+  openssl or base64 or xxd or
+  .*) and 
+  process.args:(*/etc/kubernetes/manifests/* and not (/etc/kubernetes/manifests/etcd* or /etc/kubernetes/manifests/kube-apiserver* or /etc/kubernetes/manifests/kube-scheduler* or /etc/kubernetes/manifests/kube-controller-manager*)) and 
+  not (process.args :printf* and process.working_directory :/home/*-svc-nessus) and 
+  not process.parent.executable :("/opt/nessus/sbin/nessusd" or "/opt/nessus_agent/sbin/nessus-agent-module")
+```
+
+
+
 ### LSASS Memory Dump Creation
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0721
+Index: geneve-ut-0847
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -7476,7 +8580,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0726
+Index: geneve-ut-0852
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -7494,7 +8598,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0727
+Index: geneve-ut-0853
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7508,7 +8612,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0731
+Index: geneve-ut-0858
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -7519,72 +8623,11 @@ process.args != "1"
 
 
 
-### Linux Restricted Shell Breakout via Linux Binary(s)
-
-Branch count: 303  
-Document count: 303  
-Index: geneve-ut-0732
-
-```python
-process where host.os.type == "linux" and event.type == "start" and process.executable != null and
-(
-  /* launching shell from capsh */
-  (process.name == "capsh" and process.args == "--" and not process.parent.executable == "/usr/bin/log4j-cve-2021-44228-hotpatch") or
-
-  /* launching shells from unusual parents or parent+arg combos */
-  (process.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
-    (process.parent.name : "*awk" and process.parent.args : "BEGIN {system(*)}") or
-    (process.parent.name == "git" and process.parent.args : ("!*sh", "exec *sh") and not process.name == "ssh" ) or
-    (process.parent.name : ("byebug", "ftp", "strace", "zip", "tar") and
-    (
-      process.parent.args : "BEGIN {system(*)}" or
-      (
-        (process.parent.args : "exec=*sh" or (process.parent.args : "-I" and process.parent.args : "*sh")) or
-        (process.args : "exec=*sh" or (process.args : "-I" and process.args : "*sh"))
-        )
-      )
-    ) or
-
-    /* shells specified in parent args */
-    /* nice rule is broken in 8.2 */
-    (process.parent.args : "*sh" and
-      (
-        (process.parent.name == "nice") or
-        (process.parent.name == "cpulimit" and process.parent.args == "-f") or
-        (process.parent.name == "find" and process.parent.args == "." and process.parent.args == "-exec" and
-         process.parent.args == ";" and process.parent.args : "/bin/*sh") or
-        (process.parent.name == "flock" and process.parent.args == "-u" and process.parent.args == "/")
-      )
-    )
-  )) or
-
-  /* shells specified in args */
-  (process.args : "*sh" and (
-    (process.parent.name == "crash" and process.parent.args == "-h") or
-    (process.name == "sensible-pager" and process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog")
-    /* scope to include more sensible-pager invoked shells with different parent process to reduce noise and remove false positives */
-
-  )) or
-  (process.name == "busybox" and event.action == "exec" and process.args_count == 2 and process.args : "*sh" and not
-   process.executable : "/var/lib/docker/overlay2/*/merged/bin/busybox" and not (process.parent.args == "init" and
-   process.parent.args == "runc") and not process.parent.args in ("ls-remote", "push", "fetch") and not process.parent.name == "mkinitramfs" and
-   not process.parent.executable == "/bin/busybox") or
-  (process.name == "env" and process.args_count == 2 and process.args : "*sh") or
-  (process.parent.name in ("vi", "vim") and process.parent.args == "-c" and process.parent.args : ":!*sh") or
-  (process.parent.name in ("c89", "c99", "gcc") and process.parent.args : "*sh,-s" and process.parent.args == "-wrapper") or
-  (process.parent.name == "expect" and process.parent.args == "-c" and process.parent.args : "spawn *sh;interact") or
-  (process.parent.name == "mysql" and process.parent.args == "-e" and process.parent.args : "\\!*sh") or
-  (process.parent.name == "ssh" and process.parent.args == "-o" and process.parent.args : "ProxyCommand=;*sh 0<&2 1>&2")
-)
-```
-
-
-
 ### Linux SSH X11 Forwarding
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0733
+Index: geneve-ut-0859
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -7598,7 +8641,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0736
+Index: geneve-ut-0862
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7612,7 +8655,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0738
+Index: geneve-ut-0864
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7631,9 +8674,9 @@ not (
 
 ### Linux User Added to Privileged Group
 
-Branch count: 360  
-Document count: 360  
-Index: geneve-ut-0739
+Branch count: 720  
+Document count: 720  
+Index: geneve-ut-0865
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7644,6 +8687,16 @@ process.executable != null and process.args in (
 (
   process.name in ("usermod", "adduser") or
   (process.name == "gpasswd" and process.args in ("-a", "--add", "-M", "--members"))
+) and
+not (
+  ?process.parent.executable like (
+    "/usr/lib/google/guest_agent/core_plugin", "/usr/libexec/platform-python*", "/usr/lib/google/guest_agent/GuestAgentCorePlugin/core_plugin",
+    "/usr/bin/google_guest_agent"
+  ) or
+  (
+    ?process.entry_leader.executable == "/usr/lib/venv-salt-minion/bin/python.original" and
+    ?process.entry_leader.args == "/usr/lib/venv-salt-minion/bin/salt-minion"
+  )
 )
 ```
 
@@ -7653,7 +8706,7 @@ process.executable != null and process.args in (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0743
+Index: geneve-ut-0869
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -7700,7 +8753,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0744
+Index: geneve-ut-0870
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7731,7 +8784,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 600  
 Document count: 1200  
-Index: geneve-ut-0745
+Index: geneve-ut-0871
 
 ```python
 sequence with maxspan=1m
@@ -7756,7 +8809,7 @@ sequence with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0747
+Index: geneve-ut-0873
 
 ```python
 event.dataset:o365.audit and
@@ -7769,7 +8822,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0749
+Index: geneve-ut-0875
 
 ```python
 event.dataset:o365.audit and
@@ -7782,7 +8835,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0750
+Index: geneve-ut-0876
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -7794,7 +8847,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0781
+Index: geneve-ut-0911
 
 ```python
 event.dataset:o365.audit and
@@ -7807,7 +8860,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0782
+Index: geneve-ut-0912
 
 ```python
 event.dataset:o365.audit and
@@ -7820,7 +8873,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0783
+Index: geneve-ut-0913
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -7832,7 +8885,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0784
+Index: geneve-ut-0914
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -7844,7 +8897,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0785
+Index: geneve-ut-0915
 
 ```python
 event.dataset:o365.audit and
@@ -7857,7 +8910,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0792
+Index: geneve-ut-0923
 
 ```python
 event.dataset: "o365.audit" and
@@ -7870,7 +8923,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0796
+Index: geneve-ut-0926
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7890,7 +8943,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0797
+Index: geneve-ut-0927
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -7902,7 +8955,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0798
+Index: geneve-ut-0928
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -7914,7 +8967,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0802
+Index: geneve-ut-0932
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7926,7 +8979,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0803
+Index: geneve-ut-0933
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -7938,7 +8991,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0804
+Index: geneve-ut-0934
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7950,7 +9003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0805
+Index: geneve-ut-0935
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7962,7 +9015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0806
+Index: geneve-ut-0936
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7987,7 +9040,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0807
+Index: geneve-ut-0937
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8007,7 +9060,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0808
+Index: geneve-ut-0938
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -8020,7 +9073,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-0809
+Index: geneve-ut-0939
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8035,7 +9088,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0811
+Index: geneve-ut-0941
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -8047,7 +9100,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0814
+Index: geneve-ut-0944
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -8059,7 +9112,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0815
+Index: geneve-ut-0945
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -8071,7 +9124,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0816
+Index: geneve-ut-0946
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -8105,7 +9158,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0819
+Index: geneve-ut-0949
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8119,7 +9172,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0820
+Index: geneve-ut-0950
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8140,7 +9193,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0821
+Index: geneve-ut-0951
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8154,7 +9207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0822
+Index: geneve-ut-0952
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8189,7 +9242,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0823
+Index: geneve-ut-0953
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -8214,7 +9267,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0824
+Index: geneve-ut-0954
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8229,14 +9282,14 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### Microsoft IIS Connection Strings Decryption
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0827
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-0958
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   (process.name : "aspnet_regiis.exe" or ?process.pe.original_file_name == "aspnet_regiis.exe") and
-  process.args : "connectionStrings" and process.args : "-pdf"
+  process.args : "connectionStrings" and process.args : ("-pdf", "-pd")
 ```
 
 
@@ -8245,7 +9298,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0829
+Index: geneve-ut-0960
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8276,7 +9329,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0831
+Index: geneve-ut-0962
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -8330,7 +9383,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0832
+Index: geneve-ut-0963
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -8340,12 +9393,12 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 ### Modification of AmsiEnable Registry Key
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0833
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-0964
 
 ```python
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type in ("creation", "change") and
   registry.value : "AmsiEnable" and registry.data.strings: ("0", "0x00000000")
 
   /*
@@ -8360,7 +9413,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0834
+Index: geneve-ut-0965
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8377,7 +9430,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0836
+Index: geneve-ut-0967
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8392,7 +9445,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0837
+Index: geneve-ut-0968
 
 ```python
 file where event.type != "deletion" and
@@ -8442,7 +9495,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0839
+Index: geneve-ut-0970
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8458,7 +9511,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0840
+Index: geneve-ut-0971
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -8472,7 +9525,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0842
+Index: geneve-ut-0973
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8495,7 +9548,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0843
+Index: geneve-ut-0974
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8523,7 +9576,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0844
+Index: geneve-ut-0975
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8545,7 +9598,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0845
+Index: geneve-ut-0976
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8562,9 +9615,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### MsBuild Making Network Connections
 
-Branch count: 8  
-Document count: 16  
-Index: geneve-ut-0846
+Branch count: 4  
+Document count: 8  
+Index: geneve-ut-0977
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -8582,10 +9635,6 @@ sequence by process.entity_id with maxspan=30s
   /* Exclude domains that are known to be benign */
   [network where host.os.type == "windows" and
     event.action: ("connection_attempted", "lookup_requested") and
-    (
-      process.pe.original_file_name: "MSBuild.exe" or
-      process.name: "MSBuild.exe"
-    ) and
     not user.id == "S-1-5-18" and
     not cidrmatch(destination.ip, "127.0.0.1", "::1") and
     not dns.question.name : (
@@ -8601,7 +9650,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0847
+Index: geneve-ut-0978
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -8619,7 +9668,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-0848
+Index: geneve-ut-0979
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8660,7 +9709,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-0859
+Index: geneve-ut-0992
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -8686,7 +9735,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0867
+Index: geneve-ut-1000
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -8710,7 +9759,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0870
+Index: geneve-ut-1003
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8722,9 +9771,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### NTDS or SAM Database File Copied
 
-Branch count: 210  
-Document count: 210  
-Index: geneve-ut-0871
+Branch count: 168  
+Document count: 168  
+Index: geneve-ut-1004
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8734,26 +9783,49 @@ process where host.os.type == "windows" and event.type == "start" and
     ) or
     ((?process.pe.original_file_name : "esentutl.exe" or process.name : "esentutl.exe") and process.args : ("*/y*", "*/vss*", "*/d*"))
   ) and
-  process.command_line : ("*\\ntds.dit*", "*\\config\\SAM*", "*\\*\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\*", "*/system32/config/SAM*", "*\\User Data\\*")
+  process.command_line : ("*\\ntds.dit*", "*\\config\\SAM*", "*\\*\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\*", "*/system32/config/SAM*")
 ```
 
 
 
 ### Namespace Manipulation Using Unshare
 
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-0872
+Branch count: 12  
+Document count: 12  
+Index: geneve-ut-1005
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action : ("exec", "exec_event", "start") and
-process.executable: "/usr/bin/unshare" and not (
-  process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
-  process.args == "/usr/bin/snap" and not process.parent.name in ("zz-proxmox-boot", "java") or
-  process.parent.args like (
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
+process.name: "unshare" and not (
+  ?process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
+  ?process.args == "/usr/bin/snap" and not ?process.parent.name in ("zz-proxmox-boot", "java") or
+  ?process.parent.args like (
     "/etc/kernel/postinst.d/zz-proxmox-boot", "/opt/openssh/sbin/sshd", "/usr/sbin/sshd",
     "/snap/*", "/home/*/.local/share/JetBrains/Toolbox/*"
   )
+)
+```
+
+
+
+### Namespace Manipulation Using Unshare in a Container
+
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-1006
+
+```python
+process where event.type == "start" and event.action == "exec" and
+process.name == "unshare" and container.id like "?*" and not (
+  process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
+  (process.args == "/usr/bin/snap" and not process.parent.name in ("zz-proxmox-boot", "java")) or
+  process.parent.args like (
+    "/etc/kernel/postinst.d/zz-proxmox-boot", "/opt/openssh/sbin/sshd", "/usr/sbin/sshd",
+    "/snap/*", "/home/*/.local/share/JetBrains/Toolbox/*"
+  ) or
+ (process.args == "--propagation" and process.args == "private" and process.args like "/etc/kernel/post*.d/zz-proxmox-boot") or 
+ (process.args == "--fork" and process.args == "--kill-child") or 
+  process.args like ("/usr/bin/os-prober", "/usr/bin/linux-boot-prober", "/opt/SIGOS/sitedata/exec/*")
 )
 ```
 
@@ -8763,7 +9835,7 @@ process.executable: "/usr/bin/unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0873
+Index: geneve-ut-1007
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8784,7 +9856,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0875
+Index: geneve-ut-1009
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8799,7 +9871,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0876
+Index: geneve-ut-1010
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8816,7 +9888,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0878
+Index: geneve-ut-1012
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -8836,11 +9908,57 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 
 
+### Network Connection Followed by File Creation
+
+Branch count: 112  
+Document count: 224  
+Index: geneve-ut-1014
+
+```python
+sequence by host.id, process.entity_id with maxspan=5s
+  [network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and
+  process.executable like (
+    "/boot/*", "/dev/shm/*", "/tmp/*", "/var/tmp/*", "/var/log/*", "/var/run/user/*", "/run/user/*"
+  ) and
+  not (
+    destination.ip == null or
+    destination.ip == "0.0.0.0" or 
+    cidrmatch(
+      destination.ip, "10.0.0.0/8", "127.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12",
+      "192.0.0.0/24", "192.0.0.0/29","192.0.0.8/32", "192.0.0.9/32", "192.0.0.10/32",
+      "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24",
+      "192.168.0.0/16", "192.88.99.0/24", "224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24",
+      "198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4", "::1", "FE80::/10",
+      "FF00::/8", "FC00::/7"
+    )
+  )]
+  [file where host.os.type == "linux" and event.type == "creation" and process.executable like (
+    "/boot/*", "/dev/shm/*", "/tmp/*", "/var/tmp/*", "/var/log/*", "/boot/*", "/var/run/user/*", "/run/user/*"
+  ) and
+  not (
+    file.name like "tmp*" or file.extension in ("sqlite-journal", "db-journal", "lockfile", "tmp") or
+    file.path like (
+      "/loki/wal/*", "/dev/shm/.org.chromium.Chromium.*", "/opt/rapid7/nexpose/*",
+      "/usr/local/ltechagent*", "/var/lib/cloudendure/agent_keystore_temp", "/var/cache/yum/*",
+      "/run/aws-node/ipam.json.tmp*", "/run/systemd/journal/streams/.*"
+    ) or
+    (process.executable == "/tmp/terraform" and file.path like "/tmp/terraform-provider*") or 
+    process.name in ("podman", "minikube", "logrotate", "java", "aws-k8s-agent", "grafana", "postman") or
+    process.executable : (
+      "/etc/cron.daily/logrotate", "/etc/update-motd.d/50-motd-news", "/etc/cron.hourly/0yum-hourly.cron",
+      "/etc/cron.hourly/BitdefenderRedline", "/tmp/token_handler", "/tmp/.sentry-cli*.exe", 
+      "/etc/cron.daily/0yum-daily.cron", "/etc/init.d/fortiedr"
+    )
+  )]
+```
+
+
+
 ### Network Connection Initiated by Suspicious SSHD Child Process
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-0880
+Index: geneve-ut-1015
 
 ```python
 sequence by host.id with maxspan=1s
@@ -8882,7 +10000,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-0881
+Index: geneve-ut-1016
 
 ```python
 sequence by host.id with maxspan=10s
@@ -8899,7 +10017,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0883
+Index: geneve-ut-1018
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8914,7 +10032,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0884
+Index: geneve-ut-1019
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -8933,7 +10051,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0885
+Index: geneve-ut-1020
 
 ```python
 sequence by process.entity_id
@@ -8953,7 +10071,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0886
+Index: geneve-ut-1021
 
 ```python
 sequence by process.entity_id
@@ -8972,7 +10090,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-0887
+Index: geneve-ut-1022
 
 ```python
 sequence by host.id with maxspan=1m
@@ -9001,7 +10119,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-0888
+Index: geneve-ut-1023
 
 ```python
 sequence by process.entity_id
@@ -9026,7 +10144,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0889
+Index: geneve-ut-1024
 
 ```python
 sequence by process.entity_id
@@ -9048,7 +10166,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0890
+Index: geneve-ut-1025
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -9081,7 +10199,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0891
+Index: geneve-ut-1026
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9111,7 +10229,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0894
+Index: geneve-ut-1029
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -9128,7 +10246,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0895
+Index: geneve-ut-1030
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -9165,7 +10283,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0896
+Index: geneve-ut-1031
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9178,7 +10296,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0901
+Index: geneve-ut-1036
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -9190,7 +10308,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0904
+Index: geneve-ut-1039
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -9202,7 +10320,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-0912
+Index: geneve-ut-1047
 
 ```python
 sequence by host.id with maxspan=10s
@@ -9216,7 +10334,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0913
+Index: geneve-ut-1048
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9226,11 +10344,40 @@ process where host.os.type == "linux" and event.type == "start" and
 
 
 
+### Nsenter Execution with Target Flag Inside Container
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1049
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  (process.name == "nsenter" or process.args == "nsenter") and
+  container.id like "?*" and process.args like ("-t", "--target*")
+```
+
+
+
+### Nsenter to PID Namespace via Auditd
+
+Branch count: 32  
+Document count: 32  
+Index: geneve-ut-1050
+
+```python
+host.os.type:linux and 
+event.category:process and event.action:(executed or exec) and 
+(process.name:nsenter or process.args:nsenter) and 
+process.args:((--target* or -t) and not --net=/run/netns/* and not (--assertion and snap) and not (is-active and snap.*))
+```
+
+
+
 ### Office Test Registry Persistence
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0915
+Index: geneve-ut-1052
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -9243,7 +10390,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0916
+Index: geneve-ut-1053
 
 ```python
 event.dataset: "okta.system"
@@ -9258,7 +10405,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0918
+Index: geneve-ut-1055
 
 ```python
 sequence by user.name with maxspan=30m
@@ -9280,7 +10427,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0927
+Index: geneve-ut-1064
 
 ```python
 network where event.action == "connection_accepted" and
@@ -9307,7 +10454,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0928
+Index: geneve-ut-1065
 
 ```python
 network where event.action == "lookup_requested" and
@@ -9327,7 +10474,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0929
+Index: geneve-ut-1066
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9342,7 +10489,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-0930
+Index: geneve-ut-1067
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -9369,7 +10516,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-0931
+Index: geneve-ut-1068
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -9384,7 +10531,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0932
+Index: geneve-ut-1069
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -9400,7 +10547,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0933
+Index: geneve-ut-1070
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -9414,7 +10561,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0937
+Index: geneve-ut-1076
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -9429,7 +10576,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0938
+Index: geneve-ut-1077
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9443,7 +10590,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0939
+Index: geneve-ut-1078
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9462,7 +10609,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0940
+Index: geneve-ut-1079
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9474,7 +10621,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0941
+Index: geneve-ut-1080
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9486,7 +10633,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0942
+Index: geneve-ut-1081
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9504,7 +10651,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0943
+Index: geneve-ut-1082
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9517,7 +10664,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0944
+Index: geneve-ut-1083
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9532,7 +10679,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0945
+Index: geneve-ut-1084
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -9547,7 +10694,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0947
+Index: geneve-ut-1086
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -9565,9 +10712,9 @@ process where host.os.type == "macos" and event.type == "start" and
 
 ### Persistence via Microsoft Office AddIns
 
-Branch count: 36  
-Document count: 36  
-Index: geneve-ut-0948
+Branch count: 108  
+Document count: 108  
+Index: geneve-ut-1087
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9581,7 +10728,8 @@ file where host.os.type == "windows" and event.type != "deletion" and
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Word\\Startup\\*",
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\AddIns\\*",
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*"
- )
+ ) and
+ not (file.name : "~$*" and process.name : "excel.exe" and ?file.size in (0, 165))
 ```
 
 
@@ -9590,7 +10738,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0949
+Index: geneve-ut-1088
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9604,7 +10752,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0950
+Index: geneve-ut-1089
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9623,7 +10771,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0951
+Index: geneve-ut-1090
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9647,9 +10795,9 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 ### Persistence via Suspicious Launch Agent or Launch Daemon
 
-Branch count: 190  
-Document count: 190  
-Index: geneve-ut-0952
+Branch count: 380  
+Document count: 380  
+Index: geneve-ut-1091
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -9664,7 +10812,12 @@ file where host.os.type == "macos" and event.type != "deletion" and
   not process.executable like ("/System/*", "/Library/PrivilegedHelperTools/*") and
   not (process.code_signature.signing_id in ("com.apple.vim", "com.apple.cat", "com.apple.cfprefsd",
                                             "com.jetbrains.toolbox", "com.apple.pico", "com.apple.shove",
-                                            "com.sublimetext.4", "com.apple.ditto") and process.code_signature.trusted == true)
+                                            "com.sublimetext.4", "com.apple.ditto") and process.code_signature.trusted == true) and
+  not (file.path like ("/Library/LaunchDaemons/com.jumpcloud.*",
+                       "/Library/LaunchAgents/com.jumpcloud.*",
+                       "/Library/LaunchDaemons/com.wazuh.*",
+                       "/Library/LaunchDaemons/com.zscaler.service.plist") and
+       process.executable == "/bin/bash")
 ```
 
 
@@ -9673,7 +10826,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0953
+Index: geneve-ut-1092
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9692,7 +10845,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0954
+Index: geneve-ut-1093
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9720,7 +10873,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0955
+Index: geneve-ut-1094
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9735,7 +10888,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0956
+Index: geneve-ut-1095
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9798,7 +10951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0957
+Index: geneve-ut-1096
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -9819,7 +10972,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0958
+Index: geneve-ut-1097
 
 ```python
 any where host.os.type == "windows" and
@@ -9881,7 +11034,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0960
+Index: geneve-ut-1099
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -9910,7 +11063,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0961
+Index: geneve-ut-1100
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -9922,9 +11075,9 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 ### Pluggable Authentication Module (PAM) Version Discovery
 
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-0962
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1101
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9936,10 +11089,17 @@ process where host.os.type == "linux" and event.type == "start" and
 not (
   ?process.parent.name in ("dcservice", "inspectorssmplugin") or
   ?process.working_directory in ("/var/ossec", "/opt/msp-agent") or
+  ?process.entry_leader.executable in("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/usr/sbin/ScanAssistant") or
   ?process.parent.executable in (
     "/opt/CyberCNSAgent/cybercnsagent_linux", "/usr/local/manageengine/uems_agent/bin/dcpatchscan",
     "/usr/local/manageengine/uems_agent/bin/dcconfig", "/usr/share/vicarius/topiad",
-    "/etc/rc.d/init.d/sshd-chroot"
+    "/etc/rc.d/init.d/sshd-chroot", "/var/ossec/bin/wazuh-modulesd",
+    "/usr/lib/venv-salt-minion/bin/python.original"
+  ) or
+  (
+    process.executable == "/usr/bin/rpm" and
+    ?process.parent.name == "systemd" and
+    ?process.env_vars == "LD_LIBRARY_PATH=/usr/lib/venv-salt-minion/lib"
   )
 )
 ```
@@ -9950,7 +11110,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0965
+Index: geneve-ut-1104
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -9995,9 +11155,9 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 ### Polkit Version Discovery
 
-Branch count: 24  
-Document count: 24  
-Index: geneve-ut-0966
+Branch count: 48  
+Document count: 48  
+Index: geneve-ut-1105
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10009,7 +11169,12 @@ event.action in ("exec", "exec_event", "start", "ProcessRollup2", "process_start
 ) and
 not (
   ?process.working_directory in ("/opt/msp-agent", "/opt/CyberCNSAgent") or
-  ?process.parent.executable like ("/usr/local/cpanel/3rdparty/perl/*/bin/perl", "/usr/share/vicarius/topiad")
+  ?process.parent.executable like ("/usr/local/cpanel/3rdparty/perl/*/bin/perl", "/usr/share/vicarius/topiad") or
+  ?process.entry_leader.executable in ("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/sf/edr/agent/bin/edr_monitor") or
+  (
+    ?process.parent.args == "/usr/lib/venv-salt-minion/bin/python.original" and
+    ?process.parent.args == "/usr/lib/venv-salt-minion/bin/salt-minion"
+  )
 )
 ```
 
@@ -10019,7 +11184,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0967
+Index: geneve-ut-1106
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -10032,7 +11197,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0976
+Index: geneve-ut-1116
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10049,7 +11214,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0978
+Index: geneve-ut-1118
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -10074,7 +11239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0982
+Index: geneve-ut-1122
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/*/etc/nsswitch.conf" and
@@ -10091,7 +11256,7 @@ not file.path like (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0983
+Index: geneve-ut-1123
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10107,7 +11272,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0984
+Index: geneve-ut-1124
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10128,7 +11293,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-0985
+Index: geneve-ut-1125
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10169,7 +11334,7 @@ event.action in ("exec", "exec_event", "start", "executed", "process_started", "
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0986
+Index: geneve-ut-1126
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -10186,7 +11351,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0987
+Index: geneve-ut-1127
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -10199,7 +11364,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0988
+Index: geneve-ut-1128
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10223,7 +11388,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-0990
+Index: geneve-ut-1130
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -10248,11 +11413,38 @@ sequence by host.id, user.name with maxspan = 5s
 
 
 
+### Potential Container Escape via Kernel core_pattern Modification
+
+Branch count: 288  
+Document count: 288  
+Index: geneve-ut-1132
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+process.args like ("*/proc/sys/kernel/core_pattern*", "*kernel.core_pattern*") and
+?process.parent.executable != null and
+(
+  process.name in ("tee", "cp", "mv", "dd") or
+  (
+    process.name == "sysctl" and
+    process.args like ("*-w*", "*core_pattern*")
+  ) or
+  (
+    process.name in ("bash", "dash", "sh", "zsh", "ksh", "fish", "ash", "mksh", "busybox") and
+    process.args == "-c" and process.args like ("*echo *", "*printf *")
+  )
+) and
+not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpctl", "/usr/sbin/abrtd", "/usr/bin/apport")
+```
+
+
+
 ### Potential Cookies Theft via Browser Debugging
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0992
+Index: geneve-ut-1133
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -10276,7 +11468,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0994
+Index: geneve-ut-1136
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -10292,18 +11484,18 @@ process where host.os.type == "windows" and event.code == "10" and
 
 ### Potential Credential Access via LSASS Memory Dump
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0995
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1137
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
   winlog.event_data.TargetImage : "?:\\WINDOWS\\system32\\lsass.exe" and
 
-   /* DLLs exporting MiniDumpWriteDump API to create an lsass mdmp*/
-  winlog.event_data.CallTrace : ("*dbghelp*", "*dbgcore*") and
+  /* dbgcore.dll hosts MiniDumpWriteDump on modern Windows; dbghelp-only traces are non-dump usage */
+  winlog.event_data.CallTrace : "*dbgcore*" and
 
-   /* case of lsass crashing */
+  /* crash handlers */
   not process.executable : (
         "?:\\Windows\\System32\\WerFault.exe",
         "?:\\Windows\\SysWOW64\\WerFault.exe",
@@ -10317,7 +11509,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0996
+Index: geneve-ut-1138
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -10370,17 +11562,33 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
+### Potential Credential Access via Renamed COM+ Services DLL
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1139
+
+```python
+sequence by process.entity_id with maxspan=1m
+ [process where host.os.type == "windows" and event.type == "start" and process.name : "rundll32.exe"]
+ [process where host.os.type == "windows" and event.code == "7" and
+   (file.pe.original_file_name : "COMSVCS.DLL" or file.pe.imphash : "EADBCCBB324829ACB5F2BBE87E5549A8") and
+   /* renamed COMSVCS */
+   not file.name : "COMSVCS.DLL"]
+```
+
+
+
 ### Potential Credential Access via Trusted Developer Utility
 
-Branch count: 16  
-Document count: 32  
-Index: geneve-ut-0998
+Branch count: 4  
+Document count: 8  
+Index: geneve-ut-1140
 
 ```python
 sequence by process.entity_id
  [process where host.os.type == "windows" and event.type == "start" and (process.name : "MSBuild.exe" or process.pe.original_file_name == "MSBuild.exe")]
- [any where host.os.type == "windows" and (event.category == "library" or (event.category == "process" and event.action : "Image loaded*")) and
-  (?dll.name : ("vaultcli.dll", "SAMLib.DLL") or file.name : ("vaultcli.dll", "SAMLib.DLL"))]
+ [library where host.os.type == "windows" and dll.name : ("vaultcli.dll", "SAMLib.DLL")]
 ```
 
 
@@ -10389,7 +11597,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1010
+Index: geneve-ut-1154
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10404,7 +11612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1011
+Index: geneve-ut-1155
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10435,7 +11643,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1012
+Index: geneve-ut-1156
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10449,7 +11657,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1013
+Index: geneve-ut-1157
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10462,7 +11670,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1014
+Index: geneve-ut-1158
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -10474,7 +11682,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1015
+Index: geneve-ut-1159
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10483,15 +11691,34 @@ process.parent.name == "proot"
 
 
 
+### Potential Direct Kubelet Access via Process Arguments
+
+Branch count: 136  
+Document count: 136  
+Index: geneve-ut-1161
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
+(
+  /* direct utility execution */
+  process.name like ("curl", "wget", "python*", "perl*", "php*", "node*", "java", "ruby*", "lua*", ".*") or
+
+  process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/var/run/*", "/home/*", "/run/user/*", "/busybox/*")
+) and
+process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:10255/*")
+```
+
+
+
 ### Potential Direct Kubelet Access via Process Arguments Detected via Defend for Containers
 
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-1017
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1162
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.args like "http*:10250*" and process.interactive == true and container.id like "?*"
+process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*") and container.id like "?*"
 ```
 
 
@@ -10500,7 +11727,7 @@ process.args like "http*:10250*" and process.interactive == true and container.i
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1018
+Index: geneve-ut-1163
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10521,7 +11748,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1019
+Index: geneve-ut-1164
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10535,7 +11762,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1022
+Index: geneve-ut-1167
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -10559,7 +11786,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1023
+Index: geneve-ut-1168
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -10575,7 +11802,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1024
+Index: geneve-ut-1169
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -10592,7 +11819,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1025
+Index: geneve-ut-1170
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10613,7 +11840,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1027
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -10626,7 +11853,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1029
+Index: geneve-ut-1174
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10654,7 +11881,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1032
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10670,7 +11897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1033
+Index: geneve-ut-1178
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10693,7 +11920,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1034
+Index: geneve-ut-1179
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10706,7 +11933,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1036
+Index: geneve-ut-1181
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10719,7 +11946,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1041
+Index: geneve-ut-1186
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10733,7 +11960,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1042
+Index: geneve-ut-1187
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10748,7 +11975,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1043
+Index: geneve-ut-1189
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -10771,7 +11998,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1046
+Index: geneve-ut-1192
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10814,7 +12041,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1047
+Index: geneve-ut-1193
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10832,7 +12059,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1048
+Index: geneve-ut-1194
 
 ```python
 host.os.type:"windows" and
@@ -10848,10 +12075,26 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1050
+Index: geneve-ut-1196
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
+```
+
+
+
+### Potential Kubeletctl Execution
+
+Branch count: 38  
+Document count: 38  
+Index: geneve-ut-1198
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
+(
+  process.name == "kubeletctl" or
+  (process.args in ("run", "exec", "scan", "pods", "runningpods", "attach", "portForward", "cri", "pid2pod") and process.args:("*:10250*", "*:10255*"))
+)
 ```
 
 
@@ -10860,7 +12103,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1052
+Index: geneve-ut-1199
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -10876,7 +12119,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1053
+Index: geneve-ut-1200
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10894,7 +12137,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1054
+Index: geneve-ut-1201
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -10908,7 +12151,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1056
+Index: geneve-ut-1203
 
 ```python
 sequence by host.id with maxspan=30s
@@ -10927,7 +12170,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1058
+Index: geneve-ut-1205
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -10943,7 +12186,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1059
+Index: geneve-ut-1206
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10956,7 +12199,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1060
+Index: geneve-ut-1207
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10986,7 +12229,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1065
+Index: geneve-ut-1212
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11009,7 +12252,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1066
+Index: geneve-ut-1213
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11028,7 +12271,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1071
+Index: geneve-ut-1218
 
 ```python
 process where host.os.type == "windows" and 
@@ -11170,7 +12413,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1072
+Index: geneve-ut-1219
 
 ```python
 process where host.os.type == "windows" and
@@ -11247,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1076
+Index: geneve-ut-1223
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -11264,7 +12507,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1077
+Index: geneve-ut-1224
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -11298,7 +12541,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1079
+Index: geneve-ut-1226
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -11310,7 +12553,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1080
+Index: geneve-ut-1227
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11349,7 +12592,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1082
+Index: geneve-ut-1229
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -11362,7 +12605,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1087
+Index: geneve-ut-1234
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11376,7 +12619,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1094
+Index: geneve-ut-1241
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -11404,7 +12647,8 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
       "/var/run/udev/ud.pid",
       "/var/run/udevd.pid"
     )
-  )
+  ) and
+  not file.path like ("/tmp/krb5cc*", "/tmp/ansible_*", "/storage/*", "/tmp/clearsigned.message.*", "/var/sftp/refinitiv/*", "/tmp/fileutil.message.*")
 ```
 
 
@@ -11413,7 +12657,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1095
+Index: geneve-ut-1242
 
 ```python
 network where host.os.type == "windows" and
@@ -11439,7 +12683,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1098
+Index: geneve-ut-1245
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11454,7 +12698,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1100
+Index: geneve-ut-1247
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -11468,7 +12712,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1101
+Index: geneve-ut-1248
 
 ```python
 file where host.os.type == "windows" and
@@ -11482,7 +12726,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1102
+Index: geneve-ut-1249
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11495,7 +12739,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1103
+Index: geneve-ut-1250
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11515,7 +12759,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1104
+Index: geneve-ut-1251
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11533,9 +12777,9 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 ### Potential PowerShell HackTool Script by Author
 
-Branch count: 45  
-Document count: 45  
-Index: geneve-ut-1106
+Branch count: 48  
+Document count: 48  
+Index: geneve-ut-1253
 
 ```python
 host.os.type:windows and event.category:process and
@@ -11562,7 +12806,8 @@ host.os.type:windows and event.category:process and
       "_nullbind" or "_tmenochet" or
       "jaredcatkinson" or "ChrisTruncer" or
       "monoxgas" or "TheRealWover" or
-      "splinter_code"
+      "splinter_code" or "samratashok" or
+      "leechristensen" or "nikhil_mitt"
   ) and
   not powershell.file.script_block_text : ("Get-UEFIDatabaseSigner" or "Posh-SSH")
 ```
@@ -11573,7 +12818,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1107
+Index: geneve-ut-1254
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11768,7 +13013,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1120
+Index: geneve-ut-1267
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11780,11 +13025,39 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 
 
+### Potential Privacy Control Bypass via TCCDB Modification
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-1268
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
+ process.args like "/*/Application Support/com.apple.TCC/TCC.db" and
+ (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
+### Potential Privilege Escalation in Container via Runc Init
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1269
+
+```python
+host.os.type:linux and event.category:process and 
+event.action:(executed or exec) and 
+process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
+```
+
+
+
 ### Potential Privilege Escalation through Writable Docker Socket
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1122
+Index: geneve-ut-1270
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -11801,7 +13074,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1123
+Index: geneve-ut-1271
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -11815,7 +13088,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1124
+Index: geneve-ut-1272
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11827,27 +13100,11 @@ process.interactive == true and process.parent.interactive == true
 
 
 
-### Potential Privilege Escalation via OverlayFS
-
-Branch count: 3  
-Document count: 6  
-Index: geneve-ut-1128
-
-```python
-sequence by process.parent.entity_id, host.id with maxspan=5s
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-    process.name == "unshare" and process.args : ("-r", "-rm", "m") and process.args : "*cap_setuid*"  and user.id != "0"]
-  [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
-    user.id == "0"]
-```
-
-
-
 ### Potential Privilege Escalation via PKEXEC
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1129
+Index: geneve-ut-1276
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -11859,7 +13116,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1130
+Index: geneve-ut-1277
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -11875,7 +13132,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1131
+Index: geneve-ut-1278
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11895,7 +13152,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1132
+Index: geneve-ut-1280
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11932,10 +13189,115 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1134
+Index: geneve-ut-1282
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
+```
+
+
+
+### Potential Privilege Escalation via a Parent Process Sequence
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1283
+
+```python
+sequence by host.id, process.parent.entity_id with maxspan=15s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )]
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")]
+```
+
+
+
+### Potential Privilege Escalation via a Parent/Child Process Sequence
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1284
+
+```python
+sequence by host.id with maxspan=15s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )] by process.entity_id
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")] by process.parent.entity_id
+```
+
+
+
+### Potential Privilege Escalation via a Suspicious UID Change
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1285
+
+```python
+sequence by host.id, process.entity_id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )]
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")]
+```
+
+
+
+### Potential Privilege Escalation via unshare Followed by Root Process
+
+Branch count: 341  
+Document count: 682  
+Index: geneve-ut-1286
+
+```python
+sequence by host.id, process.parent.pid with maxspan=30s
+ [process where host.os.type == "linux" and 
+  (
+   (auditd.data.syscall == "unshare" and auditd.data.class == "namespace" and auditd.data.a0 in ("10000000", "50000000", "70000000", "10020000", "50020000", "70020000")) or 
+
+   (process.name == "unshare" and  
+    (process.args in ("--user", "--map-root-user", "--map-current-user") or process.args like ("-*U*", "-*r*")))
+   ) and user.id != "0" and user.id != null]
+ [process where host.os.type == "linux" and 
+  user.id == "0" and user.id != null and 
+  (
+   process.name in ("su", "sudo", "pkexec", "passwd", "chsh", "newgrp", "doas", "run0", "sg", "dash", "sh", "bash", "zsh", "fish", 
+                    "ksh", "csh", "tcsh", "ash", "mksh", "busybox", "rbash", "rzsh", "rksh", "tmux", "screen", "node") or 
+   process.name like ("python*", "perl*", "ruby*", "php*", "lua*")
+  )]
+```
+
+
+
+### Potential Privilege Escalation via unshare and UID Change
+
+Branch count: 5  
+Document count: 10  
+Index: geneve-ut-1287
+
+```python
+sequence by process.parent.entity_id, host.id with maxspan=60s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+    process.name == "unshare" and process.args : ("-r", "-rm", "-m", "-U", "--user") and user.id != "0"]
+  [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
+    user.id == "0"]
 ```
 
 
@@ -11944,7 +13306,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1135
+Index: geneve-ut-1288
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -11958,7 +13320,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1136
+Index: geneve-ut-1289
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -11981,7 +13343,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1138
+Index: geneve-ut-1291
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -11998,7 +13360,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1139
+Index: geneve-ut-1292
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -12021,7 +13383,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1140
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12034,7 +13396,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1141
+Index: geneve-ut-1294
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +13410,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1142
+Index: geneve-ut-1295
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12061,11 +13423,65 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Potential Proxy Execution via Systemd-run
+
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-1296
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started", "start", "ProcessRollup2") and
+process.name == "systemd-run" and ?process.parent.executable != null and
+not (
+  ?process.parent.executable in (
+    "/usr/lib/systemd", "/lib/systemd/systemd", "/opt/saltstack/salt/run/run", "/etc/update-motd.d/70-available-updates",
+    "/tmp/newroot/usr/libexec/ptyxis-agent", "/usr/local/sbin/clamscan.sh", "/opt/sentinelone/bin/sentinelone-agent",
+    "/usr/local/bin/salt-minion", "/var/vanta/launcher", "/opt/traps/bin/pmd", "/usr/sbin/gdm", "/usr/bin/salt-minion",
+    "/opt/GC_Ext/GC/gc_linux_service", "/usr/lib/plesk-task-manager", "/opt/forticlient/epctrl", "/usr/lib/snapd/snap-exec",
+    "/usr/bin/yay", "/usr/local/bin/hexnode_agent", "/opt/halcyon/halcyonar/agent", "/usr/local/bin/qsetup", "/usr/bin/pamac",
+    "/usr/bin/elephant", "/usr/bin/Hyprland"
+  ) or
+  ?process.parent.executable like (
+    "/opt/tableau/tableau_server/packages/scripts.*/after-install", "/opt/acronis/bin/acp-update-controller", "/snap/*",
+    "/var/lib/amagent/*", "/opt/msp-agent/msp-agent-core", "/opt/beyondtrust/*", "/var/lib/rancher/k3s/*/bin/k3s"
+  ) or
+  ?process.parent.name like "platform-python*" or
+  ?process.parent.name in (
+    "udevadm", "daemon.start", "snap", "systemd", "ptyxis-agent", "run-slack", "run-firefox", "dbus.service", "k3s-server",
+    "systemd-udevd", "kubelet", "hyperkube", "kthreadd", "gnome-shell", "xdg-desktop-portal", "firefox", "picus_updater",
+    "rpm-ostree", "prompt-agent"
+  ) or
+  ?process.command_line in (
+    "/usr/bin/systemd-run /usr/bin/systemctl start man-db-cache-update", "systemd-run env",
+    "systemd-run --user dnf-automatic-notifyonly.timer", "systemd-run --user systemctl suspend", "systemd-run /var/lib/aws-replication-agent/uninstall-agent.sh",
+    "systemd-run --on-active=10 --timer-property=AccuracySec=100ms --slice=system.slice systemctl start gc-agent",
+    "systemd-run --user --scope --unit=tmux-server -- tmux", "systemd-run bash -c sleep 60 && reboot"
+  ) or
+  ?process.command_line like~ (
+    "systemd-run --scope -p CPUQuota=10% rpm -qa*", "systemd-run --scope -p CPUQuota=10% dpkg -l*"
+  ) or
+  ?process.parent.command_line in ("runc init", "/usr/local/bin/main") or
+  ?process.parent.command_line like ("*/var/lib/waagent/*", "bash ./run.sh") or
+  process.args in (
+    "--help", "list-timers", "/usr/lib/udev/kdump-udev-throttler", "kubectl", "--unit=ngt_guest_agent_upgrade", "i3-zoom", "google-chrome",
+    "thunar", "/usr/bin/google-chrome-stable", "snap.lxd.workaround", "--unit=firefox", "--unit=slack", "--slice=zoom.slice",
+    "autorandr-launcher", "--unit=restart-dbus", "--unit=autorandr-debounce"
+  ) or
+  process.args like ("--unit=app-Hyprland-wezterm-*.scope", "--unit=app-Hyprland-swaybg-*.scope", "--unit=rmf_sim_*") or
+  ?process.working_directory == "/opt/Tychon/Endpoint/bin" or
+  (process.args in ("rpm", "dpkg") and process.args like~ "CPUQuota=*") or
+  (process.args == "--slice=app-graphical.slice" and process.args == "--description=xdg-terminal-exec")
+)
+```
+
+
+
 ### Potential REMCOS Trojan Execution
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1143
+Index: geneve-ut-1297
 
 ```python
 any where host.os.type == "windows" and
@@ -12092,7 +13508,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1146
+Index: geneve-ut-1303
 
 ```python
 file where host.os.type == "windows" and
@@ -12107,7 +13523,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1147
+Index: geneve-ut-1304
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -12124,8 +13540,10 @@ any where host.os.type == "windows" and
 
   ) or
   (event.category == "process" and event.type == "start" and
-     (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
-     (?process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
+    (
+      (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
+      (?process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
+    )
   )
 )
 ```
@@ -12136,7 +13554,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1148
+Index: geneve-ut-1305
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12150,7 +13568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1149
+Index: geneve-ut-1306
 
 ```python
 sequence with maxspan=1m
@@ -12190,18 +13608,25 @@ sequence with maxspan=1m
 
 ### Potential Remote Install via MsiExec
 
-Branch count: 200  
-Document count: 200  
-Index: geneve-ut-1150
+Branch count: 400  
+Document count: 400  
+Index: geneve-ut-1307
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
-  process.name : "msiexec.exe" and process.args : ("-i*", "/i*", "-p*", "/p*") and process.command_line : "*http*" and
+  process.name : "msiexec.exe" and process.args : ("-i*", "/i*", "-p*", "/p*") and
+  process.command_line : ("*http:*", "*https:*") and
   process.args : ("/qn", "-qn", "-q", "/q", "/quiet") and
-  process.parent.name : ("sihost.exe", "explorer.exe", "cmd.exe", "wscript.exe", "mshta.exe", "powershell.exe", "wmiprvse.exe", "pcalua.exe", "forfiles.exe", "conhost.exe") and
-  not process.command_line : ("*--set-server=*", "*UPGRADEADD=*" , "*--url=*",
-                              "*USESERVERCONFIG=*", "*RCTENTERPRISESERVER=*", "*app.ninjarmm.com*", "*zoom.us/client*",
-                              "*SUPPORTSERVERSTSURI=*", "*START_URL=*", "*AUTOCONFIG=*", "*awscli.amazonaws.com*")
+  process.parent.name : (
+    "sihost.exe", "explorer.exe", "cmd.exe", "wscript.exe", "mshta.exe",
+    "powershell.exe", "wmiprvse.exe", "pcalua.exe", "forfiles.exe", "conhost.exe"
+  ) and
+
+  not process.command_line : (
+        "*--set-server=*", "*UPGRADEADD=*" , "*--url=*", "*USESERVERCONFIG=*", "*RCTENTERPRISESERVER=*",
+        "*app.ninjarmm.com*", "*zoom.us/client*", "*SUPPORTSERVERSTSURI=*", "*START_URL=*", "*AUTOCONFIG=*",
+        "*awscli.amazonaws.com*", "*/i \"C:*", "*/i C:\\*"
+  )
 ```
 
 
@@ -12210,7 +13635,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1151
+Index: geneve-ut-1308
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12264,7 +13689,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1152
+Index: geneve-ut-1309
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12284,7 +13709,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1153
+Index: geneve-ut-1310
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -12305,7 +13730,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1154
+Index: geneve-ut-1311
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12320,7 +13745,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1155
+Index: geneve-ut-1312
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -12340,7 +13765,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1156
+Index: geneve-ut-1313
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12360,7 +13785,7 @@ sequence by host.id with maxspan=5s
    and not (
      process.parent.args in (
        "/usr/lib/jenkins/jenkins.war", "/etc/remote-iot/services/remoteiot.jar", "/opt/pentaho/data-integration/launcher/launcher.jar",
-       "/usr/share/java/jenkins.war", "/opt//tomcat/statistics/statistics.jar", "/usr/lib64/NetExtender.jar",
+       "/usr/share/java/jenkins.war", "/opt/tomcat/statistics/statistics.jar", "/usr/lib64/NetExtender.jar",
        "/var/lib/jenkins/workspace/MP-QA/tc_certified_copy*/tc_certified_copy_web_ui_test/target/surefire/surefirebooter*.jar",
        "-javaagent:/opt/opentelemetry/opentelemetry-javaagent-all.jar", "./lib/pipeline-job-executor*SNAPSHOT.jar",
        "./lib/worker-launcher-agent*SNAPSHOT.jar", "/opt/Seqrite_EndPoint_Security/wildfly/jboss-modules.jar",
@@ -12378,11 +13803,26 @@ sequence by host.id with maxspan=5s
 
 
 
+### Potential Root Effective Shell from Non-Standard Path via Auditd
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1317
+
+```python
+host.os.type:linux and event.category:process and 
+event.action:(exec or executed) and user.id:(* and not 0) and 
+process.executable:(* and not (/bin/* or /nix/store/*/bin/sudo or /run/wrappers/wrappers*/sudo or /sbin/* or /usr/bin/* or /usr/sbin/*)) and 
+user.effective.id:0 and process.args:-p
+```
+
+
+
 ### Potential SAP NetWeaver Exploitation
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1160
+Index: geneve-ut-1318
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -12417,7 +13857,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1161
+Index: geneve-ut-1319
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -12434,7 +13874,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1162
+Index: geneve-ut-1321
 
 ```python
 sequence by host.id with maxspan=3s
@@ -12448,7 +13888,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1164
+Index: geneve-ut-1324
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -12461,7 +13901,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1165
+Index: geneve-ut-1325
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -12473,12 +13913,13 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1166
+Index: geneve-ut-1326
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
   winlog.event_data.AttributeValue :B\:828* and
-  not winlog.event_data.SubjectUserName: MSOL_*
+  not winlog.event_data.SubjectUserName: MSOL_* and
+  not winlog.event_data.ObjectClass: "msDS-Device"
 ```
 
 
@@ -12487,7 +13928,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1168
+Index: geneve-ut-1328
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -12515,7 +13956,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1169
+Index: geneve-ut-1329
 
 ```python
 sequence by host.id with maxspan=1s
@@ -12540,7 +13981,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1173
+Index: geneve-ut-1333
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -12574,7 +14015,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1174
+Index: geneve-ut-1334
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12588,7 +14029,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1175
+Index: geneve-ut-1335
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -12604,7 +14045,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1176
+Index: geneve-ut-1336
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -12618,7 +14059,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1177
+Index: geneve-ut-1337
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -12648,15 +14089,16 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1178
+Index: geneve-ut-1338
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
-  file.name : ("winload.exe", "winlod.efi", "ntoskrnl.exe", "bootmgr") and
+  file.name : ("winload.exe", "winload.efi", "ntoskrnl.exe", "bootmgr") and
   file.path : ("?:\\Windows\\*", "\\Device\\HarddiskVolume*\\Windows\\*") and
   not process.executable : (
     "?:\\Windows\\System32\\poqexec.exe",
-    "?:\\Windows\\WinSxS\\amd64_microsoft-windows-servicingstack_*\\tiworker.exe"
+    "?:\\Windows\\System32\\wbengine.exe",
+    "?:\\Windows\\WinSxS\\???64_microsoft-windows-servicingstack_*\\tiworker.exe"
   ) and
   not file.path : (
     "?:\\Windows\\WinSxS\\Temp\\InFlight\\*",
@@ -12664,7 +14106,9 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
     "?:\\Windows\\WinSxS\\amd64_microsoft-windows*",
     "?:\\Windows\\SystemTemp\\*",
     "?:\\Windows\\Temp\\????????.???\\*",
-    "?:\\Windows\\Temp\\*\\amd64_microsoft-windows-*"
+    "?:\\Windows\\Temp\\*\\amd64_microsoft-windows-*",
+    "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download*",
+    "?:\\Windows\\Temp\\BootImages\\{*}\\mount\\Windows\\*"
   )
 ```
 
@@ -12674,7 +14118,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1179
+Index: geneve-ut-1339
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12690,7 +14134,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1180
+Index: geneve-ut-1340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12704,7 +14148,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1181
+Index: geneve-ut-1341
 
 ```python
 file where host.os.type == "windows" and
@@ -12740,7 +14184,7 @@ file where host.os.type == "windows" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1184
+Index: geneve-ut-1344
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12754,7 +14198,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1185
+Index: geneve-ut-1345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12774,7 +14218,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1187
+Index: geneve-ut-1347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12791,7 +14235,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1188
+Index: geneve-ut-1348
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -12803,7 +14247,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1189
+Index: geneve-ut-1349
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -12820,7 +14264,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1190
+Index: geneve-ut-1350
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12838,7 +14282,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1196
+Index: geneve-ut-1357
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -12851,7 +14295,7 @@ file.name == "notify_on_release" and process.interactive == true and container.i
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1197
+Index: geneve-ut-1358
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12878,7 +14322,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1198
+Index: geneve-ut-1359
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -12891,7 +14335,7 @@ file.name == "release_agent" and process.interactive == true and container.id li
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1199
+Index: geneve-ut-1360
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -12905,7 +14349,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1201
+Index: geneve-ut-1362
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12920,9 +14364,9 @@ process where host.os.type == "linux" and event.type == "start" and
 
 ### PowerShell Invoke-NinjaCopy script
 
-Branch count: 21  
-Document count: 21  
-Index: geneve-ut-1202
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-1363
 
 ```python
 event.category:process and host.os.type:windows and
@@ -12932,11 +14376,9 @@ event.category:process and host.os.type:windows and
     "StealthCloseFileDelegate" or
     "StealthOpenFile" or
     "StealthCloseFile" or
-    "StealthReadFile" or
     "Invoke-NinjaCopy"
-   )
-  and not user.id : "S-1-5-18"
-  and not powershell.file.script_block_text : (
+   ) and
+  not powershell.file.script_block_text : (
     "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
   )
 ```
@@ -12947,13 +14389,11 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1204
+Index: geneve-ut-1365
 
 ```python
 event.category:process and host.os.type:windows and
-  powershell.file.script_block_text : (
-    KerberosRequestorSecurityToken
-  ) and not user.id : ("S-1-5-18" or "S-1-5-20") and
+  powershell.file.script_block_text : "KerberosRequestorSecurityToken" and
   not powershell.file.script_block_text : (
     ("sentinelbreakpoints" and ("Set-PSBreakpoint" or "Set-HookFunctionTabs")) or
     ("function global" and "\\windows\\sentinel\\4")
@@ -12966,10 +14406,11 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1207
+Index: geneve-ut-1368
 
 ```python
-event.category:process and host.os.type:windows and powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory or pmuDetirWpmuDiniM) and not user.id : "S-1-5-18"
+event.category:process and host.os.type:windows and
+powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory or pmuDetirWpmuDiniM)
 ```
 
 
@@ -12978,7 +14419,7 @@ event.category:process and host.os.type:windows and powershell.file.script_block
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1209
+Index: geneve-ut-1370
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13002,7 +14443,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1210
+Index: geneve-ut-1371
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13030,7 +14471,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1225
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13051,7 +14492,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1228
+Index: geneve-ut-1389
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13088,7 +14529,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1229
+Index: geneve-ut-1390
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -13105,7 +14546,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1230
+Index: geneve-ut-1391
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13119,7 +14560,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1231
+Index: geneve-ut-1392
 
 ```python
 file where host.os.type == "windows" and
@@ -13138,7 +14579,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1232
+Index: geneve-ut-1393
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -13150,9 +14591,9 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 ### Privilege Escalation via SUID/SGID
 
-Branch count: 434  
-Document count: 434  
-Index: geneve-ut-1233
+Branch count: 450  
+Document count: 450  
+Index: geneve-ut-1394
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13183,9 +14624,11 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     "wc", "wget", "whiptail", "xargs", "xdotool", "xmodmap", "xmore", "xxd", "xz", "yash", "zsh",
     "zsoelim"
   ) or
+  (process.name like ".*" or process.executable like ("/tmp/.*", "/var/tmp/.*", "/dev/shm/.*", "/home/*"))  or 
   (process.name == "ip" and ((process.args == "-force" and process.args in ("-batch", "-b")) or (process.args == "exec"))) or
   (process.name == "find" and process.args in ("-exec", "-execdir")) or
-  (process.name in ("bash", "csh", "dash") and process.args in ("-p", "-b"))
+  (process.name in ("bash", "csh", "dash") and process.args in ("-p", "-b")) or
+  (process.name in ("su", "sudo", "pkexec") and process.args_count == 1)
 ) and not (
   process.parent.name == "spine" or
   process.parent.executable in (
@@ -13203,7 +14646,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1234
+Index: geneve-ut-1395
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13221,7 +14664,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1236
+Index: geneve-ut-1397
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -13239,7 +14682,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1239
+Index: geneve-ut-1400
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13253,7 +14696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1241
+Index: geneve-ut-1402
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13268,7 +14711,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1242
+Index: geneve-ut-1403
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -13291,7 +14734,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1244
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13335,7 +14778,6 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
                             "?:\\Windows\\Microsoft.NET\\Framework*\\*\\ngen.exe",
                             "?:\\Windows\\Microsoft.NET\\Framework*\\*\\aspnet_regiis.exe")) and
 
-
 /* Ignores additional parent executables that run with elevated privileges */
  not process.parent.executable :
                ("?:\\Windows\\System32\\AtBroker.exe",
@@ -13374,7 +14816,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1245
+Index: geneve-ut-1406
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -13395,7 +14837,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1246
+Index: geneve-ut-1407
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -13421,7 +14863,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1248
+Index: geneve-ut-1409
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13474,7 +14916,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1249
+Index: geneve-ut-1410
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13486,7 +14928,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1250
+Index: geneve-ut-1411
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13498,7 +14940,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1251
+Index: geneve-ut-1412
 
 ```python
 process where host.os.type == "windows" and
@@ -13513,7 +14955,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1252
+Index: geneve-ut-1413
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -13543,7 +14985,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1253
+Index: geneve-ut-1414
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -13603,7 +15045,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1256
+Index: geneve-ut-1417
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -13616,7 +15058,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1257
+Index: geneve-ut-1418
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +15090,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1258
+Index: geneve-ut-1419
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -13670,14 +15112,33 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 ### Proxy Execution via Console Window Host
 
-Branch count: 17  
-Document count: 17  
-Index: geneve-ut-1259
+Branch count: 68  
+Document count: 68  
+Index: geneve-ut-1421
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  process.name : "conhost.exe" and process.args : "--headless" and
-  process.command_line : ("*powershell*", "*cmd *", "*cmd.exe *", "*script*", "*mshta*", "*curl *", "*curl.exe *", "*^*^*^*", "*.bat*", "*.cmd*", "*schtasks*", "*@SSL*", "*http*", "* \\\\*", "*.vbs*", "*.js*", "*mhsta*")
+  process.command_line : (
+    "*powershell*", "*cmd *", "*cmd.exe *", "*script*", "*mshta*", "*curl *", "*curl.exe *", "*^*^*^*",
+    "*.bat*", "*.cmd*", "*schtasks*", "*@SSL*", "*http*", "* \\\\*", "*.vbs*", "*.js*", "*mhsta*"
+  ) and
+  not (
+    /* Winget-AutoUpdate via ServiceUI */
+    process.parent.executable : "?:\\Program Files\\winget-autoupdate*\\serviceui.exe" or
+    /* Winget-AutoUpdate notification via Task Scheduler */
+    (
+      process.parent.executable : "?:\\Windows\\System32\\svchost.exe" and process.parent.args : "-s" and
+      process.parent.args : "Schedule" and process.command_line : "*WAU-Notify.ps1*"
+    ) or
+    /* Windows OpenSSH console host — SSH-specific detection handled by 8cd49fbc-a35a-4418-8688-133cc3a1e548 */
+    process.parent.executable : (
+      "?:\\Windows\\System32\\OpenSSH\\sshd.exe",
+      "?:\\Windows\\System32\\OpenSSH\\sshd-session.exe",
+      "?:\\Program Files\\OpenSSH*\\sshd.exe",
+      "?:\\Program Files\\OpenSSH*\\sshd-session.exe"
+    )
+  )
 ```
 
 
@@ -13686,12 +15147,15 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1260
+Index: geneve-ut-1422
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
- process.command_line : ("*Command=*powershell*", "*schtasks*", "*Command=*@echo off*", "*Command=*http*", "*Command=*mshta*",  "*Command=*msiexec*",
-                          "*Command=*cmd /c*", "*Command=*cmd.exe*", "*Command=\"cmd /c*", "*LocalCommand=scp*&&*", "*LocalCommand=?scp*&&*", "*Command=*script*")
+  process.command_line : (
+    "*Command=*powershell*", "*schtasks*", "*Command=*@echo off*", "*Command=*http*",
+    "*Command=*mshta*", "*Command=*msiexec*", "*Command=*cmd /c*", "*Command=*cmd.exe*",
+    "*Command=\"cmd /c*", "*LocalCommand=scp*&&*", "*LocalCommand=?scp*&&*", "*Command=*script*"
+  )
 ```
 
 
@@ -13700,7 +15164,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1261
+Index: geneve-ut-1423
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -13729,7 +15193,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1262
+Index: geneve-ut-1424
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13743,7 +15207,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1263
+Index: geneve-ut-1425
 
 ```python
 sequence by process.entity_id
@@ -13768,7 +15232,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1264
+Index: geneve-ut-1426
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -13802,7 +15266,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1265
+Index: geneve-ut-1427
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -13830,7 +15294,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1266
+Index: geneve-ut-1428
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -13849,7 +15313,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1269
+Index: geneve-ut-1432
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13877,7 +15341,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1270
+Index: geneve-ut-1433
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -13896,7 +15360,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1274
+Index: geneve-ut-1437
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -13908,7 +15372,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1275
+Index: geneve-ut-1438
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13920,7 +15384,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1276
+Index: geneve-ut-1439
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -13932,7 +15396,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1277
+Index: geneve-ut-1440
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13944,7 +15408,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1287
+Index: geneve-ut-1450
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13957,7 +15421,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1288
+Index: geneve-ut-1451
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13995,7 +15459,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1290
+Index: geneve-ut-1453
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14010,7 +15474,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1291
+Index: geneve-ut-1454
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14029,7 +15493,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1292
+Index: geneve-ut-1455
 
 ```python
 sequence with maxspan=1m
@@ -14048,18 +15512,23 @@ sequence with maxspan=1m
               "ZOHO Corporation Private Limited",
               "BeyondTrust Corporation", 
               "CyberArk Software Ltd.", 
-              "Sophos Ltd"
+              "Sophos Ltd",
+              "AO Kaspersky Lab",
+              "Anthropic, PBC",
+              "Adobe Inc.",
+              "Netwrix Corporation"
         )
       ) or
       (
         process.executable : (
           "?:\\Windows\\ccmsetup\\ccmsetup.exe",
-          "?:\\Windows\\SoftwareDistribution\\Download\\Install\\AM_Delta*.exe",
-          "?:\\Windows\\CAInvokerService.exe"
+          "?:\\Windows\\SoftwareDistribution\\Download\\Install\\*.exe",
+          "?:\\Windows\\CAInvokerService.exe",
+          "?:\\Users\\*\\AppData\\Local\\Microsoft\\OneDrive\\*\\OneDriveSetup.exe"
         ) and process.code_signature.trusted == true
       ) or
       (
-        process.executable : "G:\\SMS_*\\srvboot.exe" and 
+        process.executable : "?:\\SMS_*\\srvboot.exe" and 
         process.code_signature.trusted == true and process.code_signature.subject_name : "Microsoft Corporation"
       )
     )
@@ -14072,7 +15541,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1294
+Index: geneve-ut-1457
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -14095,7 +15564,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1296
+Index: geneve-ut-1459
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14109,7 +15578,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1297
+Index: geneve-ut-1460
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14123,7 +15592,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1299
+Index: geneve-ut-1462
 
 ```python
 sequence by host.id, process.entity_id
@@ -14140,7 +15609,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1300
+Index: geneve-ut-1463
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14154,7 +15623,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1301
+Index: geneve-ut-1464
 
 ```python
 sequence by host.id with maxspan=1m
@@ -14172,17 +15641,29 @@ sequence by host.id with maxspan=1m
 
 ### Remote SSH Login Enabled via systemsetup Command
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1302
+Branch count: 10  
+Document count: 10  
+Index: geneve-ut-1465
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
- process.name == "systemsetup" and
- process.args like~ "-setremotelogin" and 
- process.args like~ "on" and
- process.parent.executable != null and
- not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xpcproxy", "/usr/bin/sudo")
+(
+  (
+    process.name == "systemsetup" and
+    process.args like~ "-setremotelogin" and
+    process.args like~ "on"
+  ) or
+  (
+    process.name == "launchctl" and
+    process.args in ("load", "bootstrap") and
+    (
+      process.command_line like~ "*/System/Library/LaunchDaemons/ssh.plist*" or
+      process.command_line like~ "*com.openssh.sshd*"
+    )
+  )
+) and
+process.parent.executable != null and
+not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xpcproxy", "/usr/bin/sudo")
 ```
 
 
@@ -14191,7 +15672,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1303
+Index: geneve-ut-1466
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -14211,7 +15692,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1304
+Index: geneve-ut-1467
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -14224,7 +15705,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1306
+Index: geneve-ut-1469
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -14266,7 +15747,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1307
+Index: geneve-ut-1470
 
 ```python
 sequence with maxspan=1m
@@ -14289,7 +15770,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1308
+Index: geneve-ut-1471
 
 ```python
 sequence with maxspan=1s
@@ -14337,7 +15818,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1309
+Index: geneve-ut-1472
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14354,7 +15835,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1311
+Index: geneve-ut-1474
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -14383,7 +15864,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1312
+Index: geneve-ut-1475
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14411,7 +15892,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1313
+Index: geneve-ut-1476
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -14428,7 +15909,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1315
+Index: geneve-ut-1478
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -14447,7 +15928,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1316
+Index: geneve-ut-1479
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -14468,7 +15949,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1320
+Index: geneve-ut-1484
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -14482,7 +15963,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1322
+Index: geneve-ut-1486
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -14501,7 +15982,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1323
+Index: geneve-ut-1487
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -14515,7 +15996,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1324
+Index: geneve-ut-1488
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -14535,7 +16016,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1326
+Index: geneve-ut-1490
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14553,7 +16034,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1327
+Index: geneve-ut-1491
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -14574,7 +16055,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1329
+Index: geneve-ut-1493
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14586,15 +16067,15 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 ### ScreenConnect Server Spawning Suspicious Processes
 
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-1330
+Branch count: 10  
+Document count: 10  
+Index: geneve-ut-1494
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.parent.name : "ScreenConnect.Service.exe" and
   (process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "powershell_ise.exe", "csc.exe") or
-  ?process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE", "pwsh.dll", "powershell_ise.EXE"))
+  ?process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE", "pwsh.dll", "powershell_ise.EXE", "csc.exe"))
 ```
 
 
@@ -14603,7 +16084,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1331
+Index: geneve-ut-1495
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14644,7 +16125,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1333
+Index: geneve-ut-1497
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -14669,7 +16150,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1334
+Index: geneve-ut-1498
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -14708,7 +16189,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1335
+Index: geneve-ut-1499
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14722,7 +16203,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1336
+Index: geneve-ut-1500
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14746,7 +16227,12 @@ process.args like (
   ?process.parent.args in ("/opt/imperva/ragent/bin/get_sys_resources.sh", "/usr/sbin/lynis", "./terra_linux.sh") or
   process.args == "/usr/bin/coreutils" or
   (process.parent.name == "pwsh" and process.parent.command_line like "*Evaluate-STIG*") or
-  ?process.parent.executable == "/usr/sap/audit_scripts/auto_audit_gral.sh"
+  ?process.parent.executable like (
+    "/usr/sap/audit_scripts/auto_audit_gral.sh", "/opt/saltstack/salt/bin/python3*", "/opt/puppetlabs/puppet/bin/ruby"
+  ) or
+  ?process.entry_leader.executable like (
+    "/usr/sbin/ScanAssistant", "/opt/Tanium/TaniumClient/TaniumClient", "/tmp/CVU_*resource/exectask", "/opt/nessus/sbin/nessus-service"
+  )
 )
 ```
 
@@ -14756,7 +16242,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1337
+Index: geneve-ut-1501
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14770,7 +16256,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1338
+Index: geneve-ut-1502
 
 ```python
 process where event.type == "start" and
@@ -14842,7 +16328,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1341
+Index: geneve-ut-1506
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -14863,7 +16349,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1344
+Index: geneve-ut-1509
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14880,7 +16366,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1346
+Index: geneve-ut-1512
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14894,11 +16380,11 @@ process.command_line like~ (
 
 
 
-### Sensitive Privilege SeEnableDelegationPrivilege assigned to a User
+### Sensitive Privilege SeEnableDelegationPrivilege assigned to a Principal
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1347
+Index: geneve-ut-1513
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -14910,19 +16396,31 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1348
+Index: geneve-ut-1514
 
 ```python
-file where host.os.type == "windows" and 
- event.action == "open" and event.outcome == "success" and process.executable != null and 
+file where host.os.type == "windows" and
+ event.action == "open" and event.outcome == "success" and process.executable != null and
  file.path :
       ("?:\\Windows\\System32\\config\\RegBack\\SAM",
        "?:\\Windows\\System32\\config\\RegBack\\SECURITY",
-       "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and 
+       "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and
  not (
     user.id == "S-1-5-18" and process.executable : (
-        "?:\\Windows\\system32\\taskhostw.exe", "?:\\Windows\\system32\\taskhost.exe"
-    ))
+        "?:\\Windows\\system32\\taskhostw.exe",
+        "?:\\Windows\\system32\\taskhost.exe",
+        "?:\\Program Files\\Sophos\\Endpoint Defense\\SophosScanCoordinator.exe",
+        "?:\\Program Files\\Sophos\\Endpoint Defense\\SSPService.exe",
+        "?:\\Program Files\\Windows Defender Advanced Threat Protection\\MsSense.exe",
+        "?:\\Program Files\\Trend Micro\\AMSP\\coreServiceShell.exe",
+        "?:\\Program Files\\Symantec\\Symantec Endpoint Protection\\*\\Bin64\\ccSvcHst.exe",
+        "?:\\Program Files\\Bitdefender\\Endpoint Security\\EPSecurityService.exe",
+        "?:\\Program Files\\N-able Technologies\\AVDefender\\EPSecurityService.exe",
+        "?:\\Program Files\\Cylance\\Optics\\CyOptics.exe",
+        "?:\\Program Files\\Common Files\\McAfee\\AVSolution\\mcshield.exe",
+        "?:\\Program Files (x86)\\Padvish AV\\APCcSvc.exe"
+    )
+ )
 ```
 
 
@@ -14931,7 +16429,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1351
+Index: geneve-ut-1517
 
 ```python
 any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
@@ -14963,7 +16461,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1353
+Index: geneve-ut-1519
 
 ```python
 any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
@@ -14999,7 +16497,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1354
+Index: geneve-ut-1520
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -15016,7 +16514,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1355
+Index: geneve-ut-1521
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -15036,7 +16534,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1357
+Index: geneve-ut-1523
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15051,7 +16549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1358
+Index: geneve-ut-1524
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15072,7 +16570,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1359
+Index: geneve-ut-1525
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15095,7 +16593,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1360
+Index: geneve-ut-1526
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -15108,7 +16606,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1361
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15125,7 +16623,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1363
+Index: geneve-ut-1529
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -15150,7 +16648,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1365
+Index: geneve-ut-1532
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and process.interactive == true and container.id like "?*" and (
@@ -15181,7 +16679,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1366
+Index: geneve-ut-1533
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -15230,7 +16728,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1367
+Index: geneve-ut-1534
 
 ```python
 sequence by host.id with maxspan=10s
@@ -15240,11 +16738,26 @@ sequence by host.id with maxspan=10s
 
 
 
+### Shell Execution via Elastic Endpoint
+
+Branch count: 64  
+Document count: 64  
+Index: geneve-ut-1535
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.parent.executable == "/opt/Elastic/Endpoint/elastic-endpoint" and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+process.args in ("-c", "-cl", "-lc", "--command")
+```
+
+
+
 ### Shell History Clearing via Environment Variables
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1368
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15259,7 +16772,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1369
+Index: geneve-ut-1537
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -15281,7 +16794,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1370
+Index: geneve-ut-1538
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15302,7 +16815,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1373
+Index: geneve-ut-1541
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15316,7 +16829,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1374
+Index: geneve-ut-1542
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -15339,7 +16852,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1402
+Index: geneve-ut-1572
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -15364,7 +16877,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1403
+Index: geneve-ut-1573
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -15397,7 +16910,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1404
+Index: geneve-ut-1574
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -15456,7 +16969,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1406
+Index: geneve-ut-1576
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -15474,7 +16987,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1407
+Index: geneve-ut-1577
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -15486,7 +16999,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1409
+Index: geneve-ut-1579
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -15511,7 +17024,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1414
+Index: geneve-ut-1584
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15526,7 +17039,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1415
+Index: geneve-ut-1585
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -15549,7 +17062,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1418
+Index: geneve-ut-1588
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15563,7 +17076,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1420
+Index: geneve-ut-1590
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15585,7 +17098,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1422
+Index: geneve-ut-1592
 
 ```python
 sequence by host.id with maxspan=5s
@@ -15612,7 +17125,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1426
+Index: geneve-ut-1596
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -15624,6 +17137,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
     "?:\\Windows\\Syswow64\\amsi.dll",
     "?:\\$WINDOWS.~BT\\*\\amsi.dll",
     "?:\\Windows\\CbsTemp\\*\\amsi.dll",
+    "?:\\Windows\\SystemTemp\\*\\amsi.dll",
     "?:\\Windows\\SoftwareDistribution\\Download\\*",
     "?:\\Windows\\WinSxS\\*\\amsi.dll", 
     "?:\\Windows\\servicing\\*\\amsi.dll",
@@ -15638,7 +17152,8 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
     "\\Device\\HarddiskVolume*\\$SysReset\\CloudImage\\Package_for_RollupFix*\\amsi.dll",
     "\\Device\\HarddiskVolume*\\$WINDOWS.~BT\\*\\amsi.dll", 
     "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download\\*\\amsi.dll", 
-    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll", 
+    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll",
+    "\\Device\\HarddiskVolume*\\Windows\\SystemTemp\\*\\amsi.dll", 
     "\\Device\\HarddiskVolume*\\Windows\\servicing\\*\\amsi.dll"
   )
 ```
@@ -15649,7 +17164,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1427
+Index: geneve-ut-1597
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -15672,7 +17187,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1428
+Index: geneve-ut-1598
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -15686,7 +17201,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1429
+Index: geneve-ut-1599
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15702,7 +17217,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1430
+Index: geneve-ut-1600
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -15718,7 +17233,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1431
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15732,7 +17247,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1433
+Index: geneve-ut-1603
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15755,7 +17270,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1434
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15770,7 +17285,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1435
+Index: geneve-ut-1607
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15793,11 +17308,42 @@ sequence by process.entity_id with maxspan=15s
 
 
 
+### Suspicious Container Runtime CLI Execution
+
+Branch count: 14  
+Document count: 14  
+Index: geneve-ut-1609
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+(
+  (
+    process.name in ("ctr", "crictl", "nerdctl") and
+    (
+      (process.args == "tasks" and process.args == "exec") or
+      (process.args == "run" and process.args in ("--privileged", "--rm", "--mount", "--net-host", "--pid-host")) or
+      (process.args == "snapshots" and process.args == "mount")
+    )
+  ) or
+  (
+    (process.executable like ("/dev/shm/*", "/tmp/*", "/var/tmp/*") or process.name : ".*") and
+    process.args like ("*containerd.sock*", "*k8s.io*")
+  )
+) and
+not process.parent.executable in (
+  "/usr/bin/kubelet", "/usr/local/bin/kubelet",
+  "/usr/bin/containerd", "/usr/sbin/containerd",
+  "/lib/systemd/systemd", "/usr/lib/systemd/systemd", "/sbin/init"
+)
+```
+
+
+
 ### Suspicious Content Extracted or Decompressed via Funzip
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1437
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -15813,7 +17359,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1438
+Index: geneve-ut-1611
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -15826,7 +17372,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1440
+Index: geneve-ut-1613
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15842,7 +17388,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1441
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -15858,7 +17404,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1442
+Index: geneve-ut-1615
 
 ```python
 any where host.os.type == "windows" and 
@@ -15925,7 +17471,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1444
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -15941,7 +17487,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1446
+Index: geneve-ut-1619
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15977,7 +17523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1447
+Index: geneve-ut-1620
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16015,7 +17561,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1448
+Index: geneve-ut-1621
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -16050,7 +17596,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1449
+Index: geneve-ut-1622
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16084,7 +17630,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1451
+Index: geneve-ut-1624
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -16105,7 +17651,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1456
+Index: geneve-ut-1629
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -16133,7 +17679,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1457
+Index: geneve-ut-1630
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16141,7 +17687,7 @@ process where host.os.type == "windows" and event.type == "start" and
 (process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or ?process.code_signature.subject_name : "OpenJS Foundation") and
 
 (
-  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume?\\\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
+  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
 
   (process.args : "-r" and process.parent.name : "powershell.exe") or
 
@@ -16155,7 +17701,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1458
+Index: geneve-ut-1631
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16179,7 +17725,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1459
+Index: geneve-ut-1632
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16200,7 +17746,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1462
+Index: geneve-ut-1635
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16215,7 +17761,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1465
+Index: geneve-ut-1638
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16228,7 +17774,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1466
+Index: geneve-ut-1639
 
 ```python
 any where host.os.type == "windows" and
@@ -16243,7 +17789,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1467
+Index: geneve-ut-1640
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16259,7 +17805,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1468
+Index: geneve-ut-1641
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -16273,7 +17819,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1470
+Index: geneve-ut-1645
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and
@@ -16330,7 +17876,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1471
+Index: geneve-ut-1646
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16344,19 +17890,28 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1473
+Index: geneve-ut-1648
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
  [network where host.os.type == "windows" and destination.port == 88 and
   process.executable != null and process.pid != 4 and 
-  not process.executable : 
-              ("?:\\Windows\\system32\\lsass.exe", 
-               "\\device\\harddiskvolume*\\windows\\system32\\lsass.exe", 
-               "\\device\\harddiskvolume*\\windows\\system32\\svchost.exe") and
-  not (process.executable : ("C:\\Windows\\System32\\svchost.exe", 
-                             "C:\\Program Files\\VMware\\VMware View\\Server\\bin\\ws_TomcatService.exe", 
-                             "F:\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe") and user.id in ("S-1-5-20", "S-1-5-18")) and   
+  not process.executable : (
+        "?:\\Windows\\system32\\lsass.exe",
+        "\\device\\harddiskvolume*\\windows\\system32\\lsass.exe",
+        "\\device\\harddiskvolume*\\windows\\system32\\svchost.exe"
+  ) and
+  not (
+    process.executable : (
+      "C:\\Windows\\System32\\svchost.exe",
+      "C:\\Program Files\\VMware\\VMware View\\Server\\bin\\ws_TomcatService.exe",
+      "C:\\Program Files\\Omnissa\\Horizon\\Server\\bin\\ws_TomcatService.exe",
+      "C:\\Program Files\\SysAidServer\\root\\WEB-INF\\domains\\NetworkDiscovery.exe",
+      "C:\\Program Files (x86)\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe",
+      "F:\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe"
+    ) and
+    user.id in ("S-1-5-20", "S-1-5-18")
+  ) and
   source.ip != "127.0.0.1" and destination.ip != "::1" and destination.ip != "127.0.0.1"]
  [authentication where host.os.type == "windows" and event.code in ("4768", "4769")]
 ```
@@ -16367,7 +17922,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1475
+Index: geneve-ut-1650
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -16380,7 +17935,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1476
+Index: geneve-ut-1651
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16389,7 +17944,7 @@ process where host.os.type == "windows" and event.code == "10" and
    /* seclogon service accessing lsass */
   winlog.event_data.CallTrace : "*seclogon.dll*" and process.name : "svchost.exe" and
 
-   /* PROCESS_CREATE_PROCESS & PROCESS_DUP_HANDLE & PROCESS_QUERY_INFORMATION */
+   /* PROCESS_CREATE_PROCESS & PROCESS_DUP_HANDLE & PROCESS_QUERY_INFORMATION & PROCESS_QUERY_LIMITED_INFORMATION */
   winlog.event_data.GrantedAccess == "0x14c0"
 ```
 
@@ -16399,7 +17954,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1477
+Index: geneve-ut-1652
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16445,7 +18000,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1479
+Index: geneve-ut-1654
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16466,7 +18021,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1480
+Index: geneve-ut-1655
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16486,7 +18041,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1481
+Index: geneve-ut-1656
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16500,7 +18055,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1482
+Index: geneve-ut-1657
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16528,28 +18083,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Suspicious Microsoft HTML Application Child Process
-
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-1484
-
-```python
-process where host.os.type == "windows" and event.type == "start" and
- process.parent.name : "mshta.exe" and
- (
-  process.name : ("cmd.exe", "powershell.exe", "certutil.exe", "bitsadmin.exe", "curl.exe", "msiexec.exe", "schtasks.exe", "reg.exe", "wscript.exe", "rundll32.exe") or
-  process.executable : ("C:\\Users\\*\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\*.exe")
-  )
-```
-
-
-
 ### Suspicious Mining Process Creation Event
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1485
+Index: geneve-ut-1660
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -16568,80 +18106,101 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 ### Suspicious Module Loaded by LSASS
 
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-1487
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1662
 
 ```python
-any where event.category in ("library", "driver") and host.os.type == "windows" and
+library where host.os.type == "windows" and event.action == "load" and
   process.executable : "?:\\Windows\\System32\\lsass.exe" and
-  not (dll.code_signature.subject_name :
-               ("Microsoft Windows",
-                "Microsoft Corporation",
-                "Microsoft Windows Publisher",
-                "Microsoft Windows Software Compatibility Publisher",
-                "Microsoft Windows Hardware Compatibility Publisher",
-                "McAfee, Inc.",
-                "SecMaker AB",
-                "HID Global Corporation",
-                "HID Global",
-                "Apple Inc.",
-                "Citrix Systems, Inc.",
-                "Dell Inc",
-                "Hewlett-Packard Company",
-                "Symantec Corporation",
-                "National Instruments Corporation",
-                "DigitalPersona, Inc.",
-                "Novell, Inc.",
-                "gemalto",
-                "EasyAntiCheat Oy",
-                "Entrust Datacard Corporation",
-                "AuriStor, Inc.",
-                "LogMeIn, Inc.",
-                "VMware, Inc.",
-                "Istituto Poligrafico e Zecca dello Stato S.p.A.",
-                "Nubeva Technologies Ltd",
-                "Micro Focus (US), Inc.",
-                "Yubico AB",
-                "GEMALTO SA",
-                "Secure Endpoints, Inc.",
-                "Sophos Ltd",
-                "Morphisec Information Security 2014 Ltd",
-                "Entrust, Inc.",
-                "Nubeva Technologies Ltd",
-                "Micro Focus (US), Inc.",
-                "F5 Networks Inc",
-                "Bit4id",
-                "Thales DIS CPL USA, Inc.",
-                "Micro Focus International plc",
-                "HYPR Corp",
-                "Intel(R) Software Development Products",
-                "PGP Corporation",
-                "Parallels International GmbH",
-                "FrontRange Solutions Deutschland GmbH",
-                "SecureLink, Inc.",
-                "Tidexa OU",
-                "Amazon Web Services, Inc.",
-                "SentryBay Limited",
-                "Audinate Pty Ltd",
-                "CyberArk Software Ltd.",
-                "McAfeeSysPrep",
-                "NVIDIA Corporation PE Sign v2016",
-                "Trend Micro, Inc.",
-                "Fortinet Technologies (Canada) Inc.",
-                "Carbon Black, Inc.") and
-       dll.code_signature.status : ("trusted", "errorExpired", "errorCode_endpoint*", "errorChaining")) and
+  not (
+        dll.code_signature.subject_name : (
+            "Algorithmic Research LTD.",
+            "Amazon Web Services, Inc.",
+            "Apple Inc.",
+            "Audinate Pty Ltd",
+            "AuriStor, Inc.",
+            "Bit4id",
+            "Carbon Black, Inc.",
+            "Check Point Software Technologies Ltd.",
+            "Citrix Systems, Inc.",
+            "CyberArk Software Ltd.",
+            "Dell Inc",
+            "DigitalPersona, Inc.",
+            "EasyAntiCheat Oy",
+            "Entrust Corporation",
+            "Entrust Datacard Corporation",
+            "Entrust, Inc.",
+            "F5 Networks Inc",
+            "Fortinet, Inc.",
+            "Fortinet Technologies (Canada) Inc.",
+            "FrontRange Solutions Deutschland GmbH",
+            "GEMALTO SA",
+            "gemalto",
+            "Hewlett-Packard Company",
+            "HID Global",
+            "HID Global Corporation",
+            "HYPR Corp",
+            "IDEMIA IDENTITY & SECURITY FRANCE SAS",
+            "IDEMIA France SAS",
+            "Intel(R) Software Development Products",
+            "Istituto Poligrafico e Zecca dello Stato S.p.A.",
+            "LogMeIn, Inc.",
+            "McAfee, Inc.",
+            "McAfeeSysPrep",
+            "Micro Focus (US), Inc.",
+            "Micro Focus International plc",
+            "Microsoft Corporation",
+            "Microsoft Windows",
+            "Microsoft Windows Hardware Compatibility Publisher",
+            "Microsoft Windows Publisher",
+            "Microsoft Windows Software Compatibility Publisher",
+            "Morphisec Information Security 2014 Ltd",
+            "Musarubra US LLC",
+            "National Instruments Corporation",
+            "Novell, Inc.",
+            "Nubeva Technologies Ltd",
+            "NVIDIA Corporation PE Sign v2016",
+            "Palo Alto Networks (Netherlands) B.V.",
+            "Parallels International GmbH",
+            "PGP Corporation",
+            "QUEST SOFTWARE INC.",
+            "SecMaker AB",
+            "Secure Endpoints, Inc.",
+            "SecureLink, Inc.",
+            "SentinelOne Inc.",
+            "SentryBay Limited",
+            "Sophos Ltd",
+            "Symantec Corporation",
+            "Thales DIS CPL USA, Inc.",
+            "Tidexa OU",
+            "Trend Micro, Inc.",
+            "VMware, Inc.",
+            "Yubico AB"
+        ) and
+        dll.code_signature.status : ("trusted", "errorExpired", "errorCode_endpoint*", "errorChaining")
+  ) and
 
-     not dll.hash.sha256 :
-                ("811a03a5d7c03802676d2613d741be690b3461022ea925eb6b2651a5be740a4c",
-                 "1181542d9cfd63fb00c76242567446513e6773ea37db6211545629ba2ecf26a1",
-                 "ed6e735aa6233ed262f50f67585949712f1622751035db256811b4088c214ce3",
-                 "26be2e4383728eebe191c0ab19706188f0e9592add2e0bf86b37442083ae5e12",
-                 "9367e78b84ef30cf38ab27776605f2645e52e3f6e93369c674972b668a444faa",
-                 "d46cc934765c5ecd53867070f540e8d6f7701e834831c51c2b0552aba871921b",
-                 "0f77a3826d7a5cd0533990be0269d951a88a5c277bc47cff94553330b715ec61",
-                 "4aca034d3d85a9e9127b5d7a10882c2ef4c3e0daa3329ae2ac1d0797398695fb",
-                 "86031e69914d9d33c34c2f4ac4ae523cef855254d411f88ac26684265c981d95")
+  not dll.hash.sha256 : (
+          "811a03a5d7c03802676d2613d741be690b3461022ea925eb6b2651a5be740a4c",
+          "1181542d9cfd63fb00c76242567446513e6773ea37db6211545629ba2ecf26a1",
+          "ed6e735aa6233ed262f50f67585949712f1622751035db256811b4088c214ce3",
+          "26be2e4383728eebe191c0ab19706188f0e9592add2e0bf86b37442083ae5e12",
+          "9367e78b84ef30cf38ab27776605f2645e52e3f6e93369c674972b668a444faa",
+          "d46cc934765c5ecd53867070f540e8d6f7701e834831c51c2b0552aba871921b",
+          "0f77a3826d7a5cd0533990be0269d951a88a5c277bc47cff94553330b715ec61",
+          "4aca034d3d85a9e9127b5d7a10882c2ef4c3e0daa3329ae2ac1d0797398695fb",
+          "86031e69914d9d33c34c2f4ac4ae523cef855254d411f88ac26684265c981d95",
+          "4af1fee3369d9a993a84f54eafb72a661633c33e9e12fb3dd151a6a2cddbd404"
+  ) and
+  not dll.path : (
+        "C:\\Windows\\System32\\CertPolEng.dll",
+        "C:\\Windows\\System32\\FWPUCLNT.DLL",
+        "C:\\Windows\\System32\\keyiso.dll",
+        "C:\\Windows\\System32\\ngcpopkeysrv.dll",
+        "C:\\Windows\\System32\\SecureTimeAggregator.dll",
+        "C:\\Windows\\System32\\vaultsvc.dll"
+  )
 ```
 
 
@@ -16650,7 +18209,7 @@ any where event.category in ("library", "driver") and host.os.type == "windows" 
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1490
+Index: geneve-ut-1665
 
 ```python
 sequence by host.id with maxspan=5s
@@ -16698,7 +18257,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1493
+Index: geneve-ut-1668
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16724,7 +18283,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1494
+Index: geneve-ut-1669
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16769,7 +18328,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1495
+Index: geneve-ut-1670
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16793,7 +18352,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1496
+Index: geneve-ut-1671
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -16809,7 +18368,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1498
+Index: geneve-ut-1673
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -16834,7 +18393,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1499
+Index: geneve-ut-1674
 
 ```python
 event.category:process and host.os.type:windows and
@@ -16849,7 +18408,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1502
+Index: geneve-ut-1677
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -16863,7 +18422,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1503
+Index: geneve-ut-1678
 
 ```python
 sequence by host.id with maxspan=30s
@@ -16883,7 +18442,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1504
+Index: geneve-ut-1679
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16918,7 +18477,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1508
+Index: geneve-ut-1683
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -16936,7 +18495,7 @@ process where event.type == "start" and event.action == "exec" and process.inter
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1509
+Index: geneve-ut-1684
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16949,7 +18508,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1511
+Index: geneve-ut-1686
 
 ```python
 any where host.os.type == "windows" and
@@ -16982,7 +18541,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1513
+Index: geneve-ut-1688
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -17000,7 +18559,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1514
+Index: geneve-ut-1689
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -17018,11 +18577,50 @@ and not (
 
 
 
+### Suspicious SUID Binary Execution (Auditd Sequence)
+
+Branch count: 414  
+Document count: 828  
+Index: geneve-ut-1692
+
+```python
+sequence by host.id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action == "executed" and
+   user.id != "0" and user.effective.id != "0" and
+   (
+     process.name like ("python*", "perl*", "ruby*", "php*", "lua*", ".*") or
+     process.name in ("node", "bun", "java") or
+     process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+     (
+       process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+       process.args in ("-c", "--command", "-ic", "-ci", "-cl", "-lc")
+     )
+   )
+  ] by process.pid
+
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action == "executed" and
+   user.effective.id == "0" and user.id != "0" and
+   (
+     (process.name in ("sudo", "pkexec") and
+      not process.args like "-*" and
+      not process.args : ("/usr/*", "/bin/*", "/sbin/*", "/opt/*")) or
+     (process.name == "su" and
+      not process.args in ("--command", "-c", "--shell", "-s")) or
+     (process.name in ("passwd", "chsh", "newgrp") and
+      not process.args in ("--shell", "-s", "--help"))
+   )
+  ] by process.parent.pid
+```
+
+
+
 ### Suspicious ScreenConnect Client Child Process
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1516
+Index: geneve-ut-1693
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17041,7 +18639,7 @@ process where host.os.type == "windows" and event.type == "start" and
    (process.name : "rundll32.exe" and not process.args : "url.dll,FileProtocolHandler") or
    (process.name : "msiexec.exe" and process.args : ("/i", "-i") and
     process.args : ("/q", "/quiet", "/qn", "-q", "-quiet", "-qn", "-Q+")) or
-   process.name : ("mshta.exe", "certutil.exe", "bistadmin.exe", "certreq.exe", "wscript.exe", "cscript.exe", "curl.exe",
+   process.name : ("mshta.exe", "certutil.exe", "bitsadmin.exe", "certreq.exe", "wscript.exe", "cscript.exe", "curl.exe",
                    "ssh.exe", "scp.exe", "wevtutil.exe", "wget.exe", "wmic.exe")
    )
 ```
@@ -17052,7 +18650,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1517
+Index: geneve-ut-1694
 
 ```python
 any where host.os.type == "windows" and
@@ -17086,7 +18684,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1518
+Index: geneve-ut-1695
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -17100,7 +18698,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1521
+Index: geneve-ut-1698
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17131,13 +18729,13 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1522
+Index: geneve-ut-1699
 
 ```python
 any where host.os.type == "windows" and
 (
  (event.category == "library" and
-  process.executable : ("C:\\Program Files\\WebHelpDesk\\*\\java.exe", "C:\\Program Files (x86)\\WebHelpDesk\\*\\java.exe") and
+  process.executable : ("C:\\Program Files\\WebHelpDesk\\*\\java*.exe", "C:\\Program Files (x86)\\WebHelpDesk\\*\\java*.exe") and
   (dll.path : "\\Device\\Mup\\*" or dll.code_signature.trusted == false or ?dll.code_signature.exists == false)) or
 
  (event.category == "process" and process.name : ("cmd.exe", "powershell.exe", "rundll32.exe") and
@@ -17151,7 +18749,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1523
+Index: geneve-ut-1700
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17192,7 +18790,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1524
+Index: geneve-ut-1701
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -17208,7 +18806,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1525
+Index: geneve-ut-1702
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17238,7 +18836,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1529
+Index: geneve-ut-1706
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -17251,7 +18849,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1530
+Index: geneve-ut-1707
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -17275,7 +18873,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1532
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17293,7 +18891,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1534
+Index: geneve-ut-1711
 
 ```python
 any where host.os.type == "windows" and
@@ -17308,7 +18906,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1535
+Index: geneve-ut-1712
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -17326,7 +18924,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1536
+Index: geneve-ut-1713
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -17338,7 +18936,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
                   "Login Data") and
  ((process.code_signature.trusted == false or process.code_signature.exists == false) or process.name == "osascript") and
  not process.code_signature.signing_id == "org.mozilla.firefox" and
- not Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
+not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
 ```
 
 
@@ -17347,7 +18945,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1537
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17366,7 +18964,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1540
+Index: geneve-ut-1717
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17391,7 +18989,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1541
+Index: geneve-ut-1718
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17404,7 +19002,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1543
+Index: geneve-ut-1720
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -17417,7 +19015,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1545
+Index: geneve-ut-1722
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17440,7 +19038,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1547
+Index: geneve-ut-1724
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17459,7 +19057,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1548
+Index: geneve-ut-1725
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -17481,7 +19079,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1549
+Index: geneve-ut-1726
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -17514,7 +19112,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1551
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17532,7 +19130,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1552
+Index: geneve-ut-1729
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -17546,7 +19144,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1553
+Index: geneve-ut-1730
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17570,7 +19168,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1554
+Index: geneve-ut-1731
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -17593,7 +19191,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1555
+Index: geneve-ut-1732
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -17612,7 +19210,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1558
+Index: geneve-ut-1735
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and
@@ -17631,7 +19229,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1560
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -17666,7 +19264,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1561
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17683,7 +19281,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1562
+Index: geneve-ut-1739
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17703,7 +19301,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1563
+Index: geneve-ut-1740
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -17743,7 +19341,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1564
+Index: geneve-ut-1741
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -17759,7 +19357,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1565
+Index: geneve-ut-1742
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17773,7 +19371,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1566
+Index: geneve-ut-1743
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17811,7 +19409,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1567
+Index: geneve-ut-1744
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17861,11 +19459,39 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 
 
+### Systemd Service Override Configuration File Created
+
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-1745
+
+```python
+file where host.os.type == "linux" and event.action in ("rename", "creation") and
+file.extension == "conf" and file.path like (
+  "/etc/systemd/system/*.d/*.conf", "/etc/systemd/user/*.d/*.conf", "/usr/local/lib/systemd/system/*.d/*.conf",
+  "/lib/systemd/system/*.d/*.conf", "/usr/lib/systemd/system/*.d/*.conf", "/usr/lib/systemd/user/*.d/*.conf",
+  "/home/*/.config/systemd/user/*.d/*.conf", "/home/*/.local/share/systemd/user/*.d/*.conf",
+  "/root/.config/systemd/user/*.d/*.conf", "/root/.local/share/systemd/user/*.d/*.conf",
+  "/run/systemd/system/*.d/*.conf", "/var/run/systemd/system/*.d/*.conf"
+) and
+not process.executable in (
+  "/bin/dpkg", "/usr/bin/dpkg", "/bin/dockerd", "/usr/bin/dockerd", "/usr/sbin/dockerd", "/bin/microdnf",
+  "/usr/bin/microdnf", "/bin/rpm", "/usr/bin/rpm", "/bin/snapd", "/usr/bin/snapd", "/bin/yum", "/usr/bin/yum",
+  "/bin/dnf", "/usr/bin/dnf", "/bin/podman", "/usr/bin/podman", "/bin/dnf-automatic", "/usr/bin/dnf-automatic",
+  "/usr/bin/dpkg-divert", "/bin/dpkg-divert", "/sbin/apk", "/usr/sbin/apk", "/usr/local/sbin/apk", "/usr/bin/dnf5",
+  "/usr/bin/apt", "/usr/bin/puppet", "/bin/puppet", "/opt/puppetlabs/puppet/bin/puppet", "/usr/bin/pacman",
+  "/usr/bin/chef-client", "/bin/chef-client", "/usr/bin/pamac-daemon", "/bin/pamac-daemon", "/usr/local/bin/dockerd",
+  "/usr/bin/crio", "/usr/bin/podman", "/usr/bin/tdnf", "/usr/bin/apk"
+)
+```
+
+
+
 ### Systemd Shell Execution During Boot
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1569
+Index: geneve-ut-1747
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -17879,7 +19505,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1570
+Index: geneve-ut-1748
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17925,7 +19551,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1571
+Index: geneve-ut-1749
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -17964,7 +19590,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1572
+Index: geneve-ut-1750
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -17977,7 +19603,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1575
+Index: geneve-ut-1753
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -18010,7 +19636,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1576
+Index: geneve-ut-1754
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -18024,7 +19650,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1577
+Index: geneve-ut-1755
 
 ```python
 sequence by host.id with maxspan=1s
@@ -18038,7 +19664,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1578
+Index: geneve-ut-1756
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -18052,7 +19678,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1579
+Index: geneve-ut-1757
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18091,7 +19717,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1585
+Index: geneve-ut-1763
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -18133,7 +19759,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1587
+Index: geneve-ut-1765
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -18155,7 +19781,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1588
+Index: geneve-ut-1766
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -18168,7 +19794,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1590
+Index: geneve-ut-1768
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18185,7 +19811,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1591
+Index: geneve-ut-1769
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -18201,7 +19827,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1592
+Index: geneve-ut-1770
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18214,7 +19840,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1593
+Index: geneve-ut-1771
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -18229,7 +19855,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1594
+Index: geneve-ut-1772
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18250,15 +19876,16 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### UAC Bypass via ICMLuaUtil Elevated COM Interface
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1595
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1773
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  process.parent.name == "dllhost.exe" and
  process.parent.args in ("/Processid:{3E5FC7F9-9A51-4367-9063-A120244FBEC7}", "/Processid:{D2E7041B-2927-42FB-8E9F-7CE93B6DC937}") and
- process.pe.original_file_name != "WerFault.exe"
+ process.pe.original_file_name != "WerFault.exe" and
+ not (process.executable : "?:\\Program Files\\WireGuard\\wireguard.exe" and process.args : "/installmanagerservice")
 ```
 
 
@@ -18267,7 +19894,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1596
+Index: geneve-ut-1774
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18279,38 +19906,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Uncommon Destination Port Connection by Web Server
-
-Branch count: 45  
-Document count: 45  
-Index: geneve-ut-1600
-
-```python
-network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and (
-  process.name like (
-    "apache", "nginx", "apache2", "httpd", "lighttpd", "caddy", "mongrel_rails", "gunicorn",
-    "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn",
-    "daphne", "twistd", "yaws", "webfsd", "httpd.worker", "flask", "rails", "mongrel", "php-fpm*", "php-cgi",
-    "php-fcgi", "php-cgi.cagefs", "catalina.sh", "hiawatha", "lswsctrl"
-  ) or
-  user.name in ("apache", "www-data", "httpd", "nginx", "lighttpd", "tomcat", "tomcat8", "tomcat9") or
-  user.id in ("33", "498", "48") or
-  (process.name == "java" and process.working_directory like "/u0?/*")
-) and
-network.direction == "egress" and destination.ip != null and
-not destination.port in (80, 443, 8080, 8443, 8000, 8888, 3128, 3306, 5432, 8220, 8082) and
-not cidrmatch(destination.ip, "127.0.0.0/8", "::1","FE80::/10", "FF00::/8", "10.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.0.0.0/24", "192.0.0.0/29", "192.0.0.8/32", "192.0.0.9/32",
-"192.0.0.10/32", "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24", "192.168.0.0/16", "192.88.99.0/24",
-"224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24","198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "224.0.0.0/4", "240.0.0.0/4")
-```
-
-
-
 ### Unexpected Child Process of macOS Screensaver Engine
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1602
+Index: geneve-ut-1780
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -18322,7 +19922,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1603
+Index: geneve-ut-1781
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18351,7 +19951,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1605
+Index: geneve-ut-1783
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -18361,36 +19961,22 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 
 
-### Untrusted DLL Loaded by Azure AD Sync Service
+### Untrusted DLL Loaded by Azure AD Connect Authentication Agent
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1610
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1788
 
 ```python
-any where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
-(
- (event.category == "library" and event.action == "load") or
- (event.category == "process" and event.action : "Image loaded*")
-) and
+library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
 
-not (?dll.code_signature.trusted == true or file.code_signature.status == "Valid") and not
-
-  (
-   /* Elastic defend DLL path */
-   ?dll.path :
-         ("?:\\Windows\\assembly\\NativeImages*",
-          "?:\\Windows\\Microsoft.NET\\*",
-          "?:\\Windows\\WinSxS\\*",
-          "?:\\Windows\\System32\\DriverStore\\FileRepository\\*") or
-
-   /* Sysmon DLL path is mapped to file.path */
-   file.path :
-         ("?:\\Windows\\assembly\\NativeImages*",
-          "?:\\Windows\\Microsoft.NET\\*",
-          "?:\\Windows\\WinSxS\\*",
-          "?:\\Windows\\System32\\DriverStore\\FileRepository\\*")
-  )
+not dll.code_signature.trusted == true and
+not dll.path : (
+    "?:\\Windows\\assembly\\NativeImages*",
+    "?:\\Windows\\Microsoft.NET\\*",
+    "?:\\Windows\\WinSxS\\*",
+    "?:\\Windows\\System32\\DriverStore\\FileRepository\\*"
+)
 ```
 
 
@@ -18399,12 +19985,23 @@ not (?dll.code_signature.trusted == true or file.code_signature.status == "Valid
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1611
+Index: geneve-ut-1789
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
   (dll.code_signature.trusted == false or dll.code_signature.exists == false) and
-  not dll.code_signature.status : ("errorExpired", "errorRevoked", "errorCode_endpoint:*")
+  /* errorExpired and errorRevoked are handled by d12bac54-ab2a-4159-933f-d7bcefa7b61d */
+  not dll.code_signature.status : ("errorExpired", "errorRevoked", "errorCode_endpoint:*") and
+
+  not dll.hash.sha256 : (
+        /* HP DOT4 printer driver family FPs (Dot4.sys, Dot4Prt.sys, Dot4usb.sys, Dot4Scan.sys) */
+        "f21c1d478180bc5e932bb2c2e4618e3ed463ca87acedeb139682d218435f82f1",
+        "7e2f2a139e897eae56038b920bda9381094bc0ae9e626f6634e6b444b8b0c91f",
+        "12ffdf5f48a79b1b4adbb88ba2cb6c59dd6719554e8ea6beefe99b3e3c66f1ac",
+        "dbc6afaf80141e2480e19878f581edfe9c2b018da2ec527c4025ff04d5587afd",
+        /* (dc3d.sys, test-signed) */
+        "ca8f9564733ded4c3895cf7150bb254995d66889e6be08d6654e4f897e4ff7a4"
+  )
 ```
 
 
@@ -18413,7 +20010,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1616
+Index: geneve-ut-1795
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18427,16 +20024,18 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1617
+Index: geneve-ut-1796
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.parent.name : "dns.exe" and
   not process.executable : (
     "?:\\Windows\\System32\\conhost.exe",
+    "?:\\Windows\\System32\\dns.exe",
 
     /* Crowdstrike specific exclusion as it uses NT Object paths */
     "\\Device\\HarddiskVolume*\\Windows\\System32\\conhost.exe",
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\dns.exe",
     "\\Device\\HarddiskVolume*\\Program Files\\ReasonLabs\\*"
   ) and
   not ?process.parent.executable : "?:\\Program Files\\ReasonLabs\\DNS\\ui\\DNS.exe"
@@ -18448,7 +20047,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1626
+Index: geneve-ut-1805
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -18482,7 +20081,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1628
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18497,37 +20096,15 @@ process.group_leader.name != null and not (
 
 
 
-### Unusual Executable File Creation by a System Critical Process
-
-Branch count: 18  
-Document count: 18  
-Index: geneve-ut-1631
-
-```python
-file where host.os.type == "windows" and event.type != "deletion" and
-  file.extension : ("exe", "dll") and
-  process.name : ("smss.exe",
-                  "autochk.exe",
-                  "csrss.exe",
-                  "wininit.exe",
-                  "services.exe",
-                  "lsass.exe",
-                  "winlogon.exe",
-                  "userinit.exe",
-                  "LogonUI.exe")
-```
-
-
-
 ### Unusual File Creation - Alternate Data Stream
 
-Branch count: 186  
-Document count: 186  
-Index: geneve-ut-1635
+Branch count: 248  
+Document count: 248  
+Index: geneve-ut-1814
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
-   process.name : ("cmd.exe", "powershell.exe", "mshta.exe", "wscript.exe", "node.exe", "python*.exe") and
+   process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "mshta.exe", "wscript.exe", "cscript.exe", "node.exe", "python*.exe") and
    file.extension in~ (
     "pdf", "dll", "exe", "dat", "com", "bat", "cmd", "sys", "vbs", "vbe", "ps1", "hta", "txt", "js", "jse",
     "wsh", "wsf", "sct", "docx", "doc", "xlsx", "xls", "pptx", "ppt", "rtf", "gif", "jpg", "png", "bmp", "img", "iso"
@@ -18538,128 +20115,11 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
-### Unusual Instance Metadata Service (IMDS) API Request
-
-Branch count: 141  
-Document count: 282  
-Index: geneve-ut-1647
-
-```python
-sequence by host.id, process.parent.entity_id with maxspan=3s
-[
-    process
-    where host.os.type == "linux"
-        and event.type == "start"
-        and event.action == "exec"
-        and process.parent.executable != null
-
-        // common tooling / suspicious names (keep broad)
-        and (
-            process.name : (
-                "curl", "wget", "python*", "perl*", "php*", "ruby*", "lua*", "telnet", "pwsh",
-                "openssl", "nc", "ncat", "netcat", "awk", "gawk", "mawk", "nawk", "socat", "node",
-                "bash", "sh"
-            )
-            or
-            // suspicious execution locations (dropped binaries / temp execution)
-            process.executable : (
-                "./*", "/tmp/*", "/var/tmp/*", "/var/www/*", "/dev/shm/*", "/etc/init.d/*", "/etc/rc*.d/*",
-                "/etc/cron*", "/etc/update-motd.d/*", "/boot/*", "/srv/*", "/run/*", "/etc/rc.local"
-            )
-            or
-            // threat-relevant IMDS / metadata endpoints (inclusion list)
-            process.command_line : (
-                "*169.254.169.254/latest/api/token*",
-                "*169.254.169.254/latest/meta-data/iam/security-credentials*",
-                "*169.254.169.254/latest/meta-data/local-ipv4*",
-                "*169.254.169.254/latest/meta-data/local-hostname*",
-                "*169.254.169.254/latest/meta-data/public-ipv4*",
-                "*169.254.169.254/latest/user-data*",
-                "*169.254.169.254/latest/dynamic/instance-identity/document*",
-                "*169.254.169.254/latest/meta-data/instance-id*",
-                "*169.254.169.254/latest/meta-data/public-keys*",
-                "*computeMetadata/v1/instance/service-accounts/*/token*",
-                "*/metadata/identity/oauth2/token*",
-                "*169.254.169.254/opc/v*/instance*",
-                "*169.254.169.254/opc/v*/vnics*"
-            )
-        )
-
-        // global working-dir / executable / parent exclusions for known benign agents
-        and not process.working_directory : (
-            "/opt/rapid7*",
-            "/opt/nessus*",
-            "/snap/amazon-ssm-agent*",
-            "/var/snap/amazon-ssm-agent/*",
-            "/var/log/amazon/ssm/*",
-            "/srv/snp/docker/overlay2*",
-            "/opt/nessus_agent/var/nessus/*"
-        )
-
-        and not process.executable : (
-            "/opt/rumble/bin/rumble-agent*",
-            "/opt/aws/inspector/bin/inspectorssmplugin",
-            "/snap/oracle-cloud-agent/*",
-            "/lusr/libexec/oracle-cloud-agent/*"
-        )
-
-        and not process.parent.executable : (
-            "/usr/bin/setup-policy-routes",
-            "/usr/share/ec2-instance-connect/*",
-            "/var/lib/amazon/ssm/*",
-            "/etc/update-motd.d/30-banner",
-            "/usr/sbin/dhclient-script",
-            "/usr/local/bin/uwsgi",
-            "/usr/lib/skylight/al-extras",
-            "/usr/bin/cloud-init",
-            "/usr/sbin/waagent",
-            "/usr/bin/google_osconfig_agent",
-            "/usr/bin/docker",
-            "/usr/bin/containerd-shim",
-            "/usr/bin/runc"
-        )
-
-        and not process.entry_leader.executable : (
-            "/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent",
-            "/opt/Elastic/Agent/data/elastic-agent-*/elastic-agent",
-            "/opt/nessus_agent/sbin/nessus-service"
-        )
-
-        // carve-out: safe /usr/bin/curl usage (suppress noisy, legitimate agent patterns)
-        and not (
-            process.executable == "/usr/bin/curl"
-            and (
-                // AWS IMDSv2 token PUT that includes ttl header
-                (process.command_line : "*-X PUT*169.254.169.254/latest/api/token*" and process.command_line : "*X-aws-ec2-metadata-token-ttl-seconds*")
-                or
-                // Any IMDSv2 GET that includes token header for any /latest/* path
-                process.command_line : "*-H X-aws-ec2-metadata-token:*169.254.169.254/latest/*"
-                or
-                // Common amazon tooling UA
-                process.command_line : "*-A amazon-ec2-net-utils/*"
-                or
-                // Azure metadata legitimate header
-                process.command_line : "*-H Metadata:true*169.254.169.254/metadata/*"
-                or
-                // Oracle IMDS legitimate header
-                process.command_line : "*-H Authorization:*Oracle*169.254.169.254/opc/*"
-            )
-        )
-]
-[
-    network where host.os.type == "linux"
-        and event.action == "connection_attempted"
-        and destination.ip == "169.254.169.254"
-]
-```
-
-
-
 ### Unusual Kill Signal
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1650
+Index: geneve-ut-1828
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -18676,7 +20136,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1653
+Index: geneve-ut-1831
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -18693,7 +20153,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1669
+Index: geneve-ut-1847
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -18710,13 +20170,13 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 ### Unusual Parent-Child Relationship
 
-Branch count: 32  
-Document count: 32  
-Index: geneve-ut-1673
+Branch count: 66  
+Document count: 66  
+Index: geneve-ut-1851
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
-process.parent.name != null and
+process.parent.name != null and process.parent.executable like ("?:\\*", "\\Device\\*") and
  (
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
@@ -18739,11 +20199,12 @@ process.parent.name != null and
    (process.name:"userinit.exe" and not process.parent.name:("dwm.exe", "winlogon.exe", "KUsrInit.exe")) or
    (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
    /* suspicious child processes */
-   (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe")) or
+   (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
-   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe"))
+   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
+     not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe"))
   )
 ```
 
@@ -18753,7 +20214,7 @@ process.parent.name != null and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1674
+Index: geneve-ut-1852
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18798,7 +20259,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1677
+Index: geneve-ut-1855
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18836,11 +20297,39 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Unusual Process Connection to Docker or Containerd Socket
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1857
+
+```python
+host.os.type:"linux" and 
+event.category:"network" and
+event.action:"connected-to" and network.direction:"egress" and 
+destination.address:("/run/containerd/containerd.sock" or "/var/run/containerd/containerd.sock" or "/var/run/docker.sock" or "/run/docker.sock") and
+process.executable:(* and not 
+  ("/usr/bin/kubelet" or
+  "/usr/local/bin/kubelet" or
+  "/usr/bin/containerd" or
+  "/usr/sbin/containerd" or
+  "/usr/bin/containerd-shim" or
+  "/usr/bin/containerd-shim-runc-v2" or
+  "/usr/local/bin/containerd-shim-runc-v2" or
+  "/usr/bin/dockerd" or
+  "/usr/sbin/dockerd" or  
+   /var/lib/*/usr/bin/dockerd or 
+  "/usr/bin/docker-proxy")
+)
+```
+
+
+
 ### Unusual Process Execution on WBEM Path
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1681
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18864,7 +20353,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1682
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18904,7 +20393,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1683
+Index: geneve-ut-1862
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -18951,7 +20440,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1687
+Index: geneve-ut-1866
 
 ```python
 sequence by process.entity_id
@@ -18988,7 +20477,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1721
+Index: geneve-ut-1898
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19002,7 +20491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1722
+Index: geneve-ut-1899
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -19045,7 +20534,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1723
+Index: geneve-ut-1900
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -19058,7 +20547,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1725
+Index: geneve-ut-1902
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -19072,7 +20561,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1726
+Index: geneve-ut-1903
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -19081,29 +20570,11 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 
 
-### Veeam Backup Library Loaded by Unusual Process
-
-Branch count: 10  
-Document count: 10  
-Index: geneve-ut-1729
-
-```python
-library where host.os.type == "windows" and event.action == "load" and
-  (dll.name : "Veeam.Backup.Common.dll" or dll.pe.original_file_name : "Veeam.Backup.Common.dll") and
-  (
-    process.code_signature.trusted == false or
-    process.code_signature.exists == false or
-    process.name : ("powershell.exe", "pwsh.exe", "powershell_ise.exe")
-  )
-```
-
-
-
 ### Virtual Machine Fingerprinting
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1730
+Index: geneve-ut-1907
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -19128,7 +20599,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1731
+Index: geneve-ut-1908
 
 ```python
 process where event.type == "start" and
@@ -19143,7 +20614,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1732
+Index: geneve-ut-1909
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19160,7 +20631,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1733
+Index: geneve-ut-1910
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19174,7 +20645,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1734
+Index: geneve-ut-1911
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19190,7 +20661,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1735
+Index: geneve-ut-1912
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19204,7 +20675,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1736
+Index: geneve-ut-1913
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -19217,8 +20688,12 @@ file where host.os.type == "windows" and event.action != "deletion" and
   ) and
   not process.executable : (
     "C:\\Windows\\System32\\poqexec.exe",
-    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe"
-  )
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe",
+    "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+    "?:\\Windows\\System32\\omadmclient.exe"
+  ) and
+  /* System / ntoskrnl.exe (PID 4) */
+  not process.pid == 4
 ```
 
 
@@ -19227,7 +20702,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1738
+Index: geneve-ut-1915
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -19239,7 +20714,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1739
+Index: geneve-ut-1916
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19255,7 +20730,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1740
+Index: geneve-ut-1917
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -19278,7 +20753,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1741
+Index: geneve-ut-1918
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -19291,7 +20766,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1742
+Index: geneve-ut-1919
 
 ```python
 http.response.status_code:403 and http.request.method:post
@@ -19303,7 +20778,7 @@ http.response.status_code:403 and http.request.method:post
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1743
+Index: geneve-ut-1920
 
 ```python
 http.response.status_code:405
@@ -19315,7 +20790,7 @@ http.response.status_code:405
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1744
+Index: geneve-ut-1921
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -19323,22 +20798,101 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 
 
-### Web Server Potential SQL Injection Request
+### Web Server Cloud Metadata SSRF Request
 
-Branch count: 61  
-Document count: 61  
-Index: geneve-ut-1750
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1922
 
 ```python
-any where url.original like~ (
-  "*%20order%20by%*", "*dbms_pipe.receive_message%28chr%*", "*waitfor%20delay%20*", "*%28select%20*from%20pg_sleep%285*", "*%28select%28sleep%285*", "*%3bselect%20pg_sleep%285*",
-  "*select%20concat%28concat*", "*xp_cmdshell*", "*select*case*when*", "*and*extractvalue*select*", "*from*information_schema.tables*", "*boolean*mode*having*", "*extractvalue*concat*",
-  "*case*when*sleep*", "*select*sleep*", "*dbms_lock.sleep*", "*and*sleep*", "*like*sleep*", "*csleep*", "*pgsleep*", "*char*char*char*", "*union*select*", "*concat*select*",
-  "*select*else*drop*", "*having*like*", "*case*else*end*", "*if*sleep*", "*where*and*select*", "*or*1=1*", "*\"1\"=\"1\"*", "*or*'a'='a*", "*into*outfile*", "*pga_sleep*",
-  "*into%20outfile*", "*into*dumpfile*", "*load_file%28*", "*load%5ffile%28*", "*cast%28*", "*convert%28*", "*cast%28%*", "*convert%28%*", "*@@version*", "*@@version_comment*",
-  "*version%28*", "*user%28*", "*current_user%28*", "*database%28*", "*schema_name%28*", "*information_schema.columns*", "*information_schema.columns*", "*table_schema*",
-  "*column_name*", "*dbms_pipe*", "*dbms_lock%2e*sleep*", "*dbms_lock.sleep*", "*sp_executesql*", "*sp_executesql*", "*load%20data*", "*information_schema*",  "*pg_slp*",
-  "*information_schema.tables*"
+web where (
+  url.original : (
+    "*169.254.169.254*", "*169%2e254%2e169%2e254*", "*0xa9fea9fe*", "*0xa9.0xfe.0xa9.0xfe*", 
+    "*2852039166*", "*0251.0376.0251.0376*", "*::ffff:169.254.169.254*", "*::ffff:a9fe:a9fe*", "*fd00:ec2::254*",
+    "*100.100.100.200*", "*169.254.170.2*", "*metadata.google.internal*", "*metadata.goog*", "*computeMetadata/v1*",
+    "*meta-data/iam/security-credentials*", "*meta-data%2Fiam%2Fsecurity-credentials*",
+    "*latest/meta-data*", "*latest/api/token*"
+  )
+  or
+  url.query : (
+    "*169.254.169.254*", "*169%2e254%2e169%2e254*", "*0xa9fea9fe*", "*0xa9.0xfe.0xa9.0xfe*", 
+    "*2852039166*", "*0251.0376.0251.0376*", "*::ffff:169.254.169.254*", "*::ffff:a9fe:a9fe*", "*fd00:ec2::254*",
+    "*100.100.100.200*", "*169.254.170.2*", "*metadata.google.internal*", "*metadata.goog*", "*computeMetadata/v1*",
+    "*meta-data/iam/security-credentials*", "*meta-data%2Fiam%2Fsecurity-credentials*",
+    "*latest/meta-data*", "*latest/api/token*"
+  )
+)
+```
+
+
+
+### Web Server Potential SQL Injection Request
+
+Branch count: 91  
+Document count: 91  
+Index: geneve-ut-1928
+
+```python
+any where (
+url.original like~ (
+    "*dbms_pipe.receive_message%28chr%*",
+    "*waitfor%20delay%20%270%3a0%3a*",
+    "*%28select%28sleep%285*", "*%28select%20*from%20pg_sleep%285*", "*%3bselect%20pg_sleep%285*",
+    "*and%20sleep%28*%29*", "*or%20sleep%28*%29*", "*case%20when*then%20sleep%28*", "*if%28sleep%28*%29*",
+    "*benchmark%28*%2c*md5%28*",
+    "*convert%28int%2c%28select%20char%28*",
+    "*char%28*char%28*char%28*char%28*",
+    "*concat%28concat%28char%28*",
+    "*case%20when%20%28*%3d*%29%20then*else*end*",
+    "*elt%28*%3d*%2c1%29%29*",
+    "*union%20select%20null%2cnull*", "*union%20all%20select%20null*",
+    "*union%20all%20select%20*concat%28md5%28*",
+    "*extractvalue%28*concat%280x*", "*updatexml%28*concat%280x*",
+    "*procedure%2f%2a%2a%2fanalyse%28extractvalue%28*",
+    "*gtid_subset%28concat%280x*", "*gtid_subtract%28concat%280x*",
+    "*mid%28ifnull%28session_user%28%29*",
+    "*'qq'%2b%28%28select%20@@version%29%29%2b'qq'*",
+    "*%27%20or%20%271%27%3d%271*", "*%22%20or%20%221%22%3d%221*", "*%27%20or%20%27a%27%3d%27a*",
+    "*and%201%3d1--*", "*and%201%3d2--*",
+    "*%29%3bselect*if%28%28ord%28mid%28*",
+    "*xp_cmdshell*",
+    "*select%20*into%20outfile*", "*select%20*into%20dumpfile*",
+    "*load_file%28*", "*load%5ffile%28*",
+    "*select%20*from%20information_schema.tables*", "*from%20information_schema.columns%20where%20table_schema*",
+    "*dbms_pipe%2ereceive_message*", "*dbms_lock%2esleep*",
+    "*select%20@@version*", "*select%20user%28%29*", "*select%20current_user%28%29*", "*select%20database%28%29*",
+    "*sp_executesql%20*exec%20*", "*xp_dirtree*"
+  )
+  or
+  url.query like~ (
+    "*dbms_pipe.receive_message(chr*",
+    "*waitfor delay '0:0:*",
+    "*(select(sleep(5*", "*(select*from pg_sleep(5*", "*;select pg_sleep(5*",
+    "*and sleep(*)*", "*or sleep(*)*", "*case when*then sleep(*", "*if(sleep(*)*",
+    "*benchmark(*,*md5(*",
+    "*convert(int,(select char(*",
+    "*char(*char(*char(*char(*",
+    "*concat(concat(char(*",
+    "*case when (*=*) then*else*end*",
+    "*elt(*=*,1))*",
+    "*union select null,null*", "*union all select null*",
+    "*union all select*concat(md5(*",
+    "*extractvalue(*concat(0x*", "*updatexml(*concat(0x*",
+    "*procedure/**/analyse(extractvalue(*",
+    "*gtid_subset(concat(0x*", "*gtid_subtract(concat(0x*",
+    "*mid(ifnull(session_user()*",
+    "*'qq'+((select @@version))+'qq'*",
+    "*' or '1'='1*", "*\" or \"1\"=\"1*", "*' or 'a'='a*",
+    "*and 1=1--*", "*and 1=2--*",
+    "*);select*if((ord(mid(*",
+    "*xp_cmdshell*",
+    "*select*into outfile*", "*select*into dumpfile*",
+    "*load_file(*",
+    "*select*from information_schema.tables*", "*from information_schema.columns where table_schema*",
+    "*dbms_pipe.receive_message*", "*dbms_lock.sleep*",
+    "*select @@version*", "*select user()*", "*select current_user()*", "*select database()*",
+    "*sp_executesql*exec*", "*xp_dirtree*"
+  )
 )
 ```
 
@@ -19348,7 +20902,7 @@ any where url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1752
+Index: geneve-ut-1930
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19369,7 +20923,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1755
+Index: geneve-ut-1933
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -19383,7 +20937,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1756
+Index: geneve-ut-1934
 
 ```python
 file where event.type == "deletion" and
@@ -19400,7 +20954,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1757
+Index: geneve-ut-1935
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19418,7 +20972,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1759
+Index: geneve-ut-1937
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19456,7 +21010,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1761
+Index: geneve-ut-1939
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19493,7 +21047,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1762
+Index: geneve-ut-1940
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19508,7 +21062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1763
+Index: geneve-ut-1941
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -19521,7 +21075,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1764
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19540,7 +21094,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-1765
+Index: geneve-ut-1943
 
 ```python
 sequence with maxspan=1m
@@ -19565,7 +21119,7 @@ sequence with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1766
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19591,7 +21145,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1767
+Index: geneve-ut-1945
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -19613,7 +21167,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1768
+Index: geneve-ut-1946
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19630,7 +21184,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-1770
+Index: geneve-ut-1948
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -19649,7 +21203,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-1771
+Index: geneve-ut-1949
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -19689,7 +21243,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1772
+Index: geneve-ut-1950
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19706,7 +21260,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1774
+Index: geneve-ut-1952
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -19719,7 +21273,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1775
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -19733,7 +21287,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1776
+Index: geneve-ut-1954
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19761,7 +21315,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1777
+Index: geneve-ut-1955
 
 ```python
 process where event.type == "start" and
@@ -19786,7 +21340,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1778
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19796,11 +21350,27 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### XDG-Open Command Execution
+
+Branch count: 25  
+Document count: 25  
+Index: geneve-ut-1957
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2") and (
+  process.name == "xdg-open" or
+  process.args in ("/bin/xdg-open", "/usr/bin/xdg-open", "/usr/local/bin/xdg-open", "xdg-open")
+)
+```
+
+
+
 ### Yum Package Manager Plugin File Creation
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1779
+Index: geneve-ut-1958
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19835,7 +21405,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1780
+Index: geneve-ut-1959
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19853,7 +21423,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1783
+Index: geneve-ut-1962
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.4.md
+++ b/tests/reports/alerts_from_rules-9.4.md
@@ -5,22 +5,22 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.2
+Rules version: 9.4.7
 
 ## Table of contents
-   1. [Failed rules (20)](#failed-rules-20)
-   1. [Unsuccessful rules with signals (20)](#unsuccessful-rules-with-signals-20)
+   1. [Failed rules (24)](#failed-rules-24)
+   1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
-   1. [Rules with too few signals (23)](#rules-with-too-few-signals-23)
-   1. [Rules with the correct signals (770)](#rules-with-the-correct-signals-770)
+   1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
+   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
 
-## Failed rules (20)
+## Failed rules (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0271  
+Index: geneve-ut-0335  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0516  
+Index: geneve-ut-0605  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -144,7 +144,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0541  
+Index: geneve-ut-0630  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -173,7 +173,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0626  
+Index: geneve-ut-0729  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -200,11 +200,64 @@ not process.name in ("git", "dirname")
 
 
 
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0920  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Multi-Base64 Decoding Attempt from Suspicious Location
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0922  
+Index: geneve-ut-1060  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -237,7 +290,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-0947  
+Index: geneve-ut-1088  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -280,7 +333,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1013  
+Index: geneve-ut-1159  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -321,7 +374,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1042  
+Index: geneve-ut-1188  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -347,7 +400,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1058  
+Index: geneve-ut-1205  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -385,7 +438,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1116  
+Index: geneve-ut-1268  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -407,7 +460,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1130  
+Index: geneve-ut-1283  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +501,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1217  
+Index: geneve-ut-1372  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -511,7 +564,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1440  
+Index: geneve-ut-1612  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -557,7 +610,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1443  
+Index: geneve-ut-1616  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -600,7 +653,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1522  
+Index: geneve-ut-1699  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -644,11 +697,46 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1713  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Echo or Printf Execution Detected via Defend for Containers
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1546  
+Index: geneve-ut-1726  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -673,7 +761,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1556  
+Index: geneve-ut-1736  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -736,7 +824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1562  
+Index: geneve-ut-1742  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -760,11 +848,82 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1751  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1802  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1663  
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1847  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -774,13 +933,16 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -810,7 +972,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -818,12 +979,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -832,7 +998,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1692  
+Index: geneve-ut-1877  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -875,13 +1041,13 @@ process.interactive == true and container.id like "*"
 
 
 
-## Unsuccessful rules with signals (20)
+## Unsuccessful rules with signals (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0271
+Index: geneve-ut-0335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -933,7 +1099,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0516
+Index: geneve-ut-0605
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -999,7 +1165,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0541
+Index: geneve-ut-0630
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1025,7 +1191,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0626
+Index: geneve-ut-0729
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1049,11 +1215,61 @@ not process.name in ("git", "dirname")
 
 
 
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0920
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Multi-Base64 Decoding Attempt from Suspicious Location
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0922
+Index: geneve-ut-1060
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1083,7 +1299,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-0947
+Index: geneve-ut-1088
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1123,7 +1339,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1013
+Index: geneve-ut-1159
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1161,7 +1377,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1042
+Index: geneve-ut-1188
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1184,7 +1400,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1058
+Index: geneve-ut-1205
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1219,7 +1435,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1116
+Index: geneve-ut-1268
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1238,7 +1454,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1130
+Index: geneve-ut-1283
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1276,7 +1492,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1217
+Index: geneve-ut-1372
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1336,7 +1552,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1440
+Index: geneve-ut-1612
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1379,7 +1595,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1443
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1419,7 +1635,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1522
+Index: geneve-ut-1699
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1460,11 +1676,43 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1713
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Echo or Printf Execution Detected via Defend for Containers
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1546
+Index: geneve-ut-1726
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.interactive == true and
@@ -1486,7 +1734,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1556
+Index: geneve-ut-1736
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1546,7 +1794,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1562
+Index: geneve-ut-1742
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1567,24 +1815,92 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1751
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1802
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1663
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1847
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -1614,7 +1930,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -1622,12 +1937,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -1636,7 +1956,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1692
+Index: geneve-ut-1877
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1682,7 +2002,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0168
+Index: geneve-ut-0218
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1696,7 +2016,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0787
+Index: geneve-ut-0921
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1708,7 +2028,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0808
+Index: geneve-ut-0941
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1720,7 +2040,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1165
+Index: geneve-ut-1319
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1734,27 +2054,28 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 
 
-### Potential Privacy Control Bypass via TCCDB Modification
+### Protected Storage Service Access via SMB
 
-Branch count: 16  
-Document count: 16  
-Index: geneve-ut-1204
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1516
 
 ```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "sqlite*" and
- process.args like "/*/Application Support/com.apple.TCC/TCC.db" and
- (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+host.os.type:windows and event.category:file and event.code:5145 and
+  winlog.event_data.ShareName:"\\\\*\\IPC$" and
+  winlog.event_data.RelativeTargetName:"protected_storage" and
+  not source.ip:("::" or "::1" or "0.0.0.0" or "127.0.0.1")
 ```
 
 
 
-## Rules with too few signals (23)
+## Rules with too few signals (28)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0271  
+Index: geneve-ut-0335  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -1808,7 +2129,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0516  
+Index: geneve-ut-0605  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -1876,7 +2197,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0541  
+Index: geneve-ut-0630  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -1904,7 +2225,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0626  
+Index: geneve-ut-0729  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -1930,11 +2251,82 @@ not process.name in ("git", "dirname")
 
 
 
+### Kubernetes Secrets List Across Cluster or Sensitive Namespaces
+
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0897  
+Failure message(s):  
+  got 3 signals, expected 6  
+
+```python
+event.dataset:"kubernetes.audit_logs" and event.action:list and 
+kubernetes.audit.objectRef.resource:secrets and 
+kubernetes.audit.requestURI :(/api/v1/secrets or /api/v1/secrets?limit* or /api/v1/namespaces/kube-system/secrets or /api/v1/namespaces/kube-system/secrets?limit* or /api/v1/namespaces/default/secrets or /api/v1/namespaces/default/secrets?limit*) and 
+source.ip:(* and not ("::1" or "127.0.0.1")) and 
+not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator) and 
+not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
+```
+
+
+
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0920  
+Failure message(s):  
+  got 1000 signals, expected 6552  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Microsoft IIS Service Account Password Dumped
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0900  
+Index: geneve-ut-1038  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -1954,7 +2346,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0922  
+Index: geneve-ut-1060  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -1986,7 +2378,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-0947  
+Index: geneve-ut-1088  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2028,7 +2420,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1013  
+Index: geneve-ut-1159  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2068,7 +2460,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1042  
+Index: geneve-ut-1188  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2093,7 +2485,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1058  
+Index: geneve-ut-1205  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2130,7 +2522,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1116  
+Index: geneve-ut-1268  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2151,7 +2543,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1130  
+Index: geneve-ut-1283  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2191,7 +2583,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1208  
+Index: geneve-ut-1363  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2208,7 +2600,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1217  
+Index: geneve-ut-1372  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2270,7 +2662,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1315  
+Index: geneve-ut-1483  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2295,7 +2687,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1440  
+Index: geneve-ut-1612  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2340,7 +2732,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1443  
+Index: geneve-ut-1616  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -2382,7 +2774,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1522  
+Index: geneve-ut-1699  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -2425,11 +2817,45 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1713  
+Failure message(s):  
+  got 1000 signals, expected 5280  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Echo or Printf Execution Detected via Defend for Containers
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1546  
+Index: geneve-ut-1726  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -2453,7 +2879,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1556  
+Index: geneve-ut-1736  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -2515,7 +2941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1562  
+Index: geneve-ut-1742  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -2538,26 +2964,98 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1751  
+Failure message(s):  
+  got 1000 signals, expected 2457  
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1802  
+Failure message(s):  
+  got 1000 signals, expected 8576  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1663  
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1847  
 Failure message(s):  
-  got 1000 signals, expected 1053  
+  got 1000 signals, expected 2442  
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -2587,7 +3085,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -2595,12 +3092,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -2609,7 +3111,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1692  
+Index: geneve-ut-1877  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -2651,7 +3153,7 @@ process.interactive == true and container.id like "*"
 
 
 
-## Rules with the correct signals (770)
+## Rules with the correct signals (805)
 
 ### A scheduled task was created
 
@@ -2674,7 +3176,15 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
               "\\Hewlett-Packard\\HP Web Products Detection",
               "\\Microsoft\\VisualStudio\\Updates\\BackgroundDownload",
               "\\OneDrive Standalone Update Task-S-1-5-21*",
-              "\\OneDrive Standalone Update Task-S-1-12-1-*"
+              "\\OneDrive Standalone Update Task-S-1-12-1-*",
+              "\\SoftLanding\\S-1-5-21-*\\SoftLanding*",
+              "\\SoftLanding\\S-1-12-*\\SoftLanding*",
+              "\\OneDrive Reporting Task-S-1-5-21-*",
+              "\\OneDrive Reporting Task-S-1-12-1-*",
+              "\\GoogleUserPEH\\RunPlatformExperienceHelper*",
+              "\\Mozilla\\Firefox Default Browser Agent*",
+              "\\Microsoft\\Office\\Office Background Push Maintenance",
+              "\\Microsoft\\Windows\\GroupPolicy\\GPUpdate"
  )
 ```
 
@@ -2736,7 +3246,7 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0022
+Index: geneve-ut-0040
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -2750,11 +3260,47 @@ process.command_line like~ (
 
 
 
+### AWS EC2 Instance Profile Associated with Running Instance
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-0057
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "ec2.amazonaws.com"
+    and event.action: ("AssociateIamInstanceProfile" or "ReplaceIamInstanceProfile")
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService" 
+    and not aws.cloudtrail.user_identity.invoked_by: "ssm.amazonaws.com"
+```
+
+
+
+### AWS IAM Customer Managed Policy Version Created or Default Version Set
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-0087
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "iam.amazonaws.com"
+    and event.action: ("CreatePolicyVersion" or "SetDefaultPolicyVersion")
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService" 
+    and not aws.cloudtrail.user_identity.arn:arn*/terraform 
+    and not source.as.organization.name:(Amazon* or AMAZON* or "Google LLC" or "MongoDB, Inc.")
+    and not source.address: ( "cloudformation.amazonaws.com" or "servicecatalog.amazonaws.com")
+```
+
+
+
 ### AWS IAM Login Profile Added to User
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0064
+Index: geneve-ut-0094
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
@@ -2763,11 +3309,59 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 
 
+### AWS IAM Sensitive Operations via Lambda Execution Role
+
+Branch count: 22  
+Document count: 22  
+Index: geneve-ut-0105
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "iam.amazonaws.com"
+    and event.outcome: "success"
+    and aws.cloudtrail.user_identity.type: "AssumedRole"
+    and (
+        aws.cloudtrail.user_identity.invoked_by: "lambda.amazonaws.com"
+        or user_agent.original : *AWS_Lambda*
+    )
+    and event.action: (
+        "AddRoleToInstanceProfile" or
+        "AddUserToGroup" or 
+        "AttachGroupPolicy" or 
+        "AttachRolePolicy" or
+        "AttachUserPolicy" or
+        "CreateAccessKey" or
+        "CreateInstanceProfile" or
+        "CreateRole" or
+        "CreateUser" or
+        "PutRolePolicy" or
+        "PutUserPolicy"
+    )
+```
+
+
+
+### AWS KMS Key Policy Updated via PutKeyPolicy
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0112
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "kms.amazonaws.com"
+    and event.action: "PutKeyPolicy"
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService"
+```
+
+
+
 ### AWS Lambda Function Created or Updated
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0077
+Index: geneve-ut-0114
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2782,7 +3376,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0087
+Index: geneve-ut-0133
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
@@ -2791,11 +3385,27 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 
 
+### AWS STS GetFederationToken with AdministratorAccess in Request
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0169
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "sts.amazonaws.com"
+    and event.action: "GetFederationToken"
+    and event.outcome: "success"
+    and aws.cloudtrail.request_parameters: *AdministratorAccess*
+```
+
+
+
 ### AWS STS GetSessionToken Usage
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0121
+Index: geneve-ut-0170
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -2810,7 +3420,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0130
+Index: geneve-ut-0180
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -2825,7 +3435,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0139
+Index: geneve-ut-0189
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2849,7 +3459,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0140
+Index: geneve-ut-0190
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -2884,7 +3494,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0141
+Index: geneve-ut-0191
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -2901,7 +3511,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0142
+Index: geneve-ut-0192
 
 ```python
 any where host.os.type == "windows" and
@@ -2926,7 +3536,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0144
+Index: geneve-ut-0194
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -2954,7 +3564,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0146
+Index: geneve-ut-0196
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2967,7 +3577,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0148
+Index: geneve-ut-0198
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -2983,7 +3593,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0149
+Index: geneve-ut-0199
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3003,7 +3613,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0150
+Index: geneve-ut-0200
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3024,7 +3634,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0151
+Index: geneve-ut-0201
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3036,7 +3646,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0154
+Index: geneve-ut-0204
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3048,7 +3658,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0166
+Index: geneve-ut-0216
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3065,7 +3675,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0167
+Index: geneve-ut-0217
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3077,7 +3687,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0169
+Index: geneve-ut-0219
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3097,7 +3707,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0170
+Index: geneve-ut-0220
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3111,7 +3721,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0174
+Index: geneve-ut-0224
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3142,7 +3752,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0175
+Index: geneve-ut-0225
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3152,14 +3762,14 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 ### Attempt to Clear Kernel Ring Buffer
 
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-0176
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-0226
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
 event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
-process.name == "dmesg" and process.args in ("-c", "--clear")
+process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clear")
 ```
 
 
@@ -3168,7 +3778,7 @@ process.name == "dmesg" and process.args in ("-c", "--clear")
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0177
+Index: geneve-ut-0227
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3183,7 +3793,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0187
+Index: geneve-ut-0237
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -3202,7 +3812,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0188
+Index: geneve-ut-0238
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3216,7 +3826,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0190
+Index: geneve-ut-0240
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -3247,7 +3857,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0191
+Index: geneve-ut-0241
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3270,7 +3880,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0192
+Index: geneve-ut-0242
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3284,7 +3894,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0193
+Index: geneve-ut-0243
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3299,11 +3909,25 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Attempt to Install Kali Linux via WSL
+### Attempt to Install Root Certificate
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0244
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and
+  process.name == "security" and process.args like "add-trusted-cert" and
+  (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
+### Attempt to Install or Run Kali Linux via WSL
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0194
+Index: geneve-ut-0245
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3324,25 +3948,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Attempt to Install Root Certificate
-
-Branch count: 16  
-Document count: 16  
-Index: geneve-ut-0195
-
-```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and
-  process.name == "security" and process.args like "add-trusted-cert" and
-  (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
-```
-
-
-
 ### Attempt to Mount SMB Share via Command Line
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0200
+Index: geneve-ut-0250
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3361,7 +3971,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0203
+Index: geneve-ut-0253
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3374,7 +3984,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0205
+Index: geneve-ut-0255
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3416,7 +4026,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0212
+Index: geneve-ut-0262
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -3431,7 +4041,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0237
+Index: geneve-ut-0292
 
 ```python
 event.dataset:azure.activitylogs and
@@ -3441,11 +4051,29 @@ event.dataset:azure.activitylogs and
 
 
 
+### Azure Run Command Script Child Process
+
+Branch count: 22  
+Document count: 22  
+Index: geneve-ut-0295
+
+```python
+process where event.type in ("start", "process_started") and
+  (
+    (process.parent.name == "powershell.exe" and
+      process.parent.command_line like "powershell  -ExecutionPolicy Unrestricted -File script?.ps1") or
+    (process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh", "busybox") and
+      process.parent.args like "/var/lib/waagent/run-command/download/*/script.sh")
+  )
+```
+
+
+
 ### BPF Program Tampering via bpftool
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0250
+Index: geneve-ut-0313
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3463,7 +4091,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0251
+Index: geneve-ut-0314
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3481,7 +4109,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0252
+Index: geneve-ut-0315
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3496,7 +4124,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0253
+Index: geneve-ut-0316
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3510,7 +4138,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0254
+Index: geneve-ut-0317
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3525,7 +4153,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0257
+Index: geneve-ut-0320
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -3542,7 +4170,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0258
+Index: geneve-ut-0321
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -3554,7 +4182,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0259
+Index: geneve-ut-0322
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -3566,7 +4194,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0260
+Index: geneve-ut-0323
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3581,7 +4209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0261
+Index: geneve-ut-0324
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -3601,7 +4229,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0262
+Index: geneve-ut-0325
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3623,7 +4251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0264
+Index: geneve-ut-0327
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -3669,24 +4297,24 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0265
+Index: geneve-ut-0328
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.name : ("chrome.exe", "msedge.exe") and
-  process.parent.executable != null and process.command_line != null and
+  process.parent.executable != null and
   (
-  process.command_line :
-           ("\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\"",
+    process.command_line : (
+            "\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\"",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\"",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --disable-logging --log-level=3 --v=0",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --log-level=3",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --remote-debugging-port=922? --profile-directory=\"Default\"*",
-            "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --restore-last-session --remote-debugging-port=45452*") or
-
-  (process.args : "--remote-debugging-port=922?" and process.args : "--window-position=-*,-*")
-   ) and
+            "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --restore-last-session --remote-debugging-port=45452*"
+    ) or
+    (process.args : "--remote-debugging-port=922?" and process.args : "--window-position=-*,-*")
+  ) and
   not process.parent.executable :
                          ("C:\\Windows\\explorer.exe",
                           "C:\\Program Files (x86)\\*.exe",
@@ -3703,7 +4331,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0266
+Index: geneve-ut-0329
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3726,7 +4354,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0267
+Index: geneve-ut-0330
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -3748,7 +4376,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0268
+Index: geneve-ut-0331
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -3772,11 +4400,26 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 
 
+### Chroot Execution in Container Context on Linux
+
+Branch count: 40  
+Document count: 40  
+Index: geneve-ut-0332
+
+```python
+host.os.type:linux and event.category:process and 
+event.type:start and event.action:(executed or exec) and 
+(process.name:"chroot" or process.args:("chroot" or "/bin/chroot" or "/usr/bin/chroot" or "/usr/local/bin/chroot")) and 
+(process.title:"runc init" or process.entry_leader.entry_meta.type:"container" or process.parent.name:("runc" or "containerd-shim-runc-v2"))
+```
+
+
+
 ### Clearing Windows Event Logs
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0270
+Index: geneve-ut-0334
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3797,11 +4440,41 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Cloud Instance Metadata Credential Path HTTP Request
+
+Branch count: 219  
+Document count: 219  
+Index: geneve-ut-0336
+
+```python
+network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
+http.request.method == "GET" and url.path : (
+  "/latest/meta-data/iam/security-credentials/*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*metadata/identity/oauth2/token*"
+) and (
+  ?process.name : (
+    "curl", "wget", "python*", "node", "bun", "php*", "ruby", "perl", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox",
+    "bun.exe", "node.exe", "powershell.exe", "cmd.exe", "curl.exe", "wget.exe", "rundll32.exe", "w3wp.exe", "java*", 
+    "go", "nc", "netcat", "nginx", "apache*", "httpd", "tomcat*", "catalina", "spring*", "dotnet", "gunicorn", "uwsgi", 
+    ".*", "osascript"
+  ) or ?process.executable : (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*", "?:\\ProgramData\\*"
+  ) or user_agent.original : (
+    "curl*", "wget*", "python*", "ruby*", "Go-http-client*", "node*", "axios*", "undici*", "java*", "php*", "Bun*",
+    "Apache-HttpClient*", "okhttp*", "RestTemplate*", "*WindowsPowerShell*", "*roadtools*", "*fasthttp*", "*azurehound*", "*bloodhound*", "*aiohttp*"
+  )
+)
+```
+
+
+
 ### Code Signing Policy Modification Through Built-in tools
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0273
+Index: geneve-ut-0338
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3815,7 +4488,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0274
+Index: geneve-ut-0339
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3837,7 +4510,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0275
+Index: geneve-ut-0340
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -3851,7 +4524,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0276
+Index: geneve-ut-0341
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -3871,7 +4544,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0279
+Index: geneve-ut-0344
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3888,7 +4561,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-0281
+Index: geneve-ut-0346
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3972,7 +4645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0282
+Index: geneve-ut-0347
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4002,7 +4675,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0285
+Index: geneve-ut-0350
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4027,7 +4700,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0287
+Index: geneve-ut-0352
 
 ```python
 sequence by process.entity_id
@@ -4048,7 +4721,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0288
+Index: geneve-ut-0353
 
 ```python
 sequence by process.entity_id
@@ -4065,11 +4738,42 @@ sequence by process.entity_id
 
 
 
+### Container Runtime CLI Execution with Suspicious Arguments
+
+Branch count: 28  
+Document count: 28  
+Index: geneve-ut-0356
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
+(
+  (
+    process.name in ("ctr", "crictl", "nerdctl") and
+    (
+      (process.args == "tasks" and process.args == "exec") or
+      (process.args == "run" and process.args in ("--privileged", "--rm", "--mount", "--net-host", "--pid-host")) or
+      (process.args == "snapshots" and process.args == "mount")
+    )
+  ) or
+  (
+    (process.executable like ("/dev/shm/*", "/tmp/*", "/var/tmp/*") or process.name : ".*") and
+    process.args like ("*containerd.sock*", "k8s.io")
+  )
+) and
+not process.parent.executable in (
+  "/usr/bin/kubelet", "/usr/local/bin/kubelet",
+  "/usr/bin/containerd", "/usr/sbin/containerd",
+  "/lib/systemd/systemd", "/usr/lib/systemd/systemd", "/sbin/init"
+)
+```
+
+
+
 ### Container Workload Protection
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0291
+Index: geneve-ut-0357
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4081,7 +4785,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0292
+Index: geneve-ut-0358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4104,7 +4808,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0295
+Index: geneve-ut-0361
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4117,7 +4821,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0296
+Index: geneve-ut-0362
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4130,7 +4834,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0298
+Index: geneve-ut-0364
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4147,7 +4851,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0299
+Index: geneve-ut-0365
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -4158,12 +4862,12 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 ### Creation of a Hidden Local User Account
 
-Branch count: 3  
-Document count: 3  
-Index: geneve-ut-0300
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0366
 
 ```python
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type in ("change", "creation") and
   registry.path : (
     "HKLM\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
     "\\REGISTRY\\MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
@@ -4177,7 +4881,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0301
+Index: geneve-ut-0367
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -4189,7 +4893,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0302
+Index: geneve-ut-0368
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -4257,7 +4961,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0303
+Index: geneve-ut-0369
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -4275,7 +4979,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0304
+Index: geneve-ut-0370
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -4286,15 +4990,18 @@ process.args == "--json" and process.args == "filesystem"
 
 ### Credential Acquisition via Registry Hive Dumping
 
-Branch count: 8  
-Document count: 8  
-Index: geneve-ut-0305
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-0371
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  (?process.pe.original_file_name == "reg.exe" or process.name : "reg.exe") and
  process.args : ("save", "export") and
- process.args : ("hklm\\sam", "hklm\\security")
+ process.args : (
+   "hklm\\sam", "hklm\\security", "hklm\\system",
+   "hkey_local_machine\\sam", "hkey_local_machine\\security", "hkey_local_machine\\system"
+ )
 ```
 
 
@@ -4303,7 +5010,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0306
+Index: geneve-ut-0372
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4315,7 +5022,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0307
+Index: geneve-ut-0373
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4327,7 +5034,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0308
+Index: geneve-ut-0374
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4339,7 +5046,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0309
+Index: geneve-ut-0375
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4351,7 +5058,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0310
+Index: geneve-ut-0376
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -4396,7 +5103,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0312
+Index: geneve-ut-0378
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4416,7 +5123,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0313
+Index: geneve-ut-0379
 
 ```python
 sequence with maxspan=10s
@@ -4436,7 +5143,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0314
+Index: geneve-ut-0380
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4463,7 +5170,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0315
+Index: geneve-ut-0381
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4477,7 +5184,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0317
+Index: geneve-ut-0384
 
 ```python
 process where event.type == "start" and
@@ -4502,7 +5209,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0320
+Index: geneve-ut-0387
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4546,7 +5253,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0321
+Index: geneve-ut-0388
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -4580,7 +5287,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0323
+Index: geneve-ut-0390
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4625,7 +5332,7 @@ process.interactive == true and container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0324
+Index: geneve-ut-0391
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -4637,11 +5344,182 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 
 
+### DNS Request for IP Lookup Service via Unsigned Binary
+
+Branch count: 86  
+Document count: 86  
+Index: geneve-ut-0392
+
+```python
+network where host.os.type == "macos" and event.action == "lookup_result" and 
+  (process.code_signature.trusted == false or process.code_signature.exists == false) and
+  dns.question.name like~ ("*ip-api.com*", "*ipwho.is*", "*checkip.dyndns.org*", "*api.ipify.org*",
+                           "*api.npoint.io*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+                           "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*",
+                           "*ipwhois.app*", "*freeipapi.com*", "*icanhazip.com*", "*curlmyip.com*",
+                           "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*",
+                           "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*", "*api.ip.sb*",
+                           "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*",
+                           "*freegeoip.net*", "*freegeoip.app*", "*myip.ipip.net*", "*geoplugin.net*",
+                           "*myip.dnsomatic.com*", "*www.geoplugin.net*", "*api64.ipify.org*",
+                           "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+                           "*geolocation-db.com*", "*inet-ip.info*", "*httpbin.org*", "*myip.opendns.com*") and
+  not process.executable like "/Users/*/Library/Developer/CoreSimulator/*"
+```
+
+
+
+### DNS Request to Suspicious Top Level Domain
+
+Branch count: 50  
+Document count: 50  
+Index: geneve-ut-0393
+
+```python
+network where host.os.type == "linux" and dns.question.name != null and process.name != null and
+dns.question.name like~ (
+  "*.forum", "*.pro", "*.team", "*.lol", "*.kr", "*.ke", "*.nu", "*.space", "*.capital", "*.in", "*.cfd", "*.online",
+  "*.ru", "*.info", "*.top", "*.buzz", "*.xyz", "*.rest", "*.ml", "*.cf", "*.gq", "*.ga", "*.onion", "*.network",
+  "*.monster", "*.marketing", "*.cyou", "*.quest", "*.cc", "*.bar", "*.click", "*.cam", "*.surf", "*.tk", "*.shop",
+  "*.club", "*.icu", "*.pw", "*.ws", "*.fun", "*.life", "*.boats", "*.store", "*.hair", "*.mom",
+  "*.beauty", "*.bond", "*.biz", "*.live", "*.zone"
+)
+```
+
+
+
+### DNS to Commonly Abused Web Services
+
+Branch count: 218  
+Document count: 218  
+Index: geneve-ut-0395
+
+```python
+network where host.os.type == "linux" and dns.question.name != null and process.name != null and
+dns.question.name like~ (
+  /* Google services */
+  "drive.google.com", "docs.google.com", "script.google.com", "script.googleusercontent.com",
+  "*googleapis.com", "calendar.app.google*",
+
+  /* Dropbox */
+  "api.dropboxapi.com", "content.dropboxapi.com", "*dl.dropboxusercontent.com",
+
+  /* Microsoft / OneDrive / SharePoint */
+  "api.onedrive.com", "*.onedrive.org", "onedrive.live.com", "*files.1drv.com", "graph.microsoft.com",
+  "*.sharepoint.com", "login.live.com", "g.live.com",
+
+  /* Slack */
+  "*slack.com", "slack-redir.net", "slack-files.com",
+
+  /* Discord */
+  "discord.com", "cdn.discordapp.com", "discordapp.com",
+
+  /* Telegram */
+  "api.telegram.org", "t.me",
+
+  /* Azure / Cloud storage */
+  "apis.azureedge.net", "*.blob.core.windows.net", "*.blob.storage.azure.net", "*azurewebsites.net",
+
+  /* GitHub / Dev hosting */
+  "api.github.com", "raw.githubusercontent.*", "gist.githubusercontent.com", "rawcdn.githack.*",
+  "*.notabug.org",
+
+  /* Developer tunnels / reverse proxies */
+  "*.devtunnels.ms", "*global.rel.tunnels.api.visualstudio.com", "*.ngrok.io", "*.ngrok-free.app",
+  "*.portmap.*", "serveo.net", "*localtunnel.me", "*pagekite.me", "*.trycloudflare.com",
+
+  /* AWS */
+  "*s3.amazonaws.com",
+
+  /* Paste services */
+  "pastebin.*", "paste4btc.com", "paste.ee", "ghostbin.com", "paste.nrecom.net", "zerobin.net",
+  "controlc.com", "pastecode.dev", "paste.rs", "hastebin.com", "dpaste.org", "dpaste.com", "0bin.net",
+  "paste.ofcode.org", "paste.wakas.org", "nopaste.net",
+
+  /* File sharing / exfiltration */
+  "filebin.net", "file.io", "transfer.sh", "*.gofile.io", "workupload.com", "*upload.ee", "*anonfiles.com",
+  "api.anonfile.com", "*bayfiles.com", "*bublup.com", "*dropfiles.org", "*dropmefiles.com", "*easyupload.io",
+  "*filetransfer.io", "*sendspace.com", "*share.riseup.net", "*temp.sh", "*tempsend.com", "*ufile.io",
+  "*send.now", "*send.cm", "*sendit.sh", "*pixeldrain.com", "*megaupload.com", "*mediafire.com",
+  "*bashupload.com", "*bujang.online", "mediafire.zip", "*.4shared.com", "filecloud.me", "*.pcloud.com",
+  "*catbox.moe",
+
+  /* CDN / hosting / generic file infra */
+  "*cdnmegafiles.com", "www.uplooder.net", "?.top4top.io", "top4top.io", "*.b-cdn.net", "cdn*.space",
+  "i.ibb.co", "i.imgur.com",
+
+  /* Webhooks / testing / bins */
+  "webhook.site", "run.mocky.io", "mockbin.org", "requestbin.net",
+
+  /* Public hosting / misc infra */
+  "*.publicvm.com", "*.blogspot.com", "*infinityfreeapp.com", "free.keep.sh", "*.aternos.me",
+  "*hosting-profi.de",
+
+  /* IP / network utilities */
+  "api.mylnikov.org", "ipbase.com", "*.getmyip.com", "myexternalip.com", "*.geojs.io",
+  "*api.2ip.ua", "*api.db-ip.com", "*api.ip.sb", "*api.ipify.org", "*api.myip.com",
+  "*api.npoint.io", "*api64.ipify.org", "*bot.whatismyipaddress.com", "*checkip.amazonaws.com",
+  "*checkip.dyndns.org", "*curlmyip.com", "*eth0.me", "*freegeoip.app", "*freegeoip.net",
+  "*freeipapi.com", "*geoiptool.com", "*geolocation-db.com", "*httpbin.org",
+  "*icanhazip.com", "*ident.me", "*ifcfg.me", "*ifconfig.me", "*inet-ip.info", "*ip-api.com",
+  "*ip.appspot.com", "*ip.tyk.nu", "*ip4.seeip.org", "*ipecho.net", "*ipinfo.io", "*iplogger.*",
+  "*ipof.in", "*ipwho.is", "*ipwhois.app", "*ipv4.icanhazip.com", "*ipv6.icanhazip.com",
+  "*myip.dnsomatic.com", "*myip.ipip.net", "*myip.opendns.com", "*portmap.io", "*wgetip.com",
+  "*whatismyip.akamai.com", "*wtfismyip.com",
+
+  /* Social / platforms */
+  "mbasic.facebook.com", "*.zulipchat.com", "stackoverflow.com",
+
+  /* Package hosting */
+  "files.pythonhosted.org",
+
+  /* Databases / backend platforms */
+  "*.supabase.co", "*.elastic-cloud.com", "*.cloud.es.io",
+
+  /* Misc / suspicious */
+  "*up.freeo*.space", "*icp0.io", "updates.peer2profit.com", "meacz.gq", "rwrd.org", "lobfile.com",
+  "ftpupload.net", "the.earth.li",
+
+  /* URL shorteners */
+  "*shorturl.at", "*tinyurl.com", "*bit.ly", "*cutt.ly", "*is.gd", "*rebrand.ly", "*rebrandly.com",
+  "*adf.ly", "*rb.gy", "tiny.one", "t.ly", "urlz.fr", "rentry.co",
+
+  /* Crypto mining pools */
+  "*.nicehash.com", "stratum*.nicehash.com",
+  "*.2miners.com", "*.moneroocean.stream", "*.supportxmr.com",
+  "*.nanopool.org", "*.f2pool.com", "*.poolbinance.com",
+  "*.antpool.com", "*.viabtc.com", "*.braiins.com", "*.slushpool.com",
+
+  /* Decentralized */
+  "ipfs.io", "*.ipfs.io", "dweb.link", "*.dweb.link",
+  "*.ipfs.dweb.link", "*.ipns.dweb.link",
+  "gateway.pinata.cloud", "*.mypinata.cloud",
+  "web3.storage", "*.web3.storage",
+  "nftstorage.link", "*.nftstorage.link",
+  "arweave.net", "*.arweave.net",
+  "ar.io", "*.ar.io",
+  "ic0.app", "*.ic0.app",
+  "icp0.io", "*.icp0.io",
+  "*.storjshare.io"
+) and
+not process.executable like (
+  "/opt/google-cloud-ops-agent/subagents/fluent-bit/bin/fluent-bit", "/usr/lib/systemd/systemd-resolved",
+  "/opt/Elastic/Agent/data/elastic-agent-*/components/elastic-otel-collector", "/usr/bin/dockerd",
+  "/usr/bin/google_osconfig_agent", "/snap/firefox/*/usr/lib/firefox/firefox", "/usr/bin/warp-svc",
+  "/var/lib/docker/overlay2/*/merged/usr/local/bin/node", "/snap/chromium/*/usr/lib/chromium-browser/chrome",
+  "/opt/google-cloud-ops-agent/subagents/opentelemetry-collector/otelopscol", "/usr/local/bin/rclone",
+  "/var/lib/elastic-agent/data/elastic-agent-*/components/elastic-otel-collector", "/opt/google/chrome/chrome",
+  "/usr/bin/pihole-FTL"
+)
+```
+
+
+
 ### DNS-over-HTTPS Enabled via Registry
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0327
+Index: geneve-ut-0396
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4659,7 +5537,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0329
+Index: geneve-ut-0398
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -4672,7 +5550,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0330
+Index: geneve-ut-0399
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4702,7 +5580,7 @@ container.security_context.privileged == true and process.interactive == true an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0336
+Index: geneve-ut-0405
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4716,7 +5594,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0348
+Index: geneve-ut-0417
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4733,23 +5611,11 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
-### Deprecated - EggShell Backdoor Execution
-
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0354
-
-```python
-event.category:process and event.type:(process_started or start) and process.name:espl and process.args:eyJkZWJ1ZyI6*
-```
-
-
-
 ### Deprecated - Encoded Executable Stored in the Registry
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0355
+Index: geneve-ut-0424
 
 ```python
 registry where host.os.type == "windows" and
@@ -4763,7 +5629,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0365
+Index: geneve-ut-0436
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -4787,7 +5653,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0398
+Index: geneve-ut-0473
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4841,7 +5707,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0401
+Index: geneve-ut-0476
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4857,7 +5723,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0402
+Index: geneve-ut-0477
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4885,7 +5751,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0403
+Index: geneve-ut-0478
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4902,7 +5768,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0404
+Index: geneve-ut-0479
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4919,7 +5785,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0405
+Index: geneve-ut-0480
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4940,7 +5806,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0407
+Index: geneve-ut-0482
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4960,7 +5826,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0408
+Index: geneve-ut-0483
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -4975,7 +5841,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0410
+Index: geneve-ut-0485
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -4988,7 +5854,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0411
+Index: geneve-ut-0486
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5008,7 +5874,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0414
+Index: geneve-ut-0489
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -5021,7 +5887,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0415
+Index: geneve-ut-0490
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5057,13 +5923,20 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 ### Dumping Account Hashes via Built-In Commands
 
-Branch count: 8  
-Document count: 8  
-Index: geneve-ut-0416
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0491
 
 ```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and
- process.name in ("defaults", "mkpassdb") and process.args like~ ("ShadowHashData", "-dump")
+process where host.os.type == "macos" and event.type in ("start","process_started") and (
+  (process.name == "defaults" and process.args like~ "ShadowHashData") or
+  (process.name == "mkpassdb" and process.args == "-dump") or
+  (process.name == "dscl" and process.args like~ "ShadowHashData") or
+  (
+    process.name in ("plutil","cat","strings","xxd","head") and
+    process.args like "/var/db/dslocal/nodes/Default/users/*.plist"
+  )
+)
 ```
 
 
@@ -5072,7 +5945,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0417
+Index: geneve-ut-0492
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5085,7 +5958,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0418
+Index: geneve-ut-0493
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5108,7 +5981,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0420
+Index: geneve-ut-0495
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5139,7 +6012,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0421
+Index: geneve-ut-0496
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -5158,7 +6031,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0422
+Index: geneve-ut-0497
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -5201,7 +6074,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0423
+Index: geneve-ut-0498
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -5215,7 +6088,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0424
+Index: geneve-ut-0500
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5230,7 +6103,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0425
+Index: geneve-ut-0501
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5246,7 +6119,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0426
+Index: geneve-ut-0502
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5260,7 +6133,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0427
+Index: geneve-ut-0503
 
 ```python
 sequence by host.id with maxspan=3s
@@ -5286,7 +6159,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0428
+Index: geneve-ut-0504
 
 ```python
 process where event.type == "start" and
@@ -5324,7 +6197,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0435
+Index: geneve-ut-0511
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -5337,7 +6210,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0436
+Index: geneve-ut-0512
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5351,7 +6224,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0437
+Index: geneve-ut-0513
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -5373,7 +6246,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0438
+Index: geneve-ut-0514
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5408,7 +6281,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0439
+Index: geneve-ut-0515
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -5420,7 +6293,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0471
+Index: geneve-ut-0558
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -5432,7 +6305,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0493
+Index: geneve-ut-0582
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5446,7 +6319,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0496
+Index: geneve-ut-0585
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5473,7 +6346,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0499
+Index: geneve-ut-0588
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5494,7 +6367,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0500
+Index: geneve-ut-0589
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5524,7 +6397,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0503
+Index: geneve-ut-0592
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -5557,7 +6430,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0505
+Index: geneve-ut-0594
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -5574,7 +6447,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0506
+Index: geneve-ut-0595
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -5602,7 +6475,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0507
+Index: geneve-ut-0596
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -5615,7 +6488,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0509
+Index: geneve-ut-0598
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -5635,7 +6508,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0510
+Index: geneve-ut-0599
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5661,19 +6534,15 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0511
+Index: geneve-ut-0600
 
 ```python
 sequence with maxspan=2h
   [file where host.os.type == "windows" and event.type != "deletion" and file.extension : "exe" and
-     (process.name : "WINWORD.EXE" or
-      process.name : "EXCEL.EXE" or
-      process.name : "OUTLOOK.EXE" or
-      process.name : "POWERPNT.EXE" or
-      process.name : "eqnedt32.exe" or
-      process.name : "fltldr.exe" or
-      process.name : "MSPUB.EXE" or
-      process.name : "MSACCESS.EXE")
+    process.name : (
+      "WINWORD.EXE", "EXCEL.EXE", "OUTLOOK.EXE", "POWERPNT.EXE",
+      "eqnedt32.exe", "fltldr.exe", "MSPUB.EXE", "MSACCESS.EXE"
+    )
   ] by host.id, file.path
   [process where host.os.type == "windows" and event.type == "start" and 
    not (process.name : "NewOutlookInstaller.exe" and process.code_signature.subject_name : "Microsoft Corporation" and process.code_signature.trusted == true) and 
@@ -5687,7 +6556,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0512
+Index: geneve-ut-0601
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -5716,7 +6585,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0515
+Index: geneve-ut-0604
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5729,7 +6598,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0519
+Index: geneve-ut-0608
 
 ```python
 sequence by user.id with maxspan=5s
@@ -5744,7 +6613,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0520
+Index: geneve-ut-0609
 
 ```python
 process where event.type == "start" and
@@ -5766,7 +6635,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0522
+Index: geneve-ut-0611
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -5778,7 +6647,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0523
+Index: geneve-ut-0612
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5800,7 +6669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0525
+Index: geneve-ut-0614
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -5817,7 +6686,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0526
+Index: geneve-ut-0615
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5831,7 +6700,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0527
+Index: geneve-ut-0616
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -5844,7 +6713,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0528
+Index: geneve-ut-0617
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5856,7 +6725,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0529
+Index: geneve-ut-0618
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5868,7 +6737,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0530
+Index: geneve-ut-0619
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5882,7 +6751,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0531
+Index: geneve-ut-0620
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -5894,7 +6763,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 304  
 Document count: 304  
-Index: geneve-ut-0532
+Index: geneve-ut-0621
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -5916,7 +6785,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0536
+Index: geneve-ut-0625
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -5965,7 +6834,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0537
+Index: geneve-ut-0626
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -5982,7 +6851,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0538
+Index: geneve-ut-0627
 
 ```python
 sequence by host.id with maxspan=10s
@@ -5998,11 +6867,33 @@ sequence by host.id with maxspan=10s
 
 
 
+### File Download Detected via Defend for Containers
+
+Branch count: 40  
+Document count: 40  
+Index: geneve-ut-0632
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+  (
+    (process.name == "curl" or process.args in ("curl", "/bin/curl", "/usr/bin/curl", "/usr/local/bin/curl")) and
+    process.args in ("-o", "-O", "--output", "--remote-name", "--remote-name-all", "--output-dir")
+  ) or
+  (
+    (process.name == "wget" or process.args in ("wget", "/bin/wget", "/usr/bin/wget", "/usr/local/bin/wget")) and
+    process.args like ("-*O*", "--output-document=*", "--output-file=*")
+  )
+) 
+and container.id like "?*"
+```
+
+
+
 ### File Staged in Root Folder of Recycle Bin
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0546
+Index: geneve-ut-0635
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -6017,7 +6908,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0547
+Index: geneve-ut-0636
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6031,7 +6922,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0549
+Index: geneve-ut-0638
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6053,7 +6944,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0551
+Index: geneve-ut-0640
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -6074,7 +6965,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0552
+Index: geneve-ut-0641
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6100,7 +6991,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0553
+Index: geneve-ut-0642
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -6124,11 +7015,25 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Finder Sync Plugin Registered and Enabled
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0645
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
+  process.args == "-e" and process.args like~ "use" and process.args == "-i" and
+  (process.parent.name like~ ("python*", "node", "osascript", "bash", "sh", "zsh") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
 ### Full Disk Access Permission Check
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0591
+Index: geneve-ut-0680
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -6145,7 +7050,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0592
+Index: geneve-ut-0681
 
 ```python
 registry where host.os.type == "windows" and
@@ -6163,7 +7068,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0617
+Index: geneve-ut-0719
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -6202,7 +7107,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0618
+Index: geneve-ut-0720
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6229,7 +7134,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0619
+Index: geneve-ut-0721
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -6240,11 +7145,98 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 
 
+### GenAI CLI Started with Unsafe Permission Bypass
+
+Branch count: 267  
+Document count: 267  
+Index: geneve-ut-0722
+
+```python
+process where event.type == "start" and event.action in ("exec", "start") and
+(
+  (
+    process.args in (
+      "--dangerously-skip-permissions",
+      "--allow-dangerously-skip-permissions",
+      "--permission-mode=bypassPermissions"
+    ) or
+    (process.args == "--permission-mode" and process.args == "bypassPermissions")
+  ) and
+  (
+    process.name in ("claude", "claude.exe") or
+    process.executable : (
+      "*/.local/share/claude/versions/*",
+      "*/.claude/downloads/*",
+      "*Caskroom/claude-code/*",
+      "*\\Claude\\versions\\*"
+    ) or
+    (process.name in ("node", "node.exe") and process.args : "*@anthropic-ai/claude-code*")
+  )
+) or
+(
+  (
+    process.args in ("--dangerously-bypass-approvals-and-sandbox", "--full-auto", "--yolo") or
+    process.command_line : (
+      "* -s danger-full-access*",
+      "*--sandbox danger-full-access*",
+      "*--sandbox=danger-full-access*",
+      "*--ask-for-approval never*",
+      "*--ask-for-approval=never*"
+    )
+  ) and
+  (
+    process.name in (
+      "codex", "codex.exe", "codex-exec",
+      "codex-aarch64-apple-darwin", "codex-x86_64-apple-darwin",
+      "codex-linux-arm64", "codex-linux-x64"
+    ) or
+    (process.name in ("node", "node.exe") and process.args : ("*@openai/codex*", "*/codex", "*\\codex*"))
+  )
+) or
+(
+  (
+    process.args in ("--yolo", "-y") or
+    (process.args == "--approval-mode" and process.args == "yolo") or
+    process.args == "--approval-mode=yolo"
+  ) and
+  (
+    process.name in ("gemini", "gemini-cli", "gemini.exe", "gemini-cli.exe") or
+    (process.name in ("node", "node.exe") and process.args : ("*@google/gemini-cli*", "*/gemini", "*\\gemini*"))
+  )
+) or
+(
+  (
+    process.args in (
+      "--yolo",
+      "--autopilot",
+      "--allow-all",
+      "--allow-all-tools",
+      "--allow-all-paths",
+      "--allow-all-urls"
+    )
+  ) and
+  (
+    process.name in ("copilot", "copilot.exe") or
+    (process.name in ("node", "node.exe") and process.args : ("*@github/copilot*", "*/copilot", "*\\copilot*"))
+  )
+) or
+(
+  process.args == "--dangerously-skip-permissions" and
+  (
+    process.name in ("opencode", "opencode.exe", ".opencode") or
+    process.executable : ("*opencode-ai*", "*\\.opencode*") or
+    (process.name in ("node", "node.exe") and process.args : ("*opencode-ai*", "*/opencode", "*\\opencode*"))
+  )
+)
+```
+
+
+
 ### Git Hook Command Execution
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0627
+Index: geneve-ut-0730
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6262,7 +7254,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0628
+Index: geneve-ut-0731
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -6293,7 +7285,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0629
+Index: geneve-ut-0732
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6320,7 +7312,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0630
+Index: geneve-ut-0733
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -6340,7 +7332,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0634
+Index: geneve-ut-0737
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -6353,7 +7345,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0637
+Index: geneve-ut-0740
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -6365,7 +7357,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0640
+Index: geneve-ut-0743
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -6377,7 +7369,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0644
+Index: geneve-ut-0747
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -6389,7 +7381,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0646
+Index: geneve-ut-0749
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -6406,7 +7398,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0666
+Index: geneve-ut-0775
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6419,7 +7411,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0669
+Index: geneve-ut-0778
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -6443,7 +7435,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0670
+Index: geneve-ut-0779
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -6455,7 +7447,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0683
+Index: geneve-ut-0792
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6464,9 +7456,7 @@ sequence by process.entity_id with maxspan=5m
   /* Plan9FileSystem CLSID - WSL Host File System Worker */
  process.command_line : "*{DFB65C4C-B34F-435D-AFE9-A86218684AA8}*"]
 [file where host.os.type == "windows" and process.name : "dllhost.exe" and
-  not file.path : (
-        "?:\\Users\\*\\Downloads\\*",
-        "?:\\Windows\\Prefetch\\DLLHOST.exe-????????.pf")]
+  not file.path : "?:\\Windows\\Prefetch\\DLLHOST.exe-????????.pf"]
 ```
 
 
@@ -6475,7 +7465,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0684
+Index: geneve-ut-0793
 
 ```python
 any where process.executable != null and
@@ -6524,7 +7514,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0685
+Index: geneve-ut-0794
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6538,7 +7528,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0687
+Index: geneve-ut-0798
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6553,7 +7543,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0693
+Index: geneve-ut-0804
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6570,7 +7560,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0695
+Index: geneve-ut-0806
 
 ```python
 sequence with maxspan=1m
@@ -6589,12 +7579,12 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0696
+Index: geneve-ut-0807
 
 ```python
 sequence by host.id with maxspan=1m
  [network where host.os.type == "windows" and event.type == "start" and process.name : "mmc.exe" and source.port >= 49152 and
- destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
+  destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
   network.direction : ("incoming", "ingress") and network.transport == "tcp"
  ] by process.entity_id
  [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "mmc.exe"
@@ -6607,7 +7597,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0697
+Index: geneve-ut-0808
 
 ```python
 sequence by host.id with maxspan=5s
@@ -6626,7 +7616,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0698
+Index: geneve-ut-0809
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -6642,7 +7632,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0699
+Index: geneve-ut-0810
 
 ```python
 sequence by host.id with maxspan=30s
@@ -6658,7 +7648,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0700
+Index: geneve-ut-0811
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6671,7 +7661,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0705
+Index: geneve-ut-0816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6688,7 +7678,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0707
+Index: geneve-ut-0818
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6701,7 +7691,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0708
+Index: geneve-ut-0819
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -6717,7 +7707,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0709
+Index: geneve-ut-0820
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6744,7 +7734,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0710
+Index: geneve-ut-0821
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6768,7 +7758,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0711
+Index: geneve-ut-0822
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6788,7 +7778,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-0713
+Index: geneve-ut-0824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -6816,7 +7806,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0717
+Index: geneve-ut-0828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6840,7 +7830,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0718
+Index: geneve-ut-0830
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6876,7 +7866,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0719
+Index: geneve-ut-0831
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -6888,7 +7878,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0720
+Index: geneve-ut-0832
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6902,7 +7892,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0721
+Index: geneve-ut-0833
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -6915,7 +7905,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0722
+Index: geneve-ut-0834
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -6974,7 +7964,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0723
+Index: geneve-ut-0835
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6987,7 +7977,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0724
+Index: geneve-ut-0836
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -7000,7 +7990,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0725
+Index: geneve-ut-0837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7021,7 +8011,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0726
+Index: geneve-ut-0838
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7039,7 +8029,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0727
+Index: geneve-ut-0839
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7071,27 +8061,35 @@ not (
 
 ### Kernel Module Load via Built-in Utility
 
-Branch count: 48  
-Document count: 48  
-Index: geneve-ut-0728
+Branch count: 8  
+Document count: 8  
+Index: geneve-ut-0840
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and
-event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "load_module" and
+(
   (process.name == "kmod" and process.args == "insmod" and process.args like~ "*.ko*") or
   (process.name == "kmod" and process.args == "modprobe" and not process.args in ("-r", "--remove")) or
   (process.name == "insmod" and process.args like~ "*.ko*") or
   (process.name == "modprobe" and not process.args in ("-r", "--remove"))
 ) and
 not (
-  ?process.parent.executable like ("/opt/ds_agent/*", "/opt/TrendMicro/vls_agent/*", "/opt/intel/oneapi/*") or
-  ?process.working_directory in ("/opt/vinchin/agent", "/var/opt/ds_agent/am", "/opt/ds_agent", "/var/opt/TrendMicro/vls_agent/am") or
-  ?process.parent.executable in (
+  process.parent.executable like ("/opt/ds_agent/*", "/opt/TrendMicro/vls_agent/*", "/opt/intel/oneapi/*") or
+  process.working_directory in ("/opt/vinchin/agent", "/var/opt/ds_agent/am", "/opt/ds_agent", "/var/opt/TrendMicro/vls_agent/am") or
+  process.parent.executable in (
     "/usr/lib/uptrack/ksplice-apply", "/opt/commvault/commvault/Base/linux_drv", "/opt/cisco/amp/bin/cisco-amp-helper",
     "/usr/bin/kcarectl", "/usr/share/ksplice/ksplice-apply", "/opt/commvault/Base/linux_drv", "/usr/sbin/veeamsnap-loader",
     "/bin/falcoctl"
   ) or
-  (?process.parent.name like ("python*", "platform-python*") and ?process.parent.args in ("--smart-update", "--auto-update"))
+  (process.parent.name like ("python*", "platform-python*") and process.parent.args in ("--smart-update", "--auto-update")) or
+  (
+    process.name == "modprobe" and process.args == "-q" and process.args == "--" and process.args in ("net-pf-10", "netdev-", "binfmt-464c")
+  ) or
+  (
+    process.name == "modprobe" and process.args == "-n" and process.args == "-v" and process.args in ("usb-storage", "dccp", "squashfs", "udf", "sctp", "cramfs", "hfsplus")
+  ) or
+  process.parent.executable like ("/sbin/iptables-multi*", "/var/ossec/bin/wazuh-modulesd", "/usr/sbin/mkinitramfs", "/usr/share/initramfs-tools/hooks/lvm2") or
+  process.parent.args like "/usr/share/initramfs-tools/hooks/*"
 )
 ```
 
@@ -7101,7 +8099,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0729
+Index: geneve-ut-0841
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7123,7 +8121,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0731
+Index: geneve-ut-0843
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7150,7 +8148,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0732
+Index: geneve-ut-0844
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7176,7 +8174,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0733
+Index: geneve-ut-0845
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -7192,7 +8190,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0734
+Index: geneve-ut-0846
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -7208,7 +8206,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0736
+Index: geneve-ut-0848
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -7220,7 +8218,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0737
+Index: geneve-ut-0849
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7248,7 +8246,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0739
+Index: geneve-ut-0851
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7264,7 +8262,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0741
+Index: geneve-ut-0853
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -7289,7 +8287,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0742
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -7303,7 +8301,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0744
+Index: geneve-ut-0856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7322,11 +8320,44 @@ process.name == "kubectl" and (
 
 
 
+### Kubelet API Connection Attempt to Internal IP
+
+Branch count: 204  
+Document count: 204  
+Index: geneve-ut-0857
+
+```python
+network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
+  event.action in ("connected-to", "connection_attempted") and (destination.port == 10250 or destination.port == 10255) and
+  cidrmatch(
+    destination.ip,
+    "127.0.0.0/8",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "169.254.0.0/16",
+    "100.64.0.0/10",
+    "::1/128",
+    "fc00::/7",
+    "fe80::/10"
+  ) and
+  (
+    process.name in ("curl", "wget", "nc", "ncat", "netcat", "socat", "openssl", "perl", "busybox") or 
+    process.name like ".*" or process.executable like "/*/.*" or 
+    process.name like ("python*", "ruby*", "node*", "java*", "lua*", "apache*", "php*", "nginx", "httpd*", "lighttpd", "caddy", "mongrel_rails", "gunicorn", 
+                       "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn", 
+                       "daphne", "twistd", "yaws", "webfsd", "flask", "rails", "mongrel", "catalina.sh", "hiawatha", "lswsctrl") or
+    process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/var/run/*", "/home/*", "/run/user/*", "/busybox/*")
+  )
+```
+
+
+
 ### Kubelet Certificate File Access Detected via Defend for Containers
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0745
+Index: geneve-ut-0858
 
 ```python
 any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
@@ -7349,11 +8380,59 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 
 
+### Kubernetes API Server Proxying Request to Kubelet
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0861
+
+```python
+kubernetes.audit.objectRef.subresource:"proxy" and
+kubernetes.audit.objectRef.resource:"nodes" and
+not kubernetes.audit.requestURI:(*metrics* or *healthz* or *stats/summary* or *elastic-agent* or *configz*) and
+not user.name:(
+  system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:serviceaccount\:kube-system\:* or
+  system\:node\:* or
+  eks\:* or aksService
+)
+```
+
+
+
+### Kubernetes Admission Webhook Created or Modified
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0862
+
+```python
+kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
+kubernetes.audit.verb:("create" or "update" or "patch" or "delete") and
+kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" and 
+user.name:(* and not 
+  (system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:serviceaccount\:kube-system\:* or
+  eks\:* or aksService or masterclient or nodeclient or
+  system\:serviceaccount\:gke-managed-system\:* or
+  system\:serviceaccount\:cert-manager\:* or
+  system\:serviceaccount\:gatekeeper-system\:* or
+  system\:serviceaccount\:kyverno\:* or
+  system\:serviceaccount\:*\:*-operator)
+) and
+kubernetes.audit.objectRef.name:(* and not (pod-identity-webhook or vpc-resource-mutating-webhook or eks-* or gke-*)) and 
+not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kubernetes.audit.objectRef.name:"k8tz")
+```
+
+
+
 ### Kubernetes Direct API Request via Curl or Wget
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0754
+Index: geneve-ut-0872
 
 ```python
 process where event.type == "start" and
@@ -7375,7 +8454,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0768
+Index: geneve-ut-0898
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7394,7 +8473,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0771
+Index: geneve-ut-0901
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7434,11 +8513,36 @@ not (
 
 
 
+### Kubernetes Static Pod Manifest File Access
+
+Branch count: 116  
+Document count: 116  
+Index: geneve-ut-0903
+
+```python
+host.os.type:linux and event.category:process and event.action:(exec or executed) and 
+process.name:(
+  bash or sh or dash or zsh or 
+  cat or cp or mv or touch or tee or dd or
+  sed or awk or 
+  curl or wget or scp or
+  vi or vim or nano or echo or
+  busybox or
+  python* or perl* or ruby* or node or lua* or
+  openssl or base64 or xxd or
+  .*) and 
+  process.args:(*/etc/kubernetes/manifests/* and not (/etc/kubernetes/manifests/etcd* or /etc/kubernetes/manifests/kube-apiserver* or /etc/kubernetes/manifests/kube-scheduler* or /etc/kubernetes/manifests/kube-controller-manager*)) and 
+  not (process.args :printf* and process.working_directory :/home/*-svc-nessus) and 
+  not process.parent.executable :("/opt/nessus/sbin/nessusd" or "/opt/nessus_agent/sbin/nessus-agent-module")
+```
+
+
+
 ### LSASS Memory Dump Creation
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0778
+Index: geneve-ut-0911
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -7476,7 +8580,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0783
+Index: geneve-ut-0916
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -7494,7 +8598,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0784
+Index: geneve-ut-0917
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7508,7 +8612,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0788
+Index: geneve-ut-0922
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -7519,72 +8623,11 @@ process.args != "1"
 
 
 
-### Linux Restricted Shell Breakout via Linux Binary(s)
-
-Branch count: 303  
-Document count: 303  
-Index: geneve-ut-0790
-
-```python
-process where host.os.type == "linux" and event.type == "start" and process.executable != null and
-(
-  /* launching shell from capsh */
-  (process.name == "capsh" and process.args == "--" and not process.parent.executable == "/usr/bin/log4j-cve-2021-44228-hotpatch") or
-
-  /* launching shells from unusual parents or parent+arg combos */
-  (process.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
-    (process.parent.name : "*awk" and process.parent.args : "BEGIN {system(*)}") or
-    (process.parent.name == "git" and process.parent.args : ("!*sh", "exec *sh") and not process.name == "ssh" ) or
-    (process.parent.name : ("byebug", "ftp", "strace", "zip", "tar") and
-    (
-      process.parent.args : "BEGIN {system(*)}" or
-      (
-        (process.parent.args : "exec=*sh" or (process.parent.args : "-I" and process.parent.args : "*sh")) or
-        (process.args : "exec=*sh" or (process.args : "-I" and process.args : "*sh"))
-        )
-      )
-    ) or
-
-    /* shells specified in parent args */
-    /* nice rule is broken in 8.2 */
-    (process.parent.args : "*sh" and
-      (
-        (process.parent.name == "nice") or
-        (process.parent.name == "cpulimit" and process.parent.args == "-f") or
-        (process.parent.name == "find" and process.parent.args == "." and process.parent.args == "-exec" and
-         process.parent.args == ";" and process.parent.args : "/bin/*sh") or
-        (process.parent.name == "flock" and process.parent.args == "-u" and process.parent.args == "/")
-      )
-    )
-  )) or
-
-  /* shells specified in args */
-  (process.args : "*sh" and (
-    (process.parent.name == "crash" and process.parent.args == "-h") or
-    (process.name == "sensible-pager" and process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog")
-    /* scope to include more sensible-pager invoked shells with different parent process to reduce noise and remove false positives */
-
-  )) or
-  (process.name == "busybox" and event.action == "exec" and process.args_count == 2 and process.args : "*sh" and not
-   process.executable : "/var/lib/docker/overlay2/*/merged/bin/busybox" and not (process.parent.args == "init" and
-   process.parent.args == "runc") and not process.parent.args in ("ls-remote", "push", "fetch") and not process.parent.name == "mkinitramfs" and
-   not process.parent.executable == "/bin/busybox") or
-  (process.name == "env" and process.args_count == 2 and process.args : "*sh") or
-  (process.parent.name in ("vi", "vim") and process.parent.args == "-c" and process.parent.args : ":!*sh") or
-  (process.parent.name in ("c89", "c99", "gcc") and process.parent.args : "*sh,-s" and process.parent.args == "-wrapper") or
-  (process.parent.name == "expect" and process.parent.args == "-c" and process.parent.args : "spawn *sh;interact") or
-  (process.parent.name == "mysql" and process.parent.args == "-e" and process.parent.args : "\\!*sh") or
-  (process.parent.name == "ssh" and process.parent.args == "-o" and process.parent.args : "ProxyCommand=;*sh 0<&2 1>&2")
-)
-```
-
-
-
 ### Linux SSH X11 Forwarding
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0804
+Index: geneve-ut-0937
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -7598,7 +8641,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0807
+Index: geneve-ut-0940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7612,7 +8655,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0809
+Index: geneve-ut-0942
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7631,9 +8674,9 @@ not (
 
 ### Linux User Added to Privileged Group
 
-Branch count: 360  
-Document count: 360  
-Index: geneve-ut-0810
+Branch count: 720  
+Document count: 720  
+Index: geneve-ut-0943
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7644,6 +8687,16 @@ process.executable != null and process.args in (
 (
   process.name in ("usermod", "adduser") or
   (process.name == "gpasswd" and process.args in ("-a", "--add", "-M", "--members"))
+) and
+not (
+  ?process.parent.executable like (
+    "/usr/lib/google/guest_agent/core_plugin", "/usr/libexec/platform-python*", "/usr/lib/google/guest_agent/GuestAgentCorePlugin/core_plugin",
+    "/usr/bin/google_guest_agent"
+  ) or
+  (
+    ?process.entry_leader.executable == "/usr/lib/venv-salt-minion/bin/python.original" and
+    ?process.entry_leader.args == "/usr/lib/venv-salt-minion/bin/salt-minion"
+  )
 )
 ```
 
@@ -7653,7 +8706,7 @@ process.executable != null and process.args in (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0814
+Index: geneve-ut-0947
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -7700,7 +8753,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0815
+Index: geneve-ut-0948
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7731,7 +8784,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 600  
 Document count: 1200  
-Index: geneve-ut-0816
+Index: geneve-ut-0949
 
 ```python
 sequence with maxspan=1m
@@ -7756,7 +8809,7 @@ sequence with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0818
+Index: geneve-ut-0951
 
 ```python
 event.dataset:o365.audit and
@@ -7769,7 +8822,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0820
+Index: geneve-ut-0953
 
 ```python
 event.dataset:o365.audit and
@@ -7782,7 +8835,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0821
+Index: geneve-ut-0954
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -7794,7 +8847,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0852
+Index: geneve-ut-0989
 
 ```python
 event.dataset:o365.audit and
@@ -7807,7 +8860,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0853
+Index: geneve-ut-0990
 
 ```python
 event.dataset:o365.audit and
@@ -7820,7 +8873,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0854
+Index: geneve-ut-0991
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -7832,7 +8885,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0855
+Index: geneve-ut-0992
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -7844,7 +8897,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0856
+Index: geneve-ut-0993
 
 ```python
 event.dataset:o365.audit and
@@ -7857,7 +8910,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0863
+Index: geneve-ut-1001
 
 ```python
 event.dataset: "o365.audit" and
@@ -7870,7 +8923,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0867
+Index: geneve-ut-1004
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7890,7 +8943,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0868
+Index: geneve-ut-1005
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -7902,7 +8955,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0869
+Index: geneve-ut-1006
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -7914,7 +8967,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0873
+Index: geneve-ut-1010
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7926,7 +8979,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0874
+Index: geneve-ut-1011
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -7938,7 +8991,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0876
+Index: geneve-ut-1013
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7950,7 +9003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0877
+Index: geneve-ut-1014
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7962,7 +9015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0878
+Index: geneve-ut-1015
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7987,7 +9040,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0879
+Index: geneve-ut-1016
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8007,7 +9060,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0880
+Index: geneve-ut-1017
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -8020,7 +9073,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-0881
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8035,7 +9088,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0883
+Index: geneve-ut-1020
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -8047,7 +9100,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0886
+Index: geneve-ut-1023
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -8059,7 +9112,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0887
+Index: geneve-ut-1024
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -8071,7 +9124,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0888
+Index: geneve-ut-1025
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -8105,7 +9158,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0891
+Index: geneve-ut-1028
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8119,7 +9172,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0892
+Index: geneve-ut-1029
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8140,7 +9193,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0893
+Index: geneve-ut-1030
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8154,7 +9207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0894
+Index: geneve-ut-1031
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8189,7 +9242,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0895
+Index: geneve-ut-1032
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -8214,7 +9267,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0896
+Index: geneve-ut-1033
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8229,14 +9282,14 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### Microsoft IIS Connection Strings Decryption
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0899
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1037
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   (process.name : "aspnet_regiis.exe" or ?process.pe.original_file_name == "aspnet_regiis.exe") and
-  process.args : "connectionStrings" and process.args : "-pdf"
+  process.args : "connectionStrings" and process.args : ("-pdf", "-pd")
 ```
 
 
@@ -8245,7 +9298,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0901
+Index: geneve-ut-1039
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8276,7 +9329,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0903
+Index: geneve-ut-1041
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -8330,7 +9383,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0904
+Index: geneve-ut-1042
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -8340,12 +9393,12 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 ### Modification of AmsiEnable Registry Key
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0906
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1044
 
 ```python
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type in ("creation", "change") and
   registry.value : "AmsiEnable" and registry.data.strings: ("0", "0x00000000")
 
   /*
@@ -8360,7 +9413,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0907
+Index: geneve-ut-1045
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8377,7 +9430,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0909
+Index: geneve-ut-1047
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8392,7 +9445,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0910
+Index: geneve-ut-1048
 
 ```python
 file where event.type != "deletion" and
@@ -8442,7 +9495,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0912
+Index: geneve-ut-1050
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8458,7 +9511,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0913
+Index: geneve-ut-1051
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -8472,7 +9525,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0915
+Index: geneve-ut-1053
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8495,7 +9548,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0916
+Index: geneve-ut-1054
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8523,7 +9576,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0917
+Index: geneve-ut-1055
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8545,7 +9598,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0918
+Index: geneve-ut-1056
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8562,9 +9615,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### MsBuild Making Network Connections
 
-Branch count: 8  
-Document count: 16  
-Index: geneve-ut-0919
+Branch count: 4  
+Document count: 8  
+Index: geneve-ut-1057
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -8582,10 +9635,6 @@ sequence by process.entity_id with maxspan=30s
   /* Exclude domains that are known to be benign */
   [network where host.os.type == "windows" and
     event.action: ("connection_attempted", "lookup_requested") and
-    (
-      process.pe.original_file_name: "MSBuild.exe" or
-      process.name: "MSBuild.exe"
-    ) and
     not user.id == "S-1-5-18" and
     not cidrmatch(destination.ip, "127.0.0.1", "::1") and
     not dns.question.name : (
@@ -8601,7 +9650,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0920
+Index: geneve-ut-1058
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -8619,7 +9668,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-0921
+Index: geneve-ut-1059
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8660,7 +9709,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-0932
+Index: geneve-ut-1072
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -8686,7 +9735,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0940
+Index: geneve-ut-1080
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -8710,7 +9759,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0943
+Index: geneve-ut-1083
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8722,9 +9771,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### NTDS or SAM Database File Copied
 
-Branch count: 210  
-Document count: 210  
-Index: geneve-ut-0944
+Branch count: 168  
+Document count: 168  
+Index: geneve-ut-1084
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8734,26 +9783,49 @@ process where host.os.type == "windows" and event.type == "start" and
     ) or
     ((?process.pe.original_file_name : "esentutl.exe" or process.name : "esentutl.exe") and process.args : ("*/y*", "*/vss*", "*/d*"))
   ) and
-  process.command_line : ("*\\ntds.dit*", "*\\config\\SAM*", "*\\*\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\*", "*/system32/config/SAM*", "*\\User Data\\*")
+  process.command_line : ("*\\ntds.dit*", "*\\config\\SAM*", "*\\*\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\*", "*/system32/config/SAM*")
 ```
 
 
 
 ### Namespace Manipulation Using Unshare
 
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-0945
+Branch count: 12  
+Document count: 12  
+Index: geneve-ut-1085
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action : ("exec", "exec_event", "start") and
-process.executable: "/usr/bin/unshare" and not (
-  process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
-  process.args == "/usr/bin/snap" and not process.parent.name in ("zz-proxmox-boot", "java") or
-  process.parent.args like (
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
+process.name: "unshare" and not (
+  ?process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
+  ?process.args == "/usr/bin/snap" and not ?process.parent.name in ("zz-proxmox-boot", "java") or
+  ?process.parent.args like (
     "/etc/kernel/postinst.d/zz-proxmox-boot", "/opt/openssh/sbin/sshd", "/usr/sbin/sshd",
     "/snap/*", "/home/*/.local/share/JetBrains/Toolbox/*"
   )
+)
+```
+
+
+
+### Namespace Manipulation Using Unshare in a Container
+
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-1086
+
+```python
+process where event.type == "start" and event.action == "exec" and
+process.name == "unshare" and container.id like "?*" and not (
+  process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
+  (process.args == "/usr/bin/snap" and not process.parent.name in ("zz-proxmox-boot", "java")) or
+  process.parent.args like (
+    "/etc/kernel/postinst.d/zz-proxmox-boot", "/opt/openssh/sbin/sshd", "/usr/sbin/sshd",
+    "/snap/*", "/home/*/.local/share/JetBrains/Toolbox/*"
+  ) or
+ (process.args == "--propagation" and process.args == "private" and process.args like "/etc/kernel/post*.d/zz-proxmox-boot") or 
+ (process.args == "--fork" and process.args == "--kill-child") or 
+  process.args like ("/usr/bin/os-prober", "/usr/bin/linux-boot-prober", "/opt/SIGOS/sitedata/exec/*")
 )
 ```
 
@@ -8763,7 +9835,7 @@ process.executable: "/usr/bin/unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0946
+Index: geneve-ut-1087
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8784,7 +9856,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0948
+Index: geneve-ut-1089
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8799,7 +9871,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0949
+Index: geneve-ut-1090
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8816,7 +9888,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0951
+Index: geneve-ut-1092
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -8836,11 +9908,57 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 
 
+### Network Connection Followed by File Creation
+
+Branch count: 112  
+Document count: 224  
+Index: geneve-ut-1094
+
+```python
+sequence by host.id, process.entity_id with maxspan=5s
+  [network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and
+  process.executable like (
+    "/boot/*", "/dev/shm/*", "/tmp/*", "/var/tmp/*", "/var/log/*", "/var/run/user/*", "/run/user/*"
+  ) and
+  not (
+    destination.ip == null or
+    destination.ip == "0.0.0.0" or 
+    cidrmatch(
+      destination.ip, "10.0.0.0/8", "127.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12",
+      "192.0.0.0/24", "192.0.0.0/29","192.0.0.8/32", "192.0.0.9/32", "192.0.0.10/32",
+      "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24",
+      "192.168.0.0/16", "192.88.99.0/24", "224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24",
+      "198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4", "::1", "FE80::/10",
+      "FF00::/8", "FC00::/7"
+    )
+  )]
+  [file where host.os.type == "linux" and event.type == "creation" and process.executable like (
+    "/boot/*", "/dev/shm/*", "/tmp/*", "/var/tmp/*", "/var/log/*", "/boot/*", "/var/run/user/*", "/run/user/*"
+  ) and
+  not (
+    file.name like "tmp*" or file.extension in ("sqlite-journal", "db-journal", "lockfile", "tmp") or
+    file.path like (
+      "/loki/wal/*", "/dev/shm/.org.chromium.Chromium.*", "/opt/rapid7/nexpose/*",
+      "/usr/local/ltechagent*", "/var/lib/cloudendure/agent_keystore_temp", "/var/cache/yum/*",
+      "/run/aws-node/ipam.json.tmp*", "/run/systemd/journal/streams/.*"
+    ) or
+    (process.executable == "/tmp/terraform" and file.path like "/tmp/terraform-provider*") or 
+    process.name in ("podman", "minikube", "logrotate", "java", "aws-k8s-agent", "grafana", "postman") or
+    process.executable : (
+      "/etc/cron.daily/logrotate", "/etc/update-motd.d/50-motd-news", "/etc/cron.hourly/0yum-hourly.cron",
+      "/etc/cron.hourly/BitdefenderRedline", "/tmp/token_handler", "/tmp/.sentry-cli*.exe", 
+      "/etc/cron.daily/0yum-daily.cron", "/etc/init.d/fortiedr"
+    )
+  )]
+```
+
+
+
 ### Network Connection Initiated by Suspicious SSHD Child Process
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-0953
+Index: geneve-ut-1095
 
 ```python
 sequence by host.id with maxspan=1s
@@ -8882,7 +10000,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-0954
+Index: geneve-ut-1096
 
 ```python
 sequence by host.id with maxspan=10s
@@ -8899,7 +10017,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0956
+Index: geneve-ut-1098
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8914,7 +10032,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0957
+Index: geneve-ut-1099
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -8933,7 +10051,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0958
+Index: geneve-ut-1100
 
 ```python
 sequence by process.entity_id
@@ -8953,7 +10071,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0959
+Index: geneve-ut-1101
 
 ```python
 sequence by process.entity_id
@@ -8972,7 +10090,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-0961
+Index: geneve-ut-1103
 
 ```python
 sequence by host.id with maxspan=1m
@@ -9001,7 +10119,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-0962
+Index: geneve-ut-1104
 
 ```python
 sequence by process.entity_id
@@ -9026,7 +10144,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0963
+Index: geneve-ut-1105
 
 ```python
 sequence by process.entity_id
@@ -9048,7 +10166,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0964
+Index: geneve-ut-1106
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -9081,7 +10199,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0965
+Index: geneve-ut-1107
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9111,7 +10229,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0969
+Index: geneve-ut-1111
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -9128,7 +10246,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0970
+Index: geneve-ut-1112
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -9165,7 +10283,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0971
+Index: geneve-ut-1113
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9178,7 +10296,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0976
+Index: geneve-ut-1118
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -9190,7 +10308,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0979
+Index: geneve-ut-1121
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -9202,7 +10320,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-0988
+Index: geneve-ut-1130
 
 ```python
 sequence by host.id with maxspan=10s
@@ -9216,7 +10334,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0989
+Index: geneve-ut-1131
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9226,11 +10344,40 @@ process where host.os.type == "linux" and event.type == "start" and
 
 
 
+### Nsenter Execution with Target Flag Inside Container
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1132
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  (process.name == "nsenter" or process.args == "nsenter") and
+  container.id like "?*" and process.args like ("-t", "--target*")
+```
+
+
+
+### Nsenter to PID Namespace via Auditd
+
+Branch count: 32  
+Document count: 32  
+Index: geneve-ut-1133
+
+```python
+host.os.type:linux and 
+event.category:process and event.action:(executed or exec) and 
+(process.name:nsenter or process.args:nsenter) and 
+process.args:((--target* or -t) and not --net=/run/netns/* and not (--assertion and snap) and not (is-active and snap.*))
+```
+
+
+
 ### Office Test Registry Persistence
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0991
+Index: geneve-ut-1135
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -9243,7 +10390,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0992
+Index: geneve-ut-1136
 
 ```python
 event.dataset: "okta.system"
@@ -9258,7 +10405,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0994
+Index: geneve-ut-1138
 
 ```python
 sequence by user.name with maxspan=30m
@@ -9280,7 +10427,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1003
+Index: geneve-ut-1147
 
 ```python
 network where event.action == "connection_accepted" and
@@ -9307,7 +10454,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1004
+Index: geneve-ut-1148
 
 ```python
 network where event.action == "lookup_requested" and
@@ -9327,7 +10474,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1005
+Index: geneve-ut-1149
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9342,7 +10489,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1006
+Index: geneve-ut-1150
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -9369,7 +10516,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1007
+Index: geneve-ut-1151
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -9384,7 +10531,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1008
+Index: geneve-ut-1152
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -9400,7 +10547,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1009
+Index: geneve-ut-1153
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -9414,7 +10561,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1014
+Index: geneve-ut-1160
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -9429,7 +10576,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1015
+Index: geneve-ut-1161
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9443,7 +10590,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1016
+Index: geneve-ut-1162
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9462,7 +10609,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1017
+Index: geneve-ut-1163
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9474,7 +10621,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1018
+Index: geneve-ut-1164
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9486,7 +10633,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1019
+Index: geneve-ut-1165
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9504,7 +10651,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1020
+Index: geneve-ut-1166
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9517,7 +10664,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1021
+Index: geneve-ut-1167
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9532,7 +10679,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1022
+Index: geneve-ut-1168
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -9547,7 +10694,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1025
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -9565,9 +10712,9 @@ process where host.os.type == "macos" and event.type == "start" and
 
 ### Persistence via Microsoft Office AddIns
 
-Branch count: 36  
-Document count: 36  
-Index: geneve-ut-1026
+Branch count: 108  
+Document count: 108  
+Index: geneve-ut-1172
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9581,7 +10728,8 @@ file where host.os.type == "windows" and event.type != "deletion" and
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Word\\Startup\\*",
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\AddIns\\*",
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*"
- )
+ ) and
+ not (file.name : "~$*" and process.name : "excel.exe" and ?file.size in (0, 165))
 ```
 
 
@@ -9590,7 +10738,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1027
+Index: geneve-ut-1173
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9604,7 +10752,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1028
+Index: geneve-ut-1174
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9623,7 +10771,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1029
+Index: geneve-ut-1175
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9647,9 +10795,9 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 ### Persistence via Suspicious Launch Agent or Launch Daemon
 
-Branch count: 190  
-Document count: 190  
-Index: geneve-ut-1030
+Branch count: 380  
+Document count: 380  
+Index: geneve-ut-1176
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -9664,7 +10812,12 @@ file where host.os.type == "macos" and event.type != "deletion" and
   not process.executable like ("/System/*", "/Library/PrivilegedHelperTools/*") and
   not (process.code_signature.signing_id in ("com.apple.vim", "com.apple.cat", "com.apple.cfprefsd",
                                             "com.jetbrains.toolbox", "com.apple.pico", "com.apple.shove",
-                                            "com.sublimetext.4", "com.apple.ditto") and process.code_signature.trusted == true)
+                                            "com.sublimetext.4", "com.apple.ditto") and process.code_signature.trusted == true) and
+  not (file.path like ("/Library/LaunchDaemons/com.jumpcloud.*",
+                       "/Library/LaunchAgents/com.jumpcloud.*",
+                       "/Library/LaunchDaemons/com.wazuh.*",
+                       "/Library/LaunchDaemons/com.zscaler.service.plist") and
+       process.executable == "/bin/bash")
 ```
 
 
@@ -9673,7 +10826,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1031
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9692,7 +10845,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1032
+Index: geneve-ut-1178
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9720,7 +10873,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1033
+Index: geneve-ut-1179
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9735,7 +10888,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1034
+Index: geneve-ut-1180
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9798,7 +10951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1035
+Index: geneve-ut-1181
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -9819,7 +10972,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1036
+Index: geneve-ut-1182
 
 ```python
 any where host.os.type == "windows" and
@@ -9881,7 +11034,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1038
+Index: geneve-ut-1184
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -9910,7 +11063,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1039
+Index: geneve-ut-1185
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -9922,9 +11075,9 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 ### Pluggable Authentication Module (PAM) Version Discovery
 
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-1040
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1186
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9936,10 +11089,17 @@ process where host.os.type == "linux" and event.type == "start" and
 not (
   ?process.parent.name in ("dcservice", "inspectorssmplugin") or
   ?process.working_directory in ("/var/ossec", "/opt/msp-agent") or
+  ?process.entry_leader.executable in("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/usr/sbin/ScanAssistant") or
   ?process.parent.executable in (
     "/opt/CyberCNSAgent/cybercnsagent_linux", "/usr/local/manageengine/uems_agent/bin/dcpatchscan",
     "/usr/local/manageengine/uems_agent/bin/dcconfig", "/usr/share/vicarius/topiad",
-    "/etc/rc.d/init.d/sshd-chroot"
+    "/etc/rc.d/init.d/sshd-chroot", "/var/ossec/bin/wazuh-modulesd",
+    "/usr/lib/venv-salt-minion/bin/python.original"
+  ) or
+  (
+    process.executable == "/usr/bin/rpm" and
+    ?process.parent.name == "systemd" and
+    ?process.env_vars == "LD_LIBRARY_PATH=/usr/lib/venv-salt-minion/lib"
   )
 )
 ```
@@ -9950,7 +11110,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1043
+Index: geneve-ut-1189
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -9995,9 +11155,9 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 ### Polkit Version Discovery
 
-Branch count: 24  
-Document count: 24  
-Index: geneve-ut-1044
+Branch count: 48  
+Document count: 48  
+Index: geneve-ut-1190
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10009,7 +11169,12 @@ event.action in ("exec", "exec_event", "start", "ProcessRollup2", "process_start
 ) and
 not (
   ?process.working_directory in ("/opt/msp-agent", "/opt/CyberCNSAgent") or
-  ?process.parent.executable like ("/usr/local/cpanel/3rdparty/perl/*/bin/perl", "/usr/share/vicarius/topiad")
+  ?process.parent.executable like ("/usr/local/cpanel/3rdparty/perl/*/bin/perl", "/usr/share/vicarius/topiad") or
+  ?process.entry_leader.executable in ("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/sf/edr/agent/bin/edr_monitor") or
+  (
+    ?process.parent.args == "/usr/lib/venv-salt-minion/bin/python.original" and
+    ?process.parent.args == "/usr/lib/venv-salt-minion/bin/salt-minion"
+  )
 )
 ```
 
@@ -10019,7 +11184,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1045
+Index: geneve-ut-1191
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -10032,7 +11197,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1054
+Index: geneve-ut-1201
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10049,7 +11214,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1056
+Index: geneve-ut-1203
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -10074,7 +11239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1060
+Index: geneve-ut-1207
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/*/etc/nsswitch.conf" and
@@ -10091,7 +11256,7 @@ not file.path like (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1061
+Index: geneve-ut-1208
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10107,7 +11272,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1062
+Index: geneve-ut-1209
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10128,7 +11293,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1063
+Index: geneve-ut-1210
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10169,7 +11334,7 @@ event.action in ("exec", "exec_event", "start", "executed", "process_started", "
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1064
+Index: geneve-ut-1211
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -10186,7 +11351,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1065
+Index: geneve-ut-1212
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -10199,7 +11364,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1066
+Index: geneve-ut-1213
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10223,7 +11388,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1068
+Index: geneve-ut-1215
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -10248,11 +11413,38 @@ sequence by host.id, user.name with maxspan = 5s
 
 
 
+### Potential Container Escape via Kernel core_pattern Modification
+
+Branch count: 288  
+Document count: 288  
+Index: geneve-ut-1217
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+process.args like ("*/proc/sys/kernel/core_pattern*", "*kernel.core_pattern*") and
+?process.parent.executable != null and
+(
+  process.name in ("tee", "cp", "mv", "dd") or
+  (
+    process.name == "sysctl" and
+    process.args like ("*-w*", "*core_pattern*")
+  ) or
+  (
+    process.name in ("bash", "dash", "sh", "zsh", "ksh", "fish", "ash", "mksh", "busybox") and
+    process.args == "-c" and process.args like ("*echo *", "*printf *")
+  )
+) and
+not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpctl", "/usr/sbin/abrtd", "/usr/bin/apport")
+```
+
+
+
 ### Potential Cookies Theft via Browser Debugging
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1070
+Index: geneve-ut-1218
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -10276,7 +11468,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1072
+Index: geneve-ut-1221
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -10292,18 +11484,18 @@ process where host.os.type == "windows" and event.code == "10" and
 
 ### Potential Credential Access via LSASS Memory Dump
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1073
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1222
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
   winlog.event_data.TargetImage : "?:\\WINDOWS\\system32\\lsass.exe" and
 
-   /* DLLs exporting MiniDumpWriteDump API to create an lsass mdmp*/
-  winlog.event_data.CallTrace : ("*dbghelp*", "*dbgcore*") and
+  /* dbgcore.dll hosts MiniDumpWriteDump on modern Windows; dbghelp-only traces are non-dump usage */
+  winlog.event_data.CallTrace : "*dbgcore*" and
 
-   /* case of lsass crashing */
+  /* crash handlers */
   not process.executable : (
         "?:\\Windows\\System32\\WerFault.exe",
         "?:\\Windows\\SysWOW64\\WerFault.exe",
@@ -10317,7 +11509,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1074
+Index: geneve-ut-1223
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -10370,17 +11562,33 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
+### Potential Credential Access via Renamed COM+ Services DLL
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1224
+
+```python
+sequence by process.entity_id with maxspan=1m
+ [process where host.os.type == "windows" and event.type == "start" and process.name : "rundll32.exe"]
+ [process where host.os.type == "windows" and event.code == "7" and
+   (file.pe.original_file_name : "COMSVCS.DLL" or file.pe.imphash : "EADBCCBB324829ACB5F2BBE87E5549A8") and
+   /* renamed COMSVCS */
+   not file.name : "COMSVCS.DLL"]
+```
+
+
+
 ### Potential Credential Access via Trusted Developer Utility
 
-Branch count: 16  
-Document count: 32  
-Index: geneve-ut-1076
+Branch count: 4  
+Document count: 8  
+Index: geneve-ut-1225
 
 ```python
 sequence by process.entity_id
  [process where host.os.type == "windows" and event.type == "start" and (process.name : "MSBuild.exe" or process.pe.original_file_name == "MSBuild.exe")]
- [any where host.os.type == "windows" and (event.category == "library" or (event.category == "process" and event.action : "Image loaded*")) and
-  (?dll.name : ("vaultcli.dll", "SAMLib.DLL") or file.name : ("vaultcli.dll", "SAMLib.DLL"))]
+ [library where host.os.type == "windows" and dll.name : ("vaultcli.dll", "SAMLib.DLL")]
 ```
 
 
@@ -10389,7 +11597,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1089
+Index: geneve-ut-1240
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10404,7 +11612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1090
+Index: geneve-ut-1241
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10435,7 +11643,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1091
+Index: geneve-ut-1242
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10449,7 +11657,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1092
+Index: geneve-ut-1243
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10462,7 +11670,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1093
+Index: geneve-ut-1244
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -10474,7 +11682,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1094
+Index: geneve-ut-1245
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10483,15 +11691,34 @@ process.parent.name == "proot"
 
 
 
+### Potential Direct Kubelet Access via Process Arguments
+
+Branch count: 136  
+Document count: 136  
+Index: geneve-ut-1247
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
+(
+  /* direct utility execution */
+  process.name like ("curl", "wget", "python*", "perl*", "php*", "node*", "java", "ruby*", "lua*", ".*") or
+
+  process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/var/run/*", "/home/*", "/run/user/*", "/busybox/*")
+) and
+process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:10255/*")
+```
+
+
+
 ### Potential Direct Kubelet Access via Process Arguments Detected via Defend for Containers
 
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-1096
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1248
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.args like "http*:10250*" and process.interactive == true and container.id like "?*"
+process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*") and container.id like "?*"
 ```
 
 
@@ -10500,7 +11727,7 @@ process.args like "http*:10250*" and process.interactive == true and container.i
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1097
+Index: geneve-ut-1249
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10521,7 +11748,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1098
+Index: geneve-ut-1250
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10535,7 +11762,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1101
+Index: geneve-ut-1253
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -10559,7 +11786,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1102
+Index: geneve-ut-1254
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -10575,7 +11802,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1103
+Index: geneve-ut-1255
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -10592,7 +11819,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1104
+Index: geneve-ut-1256
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10613,7 +11840,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1106
+Index: geneve-ut-1258
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -10626,7 +11853,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1108
+Index: geneve-ut-1260
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10654,7 +11881,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1111
+Index: geneve-ut-1263
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10670,7 +11897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1112
+Index: geneve-ut-1264
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10693,7 +11920,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1113
+Index: geneve-ut-1265
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10706,7 +11933,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1115
+Index: geneve-ut-1267
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10719,7 +11946,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1120
+Index: geneve-ut-1272
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10733,7 +11960,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1121
+Index: geneve-ut-1273
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10748,7 +11975,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1122
+Index: geneve-ut-1275
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -10771,7 +11998,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1125
+Index: geneve-ut-1278
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10814,7 +12041,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1126
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10832,7 +12059,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1127
+Index: geneve-ut-1280
 
 ```python
 host.os.type:"windows" and
@@ -10848,10 +12075,26 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1129
+Index: geneve-ut-1282
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
+```
+
+
+
+### Potential Kubeletctl Execution
+
+Branch count: 38  
+Document count: 38  
+Index: geneve-ut-1284
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
+(
+  process.name == "kubeletctl" or
+  (process.args in ("run", "exec", "scan", "pods", "runningpods", "attach", "portForward", "cri", "pid2pod") and process.args:("*:10250*", "*:10255*"))
+)
 ```
 
 
@@ -10860,7 +12103,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1131
+Index: geneve-ut-1285
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -10876,7 +12119,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1132
+Index: geneve-ut-1286
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10894,7 +12137,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1133
+Index: geneve-ut-1287
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -10908,7 +12151,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1135
+Index: geneve-ut-1289
 
 ```python
 sequence by host.id with maxspan=30s
@@ -10927,7 +12170,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1137
+Index: geneve-ut-1291
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -10943,7 +12186,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1138
+Index: geneve-ut-1292
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10956,7 +12199,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1139
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10986,7 +12229,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1145
+Index: geneve-ut-1299
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11009,7 +12252,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1146
+Index: geneve-ut-1300
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11028,7 +12271,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1151
+Index: geneve-ut-1305
 
 ```python
 process where host.os.type == "windows" and 
@@ -11170,7 +12413,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1152
+Index: geneve-ut-1306
 
 ```python
 process where host.os.type == "windows" and
@@ -11247,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1156
+Index: geneve-ut-1310
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -11264,7 +12507,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1157
+Index: geneve-ut-1311
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -11298,7 +12541,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1159
+Index: geneve-ut-1313
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -11310,7 +12553,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1160
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11349,7 +12592,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1162
+Index: geneve-ut-1316
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -11362,7 +12605,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1167
+Index: geneve-ut-1321
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11376,7 +12619,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1174
+Index: geneve-ut-1328
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -11404,7 +12647,8 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
       "/var/run/udev/ud.pid",
       "/var/run/udevd.pid"
     )
-  )
+  ) and
+  not file.path like ("/tmp/krb5cc*", "/tmp/ansible_*", "/storage/*", "/tmp/clearsigned.message.*", "/var/sftp/refinitiv/*", "/tmp/fileutil.message.*")
 ```
 
 
@@ -11413,7 +12657,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1175
+Index: geneve-ut-1329
 
 ```python
 network where host.os.type == "windows" and
@@ -11439,7 +12683,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1178
+Index: geneve-ut-1332
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11454,7 +12698,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1181
+Index: geneve-ut-1335
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -11468,7 +12712,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1182
+Index: geneve-ut-1336
 
 ```python
 file where host.os.type == "windows" and
@@ -11482,7 +12726,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1183
+Index: geneve-ut-1337
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11495,7 +12739,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1184
+Index: geneve-ut-1338
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11515,7 +12759,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1185
+Index: geneve-ut-1339
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11533,9 +12777,9 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 ### Potential PowerShell HackTool Script by Author
 
-Branch count: 45  
-Document count: 45  
-Index: geneve-ut-1187
+Branch count: 48  
+Document count: 48  
+Index: geneve-ut-1341
 
 ```python
 host.os.type:windows and event.category:process and
@@ -11562,7 +12806,8 @@ host.os.type:windows and event.category:process and
       "_nullbind" or "_tmenochet" or
       "jaredcatkinson" or "ChrisTruncer" or
       "monoxgas" or "TheRealWover" or
-      "splinter_code"
+      "splinter_code" or "samratashok" or
+      "leechristensen" or "nikhil_mitt"
   ) and
   not powershell.file.script_block_text : ("Get-UEFIDatabaseSigner" or "Posh-SSH")
 ```
@@ -11573,7 +12818,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1188
+Index: geneve-ut-1342
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11768,7 +13013,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1203
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11780,11 +13025,39 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 
 
+### Potential Privacy Control Bypass via TCCDB Modification
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-1358
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
+ process.args like "/*/Application Support/com.apple.TCC/TCC.db" and
+ (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
+### Potential Privilege Escalation in Container via Runc Init
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1359
+
+```python
+host.os.type:linux and event.category:process and 
+event.action:(executed or exec) and 
+process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
+```
+
+
+
 ### Potential Privilege Escalation through Writable Docker Socket
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1205
+Index: geneve-ut-1360
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -11801,7 +13074,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1206
+Index: geneve-ut-1361
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -11815,7 +13088,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1207
+Index: geneve-ut-1362
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11827,27 +13100,11 @@ process.interactive == true and process.parent.interactive == true
 
 
 
-### Potential Privilege Escalation via OverlayFS
-
-Branch count: 3  
-Document count: 6  
-Index: geneve-ut-1212
-
-```python
-sequence by process.parent.entity_id, host.id with maxspan=5s
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-    process.name == "unshare" and process.args : ("-r", "-rm", "m") and process.args : "*cap_setuid*"  and user.id != "0"]
-  [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
-    user.id == "0"]
-```
-
-
-
 ### Potential Privilege Escalation via PKEXEC
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1213
+Index: geneve-ut-1367
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -11859,7 +13116,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1214
+Index: geneve-ut-1368
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -11875,7 +13132,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1215
+Index: geneve-ut-1369
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11895,7 +13152,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1216
+Index: geneve-ut-1371
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11932,10 +13189,115 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1218
+Index: geneve-ut-1373
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
+```
+
+
+
+### Potential Privilege Escalation via a Parent Process Sequence
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1374
+
+```python
+sequence by host.id, process.parent.entity_id with maxspan=15s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )]
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")]
+```
+
+
+
+### Potential Privilege Escalation via a Parent/Child Process Sequence
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1375
+
+```python
+sequence by host.id with maxspan=15s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )] by process.entity_id
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")] by process.parent.entity_id
+```
+
+
+
+### Potential Privilege Escalation via a Suspicious UID Change
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1376
+
+```python
+sequence by host.id, process.entity_id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )]
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")]
+```
+
+
+
+### Potential Privilege Escalation via unshare Followed by Root Process
+
+Branch count: 341  
+Document count: 682  
+Index: geneve-ut-1377
+
+```python
+sequence by host.id, process.parent.pid with maxspan=30s
+ [process where host.os.type == "linux" and 
+  (
+   (auditd.data.syscall == "unshare" and auditd.data.class == "namespace" and auditd.data.a0 in ("10000000", "50000000", "70000000", "10020000", "50020000", "70020000")) or 
+
+   (process.name == "unshare" and  
+    (process.args in ("--user", "--map-root-user", "--map-current-user") or process.args like ("-*U*", "-*r*")))
+   ) and user.id != "0" and user.id != null]
+ [process where host.os.type == "linux" and 
+  user.id == "0" and user.id != null and 
+  (
+   process.name in ("su", "sudo", "pkexec", "passwd", "chsh", "newgrp", "doas", "run0", "sg", "dash", "sh", "bash", "zsh", "fish", 
+                    "ksh", "csh", "tcsh", "ash", "mksh", "busybox", "rbash", "rzsh", "rksh", "tmux", "screen", "node") or 
+   process.name like ("python*", "perl*", "ruby*", "php*", "lua*")
+  )]
+```
+
+
+
+### Potential Privilege Escalation via unshare and UID Change
+
+Branch count: 5  
+Document count: 10  
+Index: geneve-ut-1378
+
+```python
+sequence by process.parent.entity_id, host.id with maxspan=60s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+    process.name == "unshare" and process.args : ("-r", "-rm", "-m", "-U", "--user") and user.id != "0"]
+  [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
+    user.id == "0"]
 ```
 
 
@@ -11944,7 +13306,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1219
+Index: geneve-ut-1379
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -11958,7 +13320,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1221
+Index: geneve-ut-1381
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -11981,7 +13343,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1223
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -11998,7 +13360,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1224
+Index: geneve-ut-1384
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -12021,7 +13383,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1225
+Index: geneve-ut-1385
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12034,7 +13396,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1226
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +13410,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1227
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12061,11 +13423,65 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Potential Proxy Execution via Systemd-run
+
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-1388
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started", "start", "ProcessRollup2") and
+process.name == "systemd-run" and ?process.parent.executable != null and
+not (
+  ?process.parent.executable in (
+    "/usr/lib/systemd", "/lib/systemd/systemd", "/opt/saltstack/salt/run/run", "/etc/update-motd.d/70-available-updates",
+    "/tmp/newroot/usr/libexec/ptyxis-agent", "/usr/local/sbin/clamscan.sh", "/opt/sentinelone/bin/sentinelone-agent",
+    "/usr/local/bin/salt-minion", "/var/vanta/launcher", "/opt/traps/bin/pmd", "/usr/sbin/gdm", "/usr/bin/salt-minion",
+    "/opt/GC_Ext/GC/gc_linux_service", "/usr/lib/plesk-task-manager", "/opt/forticlient/epctrl", "/usr/lib/snapd/snap-exec",
+    "/usr/bin/yay", "/usr/local/bin/hexnode_agent", "/opt/halcyon/halcyonar/agent", "/usr/local/bin/qsetup", "/usr/bin/pamac",
+    "/usr/bin/elephant", "/usr/bin/Hyprland"
+  ) or
+  ?process.parent.executable like (
+    "/opt/tableau/tableau_server/packages/scripts.*/after-install", "/opt/acronis/bin/acp-update-controller", "/snap/*",
+    "/var/lib/amagent/*", "/opt/msp-agent/msp-agent-core", "/opt/beyondtrust/*", "/var/lib/rancher/k3s/*/bin/k3s"
+  ) or
+  ?process.parent.name like "platform-python*" or
+  ?process.parent.name in (
+    "udevadm", "daemon.start", "snap", "systemd", "ptyxis-agent", "run-slack", "run-firefox", "dbus.service", "k3s-server",
+    "systemd-udevd", "kubelet", "hyperkube", "kthreadd", "gnome-shell", "xdg-desktop-portal", "firefox", "picus_updater",
+    "rpm-ostree", "prompt-agent"
+  ) or
+  ?process.command_line in (
+    "/usr/bin/systemd-run /usr/bin/systemctl start man-db-cache-update", "systemd-run env",
+    "systemd-run --user dnf-automatic-notifyonly.timer", "systemd-run --user systemctl suspend", "systemd-run /var/lib/aws-replication-agent/uninstall-agent.sh",
+    "systemd-run --on-active=10 --timer-property=AccuracySec=100ms --slice=system.slice systemctl start gc-agent",
+    "systemd-run --user --scope --unit=tmux-server -- tmux", "systemd-run bash -c sleep 60 && reboot"
+  ) or
+  ?process.command_line like~ (
+    "systemd-run --scope -p CPUQuota=10% rpm -qa*", "systemd-run --scope -p CPUQuota=10% dpkg -l*"
+  ) or
+  ?process.parent.command_line in ("runc init", "/usr/local/bin/main") or
+  ?process.parent.command_line like ("*/var/lib/waagent/*", "bash ./run.sh") or
+  process.args in (
+    "--help", "list-timers", "/usr/lib/udev/kdump-udev-throttler", "kubectl", "--unit=ngt_guest_agent_upgrade", "i3-zoom", "google-chrome",
+    "thunar", "/usr/bin/google-chrome-stable", "snap.lxd.workaround", "--unit=firefox", "--unit=slack", "--slice=zoom.slice",
+    "autorandr-launcher", "--unit=restart-dbus", "--unit=autorandr-debounce"
+  ) or
+  process.args like ("--unit=app-Hyprland-wezterm-*.scope", "--unit=app-Hyprland-swaybg-*.scope", "--unit=rmf_sim_*") or
+  ?process.working_directory == "/opt/Tychon/Endpoint/bin" or
+  (process.args in ("rpm", "dpkg") and process.args like~ "CPUQuota=*") or
+  (process.args == "--slice=app-graphical.slice" and process.args == "--description=xdg-terminal-exec")
+)
+```
+
+
+
 ### Potential REMCOS Trojan Execution
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1228
+Index: geneve-ut-1389
 
 ```python
 any where host.os.type == "windows" and
@@ -12092,7 +13508,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1231
+Index: geneve-ut-1395
 
 ```python
 file where host.os.type == "windows" and
@@ -12107,7 +13523,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1232
+Index: geneve-ut-1396
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -12124,8 +13540,10 @@ any where host.os.type == "windows" and
 
   ) or
   (event.category == "process" and event.type == "start" and
-     (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
-     (?process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
+    (
+      (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
+      (?process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
+    )
   )
 )
 ```
@@ -12136,7 +13554,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1233
+Index: geneve-ut-1397
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12150,7 +13568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1234
+Index: geneve-ut-1398
 
 ```python
 sequence with maxspan=1m
@@ -12190,18 +13608,25 @@ sequence with maxspan=1m
 
 ### Potential Remote Install via MsiExec
 
-Branch count: 200  
-Document count: 200  
-Index: geneve-ut-1235
+Branch count: 400  
+Document count: 400  
+Index: geneve-ut-1399
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
-  process.name : "msiexec.exe" and process.args : ("-i*", "/i*", "-p*", "/p*") and process.command_line : "*http*" and
+  process.name : "msiexec.exe" and process.args : ("-i*", "/i*", "-p*", "/p*") and
+  process.command_line : ("*http:*", "*https:*") and
   process.args : ("/qn", "-qn", "-q", "/q", "/quiet") and
-  process.parent.name : ("sihost.exe", "explorer.exe", "cmd.exe", "wscript.exe", "mshta.exe", "powershell.exe", "wmiprvse.exe", "pcalua.exe", "forfiles.exe", "conhost.exe") and
-  not process.command_line : ("*--set-server=*", "*UPGRADEADD=*" , "*--url=*",
-                              "*USESERVERCONFIG=*", "*RCTENTERPRISESERVER=*", "*app.ninjarmm.com*", "*zoom.us/client*",
-                              "*SUPPORTSERVERSTSURI=*", "*START_URL=*", "*AUTOCONFIG=*", "*awscli.amazonaws.com*")
+  process.parent.name : (
+    "sihost.exe", "explorer.exe", "cmd.exe", "wscript.exe", "mshta.exe",
+    "powershell.exe", "wmiprvse.exe", "pcalua.exe", "forfiles.exe", "conhost.exe"
+  ) and
+
+  not process.command_line : (
+        "*--set-server=*", "*UPGRADEADD=*" , "*--url=*", "*USESERVERCONFIG=*", "*RCTENTERPRISESERVER=*",
+        "*app.ninjarmm.com*", "*zoom.us/client*", "*SUPPORTSERVERSTSURI=*", "*START_URL=*", "*AUTOCONFIG=*",
+        "*awscli.amazonaws.com*", "*/i \"C:*", "*/i C:\\*"
+  )
 ```
 
 
@@ -12210,7 +13635,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1236
+Index: geneve-ut-1400
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12264,7 +13689,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1237
+Index: geneve-ut-1401
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12284,7 +13709,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1238
+Index: geneve-ut-1402
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -12305,7 +13730,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1239
+Index: geneve-ut-1403
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12320,7 +13745,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1240
+Index: geneve-ut-1404
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -12340,7 +13765,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1241
+Index: geneve-ut-1405
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12360,7 +13785,7 @@ sequence by host.id with maxspan=5s
    and not (
      process.parent.args in (
        "/usr/lib/jenkins/jenkins.war", "/etc/remote-iot/services/remoteiot.jar", "/opt/pentaho/data-integration/launcher/launcher.jar",
-       "/usr/share/java/jenkins.war", "/opt//tomcat/statistics/statistics.jar", "/usr/lib64/NetExtender.jar",
+       "/usr/share/java/jenkins.war", "/opt/tomcat/statistics/statistics.jar", "/usr/lib64/NetExtender.jar",
        "/var/lib/jenkins/workspace/MP-QA/tc_certified_copy*/tc_certified_copy_web_ui_test/target/surefire/surefirebooter*.jar",
        "-javaagent:/opt/opentelemetry/opentelemetry-javaagent-all.jar", "./lib/pipeline-job-executor*SNAPSHOT.jar",
        "./lib/worker-launcher-agent*SNAPSHOT.jar", "/opt/Seqrite_EndPoint_Security/wildfly/jboss-modules.jar",
@@ -12378,11 +13803,26 @@ sequence by host.id with maxspan=5s
 
 
 
+### Potential Root Effective Shell from Non-Standard Path via Auditd
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1409
+
+```python
+host.os.type:linux and event.category:process and 
+event.action:(exec or executed) and user.id:(* and not 0) and 
+process.executable:(* and not (/bin/* or /nix/store/*/bin/sudo or /run/wrappers/wrappers*/sudo or /sbin/* or /usr/bin/* or /usr/sbin/*)) and 
+user.effective.id:0 and process.args:-p
+```
+
+
+
 ### Potential SAP NetWeaver Exploitation
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1245
+Index: geneve-ut-1410
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -12417,7 +13857,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1246
+Index: geneve-ut-1411
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -12434,7 +13874,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1248
+Index: geneve-ut-1414
 
 ```python
 sequence by host.id with maxspan=3s
@@ -12448,7 +13888,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1250
+Index: geneve-ut-1417
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -12461,7 +13901,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1251
+Index: geneve-ut-1418
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -12473,12 +13913,13 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1252
+Index: geneve-ut-1419
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
   winlog.event_data.AttributeValue :B\:828* and
-  not winlog.event_data.SubjectUserName: MSOL_*
+  not winlog.event_data.SubjectUserName: MSOL_* and
+  not winlog.event_data.ObjectClass: "msDS-Device"
 ```
 
 
@@ -12487,7 +13928,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1254
+Index: geneve-ut-1421
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -12515,7 +13956,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1256
+Index: geneve-ut-1423
 
 ```python
 sequence by host.id with maxspan=1s
@@ -12540,7 +13981,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1260
+Index: geneve-ut-1427
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -12574,7 +14015,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1261
+Index: geneve-ut-1428
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12588,7 +14029,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1262
+Index: geneve-ut-1429
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -12604,7 +14045,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1263
+Index: geneve-ut-1430
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -12618,7 +14059,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1264
+Index: geneve-ut-1431
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -12648,15 +14089,16 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1265
+Index: geneve-ut-1432
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
-  file.name : ("winload.exe", "winlod.efi", "ntoskrnl.exe", "bootmgr") and
+  file.name : ("winload.exe", "winload.efi", "ntoskrnl.exe", "bootmgr") and
   file.path : ("?:\\Windows\\*", "\\Device\\HarddiskVolume*\\Windows\\*") and
   not process.executable : (
     "?:\\Windows\\System32\\poqexec.exe",
-    "?:\\Windows\\WinSxS\\amd64_microsoft-windows-servicingstack_*\\tiworker.exe"
+    "?:\\Windows\\System32\\wbengine.exe",
+    "?:\\Windows\\WinSxS\\???64_microsoft-windows-servicingstack_*\\tiworker.exe"
   ) and
   not file.path : (
     "?:\\Windows\\WinSxS\\Temp\\InFlight\\*",
@@ -12664,7 +14106,9 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
     "?:\\Windows\\WinSxS\\amd64_microsoft-windows*",
     "?:\\Windows\\SystemTemp\\*",
     "?:\\Windows\\Temp\\????????.???\\*",
-    "?:\\Windows\\Temp\\*\\amd64_microsoft-windows-*"
+    "?:\\Windows\\Temp\\*\\amd64_microsoft-windows-*",
+    "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download*",
+    "?:\\Windows\\Temp\\BootImages\\{*}\\mount\\Windows\\*"
   )
 ```
 
@@ -12674,7 +14118,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1266
+Index: geneve-ut-1433
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12690,7 +14134,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1267
+Index: geneve-ut-1434
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12704,7 +14148,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1268
+Index: geneve-ut-1435
 
 ```python
 file where host.os.type == "windows" and
@@ -12740,7 +14184,7 @@ file where host.os.type == "windows" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1271
+Index: geneve-ut-1438
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12754,7 +14198,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1272
+Index: geneve-ut-1439
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12774,7 +14218,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1274
+Index: geneve-ut-1441
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12791,7 +14235,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1275
+Index: geneve-ut-1442
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -12803,7 +14247,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1276
+Index: geneve-ut-1443
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -12820,7 +14264,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1277
+Index: geneve-ut-1444
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12838,7 +14282,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1283
+Index: geneve-ut-1451
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -12851,7 +14295,7 @@ file.name == "notify_on_release" and process.interactive == true and container.i
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1284
+Index: geneve-ut-1452
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12878,7 +14322,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1285
+Index: geneve-ut-1453
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -12891,7 +14335,7 @@ file.name == "release_agent" and process.interactive == true and container.id li
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1286
+Index: geneve-ut-1454
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -12905,7 +14349,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1288
+Index: geneve-ut-1456
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12920,9 +14364,9 @@ process where host.os.type == "linux" and event.type == "start" and
 
 ### PowerShell Invoke-NinjaCopy script
 
-Branch count: 21  
-Document count: 21  
-Index: geneve-ut-1289
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-1457
 
 ```python
 event.category:process and host.os.type:windows and
@@ -12932,11 +14376,9 @@ event.category:process and host.os.type:windows and
     "StealthCloseFileDelegate" or
     "StealthOpenFile" or
     "StealthCloseFile" or
-    "StealthReadFile" or
     "Invoke-NinjaCopy"
-   )
-  and not user.id : "S-1-5-18"
-  and not powershell.file.script_block_text : (
+   ) and
+  not powershell.file.script_block_text : (
     "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
   )
 ```
@@ -12947,13 +14389,11 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1291
+Index: geneve-ut-1459
 
 ```python
 event.category:process and host.os.type:windows and
-  powershell.file.script_block_text : (
-    KerberosRequestorSecurityToken
-  ) and not user.id : ("S-1-5-18" or "S-1-5-20") and
+  powershell.file.script_block_text : "KerberosRequestorSecurityToken" and
   not powershell.file.script_block_text : (
     ("sentinelbreakpoints" and ("Set-PSBreakpoint" or "Set-HookFunctionTabs")) or
     ("function global" and "\\windows\\sentinel\\4")
@@ -12966,10 +14406,11 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1294
+Index: geneve-ut-1462
 
 ```python
-event.category:process and host.os.type:windows and powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory or pmuDetirWpmuDiniM) and not user.id : "S-1-5-18"
+event.category:process and host.os.type:windows and
+powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory or pmuDetirWpmuDiniM)
 ```
 
 
@@ -12978,7 +14419,7 @@ event.category:process and host.os.type:windows and powershell.file.script_block
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1296
+Index: geneve-ut-1464
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13002,7 +14443,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1297
+Index: geneve-ut-1465
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13030,7 +14471,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1313
+Index: geneve-ut-1481
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13051,7 +14492,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1316
+Index: geneve-ut-1484
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13088,7 +14529,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1317
+Index: geneve-ut-1485
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -13105,7 +14546,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1318
+Index: geneve-ut-1486
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13119,7 +14560,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1319
+Index: geneve-ut-1487
 
 ```python
 file where host.os.type == "windows" and
@@ -13138,7 +14579,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1320
+Index: geneve-ut-1488
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -13150,9 +14591,9 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 ### Privilege Escalation via SUID/SGID
 
-Branch count: 434  
-Document count: 434  
-Index: geneve-ut-1321
+Branch count: 450  
+Document count: 450  
+Index: geneve-ut-1489
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13183,9 +14624,11 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     "wc", "wget", "whiptail", "xargs", "xdotool", "xmodmap", "xmore", "xxd", "xz", "yash", "zsh",
     "zsoelim"
   ) or
+  (process.name like ".*" or process.executable like ("/tmp/.*", "/var/tmp/.*", "/dev/shm/.*", "/home/*"))  or 
   (process.name == "ip" and ((process.args == "-force" and process.args in ("-batch", "-b")) or (process.args == "exec"))) or
   (process.name == "find" and process.args in ("-exec", "-execdir")) or
-  (process.name in ("bash", "csh", "dash") and process.args in ("-p", "-b"))
+  (process.name in ("bash", "csh", "dash") and process.args in ("-p", "-b")) or
+  (process.name in ("su", "sudo", "pkexec") and process.args_count == 1)
 ) and not (
   process.parent.name == "spine" or
   process.parent.executable in (
@@ -13203,7 +14646,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1322
+Index: geneve-ut-1490
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13221,7 +14664,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1324
+Index: geneve-ut-1492
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -13239,7 +14682,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1327
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13253,7 +14696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1329
+Index: geneve-ut-1497
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13268,7 +14711,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1330
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -13291,7 +14734,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1332
+Index: geneve-ut-1500
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13335,7 +14778,6 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
                             "?:\\Windows\\Microsoft.NET\\Framework*\\*\\ngen.exe",
                             "?:\\Windows\\Microsoft.NET\\Framework*\\*\\aspnet_regiis.exe")) and
 
-
 /* Ignores additional parent executables that run with elevated privileges */
  not process.parent.executable :
                ("?:\\Windows\\System32\\AtBroker.exe",
@@ -13374,7 +14816,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1333
+Index: geneve-ut-1501
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -13395,7 +14837,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1334
+Index: geneve-ut-1502
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -13421,7 +14863,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1337
+Index: geneve-ut-1505
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13474,7 +14916,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1338
+Index: geneve-ut-1506
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13486,7 +14928,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1339
+Index: geneve-ut-1507
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13498,7 +14940,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1340
+Index: geneve-ut-1508
 
 ```python
 process where host.os.type == "windows" and
@@ -13513,7 +14955,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1341
+Index: geneve-ut-1509
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -13543,7 +14985,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1342
+Index: geneve-ut-1510
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -13603,7 +15045,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1345
+Index: geneve-ut-1513
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -13616,7 +15058,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1346
+Index: geneve-ut-1514
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +15090,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1347
+Index: geneve-ut-1515
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -13670,14 +15112,33 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 ### Proxy Execution via Console Window Host
 
-Branch count: 17  
-Document count: 17  
-Index: geneve-ut-1348
+Branch count: 68  
+Document count: 68  
+Index: geneve-ut-1517
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  process.name : "conhost.exe" and process.args : "--headless" and
-  process.command_line : ("*powershell*", "*cmd *", "*cmd.exe *", "*script*", "*mshta*", "*curl *", "*curl.exe *", "*^*^*^*", "*.bat*", "*.cmd*", "*schtasks*", "*@SSL*", "*http*", "* \\\\*", "*.vbs*", "*.js*", "*mhsta*")
+  process.command_line : (
+    "*powershell*", "*cmd *", "*cmd.exe *", "*script*", "*mshta*", "*curl *", "*curl.exe *", "*^*^*^*",
+    "*.bat*", "*.cmd*", "*schtasks*", "*@SSL*", "*http*", "* \\\\*", "*.vbs*", "*.js*", "*mhsta*"
+  ) and
+  not (
+    /* Winget-AutoUpdate via ServiceUI */
+    process.parent.executable : "?:\\Program Files\\winget-autoupdate*\\serviceui.exe" or
+    /* Winget-AutoUpdate notification via Task Scheduler */
+    (
+      process.parent.executable : "?:\\Windows\\System32\\svchost.exe" and process.parent.args : "-s" and
+      process.parent.args : "Schedule" and process.command_line : "*WAU-Notify.ps1*"
+    ) or
+    /* Windows OpenSSH console host — SSH-specific detection handled by 8cd49fbc-a35a-4418-8688-133cc3a1e548 */
+    process.parent.executable : (
+      "?:\\Windows\\System32\\OpenSSH\\sshd.exe",
+      "?:\\Windows\\System32\\OpenSSH\\sshd-session.exe",
+      "?:\\Program Files\\OpenSSH*\\sshd.exe",
+      "?:\\Program Files\\OpenSSH*\\sshd-session.exe"
+    )
+  )
 ```
 
 
@@ -13686,12 +15147,15 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1349
+Index: geneve-ut-1518
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
- process.command_line : ("*Command=*powershell*", "*schtasks*", "*Command=*@echo off*", "*Command=*http*", "*Command=*mshta*",  "*Command=*msiexec*",
-                          "*Command=*cmd /c*", "*Command=*cmd.exe*", "*Command=\"cmd /c*", "*LocalCommand=scp*&&*", "*LocalCommand=?scp*&&*", "*Command=*script*")
+  process.command_line : (
+    "*Command=*powershell*", "*schtasks*", "*Command=*@echo off*", "*Command=*http*",
+    "*Command=*mshta*", "*Command=*msiexec*", "*Command=*cmd /c*", "*Command=*cmd.exe*",
+    "*Command=\"cmd /c*", "*LocalCommand=scp*&&*", "*LocalCommand=?scp*&&*", "*Command=*script*"
+  )
 ```
 
 
@@ -13700,7 +15164,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1351
+Index: geneve-ut-1520
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -13729,7 +15193,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1352
+Index: geneve-ut-1521
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13743,7 +15207,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1353
+Index: geneve-ut-1522
 
 ```python
 sequence by process.entity_id
@@ -13768,7 +15232,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1354
+Index: geneve-ut-1523
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -13802,7 +15266,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1355
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -13830,7 +15294,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1356
+Index: geneve-ut-1525
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -13849,7 +15313,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1361
+Index: geneve-ut-1531
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13877,7 +15341,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1362
+Index: geneve-ut-1532
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -13896,7 +15360,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1366
+Index: geneve-ut-1536
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -13908,7 +15372,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1367
+Index: geneve-ut-1537
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13920,7 +15384,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1368
+Index: geneve-ut-1538
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -13932,7 +15396,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1369
+Index: geneve-ut-1539
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13944,7 +15408,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1380
+Index: geneve-ut-1550
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13957,7 +15421,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1381
+Index: geneve-ut-1551
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13995,7 +15459,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1383
+Index: geneve-ut-1553
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14010,7 +15474,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1384
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14029,7 +15493,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1385
+Index: geneve-ut-1555
 
 ```python
 sequence with maxspan=1m
@@ -14048,18 +15512,23 @@ sequence with maxspan=1m
               "ZOHO Corporation Private Limited",
               "BeyondTrust Corporation", 
               "CyberArk Software Ltd.", 
-              "Sophos Ltd"
+              "Sophos Ltd",
+              "AO Kaspersky Lab",
+              "Anthropic, PBC",
+              "Adobe Inc.",
+              "Netwrix Corporation"
         )
       ) or
       (
         process.executable : (
           "?:\\Windows\\ccmsetup\\ccmsetup.exe",
-          "?:\\Windows\\SoftwareDistribution\\Download\\Install\\AM_Delta*.exe",
-          "?:\\Windows\\CAInvokerService.exe"
+          "?:\\Windows\\SoftwareDistribution\\Download\\Install\\*.exe",
+          "?:\\Windows\\CAInvokerService.exe",
+          "?:\\Users\\*\\AppData\\Local\\Microsoft\\OneDrive\\*\\OneDriveSetup.exe"
         ) and process.code_signature.trusted == true
       ) or
       (
-        process.executable : "G:\\SMS_*\\srvboot.exe" and 
+        process.executable : "?:\\SMS_*\\srvboot.exe" and 
         process.code_signature.trusted == true and process.code_signature.subject_name : "Microsoft Corporation"
       )
     )
@@ -14072,7 +15541,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1387
+Index: geneve-ut-1557
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -14095,7 +15564,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1389
+Index: geneve-ut-1559
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14109,7 +15578,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1390
+Index: geneve-ut-1560
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14123,7 +15592,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1392
+Index: geneve-ut-1562
 
 ```python
 sequence by host.id, process.entity_id
@@ -14140,7 +15609,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1393
+Index: geneve-ut-1563
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14154,7 +15623,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1394
+Index: geneve-ut-1564
 
 ```python
 sequence by host.id with maxspan=1m
@@ -14172,17 +15641,29 @@ sequence by host.id with maxspan=1m
 
 ### Remote SSH Login Enabled via systemsetup Command
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1395
+Branch count: 10  
+Document count: 10  
+Index: geneve-ut-1565
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
- process.name == "systemsetup" and
- process.args like~ "-setremotelogin" and 
- process.args like~ "on" and
- process.parent.executable != null and
- not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xpcproxy", "/usr/bin/sudo")
+(
+  (
+    process.name == "systemsetup" and
+    process.args like~ "-setremotelogin" and
+    process.args like~ "on"
+  ) or
+  (
+    process.name == "launchctl" and
+    process.args in ("load", "bootstrap") and
+    (
+      process.command_line like~ "*/System/Library/LaunchDaemons/ssh.plist*" or
+      process.command_line like~ "*com.openssh.sshd*"
+    )
+  )
+) and
+process.parent.executable != null and
+not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xpcproxy", "/usr/bin/sudo")
 ```
 
 
@@ -14191,7 +15672,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1396
+Index: geneve-ut-1566
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -14211,7 +15692,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1397
+Index: geneve-ut-1567
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -14224,7 +15705,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1399
+Index: geneve-ut-1569
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -14266,7 +15747,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1400
+Index: geneve-ut-1570
 
 ```python
 sequence with maxspan=1m
@@ -14289,7 +15770,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1401
+Index: geneve-ut-1571
 
 ```python
 sequence with maxspan=1s
@@ -14337,7 +15818,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1402
+Index: geneve-ut-1572
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14354,7 +15835,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1404
+Index: geneve-ut-1574
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -14383,7 +15864,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1406
+Index: geneve-ut-1576
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14411,7 +15892,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1407
+Index: geneve-ut-1577
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -14428,7 +15909,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1409
+Index: geneve-ut-1579
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -14447,7 +15928,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1410
+Index: geneve-ut-1580
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -14468,7 +15949,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1418
+Index: geneve-ut-1589
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -14482,7 +15963,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1420
+Index: geneve-ut-1591
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -14501,7 +15982,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1421
+Index: geneve-ut-1592
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -14515,7 +15996,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1422
+Index: geneve-ut-1593
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -14535,7 +16016,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1424
+Index: geneve-ut-1595
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14553,7 +16034,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1425
+Index: geneve-ut-1596
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -14574,7 +16055,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1427
+Index: geneve-ut-1598
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14586,15 +16067,15 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 ### ScreenConnect Server Spawning Suspicious Processes
 
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-1428
+Branch count: 10  
+Document count: 10  
+Index: geneve-ut-1599
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.parent.name : "ScreenConnect.Service.exe" and
   (process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "powershell_ise.exe", "csc.exe") or
-  ?process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE", "pwsh.dll", "powershell_ise.EXE"))
+  ?process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE", "pwsh.dll", "powershell_ise.EXE", "csc.exe"))
 ```
 
 
@@ -14603,7 +16084,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1429
+Index: geneve-ut-1600
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14644,7 +16125,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1431
+Index: geneve-ut-1602
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -14669,7 +16150,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1432
+Index: geneve-ut-1603
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -14708,7 +16189,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1433
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14722,7 +16203,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1434
+Index: geneve-ut-1605
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14746,7 +16227,12 @@ process.args like (
   ?process.parent.args in ("/opt/imperva/ragent/bin/get_sys_resources.sh", "/usr/sbin/lynis", "./terra_linux.sh") or
   process.args == "/usr/bin/coreutils" or
   (process.parent.name == "pwsh" and process.parent.command_line like "*Evaluate-STIG*") or
-  ?process.parent.executable == "/usr/sap/audit_scripts/auto_audit_gral.sh"
+  ?process.parent.executable like (
+    "/usr/sap/audit_scripts/auto_audit_gral.sh", "/opt/saltstack/salt/bin/python3*", "/opt/puppetlabs/puppet/bin/ruby"
+  ) or
+  ?process.entry_leader.executable like (
+    "/usr/sbin/ScanAssistant", "/opt/Tanium/TaniumClient/TaniumClient", "/tmp/CVU_*resource/exectask", "/opt/nessus/sbin/nessus-service"
+  )
 )
 ```
 
@@ -14756,7 +16242,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1435
+Index: geneve-ut-1606
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14770,7 +16256,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1436
+Index: geneve-ut-1607
 
 ```python
 process where event.type == "start" and
@@ -14842,7 +16328,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1439
+Index: geneve-ut-1611
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -14863,7 +16349,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1442
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14880,7 +16366,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1444
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14894,11 +16380,11 @@ process.command_line like~ (
 
 
 
-### Sensitive Privilege SeEnableDelegationPrivilege assigned to a User
+### Sensitive Privilege SeEnableDelegationPrivilege assigned to a Principal
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1445
+Index: geneve-ut-1618
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -14910,19 +16396,31 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1446
+Index: geneve-ut-1619
 
 ```python
-file where host.os.type == "windows" and 
- event.action == "open" and event.outcome == "success" and process.executable != null and 
+file where host.os.type == "windows" and
+ event.action == "open" and event.outcome == "success" and process.executable != null and
  file.path :
       ("?:\\Windows\\System32\\config\\RegBack\\SAM",
        "?:\\Windows\\System32\\config\\RegBack\\SECURITY",
-       "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and 
+       "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and
  not (
     user.id == "S-1-5-18" and process.executable : (
-        "?:\\Windows\\system32\\taskhostw.exe", "?:\\Windows\\system32\\taskhost.exe"
-    ))
+        "?:\\Windows\\system32\\taskhostw.exe",
+        "?:\\Windows\\system32\\taskhost.exe",
+        "?:\\Program Files\\Sophos\\Endpoint Defense\\SophosScanCoordinator.exe",
+        "?:\\Program Files\\Sophos\\Endpoint Defense\\SSPService.exe",
+        "?:\\Program Files\\Windows Defender Advanced Threat Protection\\MsSense.exe",
+        "?:\\Program Files\\Trend Micro\\AMSP\\coreServiceShell.exe",
+        "?:\\Program Files\\Symantec\\Symantec Endpoint Protection\\*\\Bin64\\ccSvcHst.exe",
+        "?:\\Program Files\\Bitdefender\\Endpoint Security\\EPSecurityService.exe",
+        "?:\\Program Files\\N-able Technologies\\AVDefender\\EPSecurityService.exe",
+        "?:\\Program Files\\Cylance\\Optics\\CyOptics.exe",
+        "?:\\Program Files\\Common Files\\McAfee\\AVSolution\\mcshield.exe",
+        "?:\\Program Files (x86)\\Padvish AV\\APCcSvc.exe"
+    )
+ )
 ```
 
 
@@ -14931,7 +16429,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1449
+Index: geneve-ut-1622
 
 ```python
 any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
@@ -14963,7 +16461,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1451
+Index: geneve-ut-1624
 
 ```python
 any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
@@ -14999,7 +16497,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1452
+Index: geneve-ut-1625
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -15016,7 +16514,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1453
+Index: geneve-ut-1626
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -15036,7 +16534,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1455
+Index: geneve-ut-1628
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15051,7 +16549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1456
+Index: geneve-ut-1629
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15072,7 +16570,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1457
+Index: geneve-ut-1630
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15095,7 +16593,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1458
+Index: geneve-ut-1631
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -15108,7 +16606,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1459
+Index: geneve-ut-1632
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15125,7 +16623,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1462
+Index: geneve-ut-1635
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -15150,7 +16648,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1464
+Index: geneve-ut-1638
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and process.interactive == true and container.id like "?*" and (
@@ -15181,7 +16679,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1465
+Index: geneve-ut-1639
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -15230,7 +16728,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1466
+Index: geneve-ut-1640
 
 ```python
 sequence by host.id with maxspan=10s
@@ -15240,11 +16738,26 @@ sequence by host.id with maxspan=10s
 
 
 
+### Shell Execution via Elastic Endpoint
+
+Branch count: 64  
+Document count: 64  
+Index: geneve-ut-1641
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.parent.executable == "/opt/Elastic/Endpoint/elastic-endpoint" and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+process.args in ("-c", "-cl", "-lc", "--command")
+```
+
+
+
 ### Shell History Clearing via Environment Variables
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1467
+Index: geneve-ut-1642
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15259,7 +16772,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1468
+Index: geneve-ut-1643
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -15281,7 +16794,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1469
+Index: geneve-ut-1644
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15302,7 +16815,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1473
+Index: geneve-ut-1648
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15316,7 +16829,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1474
+Index: geneve-ut-1649
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -15339,7 +16852,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1502
+Index: geneve-ut-1679
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -15364,7 +16877,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1503
+Index: geneve-ut-1680
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -15397,7 +16910,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1504
+Index: geneve-ut-1681
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -15456,7 +16969,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1506
+Index: geneve-ut-1683
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -15474,7 +16987,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1507
+Index: geneve-ut-1684
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -15486,7 +16999,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1510
+Index: geneve-ut-1687
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -15511,7 +17024,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1515
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15526,7 +17039,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1516
+Index: geneve-ut-1693
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -15549,7 +17062,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1519
+Index: geneve-ut-1696
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15563,7 +17076,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1521
+Index: geneve-ut-1698
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15585,7 +17098,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1523
+Index: geneve-ut-1700
 
 ```python
 sequence by host.id with maxspan=5s
@@ -15612,7 +17125,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1527
+Index: geneve-ut-1704
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -15624,6 +17137,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
     "?:\\Windows\\Syswow64\\amsi.dll",
     "?:\\$WINDOWS.~BT\\*\\amsi.dll",
     "?:\\Windows\\CbsTemp\\*\\amsi.dll",
+    "?:\\Windows\\SystemTemp\\*\\amsi.dll",
     "?:\\Windows\\SoftwareDistribution\\Download\\*",
     "?:\\Windows\\WinSxS\\*\\amsi.dll", 
     "?:\\Windows\\servicing\\*\\amsi.dll",
@@ -15638,7 +17152,8 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
     "\\Device\\HarddiskVolume*\\$SysReset\\CloudImage\\Package_for_RollupFix*\\amsi.dll",
     "\\Device\\HarddiskVolume*\\$WINDOWS.~BT\\*\\amsi.dll", 
     "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download\\*\\amsi.dll", 
-    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll", 
+    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll",
+    "\\Device\\HarddiskVolume*\\Windows\\SystemTemp\\*\\amsi.dll", 
     "\\Device\\HarddiskVolume*\\Windows\\servicing\\*\\amsi.dll"
   )
 ```
@@ -15649,7 +17164,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1528
+Index: geneve-ut-1705
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -15672,7 +17187,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1529
+Index: geneve-ut-1706
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -15686,7 +17201,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1530
+Index: geneve-ut-1707
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15702,7 +17217,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1531
+Index: geneve-ut-1708
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -15718,7 +17233,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1532
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15732,7 +17247,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1534
+Index: geneve-ut-1711
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15755,7 +17270,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1535
+Index: geneve-ut-1712
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15770,7 +17285,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1536
+Index: geneve-ut-1715
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15793,11 +17308,42 @@ sequence by process.entity_id with maxspan=15s
 
 
 
+### Suspicious Container Runtime CLI Execution
+
+Branch count: 14  
+Document count: 14  
+Index: geneve-ut-1717
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+(
+  (
+    process.name in ("ctr", "crictl", "nerdctl") and
+    (
+      (process.args == "tasks" and process.args == "exec") or
+      (process.args == "run" and process.args in ("--privileged", "--rm", "--mount", "--net-host", "--pid-host")) or
+      (process.args == "snapshots" and process.args == "mount")
+    )
+  ) or
+  (
+    (process.executable like ("/dev/shm/*", "/tmp/*", "/var/tmp/*") or process.name : ".*") and
+    process.args like ("*containerd.sock*", "*k8s.io*")
+  )
+) and
+not process.parent.executable in (
+  "/usr/bin/kubelet", "/usr/local/bin/kubelet",
+  "/usr/bin/containerd", "/usr/sbin/containerd",
+  "/lib/systemd/systemd", "/usr/lib/systemd/systemd", "/sbin/init"
+)
+```
+
+
+
 ### Suspicious Content Extracted or Decompressed via Funzip
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1538
+Index: geneve-ut-1718
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -15813,7 +17359,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1539
+Index: geneve-ut-1719
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -15826,7 +17372,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1541
+Index: geneve-ut-1721
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15842,7 +17388,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1542
+Index: geneve-ut-1722
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -15858,7 +17404,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1543
+Index: geneve-ut-1723
 
 ```python
 any where host.os.type == "windows" and 
@@ -15925,7 +17471,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1545
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -15941,7 +17487,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1547
+Index: geneve-ut-1727
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15977,7 +17523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1548
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16015,7 +17561,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1549
+Index: geneve-ut-1729
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -16050,7 +17596,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1550
+Index: geneve-ut-1730
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16084,7 +17630,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1552
+Index: geneve-ut-1732
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -16105,7 +17651,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1557
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -16133,7 +17679,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1558
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16141,7 +17687,7 @@ process where host.os.type == "windows" and event.type == "start" and
 (process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or ?process.code_signature.subject_name : "OpenJS Foundation") and
 
 (
-  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume?\\\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
+  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
 
   (process.args : "-r" and process.parent.name : "powershell.exe") or
 
@@ -16155,7 +17701,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1559
+Index: geneve-ut-1739
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16179,7 +17725,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1561
+Index: geneve-ut-1741
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16200,7 +17746,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1564
+Index: geneve-ut-1744
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16215,7 +17761,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1567
+Index: geneve-ut-1747
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16228,7 +17774,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1568
+Index: geneve-ut-1748
 
 ```python
 any where host.os.type == "windows" and
@@ -16243,7 +17789,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1569
+Index: geneve-ut-1749
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16259,7 +17805,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1570
+Index: geneve-ut-1750
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -16273,7 +17819,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1572
+Index: geneve-ut-1754
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and
@@ -16330,7 +17876,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1573
+Index: geneve-ut-1755
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16344,19 +17890,28 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1575
+Index: geneve-ut-1757
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
  [network where host.os.type == "windows" and destination.port == 88 and
   process.executable != null and process.pid != 4 and 
-  not process.executable : 
-              ("?:\\Windows\\system32\\lsass.exe", 
-               "\\device\\harddiskvolume*\\windows\\system32\\lsass.exe", 
-               "\\device\\harddiskvolume*\\windows\\system32\\svchost.exe") and
-  not (process.executable : ("C:\\Windows\\System32\\svchost.exe", 
-                             "C:\\Program Files\\VMware\\VMware View\\Server\\bin\\ws_TomcatService.exe", 
-                             "F:\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe") and user.id in ("S-1-5-20", "S-1-5-18")) and   
+  not process.executable : (
+        "?:\\Windows\\system32\\lsass.exe",
+        "\\device\\harddiskvolume*\\windows\\system32\\lsass.exe",
+        "\\device\\harddiskvolume*\\windows\\system32\\svchost.exe"
+  ) and
+  not (
+    process.executable : (
+      "C:\\Windows\\System32\\svchost.exe",
+      "C:\\Program Files\\VMware\\VMware View\\Server\\bin\\ws_TomcatService.exe",
+      "C:\\Program Files\\Omnissa\\Horizon\\Server\\bin\\ws_TomcatService.exe",
+      "C:\\Program Files\\SysAidServer\\root\\WEB-INF\\domains\\NetworkDiscovery.exe",
+      "C:\\Program Files (x86)\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe",
+      "F:\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe"
+    ) and
+    user.id in ("S-1-5-20", "S-1-5-18")
+  ) and
   source.ip != "127.0.0.1" and destination.ip != "::1" and destination.ip != "127.0.0.1"]
  [authentication where host.os.type == "windows" and event.code in ("4768", "4769")]
 ```
@@ -16367,7 +17922,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1577
+Index: geneve-ut-1759
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -16380,7 +17935,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1578
+Index: geneve-ut-1760
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16389,7 +17944,7 @@ process where host.os.type == "windows" and event.code == "10" and
    /* seclogon service accessing lsass */
   winlog.event_data.CallTrace : "*seclogon.dll*" and process.name : "svchost.exe" and
 
-   /* PROCESS_CREATE_PROCESS & PROCESS_DUP_HANDLE & PROCESS_QUERY_INFORMATION */
+   /* PROCESS_CREATE_PROCESS & PROCESS_DUP_HANDLE & PROCESS_QUERY_INFORMATION & PROCESS_QUERY_LIMITED_INFORMATION */
   winlog.event_data.GrantedAccess == "0x14c0"
 ```
 
@@ -16399,7 +17954,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1579
+Index: geneve-ut-1761
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16445,7 +18000,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1581
+Index: geneve-ut-1763
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16466,7 +18021,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1582
+Index: geneve-ut-1764
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16486,7 +18041,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1583
+Index: geneve-ut-1765
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16500,7 +18055,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1584
+Index: geneve-ut-1766
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16528,28 +18083,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Suspicious Microsoft HTML Application Child Process
-
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-1586
-
-```python
-process where host.os.type == "windows" and event.type == "start" and
- process.parent.name : "mshta.exe" and
- (
-  process.name : ("cmd.exe", "powershell.exe", "certutil.exe", "bitsadmin.exe", "curl.exe", "msiexec.exe", "schtasks.exe", "reg.exe", "wscript.exe", "rundll32.exe") or
-  process.executable : ("C:\\Users\\*\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\*.exe")
-  )
-```
-
-
-
 ### Suspicious Mining Process Creation Event
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1587
+Index: geneve-ut-1769
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -16568,80 +18106,101 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 ### Suspicious Module Loaded by LSASS
 
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-1589
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1771
 
 ```python
-any where event.category in ("library", "driver") and host.os.type == "windows" and
+library where host.os.type == "windows" and event.action == "load" and
   process.executable : "?:\\Windows\\System32\\lsass.exe" and
-  not (dll.code_signature.subject_name :
-               ("Microsoft Windows",
-                "Microsoft Corporation",
-                "Microsoft Windows Publisher",
-                "Microsoft Windows Software Compatibility Publisher",
-                "Microsoft Windows Hardware Compatibility Publisher",
-                "McAfee, Inc.",
-                "SecMaker AB",
-                "HID Global Corporation",
-                "HID Global",
-                "Apple Inc.",
-                "Citrix Systems, Inc.",
-                "Dell Inc",
-                "Hewlett-Packard Company",
-                "Symantec Corporation",
-                "National Instruments Corporation",
-                "DigitalPersona, Inc.",
-                "Novell, Inc.",
-                "gemalto",
-                "EasyAntiCheat Oy",
-                "Entrust Datacard Corporation",
-                "AuriStor, Inc.",
-                "LogMeIn, Inc.",
-                "VMware, Inc.",
-                "Istituto Poligrafico e Zecca dello Stato S.p.A.",
-                "Nubeva Technologies Ltd",
-                "Micro Focus (US), Inc.",
-                "Yubico AB",
-                "GEMALTO SA",
-                "Secure Endpoints, Inc.",
-                "Sophos Ltd",
-                "Morphisec Information Security 2014 Ltd",
-                "Entrust, Inc.",
-                "Nubeva Technologies Ltd",
-                "Micro Focus (US), Inc.",
-                "F5 Networks Inc",
-                "Bit4id",
-                "Thales DIS CPL USA, Inc.",
-                "Micro Focus International plc",
-                "HYPR Corp",
-                "Intel(R) Software Development Products",
-                "PGP Corporation",
-                "Parallels International GmbH",
-                "FrontRange Solutions Deutschland GmbH",
-                "SecureLink, Inc.",
-                "Tidexa OU",
-                "Amazon Web Services, Inc.",
-                "SentryBay Limited",
-                "Audinate Pty Ltd",
-                "CyberArk Software Ltd.",
-                "McAfeeSysPrep",
-                "NVIDIA Corporation PE Sign v2016",
-                "Trend Micro, Inc.",
-                "Fortinet Technologies (Canada) Inc.",
-                "Carbon Black, Inc.") and
-       dll.code_signature.status : ("trusted", "errorExpired", "errorCode_endpoint*", "errorChaining")) and
+  not (
+        dll.code_signature.subject_name : (
+            "Algorithmic Research LTD.",
+            "Amazon Web Services, Inc.",
+            "Apple Inc.",
+            "Audinate Pty Ltd",
+            "AuriStor, Inc.",
+            "Bit4id",
+            "Carbon Black, Inc.",
+            "Check Point Software Technologies Ltd.",
+            "Citrix Systems, Inc.",
+            "CyberArk Software Ltd.",
+            "Dell Inc",
+            "DigitalPersona, Inc.",
+            "EasyAntiCheat Oy",
+            "Entrust Corporation",
+            "Entrust Datacard Corporation",
+            "Entrust, Inc.",
+            "F5 Networks Inc",
+            "Fortinet, Inc.",
+            "Fortinet Technologies (Canada) Inc.",
+            "FrontRange Solutions Deutschland GmbH",
+            "GEMALTO SA",
+            "gemalto",
+            "Hewlett-Packard Company",
+            "HID Global",
+            "HID Global Corporation",
+            "HYPR Corp",
+            "IDEMIA IDENTITY & SECURITY FRANCE SAS",
+            "IDEMIA France SAS",
+            "Intel(R) Software Development Products",
+            "Istituto Poligrafico e Zecca dello Stato S.p.A.",
+            "LogMeIn, Inc.",
+            "McAfee, Inc.",
+            "McAfeeSysPrep",
+            "Micro Focus (US), Inc.",
+            "Micro Focus International plc",
+            "Microsoft Corporation",
+            "Microsoft Windows",
+            "Microsoft Windows Hardware Compatibility Publisher",
+            "Microsoft Windows Publisher",
+            "Microsoft Windows Software Compatibility Publisher",
+            "Morphisec Information Security 2014 Ltd",
+            "Musarubra US LLC",
+            "National Instruments Corporation",
+            "Novell, Inc.",
+            "Nubeva Technologies Ltd",
+            "NVIDIA Corporation PE Sign v2016",
+            "Palo Alto Networks (Netherlands) B.V.",
+            "Parallels International GmbH",
+            "PGP Corporation",
+            "QUEST SOFTWARE INC.",
+            "SecMaker AB",
+            "Secure Endpoints, Inc.",
+            "SecureLink, Inc.",
+            "SentinelOne Inc.",
+            "SentryBay Limited",
+            "Sophos Ltd",
+            "Symantec Corporation",
+            "Thales DIS CPL USA, Inc.",
+            "Tidexa OU",
+            "Trend Micro, Inc.",
+            "VMware, Inc.",
+            "Yubico AB"
+        ) and
+        dll.code_signature.status : ("trusted", "errorExpired", "errorCode_endpoint*", "errorChaining")
+  ) and
 
-     not dll.hash.sha256 :
-                ("811a03a5d7c03802676d2613d741be690b3461022ea925eb6b2651a5be740a4c",
-                 "1181542d9cfd63fb00c76242567446513e6773ea37db6211545629ba2ecf26a1",
-                 "ed6e735aa6233ed262f50f67585949712f1622751035db256811b4088c214ce3",
-                 "26be2e4383728eebe191c0ab19706188f0e9592add2e0bf86b37442083ae5e12",
-                 "9367e78b84ef30cf38ab27776605f2645e52e3f6e93369c674972b668a444faa",
-                 "d46cc934765c5ecd53867070f540e8d6f7701e834831c51c2b0552aba871921b",
-                 "0f77a3826d7a5cd0533990be0269d951a88a5c277bc47cff94553330b715ec61",
-                 "4aca034d3d85a9e9127b5d7a10882c2ef4c3e0daa3329ae2ac1d0797398695fb",
-                 "86031e69914d9d33c34c2f4ac4ae523cef855254d411f88ac26684265c981d95")
+  not dll.hash.sha256 : (
+          "811a03a5d7c03802676d2613d741be690b3461022ea925eb6b2651a5be740a4c",
+          "1181542d9cfd63fb00c76242567446513e6773ea37db6211545629ba2ecf26a1",
+          "ed6e735aa6233ed262f50f67585949712f1622751035db256811b4088c214ce3",
+          "26be2e4383728eebe191c0ab19706188f0e9592add2e0bf86b37442083ae5e12",
+          "9367e78b84ef30cf38ab27776605f2645e52e3f6e93369c674972b668a444faa",
+          "d46cc934765c5ecd53867070f540e8d6f7701e834831c51c2b0552aba871921b",
+          "0f77a3826d7a5cd0533990be0269d951a88a5c277bc47cff94553330b715ec61",
+          "4aca034d3d85a9e9127b5d7a10882c2ef4c3e0daa3329ae2ac1d0797398695fb",
+          "86031e69914d9d33c34c2f4ac4ae523cef855254d411f88ac26684265c981d95",
+          "4af1fee3369d9a993a84f54eafb72a661633c33e9e12fb3dd151a6a2cddbd404"
+  ) and
+  not dll.path : (
+        "C:\\Windows\\System32\\CertPolEng.dll",
+        "C:\\Windows\\System32\\FWPUCLNT.DLL",
+        "C:\\Windows\\System32\\keyiso.dll",
+        "C:\\Windows\\System32\\ngcpopkeysrv.dll",
+        "C:\\Windows\\System32\\SecureTimeAggregator.dll",
+        "C:\\Windows\\System32\\vaultsvc.dll"
+  )
 ```
 
 
@@ -16650,7 +18209,7 @@ any where event.category in ("library", "driver") and host.os.type == "windows" 
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1593
+Index: geneve-ut-1775
 
 ```python
 sequence by host.id with maxspan=5s
@@ -16698,7 +18257,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1596
+Index: geneve-ut-1778
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16724,7 +18283,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1597
+Index: geneve-ut-1779
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16769,7 +18328,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1598
+Index: geneve-ut-1780
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16793,7 +18352,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1599
+Index: geneve-ut-1781
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -16809,7 +18368,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1601
+Index: geneve-ut-1783
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -16834,7 +18393,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1602
+Index: geneve-ut-1784
 
 ```python
 event.category:process and host.os.type:windows and
@@ -16849,7 +18408,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1605
+Index: geneve-ut-1787
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -16863,7 +18422,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1606
+Index: geneve-ut-1788
 
 ```python
 sequence by host.id with maxspan=30s
@@ -16883,7 +18442,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1607
+Index: geneve-ut-1789
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16918,7 +18477,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1611
+Index: geneve-ut-1793
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -16936,7 +18495,7 @@ process where event.type == "start" and event.action == "exec" and process.inter
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1612
+Index: geneve-ut-1794
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16949,7 +18508,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1615
+Index: geneve-ut-1797
 
 ```python
 any where host.os.type == "windows" and
@@ -16982,7 +18541,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1617
+Index: geneve-ut-1799
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -17000,7 +18559,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1618
+Index: geneve-ut-1800
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -17018,11 +18577,50 @@ and not (
 
 
 
+### Suspicious SUID Binary Execution (Auditd Sequence)
+
+Branch count: 414  
+Document count: 828  
+Index: geneve-ut-1803
+
+```python
+sequence by host.id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action == "executed" and
+   user.id != "0" and user.effective.id != "0" and
+   (
+     process.name like ("python*", "perl*", "ruby*", "php*", "lua*", ".*") or
+     process.name in ("node", "bun", "java") or
+     process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+     (
+       process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+       process.args in ("-c", "--command", "-ic", "-ci", "-cl", "-lc")
+     )
+   )
+  ] by process.pid
+
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action == "executed" and
+   user.effective.id == "0" and user.id != "0" and
+   (
+     (process.name in ("sudo", "pkexec") and
+      not process.args like "-*" and
+      not process.args : ("/usr/*", "/bin/*", "/sbin/*", "/opt/*")) or
+     (process.name == "su" and
+      not process.args in ("--command", "-c", "--shell", "-s")) or
+     (process.name in ("passwd", "chsh", "newgrp") and
+      not process.args in ("--shell", "-s", "--help"))
+   )
+  ] by process.parent.pid
+```
+
+
+
 ### Suspicious ScreenConnect Client Child Process
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1620
+Index: geneve-ut-1804
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17041,7 +18639,7 @@ process where host.os.type == "windows" and event.type == "start" and
    (process.name : "rundll32.exe" and not process.args : "url.dll,FileProtocolHandler") or
    (process.name : "msiexec.exe" and process.args : ("/i", "-i") and
     process.args : ("/q", "/quiet", "/qn", "-q", "-quiet", "-qn", "-Q+")) or
-   process.name : ("mshta.exe", "certutil.exe", "bistadmin.exe", "certreq.exe", "wscript.exe", "cscript.exe", "curl.exe",
+   process.name : ("mshta.exe", "certutil.exe", "bitsadmin.exe", "certreq.exe", "wscript.exe", "cscript.exe", "curl.exe",
                    "ssh.exe", "scp.exe", "wevtutil.exe", "wget.exe", "wmic.exe")
    )
 ```
@@ -17052,7 +18650,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1621
+Index: geneve-ut-1805
 
 ```python
 any where host.os.type == "windows" and
@@ -17086,7 +18684,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1622
+Index: geneve-ut-1806
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -17100,7 +18698,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1625
+Index: geneve-ut-1809
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17131,13 +18729,13 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1626
+Index: geneve-ut-1810
 
 ```python
 any where host.os.type == "windows" and
 (
  (event.category == "library" and
-  process.executable : ("C:\\Program Files\\WebHelpDesk\\*\\java.exe", "C:\\Program Files (x86)\\WebHelpDesk\\*\\java.exe") and
+  process.executable : ("C:\\Program Files\\WebHelpDesk\\*\\java*.exe", "C:\\Program Files (x86)\\WebHelpDesk\\*\\java*.exe") and
   (dll.path : "\\Device\\Mup\\*" or dll.code_signature.trusted == false or ?dll.code_signature.exists == false)) or
 
  (event.category == "process" and process.name : ("cmd.exe", "powershell.exe", "rundll32.exe") and
@@ -17151,7 +18749,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1627
+Index: geneve-ut-1811
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17192,7 +18790,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1628
+Index: geneve-ut-1812
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -17208,7 +18806,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1629
+Index: geneve-ut-1813
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17238,7 +18836,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1633
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -17251,7 +18849,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1634
+Index: geneve-ut-1818
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -17275,7 +18873,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1636
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17293,7 +18891,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1638
+Index: geneve-ut-1822
 
 ```python
 any where host.os.type == "windows" and
@@ -17308,7 +18906,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1639
+Index: geneve-ut-1823
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -17326,7 +18924,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1640
+Index: geneve-ut-1824
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -17338,7 +18936,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
                   "Login Data") and
  ((process.code_signature.trusted == false or process.code_signature.exists == false) or process.name == "osascript") and
  not process.code_signature.signing_id == "org.mozilla.firefox" and
- not Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
+not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
 ```
 
 
@@ -17347,7 +18945,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1641
+Index: geneve-ut-1825
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17366,7 +18964,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1644
+Index: geneve-ut-1828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17391,7 +18989,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1645
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17404,7 +19002,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1647
+Index: geneve-ut-1831
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -17417,7 +19015,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1649
+Index: geneve-ut-1833
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17440,7 +19038,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1651
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17459,7 +19057,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1652
+Index: geneve-ut-1836
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -17481,7 +19079,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1653
+Index: geneve-ut-1837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -17514,7 +19112,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1655
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17532,7 +19130,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1656
+Index: geneve-ut-1840
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -17546,7 +19144,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1657
+Index: geneve-ut-1841
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17570,7 +19168,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1658
+Index: geneve-ut-1842
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -17593,7 +19191,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1659
+Index: geneve-ut-1843
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -17612,7 +19210,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1662
+Index: geneve-ut-1846
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and
@@ -17631,7 +19229,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1664
+Index: geneve-ut-1848
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -17666,7 +19264,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1665
+Index: geneve-ut-1849
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17683,7 +19281,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1666
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17703,7 +19301,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1667
+Index: geneve-ut-1851
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -17743,7 +19341,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1668
+Index: geneve-ut-1852
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -17759,7 +19357,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1669
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17773,7 +19371,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1670
+Index: geneve-ut-1854
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17811,7 +19409,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1671
+Index: geneve-ut-1855
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17861,11 +19459,39 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 
 
+### Systemd Service Override Configuration File Created
+
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-1856
+
+```python
+file where host.os.type == "linux" and event.action in ("rename", "creation") and
+file.extension == "conf" and file.path like (
+  "/etc/systemd/system/*.d/*.conf", "/etc/systemd/user/*.d/*.conf", "/usr/local/lib/systemd/system/*.d/*.conf",
+  "/lib/systemd/system/*.d/*.conf", "/usr/lib/systemd/system/*.d/*.conf", "/usr/lib/systemd/user/*.d/*.conf",
+  "/home/*/.config/systemd/user/*.d/*.conf", "/home/*/.local/share/systemd/user/*.d/*.conf",
+  "/root/.config/systemd/user/*.d/*.conf", "/root/.local/share/systemd/user/*.d/*.conf",
+  "/run/systemd/system/*.d/*.conf", "/var/run/systemd/system/*.d/*.conf"
+) and
+not process.executable in (
+  "/bin/dpkg", "/usr/bin/dpkg", "/bin/dockerd", "/usr/bin/dockerd", "/usr/sbin/dockerd", "/bin/microdnf",
+  "/usr/bin/microdnf", "/bin/rpm", "/usr/bin/rpm", "/bin/snapd", "/usr/bin/snapd", "/bin/yum", "/usr/bin/yum",
+  "/bin/dnf", "/usr/bin/dnf", "/bin/podman", "/usr/bin/podman", "/bin/dnf-automatic", "/usr/bin/dnf-automatic",
+  "/usr/bin/dpkg-divert", "/bin/dpkg-divert", "/sbin/apk", "/usr/sbin/apk", "/usr/local/sbin/apk", "/usr/bin/dnf5",
+  "/usr/bin/apt", "/usr/bin/puppet", "/bin/puppet", "/opt/puppetlabs/puppet/bin/puppet", "/usr/bin/pacman",
+  "/usr/bin/chef-client", "/bin/chef-client", "/usr/bin/pamac-daemon", "/bin/pamac-daemon", "/usr/local/bin/dockerd",
+  "/usr/bin/crio", "/usr/bin/podman", "/usr/bin/tdnf", "/usr/bin/apk"
+)
+```
+
+
+
 ### Systemd Shell Execution During Boot
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1673
+Index: geneve-ut-1858
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -17879,7 +19505,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1674
+Index: geneve-ut-1859
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17925,7 +19551,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1675
+Index: geneve-ut-1860
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -17964,7 +19590,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1676
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -17977,7 +19603,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1680
+Index: geneve-ut-1865
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -18010,7 +19636,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1681
+Index: geneve-ut-1866
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -18024,7 +19650,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1682
+Index: geneve-ut-1867
 
 ```python
 sequence by host.id with maxspan=1s
@@ -18038,7 +19664,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1683
+Index: geneve-ut-1868
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -18052,7 +19678,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1684
+Index: geneve-ut-1869
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18091,7 +19717,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1691
+Index: geneve-ut-1876
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -18133,7 +19759,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1693
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -18155,7 +19781,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1695
+Index: geneve-ut-1880
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -18168,7 +19794,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1698
+Index: geneve-ut-1883
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18185,7 +19811,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1699
+Index: geneve-ut-1884
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -18201,7 +19827,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1700
+Index: geneve-ut-1885
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18214,7 +19840,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1701
+Index: geneve-ut-1886
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -18229,7 +19855,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1702
+Index: geneve-ut-1887
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18250,15 +19876,16 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### UAC Bypass via ICMLuaUtil Elevated COM Interface
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1703
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1888
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  process.parent.name == "dllhost.exe" and
  process.parent.args in ("/Processid:{3E5FC7F9-9A51-4367-9063-A120244FBEC7}", "/Processid:{D2E7041B-2927-42FB-8E9F-7CE93B6DC937}") and
- process.pe.original_file_name != "WerFault.exe"
+ process.pe.original_file_name != "WerFault.exe" and
+ not (process.executable : "?:\\Program Files\\WireGuard\\wireguard.exe" and process.args : "/installmanagerservice")
 ```
 
 
@@ -18267,7 +19894,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1704
+Index: geneve-ut-1889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18279,38 +19906,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Uncommon Destination Port Connection by Web Server
-
-Branch count: 45  
-Document count: 45  
-Index: geneve-ut-1708
-
-```python
-network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and (
-  process.name like (
-    "apache", "nginx", "apache2", "httpd", "lighttpd", "caddy", "mongrel_rails", "gunicorn",
-    "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn",
-    "daphne", "twistd", "yaws", "webfsd", "httpd.worker", "flask", "rails", "mongrel", "php-fpm*", "php-cgi",
-    "php-fcgi", "php-cgi.cagefs", "catalina.sh", "hiawatha", "lswsctrl"
-  ) or
-  user.name in ("apache", "www-data", "httpd", "nginx", "lighttpd", "tomcat", "tomcat8", "tomcat9") or
-  user.id in ("33", "498", "48") or
-  (process.name == "java" and process.working_directory like "/u0?/*")
-) and
-network.direction == "egress" and destination.ip != null and
-not destination.port in (80, 443, 8080, 8443, 8000, 8888, 3128, 3306, 5432, 8220, 8082) and
-not cidrmatch(destination.ip, "127.0.0.0/8", "::1","FE80::/10", "FF00::/8", "10.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.0.0.0/24", "192.0.0.0/29", "192.0.0.8/32", "192.0.0.9/32",
-"192.0.0.10/32", "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24", "192.168.0.0/16", "192.88.99.0/24",
-"224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24","198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "224.0.0.0/4", "240.0.0.0/4")
-```
-
-
-
 ### Unexpected Child Process of macOS Screensaver Engine
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1710
+Index: geneve-ut-1895
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -18322,7 +19922,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1711
+Index: geneve-ut-1896
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18351,7 +19951,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1713
+Index: geneve-ut-1898
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -18361,36 +19961,22 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 
 
-### Untrusted DLL Loaded by Azure AD Sync Service
+### Untrusted DLL Loaded by Azure AD Connect Authentication Agent
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1718
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1903
 
 ```python
-any where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
-(
- (event.category == "library" and event.action == "load") or
- (event.category == "process" and event.action : "Image loaded*")
-) and
+library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
 
-not (?dll.code_signature.trusted == true or file.code_signature.status == "Valid") and not
-
-  (
-   /* Elastic defend DLL path */
-   ?dll.path :
-         ("?:\\Windows\\assembly\\NativeImages*",
-          "?:\\Windows\\Microsoft.NET\\*",
-          "?:\\Windows\\WinSxS\\*",
-          "?:\\Windows\\System32\\DriverStore\\FileRepository\\*") or
-
-   /* Sysmon DLL path is mapped to file.path */
-   file.path :
-         ("?:\\Windows\\assembly\\NativeImages*",
-          "?:\\Windows\\Microsoft.NET\\*",
-          "?:\\Windows\\WinSxS\\*",
-          "?:\\Windows\\System32\\DriverStore\\FileRepository\\*")
-  )
+not dll.code_signature.trusted == true and
+not dll.path : (
+    "?:\\Windows\\assembly\\NativeImages*",
+    "?:\\Windows\\Microsoft.NET\\*",
+    "?:\\Windows\\WinSxS\\*",
+    "?:\\Windows\\System32\\DriverStore\\FileRepository\\*"
+)
 ```
 
 
@@ -18399,12 +19985,23 @@ not (?dll.code_signature.trusted == true or file.code_signature.status == "Valid
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1719
+Index: geneve-ut-1904
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
   (dll.code_signature.trusted == false or dll.code_signature.exists == false) and
-  not dll.code_signature.status : ("errorExpired", "errorRevoked", "errorCode_endpoint:*")
+  /* errorExpired and errorRevoked are handled by d12bac54-ab2a-4159-933f-d7bcefa7b61d */
+  not dll.code_signature.status : ("errorExpired", "errorRevoked", "errorCode_endpoint:*") and
+
+  not dll.hash.sha256 : (
+        /* HP DOT4 printer driver family FPs (Dot4.sys, Dot4Prt.sys, Dot4usb.sys, Dot4Scan.sys) */
+        "f21c1d478180bc5e932bb2c2e4618e3ed463ca87acedeb139682d218435f82f1",
+        "7e2f2a139e897eae56038b920bda9381094bc0ae9e626f6634e6b444b8b0c91f",
+        "12ffdf5f48a79b1b4adbb88ba2cb6c59dd6719554e8ea6beefe99b3e3c66f1ac",
+        "dbc6afaf80141e2480e19878f581edfe9c2b018da2ec527c4025ff04d5587afd",
+        /* (dc3d.sys, test-signed) */
+        "ca8f9564733ded4c3895cf7150bb254995d66889e6be08d6654e4f897e4ff7a4"
+  )
 ```
 
 
@@ -18413,7 +20010,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1724
+Index: geneve-ut-1910
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18427,16 +20024,18 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1725
+Index: geneve-ut-1911
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.parent.name : "dns.exe" and
   not process.executable : (
     "?:\\Windows\\System32\\conhost.exe",
+    "?:\\Windows\\System32\\dns.exe",
 
     /* Crowdstrike specific exclusion as it uses NT Object paths */
     "\\Device\\HarddiskVolume*\\Windows\\System32\\conhost.exe",
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\dns.exe",
     "\\Device\\HarddiskVolume*\\Program Files\\ReasonLabs\\*"
   ) and
   not ?process.parent.executable : "?:\\Program Files\\ReasonLabs\\DNS\\ui\\DNS.exe"
@@ -18448,7 +20047,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1734
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -18482,7 +20081,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1736
+Index: geneve-ut-1922
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18497,37 +20096,15 @@ process.group_leader.name != null and not (
 
 
 
-### Unusual Executable File Creation by a System Critical Process
-
-Branch count: 18  
-Document count: 18  
-Index: geneve-ut-1739
-
-```python
-file where host.os.type == "windows" and event.type != "deletion" and
-  file.extension : ("exe", "dll") and
-  process.name : ("smss.exe",
-                  "autochk.exe",
-                  "csrss.exe",
-                  "wininit.exe",
-                  "services.exe",
-                  "lsass.exe",
-                  "winlogon.exe",
-                  "userinit.exe",
-                  "LogonUI.exe")
-```
-
-
-
 ### Unusual File Creation - Alternate Data Stream
 
-Branch count: 186  
-Document count: 186  
-Index: geneve-ut-1743
+Branch count: 248  
+Document count: 248  
+Index: geneve-ut-1929
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
-   process.name : ("cmd.exe", "powershell.exe", "mshta.exe", "wscript.exe", "node.exe", "python*.exe") and
+   process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "mshta.exe", "wscript.exe", "cscript.exe", "node.exe", "python*.exe") and
    file.extension in~ (
     "pdf", "dll", "exe", "dat", "com", "bat", "cmd", "sys", "vbs", "vbe", "ps1", "hta", "txt", "js", "jse",
     "wsh", "wsf", "sct", "docx", "doc", "xlsx", "xls", "pptx", "ppt", "rtf", "gif", "jpg", "png", "bmp", "img", "iso"
@@ -18538,128 +20115,11 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
-### Unusual Instance Metadata Service (IMDS) API Request
-
-Branch count: 141  
-Document count: 282  
-Index: geneve-ut-1755
-
-```python
-sequence by host.id, process.parent.entity_id with maxspan=3s
-[
-    process
-    where host.os.type == "linux"
-        and event.type == "start"
-        and event.action == "exec"
-        and process.parent.executable != null
-
-        // common tooling / suspicious names (keep broad)
-        and (
-            process.name : (
-                "curl", "wget", "python*", "perl*", "php*", "ruby*", "lua*", "telnet", "pwsh",
-                "openssl", "nc", "ncat", "netcat", "awk", "gawk", "mawk", "nawk", "socat", "node",
-                "bash", "sh"
-            )
-            or
-            // suspicious execution locations (dropped binaries / temp execution)
-            process.executable : (
-                "./*", "/tmp/*", "/var/tmp/*", "/var/www/*", "/dev/shm/*", "/etc/init.d/*", "/etc/rc*.d/*",
-                "/etc/cron*", "/etc/update-motd.d/*", "/boot/*", "/srv/*", "/run/*", "/etc/rc.local"
-            )
-            or
-            // threat-relevant IMDS / metadata endpoints (inclusion list)
-            process.command_line : (
-                "*169.254.169.254/latest/api/token*",
-                "*169.254.169.254/latest/meta-data/iam/security-credentials*",
-                "*169.254.169.254/latest/meta-data/local-ipv4*",
-                "*169.254.169.254/latest/meta-data/local-hostname*",
-                "*169.254.169.254/latest/meta-data/public-ipv4*",
-                "*169.254.169.254/latest/user-data*",
-                "*169.254.169.254/latest/dynamic/instance-identity/document*",
-                "*169.254.169.254/latest/meta-data/instance-id*",
-                "*169.254.169.254/latest/meta-data/public-keys*",
-                "*computeMetadata/v1/instance/service-accounts/*/token*",
-                "*/metadata/identity/oauth2/token*",
-                "*169.254.169.254/opc/v*/instance*",
-                "*169.254.169.254/opc/v*/vnics*"
-            )
-        )
-
-        // global working-dir / executable / parent exclusions for known benign agents
-        and not process.working_directory : (
-            "/opt/rapid7*",
-            "/opt/nessus*",
-            "/snap/amazon-ssm-agent*",
-            "/var/snap/amazon-ssm-agent/*",
-            "/var/log/amazon/ssm/*",
-            "/srv/snp/docker/overlay2*",
-            "/opt/nessus_agent/var/nessus/*"
-        )
-
-        and not process.executable : (
-            "/opt/rumble/bin/rumble-agent*",
-            "/opt/aws/inspector/bin/inspectorssmplugin",
-            "/snap/oracle-cloud-agent/*",
-            "/lusr/libexec/oracle-cloud-agent/*"
-        )
-
-        and not process.parent.executable : (
-            "/usr/bin/setup-policy-routes",
-            "/usr/share/ec2-instance-connect/*",
-            "/var/lib/amazon/ssm/*",
-            "/etc/update-motd.d/30-banner",
-            "/usr/sbin/dhclient-script",
-            "/usr/local/bin/uwsgi",
-            "/usr/lib/skylight/al-extras",
-            "/usr/bin/cloud-init",
-            "/usr/sbin/waagent",
-            "/usr/bin/google_osconfig_agent",
-            "/usr/bin/docker",
-            "/usr/bin/containerd-shim",
-            "/usr/bin/runc"
-        )
-
-        and not process.entry_leader.executable : (
-            "/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent",
-            "/opt/Elastic/Agent/data/elastic-agent-*/elastic-agent",
-            "/opt/nessus_agent/sbin/nessus-service"
-        )
-
-        // carve-out: safe /usr/bin/curl usage (suppress noisy, legitimate agent patterns)
-        and not (
-            process.executable == "/usr/bin/curl"
-            and (
-                // AWS IMDSv2 token PUT that includes ttl header
-                (process.command_line : "*-X PUT*169.254.169.254/latest/api/token*" and process.command_line : "*X-aws-ec2-metadata-token-ttl-seconds*")
-                or
-                // Any IMDSv2 GET that includes token header for any /latest/* path
-                process.command_line : "*-H X-aws-ec2-metadata-token:*169.254.169.254/latest/*"
-                or
-                // Common amazon tooling UA
-                process.command_line : "*-A amazon-ec2-net-utils/*"
-                or
-                // Azure metadata legitimate header
-                process.command_line : "*-H Metadata:true*169.254.169.254/metadata/*"
-                or
-                // Oracle IMDS legitimate header
-                process.command_line : "*-H Authorization:*Oracle*169.254.169.254/opc/*"
-            )
-        )
-]
-[
-    network where host.os.type == "linux"
-        and event.action == "connection_attempted"
-        and destination.ip == "169.254.169.254"
-]
-```
-
-
-
 ### Unusual Kill Signal
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1758
+Index: geneve-ut-1943
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -18676,7 +20136,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1761
+Index: geneve-ut-1946
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -18693,7 +20153,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1777
+Index: geneve-ut-1962
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -18710,13 +20170,13 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 ### Unusual Parent-Child Relationship
 
-Branch count: 32  
-Document count: 32  
-Index: geneve-ut-1781
+Branch count: 66  
+Document count: 66  
+Index: geneve-ut-1966
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
-process.parent.name != null and
+process.parent.name != null and process.parent.executable like ("?:\\*", "\\Device\\*") and
  (
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
@@ -18739,11 +20199,12 @@ process.parent.name != null and
    (process.name:"userinit.exe" and not process.parent.name:("dwm.exe", "winlogon.exe", "KUsrInit.exe")) or
    (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
    /* suspicious child processes */
-   (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe")) or
+   (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
-   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe"))
+   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
+     not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe"))
   )
 ```
 
@@ -18753,7 +20214,7 @@ process.parent.name != null and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1782
+Index: geneve-ut-1967
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18798,7 +20259,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1785
+Index: geneve-ut-1970
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18836,11 +20297,39 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Unusual Process Connection to Docker or Containerd Socket
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1972
+
+```python
+host.os.type:"linux" and 
+event.category:"network" and
+event.action:"connected-to" and network.direction:"egress" and 
+destination.address:("/run/containerd/containerd.sock" or "/var/run/containerd/containerd.sock" or "/var/run/docker.sock" or "/run/docker.sock") and
+process.executable:(* and not 
+  ("/usr/bin/kubelet" or
+  "/usr/local/bin/kubelet" or
+  "/usr/bin/containerd" or
+  "/usr/sbin/containerd" or
+  "/usr/bin/containerd-shim" or
+  "/usr/bin/containerd-shim-runc-v2" or
+  "/usr/local/bin/containerd-shim-runc-v2" or
+  "/usr/bin/dockerd" or
+  "/usr/sbin/dockerd" or  
+   /var/lib/*/usr/bin/dockerd or 
+  "/usr/bin/docker-proxy")
+)
+```
+
+
+
 ### Unusual Process Execution on WBEM Path
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1790
+Index: geneve-ut-1976
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18864,7 +20353,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1791
+Index: geneve-ut-1977
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18904,7 +20393,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1792
+Index: geneve-ut-1978
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -18951,7 +20440,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1796
+Index: geneve-ut-1982
 
 ```python
 sequence by process.entity_id
@@ -18988,7 +20477,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1830
+Index: geneve-ut-2014
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19002,7 +20491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1831
+Index: geneve-ut-2015
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -19045,7 +20534,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1832
+Index: geneve-ut-2016
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -19058,7 +20547,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1835
+Index: geneve-ut-2019
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -19072,7 +20561,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1836
+Index: geneve-ut-2020
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -19081,29 +20570,11 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 
 
-### Veeam Backup Library Loaded by Unusual Process
-
-Branch count: 10  
-Document count: 10  
-Index: geneve-ut-1839
-
-```python
-library where host.os.type == "windows" and event.action == "load" and
-  (dll.name : "Veeam.Backup.Common.dll" or dll.pe.original_file_name : "Veeam.Backup.Common.dll") and
-  (
-    process.code_signature.trusted == false or
-    process.code_signature.exists == false or
-    process.name : ("powershell.exe", "pwsh.exe", "powershell_ise.exe")
-  )
-```
-
-
-
 ### Virtual Machine Fingerprinting
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1840
+Index: geneve-ut-2024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -19128,7 +20599,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1841
+Index: geneve-ut-2025
 
 ```python
 process where event.type == "start" and
@@ -19143,7 +20614,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1842
+Index: geneve-ut-2026
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19160,7 +20631,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1843
+Index: geneve-ut-2027
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19174,7 +20645,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1844
+Index: geneve-ut-2028
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19190,7 +20661,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1845
+Index: geneve-ut-2029
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19204,7 +20675,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1846
+Index: geneve-ut-2030
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -19217,8 +20688,12 @@ file where host.os.type == "windows" and event.action != "deletion" and
   ) and
   not process.executable : (
     "C:\\Windows\\System32\\poqexec.exe",
-    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe"
-  )
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe",
+    "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+    "?:\\Windows\\System32\\omadmclient.exe"
+  ) and
+  /* System / ntoskrnl.exe (PID 4) */
+  not process.pid == 4
 ```
 
 
@@ -19227,7 +20702,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1848
+Index: geneve-ut-2032
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -19239,7 +20714,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1849
+Index: geneve-ut-2033
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19255,7 +20730,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1850
+Index: geneve-ut-2034
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -19278,7 +20753,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1851
+Index: geneve-ut-2035
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -19291,7 +20766,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1853
+Index: geneve-ut-2037
 
 ```python
 http.response.status_code:403 and http.request.method:post
@@ -19303,7 +20778,7 @@ http.response.status_code:403 and http.request.method:post
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1854
+Index: geneve-ut-2038
 
 ```python
 http.response.status_code:405
@@ -19315,7 +20790,7 @@ http.response.status_code:405
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1855
+Index: geneve-ut-2039
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -19323,22 +20798,101 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 
 
-### Web Server Potential SQL Injection Request
+### Web Server Cloud Metadata SSRF Request
 
-Branch count: 61  
-Document count: 61  
-Index: geneve-ut-1861
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-2040
 
 ```python
-any where url.original like~ (
-  "*%20order%20by%*", "*dbms_pipe.receive_message%28chr%*", "*waitfor%20delay%20*", "*%28select%20*from%20pg_sleep%285*", "*%28select%28sleep%285*", "*%3bselect%20pg_sleep%285*",
-  "*select%20concat%28concat*", "*xp_cmdshell*", "*select*case*when*", "*and*extractvalue*select*", "*from*information_schema.tables*", "*boolean*mode*having*", "*extractvalue*concat*",
-  "*case*when*sleep*", "*select*sleep*", "*dbms_lock.sleep*", "*and*sleep*", "*like*sleep*", "*csleep*", "*pgsleep*", "*char*char*char*", "*union*select*", "*concat*select*",
-  "*select*else*drop*", "*having*like*", "*case*else*end*", "*if*sleep*", "*where*and*select*", "*or*1=1*", "*\"1\"=\"1\"*", "*or*'a'='a*", "*into*outfile*", "*pga_sleep*",
-  "*into%20outfile*", "*into*dumpfile*", "*load_file%28*", "*load%5ffile%28*", "*cast%28*", "*convert%28*", "*cast%28%*", "*convert%28%*", "*@@version*", "*@@version_comment*",
-  "*version%28*", "*user%28*", "*current_user%28*", "*database%28*", "*schema_name%28*", "*information_schema.columns*", "*information_schema.columns*", "*table_schema*",
-  "*column_name*", "*dbms_pipe*", "*dbms_lock%2e*sleep*", "*dbms_lock.sleep*", "*sp_executesql*", "*sp_executesql*", "*load%20data*", "*information_schema*",  "*pg_slp*",
-  "*information_schema.tables*"
+web where (
+  url.original : (
+    "*169.254.169.254*", "*169%2e254%2e169%2e254*", "*0xa9fea9fe*", "*0xa9.0xfe.0xa9.0xfe*", 
+    "*2852039166*", "*0251.0376.0251.0376*", "*::ffff:169.254.169.254*", "*::ffff:a9fe:a9fe*", "*fd00:ec2::254*",
+    "*100.100.100.200*", "*169.254.170.2*", "*metadata.google.internal*", "*metadata.goog*", "*computeMetadata/v1*",
+    "*meta-data/iam/security-credentials*", "*meta-data%2Fiam%2Fsecurity-credentials*",
+    "*latest/meta-data*", "*latest/api/token*"
+  )
+  or
+  url.query : (
+    "*169.254.169.254*", "*169%2e254%2e169%2e254*", "*0xa9fea9fe*", "*0xa9.0xfe.0xa9.0xfe*", 
+    "*2852039166*", "*0251.0376.0251.0376*", "*::ffff:169.254.169.254*", "*::ffff:a9fe:a9fe*", "*fd00:ec2::254*",
+    "*100.100.100.200*", "*169.254.170.2*", "*metadata.google.internal*", "*metadata.goog*", "*computeMetadata/v1*",
+    "*meta-data/iam/security-credentials*", "*meta-data%2Fiam%2Fsecurity-credentials*",
+    "*latest/meta-data*", "*latest/api/token*"
+  )
+)
+```
+
+
+
+### Web Server Potential SQL Injection Request
+
+Branch count: 91  
+Document count: 91  
+Index: geneve-ut-2046
+
+```python
+any where (
+url.original like~ (
+    "*dbms_pipe.receive_message%28chr%*",
+    "*waitfor%20delay%20%270%3a0%3a*",
+    "*%28select%28sleep%285*", "*%28select%20*from%20pg_sleep%285*", "*%3bselect%20pg_sleep%285*",
+    "*and%20sleep%28*%29*", "*or%20sleep%28*%29*", "*case%20when*then%20sleep%28*", "*if%28sleep%28*%29*",
+    "*benchmark%28*%2c*md5%28*",
+    "*convert%28int%2c%28select%20char%28*",
+    "*char%28*char%28*char%28*char%28*",
+    "*concat%28concat%28char%28*",
+    "*case%20when%20%28*%3d*%29%20then*else*end*",
+    "*elt%28*%3d*%2c1%29%29*",
+    "*union%20select%20null%2cnull*", "*union%20all%20select%20null*",
+    "*union%20all%20select%20*concat%28md5%28*",
+    "*extractvalue%28*concat%280x*", "*updatexml%28*concat%280x*",
+    "*procedure%2f%2a%2a%2fanalyse%28extractvalue%28*",
+    "*gtid_subset%28concat%280x*", "*gtid_subtract%28concat%280x*",
+    "*mid%28ifnull%28session_user%28%29*",
+    "*'qq'%2b%28%28select%20@@version%29%29%2b'qq'*",
+    "*%27%20or%20%271%27%3d%271*", "*%22%20or%20%221%22%3d%221*", "*%27%20or%20%27a%27%3d%27a*",
+    "*and%201%3d1--*", "*and%201%3d2--*",
+    "*%29%3bselect*if%28%28ord%28mid%28*",
+    "*xp_cmdshell*",
+    "*select%20*into%20outfile*", "*select%20*into%20dumpfile*",
+    "*load_file%28*", "*load%5ffile%28*",
+    "*select%20*from%20information_schema.tables*", "*from%20information_schema.columns%20where%20table_schema*",
+    "*dbms_pipe%2ereceive_message*", "*dbms_lock%2esleep*",
+    "*select%20@@version*", "*select%20user%28%29*", "*select%20current_user%28%29*", "*select%20database%28%29*",
+    "*sp_executesql%20*exec%20*", "*xp_dirtree*"
+  )
+  or
+  url.query like~ (
+    "*dbms_pipe.receive_message(chr*",
+    "*waitfor delay '0:0:*",
+    "*(select(sleep(5*", "*(select*from pg_sleep(5*", "*;select pg_sleep(5*",
+    "*and sleep(*)*", "*or sleep(*)*", "*case when*then sleep(*", "*if(sleep(*)*",
+    "*benchmark(*,*md5(*",
+    "*convert(int,(select char(*",
+    "*char(*char(*char(*char(*",
+    "*concat(concat(char(*",
+    "*case when (*=*) then*else*end*",
+    "*elt(*=*,1))*",
+    "*union select null,null*", "*union all select null*",
+    "*union all select*concat(md5(*",
+    "*extractvalue(*concat(0x*", "*updatexml(*concat(0x*",
+    "*procedure/**/analyse(extractvalue(*",
+    "*gtid_subset(concat(0x*", "*gtid_subtract(concat(0x*",
+    "*mid(ifnull(session_user()*",
+    "*'qq'+((select @@version))+'qq'*",
+    "*' or '1'='1*", "*\" or \"1\"=\"1*", "*' or 'a'='a*",
+    "*and 1=1--*", "*and 1=2--*",
+    "*);select*if((ord(mid(*",
+    "*xp_cmdshell*",
+    "*select*into outfile*", "*select*into dumpfile*",
+    "*load_file(*",
+    "*select*from information_schema.tables*", "*from information_schema.columns where table_schema*",
+    "*dbms_pipe.receive_message*", "*dbms_lock.sleep*",
+    "*select @@version*", "*select user()*", "*select current_user()*", "*select database()*",
+    "*sp_executesql*exec*", "*xp_dirtree*"
+  )
 )
 ```
 
@@ -19348,7 +20902,7 @@ any where url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1863
+Index: geneve-ut-2048
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19369,7 +20923,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1866
+Index: geneve-ut-2051
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -19383,7 +20937,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1867
+Index: geneve-ut-2052
 
 ```python
 file where event.type == "deletion" and
@@ -19400,7 +20954,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1868
+Index: geneve-ut-2053
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19418,7 +20972,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1871
+Index: geneve-ut-2056
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19456,7 +21010,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1873
+Index: geneve-ut-2058
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19493,7 +21047,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1874
+Index: geneve-ut-2059
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19508,7 +21062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1875
+Index: geneve-ut-2060
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -19521,7 +21075,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1876
+Index: geneve-ut-2061
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19540,7 +21094,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-1877
+Index: geneve-ut-2062
 
 ```python
 sequence with maxspan=1m
@@ -19565,7 +21119,7 @@ sequence with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1878
+Index: geneve-ut-2063
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19591,7 +21145,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1879
+Index: geneve-ut-2064
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -19613,7 +21167,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1880
+Index: geneve-ut-2065
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19630,7 +21184,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-1882
+Index: geneve-ut-2067
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -19649,7 +21203,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-1883
+Index: geneve-ut-2068
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -19689,7 +21243,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1884
+Index: geneve-ut-2069
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19706,7 +21260,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1886
+Index: geneve-ut-2071
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -19719,7 +21273,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1887
+Index: geneve-ut-2072
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -19733,7 +21287,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1888
+Index: geneve-ut-2073
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19761,7 +21315,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1889
+Index: geneve-ut-2074
 
 ```python
 process where event.type == "start" and
@@ -19786,7 +21340,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1890
+Index: geneve-ut-2075
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19796,11 +21350,27 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### XDG-Open Command Execution
+
+Branch count: 25  
+Document count: 25  
+Index: geneve-ut-2076
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2") and (
+  process.name == "xdg-open" or
+  process.args in ("/bin/xdg-open", "/usr/bin/xdg-open", "/usr/local/bin/xdg-open", "xdg-open")
+)
+```
+
+
+
 ### Yum Package Manager Plugin File Creation
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1891
+Index: geneve-ut-2077
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19835,7 +21405,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1892
+Index: geneve-ut-2078
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19853,7 +21423,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1895
+Index: geneve-ut-2081
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-serverless.md
+++ b/tests/reports/alerts_from_rules-serverless.md
@@ -5,22 +5,22 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.2
+Rules version: 9.4.7
 
 ## Table of contents
-   1. [Failed rules (20)](#failed-rules-20)
-   1. [Unsuccessful rules with signals (20)](#unsuccessful-rules-with-signals-20)
+   1. [Failed rules (24)](#failed-rules-24)
+   1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
-   1. [Rules with too few signals (23)](#rules-with-too-few-signals-23)
-   1. [Rules with the correct signals (770)](#rules-with-the-correct-signals-770)
+   1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
+   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
 
-## Failed rules (20)
+## Failed rules (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0271  
+Index: geneve-ut-0335  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0516  
+Index: geneve-ut-0605  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -144,7 +144,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0541  
+Index: geneve-ut-0630  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -173,7 +173,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0626  
+Index: geneve-ut-0729  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -200,11 +200,64 @@ not process.name in ("git", "dirname")
 
 
 
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0920  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Multi-Base64 Decoding Attempt from Suspicious Location
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0922  
+Index: geneve-ut-1060  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -237,7 +290,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-0947  
+Index: geneve-ut-1088  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -280,7 +333,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1013  
+Index: geneve-ut-1159  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -321,7 +374,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1042  
+Index: geneve-ut-1188  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -347,7 +400,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1058  
+Index: geneve-ut-1205  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -385,7 +438,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1116  
+Index: geneve-ut-1268  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -407,7 +460,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1130  
+Index: geneve-ut-1283  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +501,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1217  
+Index: geneve-ut-1372  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -511,7 +564,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1440  
+Index: geneve-ut-1612  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -557,7 +610,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1443  
+Index: geneve-ut-1616  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -600,7 +653,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1522  
+Index: geneve-ut-1699  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -644,11 +697,46 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1713  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Echo or Printf Execution Detected via Defend for Containers
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1546  
+Index: geneve-ut-1726  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -673,7 +761,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1556  
+Index: geneve-ut-1736  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -736,7 +824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1562  
+Index: geneve-ut-1742  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -760,11 +848,82 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1751  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1802  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1663  
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1847  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -774,13 +933,16 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -810,7 +972,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -818,12 +979,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -832,7 +998,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1692  
+Index: geneve-ut-1877  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -875,13 +1041,13 @@ process.interactive == true and container.id like "*"
 
 
 
-## Unsuccessful rules with signals (20)
+## Unsuccessful rules with signals (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0271
+Index: geneve-ut-0335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -933,7 +1099,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0516
+Index: geneve-ut-0605
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -999,7 +1165,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0541
+Index: geneve-ut-0630
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1025,7 +1191,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0626
+Index: geneve-ut-0729
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1049,11 +1215,61 @@ not process.name in ("git", "dirname")
 
 
 
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0920
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Multi-Base64 Decoding Attempt from Suspicious Location
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0922
+Index: geneve-ut-1060
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1083,7 +1299,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-0947
+Index: geneve-ut-1088
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1123,7 +1339,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1013
+Index: geneve-ut-1159
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1161,7 +1377,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1042
+Index: geneve-ut-1188
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1184,7 +1400,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1058
+Index: geneve-ut-1205
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1219,7 +1435,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1116
+Index: geneve-ut-1268
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1238,7 +1454,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1130
+Index: geneve-ut-1283
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1276,7 +1492,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1217
+Index: geneve-ut-1372
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1336,7 +1552,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1440
+Index: geneve-ut-1612
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1379,7 +1595,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1443
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1419,7 +1635,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1522
+Index: geneve-ut-1699
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1460,11 +1676,43 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1713
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Echo or Printf Execution Detected via Defend for Containers
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1546
+Index: geneve-ut-1726
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.interactive == true and
@@ -1486,7 +1734,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1556
+Index: geneve-ut-1736
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1546,7 +1794,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1562
+Index: geneve-ut-1742
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1567,24 +1815,92 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1751
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1802
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1663
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1847
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -1614,7 +1930,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -1622,12 +1937,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -1636,7 +1956,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1692
+Index: geneve-ut-1877
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1682,7 +2002,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0168
+Index: geneve-ut-0218
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1696,7 +2016,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0787
+Index: geneve-ut-0921
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1708,7 +2028,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0808
+Index: geneve-ut-0941
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1720,7 +2040,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1165
+Index: geneve-ut-1319
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1734,27 +2054,28 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 
 
-### Potential Privacy Control Bypass via TCCDB Modification
+### Protected Storage Service Access via SMB
 
-Branch count: 16  
-Document count: 16  
-Index: geneve-ut-1204
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1516
 
 ```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "sqlite*" and
- process.args like "/*/Application Support/com.apple.TCC/TCC.db" and
- (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+host.os.type:windows and event.category:file and event.code:5145 and
+  winlog.event_data.ShareName:"\\\\*\\IPC$" and
+  winlog.event_data.RelativeTargetName:"protected_storage" and
+  not source.ip:("::" or "::1" or "0.0.0.0" or "127.0.0.1")
 ```
 
 
 
-## Rules with too few signals (23)
+## Rules with too few signals (28)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0271  
+Index: geneve-ut-0335  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -1808,7 +2129,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0516  
+Index: geneve-ut-0605  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -1876,7 +2197,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0541  
+Index: geneve-ut-0630  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -1904,7 +2225,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0626  
+Index: geneve-ut-0729  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -1930,11 +2251,82 @@ not process.name in ("git", "dirname")
 
 
 
+### Kubernetes Secrets List Across Cluster or Sensitive Namespaces
+
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0897  
+Failure message(s):  
+  got 3 signals, expected 6  
+
+```python
+event.dataset:"kubernetes.audit_logs" and event.action:list and 
+kubernetes.audit.objectRef.resource:secrets and 
+kubernetes.audit.requestURI :(/api/v1/secrets or /api/v1/secrets?limit* or /api/v1/namespaces/kube-system/secrets or /api/v1/namespaces/kube-system/secrets?limit* or /api/v1/namespaces/default/secrets or /api/v1/namespaces/default/secrets?limit*) and 
+source.ip:(* and not ("::1" or "127.0.0.1")) and 
+not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator) and 
+not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
+```
+
+
+
+### Linux External IP Address Discovery via Curl
+
+Branch count: 6552  
+Document count: 6552  
+Index: geneve-ut-0920  
+Failure message(s):  
+  got 1000 signals, expected 6552  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "curl" and (
+  process.parent.name like ".*" or process.parent.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/opt/*",  "/etc/*", "./*", "/run/user/*", "/var/run/user/*",
+    "/usr/bin/*", "/bin/*", "/usr/local/bin/*", "/sbin/*", "/usr/sbin/*", "/usr/local/sbin/*",
+    "/usr/lib/*", "/usr/local/lib/*", "/lib/*", "/lib64/*", "/usr/lib64/*", "/usr/local/lib64/*"
+  )
+) and
+process.command_line like~ (
+  "*ip-api.com*", "*checkip.dyndns.org*", "*api.ipify.org*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+  "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*", "*icanhazip.com*", "*curlmyip.com*",
+  "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*", "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*",
+  "*api.ip.sb*", "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*", "*freegeoip.net*",
+  "*freegeoip.app*", "*geoplugin.net*", "*myip.dnsomatic.com*", "*www.geoplugin.net*",
+  "*api64.ipify.org*", "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+  "*geolocation-db.com*", "*httpbin.org*", "*myip.opendns.com*", "*ipv4.icanhazip.com*", "*ipv6.icanhazip.com*"
+) and
+not (
+  process.parent.name in ("jamf", "make") or
+  process.parent.name in (".", "./alert_api_call.sh", "nvim", "teleport") or
+  process.parent.executable like (
+    "/usr/local/bin/teleport", "/usr/local/bin/current_ip", "/tmp/go-build*", "/usr/bin/neofetch",
+    "/usr/bin/show-location-info", "/opt/tpot/bin/myip.sh", "/usr/sbin/sshd", "/tmp/newroot/var/quest/kace/scripts/*",
+    "./Linux_Inventory_Sheets.sh", "/opt/qvm/bin/update_info_qsuite", "/usr/lib/check_mk_agent/local/public_ip_check",
+    "/opt/teleport/system/bin/teleport", "/opt/Elastic/Endpoint/elastic-endpoint", "/etc/update-motd.d/motd.sh",
+    "/opt/coe/cadence/IC231/tools.lnx86/cda/bin/64bit/cda.exe", "/etc/update-motd.d/10-armbian-header",
+    "/opt/saltstack/salt/bin/python*", "/usr/bin/python*", "/usr/local/bin/detect-external-ip"
+  ) or
+  process.parent.args in ("/var/www/html/admin/modules/leucoalarm/scripts/system.php", "/etc/cont-init.d/50-ddns") or
+  (
+    process.parent.executable == "/usr/bin/java" and
+    process.args like "/opt/streamsets-datacollector/libexec/bootstrap-libs/*"
+  ) or
+  process.parent.command_line == "runc init" or
+  (
+    process.parent.executable == "/usr/bin/busybox" and
+    (process.parent.command_line == "sh /etc/cont-init.d/50-ddns" or process.working_directory == "/opt/outline-server")
+  )
+)
+```
+
+
+
 ### Microsoft IIS Service Account Password Dumped
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0900  
+Index: geneve-ut-1038  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -1954,7 +2346,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0922  
+Index: geneve-ut-1060  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -1986,7 +2378,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-0947  
+Index: geneve-ut-1088  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2028,7 +2420,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1013  
+Index: geneve-ut-1159  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2068,7 +2460,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1042  
+Index: geneve-ut-1188  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2093,7 +2485,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1058  
+Index: geneve-ut-1205  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2130,7 +2522,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1116  
+Index: geneve-ut-1268  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2151,7 +2543,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1130  
+Index: geneve-ut-1283  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2191,7 +2583,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1208  
+Index: geneve-ut-1363  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2208,7 +2600,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1217  
+Index: geneve-ut-1372  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2270,7 +2662,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1315  
+Index: geneve-ut-1483  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2295,7 +2687,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1440  
+Index: geneve-ut-1612  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2340,7 +2732,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1443  
+Index: geneve-ut-1616  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -2382,7 +2774,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1522  
+Index: geneve-ut-1699  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -2425,11 +2817,45 @@ sequence by host.id with maxspan=5s
 
 
 
+### Suspicious Command Execution via Busybox Proxy
+
+Branch count: 5280  
+Document count: 5280  
+Index: geneve-ut-1713  
+Failure message(s):  
+  got 1000 signals, expected 5280  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.name == "busybox" and (
+  process.args in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+  process.command_line like (
+    "*nc *", "*netcat*", "*openssl*", "*telnet*", "*exec*", "*import*pty*spawn*", "*import*subprocess*call*", "*socket*",
+    "*system*", "*io.popen*", "*os.execute*", "*fsockopen*", "*/inet/tcp/*", "*/dev/tcp/*", "*/dev/udp/*", "*nohup*",
+    "*setsid*", "*/dev/shm/*", "*ld-linux*.so*", "*/tmp/*", "*/var/tmp/*", "*rm*-rf*"
+  )
+) and (
+  process.parent.executable like (
+      "/tmp/*", "/var/tmp/*", "/dev/shm/*", "./*", "/run/*", "/var/run/*", "/boot/*", "/sys/*", "/lost+found/*",
+      "/proc/*", "/var/mail/*", "/var/www/*", "/home/*", "/root/*" 
+    ) or
+    process.parent.name like ".*"
+) and not (
+  process.parent.command_line in ("runc init", "/usr/local/bin/runc init") or
+  process.parent.executable == "./runc" or
+  process.parent.executable like ("/run/containerd/io.containerd.runtime.v2.task/k8s.io/*/bin/php", "/tmp/go-build*.test") or
+  process.command_line == "sh -c echo EXEC" or
+  process.parent.name in ("ninja_test", "ocamlrun", "ocamlopt.opt", "make", "process-wrapper")
+)
+```
+
+
+
 ### Suspicious Echo or Printf Execution Detected via Defend for Containers
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1546  
+Index: geneve-ut-1726  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -2453,7 +2879,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1556  
+Index: geneve-ut-1736  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -2515,7 +2941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1562  
+Index: geneve-ut-1742  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -2538,26 +2964,98 @@ sequence by process.entity_id with maxspan=30s
 
 
 
+### Suspicious Instance Metadata Service (IMDS) API Command Line Execution
+
+Branch count: 2457  
+Document count: 2457  
+Index: geneve-ut-1751  
+Failure message(s):  
+  got 1000 signals, expected 2457  
+
+```python
+process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
+event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
+(
+  process.name in~ (
+    "curl", "curl.exe", "wget", "wget.exe", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox", "powershell.exe", "cmd.exe", "pwsh.exe", "pwsh"
+  ) or
+  process.name like~ (".*", "python*", "perl*", "ruby*", "php*", "lua*", "java*") or
+  ?process.executable like~ (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*",
+    "?:\\ProgramData\\*", "/var/www/*", "./*"
+  )
+) and
+process.args like~ (
+  "*/latest/meta-data/iam/security-credentials/?*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*/metadata/identity/oauth2/token*resource=*"
+)
+```
+
+
+
+### Suspicious SUID Binary Execution
+
+Branch count: 8576  
+Document count: 8576  
+Index: geneve-ut-1802  
+Failure message(s):  
+  got 1000 signals, expected 8576  
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.user.id == "0" and process.real_user.id != "0" and process.parent.user.id != "0") or
+  (process.group.id == "0" and process.real_group.id != "0" and process.parent.group.id != "0")
+) and
+(
+  (process.name in ("su", "passwd", "unix_chkpwd") and process.args_count <= 2) or
+  (
+    process.name in ("sudo", "pkexec", "fusermount", "fusermount3", "mount", "umount", "newgrp", "chsh") and
+    process.args_count == 1
+  ) or
+  process.name in (
+    "sudoedit", "gpasswd", "chfn", "polkit-agent-helper-1", "dbus-daemon-launch-helper", "ssh-keysign",
+    "pam_extrausers_chkpwd", "expiry", "chage", "crontab", "wall", "bsd-write", "ssh-agent", "ping",
+    "ping6", "traceroute", "mtr", "ntfs-3g", "Xorg.wrap", "chrome-sandbox", "bwrap"
+  )
+) and
+(
+  process.parent.name like (".*", "python*", "perl*", "ruby*", "lua*", "php*", "node", "deno", "bun", "java") or
+  process.parent.executable like ("./*", "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+  (
+    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+    process.parent.args in ("-c", "-cl", "-lc", "--command", "-ic", "-ci", "-bash", "-sh", "-zsh", "-dash", "-fish", "-ksh", "-mksh") and
+    process.parent.args_count <= 4
+  )
+)
+```
+
+
+
 ### System Public IP Discovery via DNS Query
 
-Branch count: 1053  
-Document count: 1053  
-Index: geneve-ut-1663  
+Branch count: 2442  
+Document count: 2442  
+Index: geneve-ut-1847  
 Failure message(s):  
-  got 1000 signals, expected 1053  
+  got 1000 signals, expected 2442  
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
 (
   process.name : ("MSBuild.exe", "mshta.exe", "wscript.exe", "powershell.exe", "pwsh.exe", "msiexec.exe", "rundll32.exe",
   "bitsadmin.exe", "InstallUtil.exe", "RegAsm.exe", "vbc.exe", "RegSvcs.exe", "python.exe", "regsvr32.exe", "dllhost.exe",
-  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com") or
+  "node.exe", "javaw.exe", "java.exe", "*.pif", "*.com", "curl.exe", "bun.exe") or
 
   (?process.code_signature.trusted == false or ?process.code_signature.exists == false) or
 
   ?process.code_signature.subject_name : ("AutoIt Consulting Ltd", "OpenJS Foundation", "Python Software Foundation") or
 
-  ?process.executable : ("?:\\Users\\*.exe", "?:\\ProgramData\\*.exe")
+  ?process.executable : (
+    "?:\\Users\\Public\\*.exe", "?:\\ProgramData\\*.exe", "?:\\Users\\*\\Downloads\\*.exe",
+    "\\Device\\HarddiskVolume*\\Users\\Public\\*.exe", "\\Device\\HarddiskVolume*\\ProgramData\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\Downloads\\*.exe"
+  )
  ) and
  dns.question.name :
          (
@@ -2587,7 +3085,6 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "iplogger.*",
           "freegeoip.net",
           "freegeoip.app",
-          "ipinfo.io",
           "geoplugin.net",
           "myip.dnsomatic.com",
           "www.geoplugin.net",
@@ -2595,12 +3092,17 @@ network where host.os.type == "windows" and dns.question.name != null and proces
           "ip4.seeip.org",
           "*.geojs.io",
           "*portmap.io",
-          "api.2ip.ua",
           "api.db-ip.com",
           "geolocation-db.com",
           "httpbin.org",
           "myip.opendns.com"
-         )
+         ) and
+not (
+  process.executable : (
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
+    "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
+  ) and user.id == "S-1-5-18"
+)
 ```
 
 
@@ -2609,7 +3111,7 @@ network where host.os.type == "windows" and dns.question.name != null and proces
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1692  
+Index: geneve-ut-1877  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -2651,7 +3153,7 @@ process.interactive == true and container.id like "*"
 
 
 
-## Rules with the correct signals (770)
+## Rules with the correct signals (805)
 
 ### A scheduled task was created
 
@@ -2674,7 +3176,15 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
               "\\Hewlett-Packard\\HP Web Products Detection",
               "\\Microsoft\\VisualStudio\\Updates\\BackgroundDownload",
               "\\OneDrive Standalone Update Task-S-1-5-21*",
-              "\\OneDrive Standalone Update Task-S-1-12-1-*"
+              "\\OneDrive Standalone Update Task-S-1-12-1-*",
+              "\\SoftLanding\\S-1-5-21-*\\SoftLanding*",
+              "\\SoftLanding\\S-1-12-*\\SoftLanding*",
+              "\\OneDrive Reporting Task-S-1-5-21-*",
+              "\\OneDrive Reporting Task-S-1-12-1-*",
+              "\\GoogleUserPEH\\RunPlatformExperienceHelper*",
+              "\\Mozilla\\Firefox Default Browser Agent*",
+              "\\Microsoft\\Office\\Office Background Push Maintenance",
+              "\\Microsoft\\Windows\\GroupPolicy\\GPUpdate"
  )
 ```
 
@@ -2736,7 +3246,7 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0022
+Index: geneve-ut-0040
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -2750,11 +3260,47 @@ process.command_line like~ (
 
 
 
+### AWS EC2 Instance Profile Associated with Running Instance
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-0057
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "ec2.amazonaws.com"
+    and event.action: ("AssociateIamInstanceProfile" or "ReplaceIamInstanceProfile")
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService" 
+    and not aws.cloudtrail.user_identity.invoked_by: "ssm.amazonaws.com"
+```
+
+
+
+### AWS IAM Customer Managed Policy Version Created or Default Version Set
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-0087
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "iam.amazonaws.com"
+    and event.action: ("CreatePolicyVersion" or "SetDefaultPolicyVersion")
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService" 
+    and not aws.cloudtrail.user_identity.arn:arn*/terraform 
+    and not source.as.organization.name:(Amazon* or AMAZON* or "Google LLC" or "MongoDB, Inc.")
+    and not source.address: ( "cloudformation.amazonaws.com" or "servicecatalog.amazonaws.com")
+```
+
+
+
 ### AWS IAM Login Profile Added to User
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0064
+Index: geneve-ut-0094
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
@@ -2763,11 +3309,59 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 
 
+### AWS IAM Sensitive Operations via Lambda Execution Role
+
+Branch count: 22  
+Document count: 22  
+Index: geneve-ut-0105
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "iam.amazonaws.com"
+    and event.outcome: "success"
+    and aws.cloudtrail.user_identity.type: "AssumedRole"
+    and (
+        aws.cloudtrail.user_identity.invoked_by: "lambda.amazonaws.com"
+        or user_agent.original : *AWS_Lambda*
+    )
+    and event.action: (
+        "AddRoleToInstanceProfile" or
+        "AddUserToGroup" or 
+        "AttachGroupPolicy" or 
+        "AttachRolePolicy" or
+        "AttachUserPolicy" or
+        "CreateAccessKey" or
+        "CreateInstanceProfile" or
+        "CreateRole" or
+        "CreateUser" or
+        "PutRolePolicy" or
+        "PutUserPolicy"
+    )
+```
+
+
+
+### AWS KMS Key Policy Updated via PutKeyPolicy
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0112
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "kms.amazonaws.com"
+    and event.action: "PutKeyPolicy"
+    and event.outcome: "success"
+    and not aws.cloudtrail.user_identity.type: "AWSService"
+```
+
+
+
 ### AWS Lambda Function Created or Updated
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0077
+Index: geneve-ut-0114
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2782,7 +3376,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0087
+Index: geneve-ut-0133
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
@@ -2791,11 +3385,27 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 
 
+### AWS STS GetFederationToken with AdministratorAccess in Request
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0169
+
+```python
+event.dataset: "aws.cloudtrail"
+    and event.provider: "sts.amazonaws.com"
+    and event.action: "GetFederationToken"
+    and event.outcome: "success"
+    and aws.cloudtrail.request_parameters: *AdministratorAccess*
+```
+
+
+
 ### AWS STS GetSessionToken Usage
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0121
+Index: geneve-ut-0170
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -2810,7 +3420,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0130
+Index: geneve-ut-0180
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -2825,7 +3435,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0139
+Index: geneve-ut-0189
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2849,7 +3459,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0140
+Index: geneve-ut-0190
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -2884,7 +3494,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0141
+Index: geneve-ut-0191
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -2901,7 +3511,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0142
+Index: geneve-ut-0192
 
 ```python
 any where host.os.type == "windows" and
@@ -2926,7 +3536,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0144
+Index: geneve-ut-0194
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -2954,7 +3564,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0146
+Index: geneve-ut-0196
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2967,7 +3577,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0148
+Index: geneve-ut-0198
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -2983,7 +3593,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0149
+Index: geneve-ut-0199
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3003,7 +3613,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0150
+Index: geneve-ut-0200
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3024,7 +3634,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0151
+Index: geneve-ut-0201
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3036,7 +3646,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0154
+Index: geneve-ut-0204
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3048,7 +3658,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0166
+Index: geneve-ut-0216
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3065,7 +3675,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0167
+Index: geneve-ut-0217
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3077,7 +3687,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0169
+Index: geneve-ut-0219
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3097,7 +3707,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0170
+Index: geneve-ut-0220
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3111,7 +3721,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0174
+Index: geneve-ut-0224
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3142,7 +3752,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0175
+Index: geneve-ut-0225
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3152,14 +3762,14 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 ### Attempt to Clear Kernel Ring Buffer
 
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-0176
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-0226
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
 event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
-process.name == "dmesg" and process.args in ("-c", "--clear")
+process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clear")
 ```
 
 
@@ -3168,7 +3778,7 @@ process.name == "dmesg" and process.args in ("-c", "--clear")
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0177
+Index: geneve-ut-0227
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3183,7 +3793,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0187
+Index: geneve-ut-0237
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -3202,7 +3812,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0188
+Index: geneve-ut-0238
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3216,7 +3826,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0190
+Index: geneve-ut-0240
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -3247,7 +3857,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0191
+Index: geneve-ut-0241
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3270,7 +3880,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0192
+Index: geneve-ut-0242
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3284,7 +3894,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0193
+Index: geneve-ut-0243
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3299,11 +3909,25 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Attempt to Install Kali Linux via WSL
+### Attempt to Install Root Certificate
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0244
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and
+  process.name == "security" and process.args like "add-trusted-cert" and
+  (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
+### Attempt to Install or Run Kali Linux via WSL
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0194
+Index: geneve-ut-0245
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3324,25 +3948,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Attempt to Install Root Certificate
-
-Branch count: 16  
-Document count: 16  
-Index: geneve-ut-0195
-
-```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and
-  process.name == "security" and process.args like "add-trusted-cert" and
-  (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
-```
-
-
-
 ### Attempt to Mount SMB Share via Command Line
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0200
+Index: geneve-ut-0250
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3361,7 +3971,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0203
+Index: geneve-ut-0253
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3374,7 +3984,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0205
+Index: geneve-ut-0255
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3416,7 +4026,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0212
+Index: geneve-ut-0262
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -3431,7 +4041,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0237
+Index: geneve-ut-0292
 
 ```python
 event.dataset:azure.activitylogs and
@@ -3441,11 +4051,29 @@ event.dataset:azure.activitylogs and
 
 
 
+### Azure Run Command Script Child Process
+
+Branch count: 22  
+Document count: 22  
+Index: geneve-ut-0295
+
+```python
+process where event.type in ("start", "process_started") and
+  (
+    (process.parent.name == "powershell.exe" and
+      process.parent.command_line like "powershell  -ExecutionPolicy Unrestricted -File script?.ps1") or
+    (process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh", "busybox") and
+      process.parent.args like "/var/lib/waagent/run-command/download/*/script.sh")
+  )
+```
+
+
+
 ### BPF Program Tampering via bpftool
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0250
+Index: geneve-ut-0313
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3463,7 +4091,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0251
+Index: geneve-ut-0314
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3481,7 +4109,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0252
+Index: geneve-ut-0315
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3496,7 +4124,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0253
+Index: geneve-ut-0316
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3510,7 +4138,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0254
+Index: geneve-ut-0317
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3525,7 +4153,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0257
+Index: geneve-ut-0320
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -3542,7 +4170,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0258
+Index: geneve-ut-0321
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -3554,7 +4182,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0259
+Index: geneve-ut-0322
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -3566,7 +4194,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0260
+Index: geneve-ut-0323
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3581,7 +4209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0261
+Index: geneve-ut-0324
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -3601,7 +4229,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0262
+Index: geneve-ut-0325
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3623,7 +4251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0264
+Index: geneve-ut-0327
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -3669,24 +4297,24 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0265
+Index: geneve-ut-0328
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.name : ("chrome.exe", "msedge.exe") and
-  process.parent.executable != null and process.command_line != null and
+  process.parent.executable != null and
   (
-  process.command_line :
-           ("\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\"",
+    process.command_line : (
+            "\"C:\\Program Files (x86)\\Microsoft\\Edge\\Application\\msedge.exe\"",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\"",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --disable-logging --log-level=3 --v=0",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --log-level=3",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless",
             "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --remote-debugging-port=922? --profile-directory=\"Default\"*",
-            "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --restore-last-session --remote-debugging-port=45452*") or
-
-  (process.args : "--remote-debugging-port=922?" and process.args : "--window-position=-*,-*")
-   ) and
+            "\"C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe\" --headless --restore-last-session --remote-debugging-port=45452*"
+    ) or
+    (process.args : "--remote-debugging-port=922?" and process.args : "--window-position=-*,-*")
+  ) and
   not process.parent.executable :
                          ("C:\\Windows\\explorer.exe",
                           "C:\\Program Files (x86)\\*.exe",
@@ -3703,7 +4331,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0266
+Index: geneve-ut-0329
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3726,7 +4354,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0267
+Index: geneve-ut-0330
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -3748,7 +4376,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0268
+Index: geneve-ut-0331
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -3772,11 +4400,26 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 
 
+### Chroot Execution in Container Context on Linux
+
+Branch count: 40  
+Document count: 40  
+Index: geneve-ut-0332
+
+```python
+host.os.type:linux and event.category:process and 
+event.type:start and event.action:(executed or exec) and 
+(process.name:"chroot" or process.args:("chroot" or "/bin/chroot" or "/usr/bin/chroot" or "/usr/local/bin/chroot")) and 
+(process.title:"runc init" or process.entry_leader.entry_meta.type:"container" or process.parent.name:("runc" or "containerd-shim-runc-v2"))
+```
+
+
+
 ### Clearing Windows Event Logs
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0270
+Index: geneve-ut-0334
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3797,11 +4440,41 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Cloud Instance Metadata Credential Path HTTP Request
+
+Branch count: 219  
+Document count: 219  
+Index: geneve-ut-0336
+
+```python
+network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
+http.request.method == "GET" and url.path : (
+  "/latest/meta-data/iam/security-credentials/*",
+  "*computeMetadata/v1/instance/service-accounts/*/oauth2/access_token*",
+  "*metadata/identity/oauth2/token*"
+) and (
+  ?process.name : (
+    "curl", "wget", "python*", "node", "bun", "php*", "ruby", "perl", "bash", "dash", "sh", "tcsh", "tclsh", "wish",
+    "csh", "zsh", "ksh", "fish", "mksh", "busybox",
+    "bun.exe", "node.exe", "powershell.exe", "cmd.exe", "curl.exe", "wget.exe", "rundll32.exe", "w3wp.exe", "java*", 
+    "go", "nc", "netcat", "nginx", "apache*", "httpd", "tomcat*", "catalina", "spring*", "dotnet", "gunicorn", "uwsgi", 
+    ".*", "osascript"
+  ) or ?process.executable : (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/home/*/*", "/var/run/*", "/run/*", "/boot/*", "/.*", "C:\\Users\\*", "?:\\ProgramData\\*"
+  ) or user_agent.original : (
+    "curl*", "wget*", "python*", "ruby*", "Go-http-client*", "node*", "axios*", "undici*", "java*", "php*", "Bun*",
+    "Apache-HttpClient*", "okhttp*", "RestTemplate*", "*WindowsPowerShell*", "*roadtools*", "*fasthttp*", "*azurehound*", "*bloodhound*", "*aiohttp*"
+  )
+)
+```
+
+
+
 ### Code Signing Policy Modification Through Built-in tools
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0273
+Index: geneve-ut-0338
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3815,7 +4488,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0274
+Index: geneve-ut-0339
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3837,7 +4510,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0275
+Index: geneve-ut-0340
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -3851,7 +4524,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0276
+Index: geneve-ut-0341
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -3871,7 +4544,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0279
+Index: geneve-ut-0344
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3888,7 +4561,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-0281
+Index: geneve-ut-0346
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3972,7 +4645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0282
+Index: geneve-ut-0347
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4002,7 +4675,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0285
+Index: geneve-ut-0350
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4027,7 +4700,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0287
+Index: geneve-ut-0352
 
 ```python
 sequence by process.entity_id
@@ -4048,7 +4721,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0288
+Index: geneve-ut-0353
 
 ```python
 sequence by process.entity_id
@@ -4065,11 +4738,42 @@ sequence by process.entity_id
 
 
 
+### Container Runtime CLI Execution with Suspicious Arguments
+
+Branch count: 28  
+Document count: 28  
+Index: geneve-ut-0356
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
+(
+  (
+    process.name in ("ctr", "crictl", "nerdctl") and
+    (
+      (process.args == "tasks" and process.args == "exec") or
+      (process.args == "run" and process.args in ("--privileged", "--rm", "--mount", "--net-host", "--pid-host")) or
+      (process.args == "snapshots" and process.args == "mount")
+    )
+  ) or
+  (
+    (process.executable like ("/dev/shm/*", "/tmp/*", "/var/tmp/*") or process.name : ".*") and
+    process.args like ("*containerd.sock*", "k8s.io")
+  )
+) and
+not process.parent.executable in (
+  "/usr/bin/kubelet", "/usr/local/bin/kubelet",
+  "/usr/bin/containerd", "/usr/sbin/containerd",
+  "/lib/systemd/systemd", "/usr/lib/systemd/systemd", "/sbin/init"
+)
+```
+
+
+
 ### Container Workload Protection
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0291
+Index: geneve-ut-0357
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4081,7 +4785,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0292
+Index: geneve-ut-0358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4104,7 +4808,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0295
+Index: geneve-ut-0361
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4117,7 +4821,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0296
+Index: geneve-ut-0362
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4130,7 +4834,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0298
+Index: geneve-ut-0364
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4147,7 +4851,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0299
+Index: geneve-ut-0365
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -4158,12 +4862,12 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 ### Creation of a Hidden Local User Account
 
-Branch count: 3  
-Document count: 3  
-Index: geneve-ut-0300
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0366
 
 ```python
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type in ("change", "creation") and
   registry.path : (
     "HKLM\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
     "\\REGISTRY\\MACHINE\\SAM\\SAM\\Domains\\Account\\Users\\Names\\*$\\",
@@ -4177,7 +4881,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0301
+Index: geneve-ut-0367
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -4189,7 +4893,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0302
+Index: geneve-ut-0368
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -4257,7 +4961,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0303
+Index: geneve-ut-0369
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -4275,7 +4979,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0304
+Index: geneve-ut-0370
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -4286,15 +4990,18 @@ process.args == "--json" and process.args == "filesystem"
 
 ### Credential Acquisition via Registry Hive Dumping
 
-Branch count: 8  
-Document count: 8  
-Index: geneve-ut-0305
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-0371
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  (?process.pe.original_file_name == "reg.exe" or process.name : "reg.exe") and
  process.args : ("save", "export") and
- process.args : ("hklm\\sam", "hklm\\security")
+ process.args : (
+   "hklm\\sam", "hklm\\security", "hklm\\system",
+   "hkey_local_machine\\sam", "hkey_local_machine\\security", "hkey_local_machine\\system"
+ )
 ```
 
 
@@ -4303,7 +5010,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0306
+Index: geneve-ut-0372
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4315,7 +5022,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0307
+Index: geneve-ut-0373
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4327,7 +5034,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0308
+Index: geneve-ut-0374
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4339,7 +5046,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0309
+Index: geneve-ut-0375
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4351,7 +5058,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0310
+Index: geneve-ut-0376
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -4396,7 +5103,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0312
+Index: geneve-ut-0378
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4416,7 +5123,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0313
+Index: geneve-ut-0379
 
 ```python
 sequence with maxspan=10s
@@ -4436,7 +5143,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0314
+Index: geneve-ut-0380
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4463,7 +5170,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0315
+Index: geneve-ut-0381
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4477,7 +5184,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0317
+Index: geneve-ut-0384
 
 ```python
 process where event.type == "start" and
@@ -4502,7 +5209,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0320
+Index: geneve-ut-0387
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4546,7 +5253,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0321
+Index: geneve-ut-0388
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -4580,7 +5287,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0323
+Index: geneve-ut-0390
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4625,7 +5332,7 @@ process.interactive == true and container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0324
+Index: geneve-ut-0391
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -4637,11 +5344,182 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 
 
+### DNS Request for IP Lookup Service via Unsigned Binary
+
+Branch count: 86  
+Document count: 86  
+Index: geneve-ut-0392
+
+```python
+network where host.os.type == "macos" and event.action == "lookup_result" and 
+  (process.code_signature.trusted == false or process.code_signature.exists == false) and
+  dns.question.name like~ ("*ip-api.com*", "*ipwho.is*", "*checkip.dyndns.org*", "*api.ipify.org*",
+                           "*api.npoint.io*", "*whatismyip.akamai.com*", "*bot.whatismyipaddress.com*",
+                           "*ifcfg.me*", "*ifconfig.me*", "*ident.me*", "*ipof.in*", "*ip.tyk.nu*",
+                           "*ipwhois.app*", "*freeipapi.com*", "*icanhazip.com*", "*curlmyip.com*",
+                           "*wgetip.com*", "*eth0.me*", "*ipecho.net*", "*ip.appspot.com*",
+                           "*api.myip.com*", "*geoiptool.com*", "*api.2ip.ua*", "*api.ip.sb*",
+                           "*ipinfo.io*", "*checkip.amazonaws.com*", "*wtfismyip.com*", "*iplogger.*",
+                           "*freegeoip.net*", "*freegeoip.app*", "*myip.ipip.net*", "*geoplugin.net*",
+                           "*myip.dnsomatic.com*", "*www.geoplugin.net*", "*api64.ipify.org*",
+                           "*ip4.seeip.org*", "*.geojs.io*", "*portmap.io*", "*api.db-ip.com*",
+                           "*geolocation-db.com*", "*inet-ip.info*", "*httpbin.org*", "*myip.opendns.com*") and
+  not process.executable like "/Users/*/Library/Developer/CoreSimulator/*"
+```
+
+
+
+### DNS Request to Suspicious Top Level Domain
+
+Branch count: 50  
+Document count: 50  
+Index: geneve-ut-0393
+
+```python
+network where host.os.type == "linux" and dns.question.name != null and process.name != null and
+dns.question.name like~ (
+  "*.forum", "*.pro", "*.team", "*.lol", "*.kr", "*.ke", "*.nu", "*.space", "*.capital", "*.in", "*.cfd", "*.online",
+  "*.ru", "*.info", "*.top", "*.buzz", "*.xyz", "*.rest", "*.ml", "*.cf", "*.gq", "*.ga", "*.onion", "*.network",
+  "*.monster", "*.marketing", "*.cyou", "*.quest", "*.cc", "*.bar", "*.click", "*.cam", "*.surf", "*.tk", "*.shop",
+  "*.club", "*.icu", "*.pw", "*.ws", "*.fun", "*.life", "*.boats", "*.store", "*.hair", "*.mom",
+  "*.beauty", "*.bond", "*.biz", "*.live", "*.zone"
+)
+```
+
+
+
+### DNS to Commonly Abused Web Services
+
+Branch count: 218  
+Document count: 218  
+Index: geneve-ut-0395
+
+```python
+network where host.os.type == "linux" and dns.question.name != null and process.name != null and
+dns.question.name like~ (
+  /* Google services */
+  "drive.google.com", "docs.google.com", "script.google.com", "script.googleusercontent.com",
+  "*googleapis.com", "calendar.app.google*",
+
+  /* Dropbox */
+  "api.dropboxapi.com", "content.dropboxapi.com", "*dl.dropboxusercontent.com",
+
+  /* Microsoft / OneDrive / SharePoint */
+  "api.onedrive.com", "*.onedrive.org", "onedrive.live.com", "*files.1drv.com", "graph.microsoft.com",
+  "*.sharepoint.com", "login.live.com", "g.live.com",
+
+  /* Slack */
+  "*slack.com", "slack-redir.net", "slack-files.com",
+
+  /* Discord */
+  "discord.com", "cdn.discordapp.com", "discordapp.com",
+
+  /* Telegram */
+  "api.telegram.org", "t.me",
+
+  /* Azure / Cloud storage */
+  "apis.azureedge.net", "*.blob.core.windows.net", "*.blob.storage.azure.net", "*azurewebsites.net",
+
+  /* GitHub / Dev hosting */
+  "api.github.com", "raw.githubusercontent.*", "gist.githubusercontent.com", "rawcdn.githack.*",
+  "*.notabug.org",
+
+  /* Developer tunnels / reverse proxies */
+  "*.devtunnels.ms", "*global.rel.tunnels.api.visualstudio.com", "*.ngrok.io", "*.ngrok-free.app",
+  "*.portmap.*", "serveo.net", "*localtunnel.me", "*pagekite.me", "*.trycloudflare.com",
+
+  /* AWS */
+  "*s3.amazonaws.com",
+
+  /* Paste services */
+  "pastebin.*", "paste4btc.com", "paste.ee", "ghostbin.com", "paste.nrecom.net", "zerobin.net",
+  "controlc.com", "pastecode.dev", "paste.rs", "hastebin.com", "dpaste.org", "dpaste.com", "0bin.net",
+  "paste.ofcode.org", "paste.wakas.org", "nopaste.net",
+
+  /* File sharing / exfiltration */
+  "filebin.net", "file.io", "transfer.sh", "*.gofile.io", "workupload.com", "*upload.ee", "*anonfiles.com",
+  "api.anonfile.com", "*bayfiles.com", "*bublup.com", "*dropfiles.org", "*dropmefiles.com", "*easyupload.io",
+  "*filetransfer.io", "*sendspace.com", "*share.riseup.net", "*temp.sh", "*tempsend.com", "*ufile.io",
+  "*send.now", "*send.cm", "*sendit.sh", "*pixeldrain.com", "*megaupload.com", "*mediafire.com",
+  "*bashupload.com", "*bujang.online", "mediafire.zip", "*.4shared.com", "filecloud.me", "*.pcloud.com",
+  "*catbox.moe",
+
+  /* CDN / hosting / generic file infra */
+  "*cdnmegafiles.com", "www.uplooder.net", "?.top4top.io", "top4top.io", "*.b-cdn.net", "cdn*.space",
+  "i.ibb.co", "i.imgur.com",
+
+  /* Webhooks / testing / bins */
+  "webhook.site", "run.mocky.io", "mockbin.org", "requestbin.net",
+
+  /* Public hosting / misc infra */
+  "*.publicvm.com", "*.blogspot.com", "*infinityfreeapp.com", "free.keep.sh", "*.aternos.me",
+  "*hosting-profi.de",
+
+  /* IP / network utilities */
+  "api.mylnikov.org", "ipbase.com", "*.getmyip.com", "myexternalip.com", "*.geojs.io",
+  "*api.2ip.ua", "*api.db-ip.com", "*api.ip.sb", "*api.ipify.org", "*api.myip.com",
+  "*api.npoint.io", "*api64.ipify.org", "*bot.whatismyipaddress.com", "*checkip.amazonaws.com",
+  "*checkip.dyndns.org", "*curlmyip.com", "*eth0.me", "*freegeoip.app", "*freegeoip.net",
+  "*freeipapi.com", "*geoiptool.com", "*geolocation-db.com", "*httpbin.org",
+  "*icanhazip.com", "*ident.me", "*ifcfg.me", "*ifconfig.me", "*inet-ip.info", "*ip-api.com",
+  "*ip.appspot.com", "*ip.tyk.nu", "*ip4.seeip.org", "*ipecho.net", "*ipinfo.io", "*iplogger.*",
+  "*ipof.in", "*ipwho.is", "*ipwhois.app", "*ipv4.icanhazip.com", "*ipv6.icanhazip.com",
+  "*myip.dnsomatic.com", "*myip.ipip.net", "*myip.opendns.com", "*portmap.io", "*wgetip.com",
+  "*whatismyip.akamai.com", "*wtfismyip.com",
+
+  /* Social / platforms */
+  "mbasic.facebook.com", "*.zulipchat.com", "stackoverflow.com",
+
+  /* Package hosting */
+  "files.pythonhosted.org",
+
+  /* Databases / backend platforms */
+  "*.supabase.co", "*.elastic-cloud.com", "*.cloud.es.io",
+
+  /* Misc / suspicious */
+  "*up.freeo*.space", "*icp0.io", "updates.peer2profit.com", "meacz.gq", "rwrd.org", "lobfile.com",
+  "ftpupload.net", "the.earth.li",
+
+  /* URL shorteners */
+  "*shorturl.at", "*tinyurl.com", "*bit.ly", "*cutt.ly", "*is.gd", "*rebrand.ly", "*rebrandly.com",
+  "*adf.ly", "*rb.gy", "tiny.one", "t.ly", "urlz.fr", "rentry.co",
+
+  /* Crypto mining pools */
+  "*.nicehash.com", "stratum*.nicehash.com",
+  "*.2miners.com", "*.moneroocean.stream", "*.supportxmr.com",
+  "*.nanopool.org", "*.f2pool.com", "*.poolbinance.com",
+  "*.antpool.com", "*.viabtc.com", "*.braiins.com", "*.slushpool.com",
+
+  /* Decentralized */
+  "ipfs.io", "*.ipfs.io", "dweb.link", "*.dweb.link",
+  "*.ipfs.dweb.link", "*.ipns.dweb.link",
+  "gateway.pinata.cloud", "*.mypinata.cloud",
+  "web3.storage", "*.web3.storage",
+  "nftstorage.link", "*.nftstorage.link",
+  "arweave.net", "*.arweave.net",
+  "ar.io", "*.ar.io",
+  "ic0.app", "*.ic0.app",
+  "icp0.io", "*.icp0.io",
+  "*.storjshare.io"
+) and
+not process.executable like (
+  "/opt/google-cloud-ops-agent/subagents/fluent-bit/bin/fluent-bit", "/usr/lib/systemd/systemd-resolved",
+  "/opt/Elastic/Agent/data/elastic-agent-*/components/elastic-otel-collector", "/usr/bin/dockerd",
+  "/usr/bin/google_osconfig_agent", "/snap/firefox/*/usr/lib/firefox/firefox", "/usr/bin/warp-svc",
+  "/var/lib/docker/overlay2/*/merged/usr/local/bin/node", "/snap/chromium/*/usr/lib/chromium-browser/chrome",
+  "/opt/google-cloud-ops-agent/subagents/opentelemetry-collector/otelopscol", "/usr/local/bin/rclone",
+  "/var/lib/elastic-agent/data/elastic-agent-*/components/elastic-otel-collector", "/opt/google/chrome/chrome",
+  "/usr/bin/pihole-FTL"
+)
+```
+
+
+
 ### DNS-over-HTTPS Enabled via Registry
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0327
+Index: geneve-ut-0396
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4659,7 +5537,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0329
+Index: geneve-ut-0398
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -4672,7 +5550,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0330
+Index: geneve-ut-0399
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4702,7 +5580,7 @@ container.security_context.privileged == true and process.interactive == true an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0336
+Index: geneve-ut-0405
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4716,7 +5594,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0348
+Index: geneve-ut-0417
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4733,23 +5611,11 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
-### Deprecated - EggShell Backdoor Execution
-
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0354
-
-```python
-event.category:process and event.type:(process_started or start) and process.name:espl and process.args:eyJkZWJ1ZyI6*
-```
-
-
-
 ### Deprecated - Encoded Executable Stored in the Registry
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0355
+Index: geneve-ut-0424
 
 ```python
 registry where host.os.type == "windows" and
@@ -4763,7 +5629,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0365
+Index: geneve-ut-0436
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -4787,7 +5653,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0398
+Index: geneve-ut-0473
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4841,7 +5707,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0401
+Index: geneve-ut-0476
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4857,7 +5723,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0402
+Index: geneve-ut-0477
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4885,7 +5751,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0403
+Index: geneve-ut-0478
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4902,7 +5768,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0404
+Index: geneve-ut-0479
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4919,7 +5785,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0405
+Index: geneve-ut-0480
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4940,7 +5806,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0407
+Index: geneve-ut-0482
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4960,7 +5826,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0408
+Index: geneve-ut-0483
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -4975,7 +5841,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0410
+Index: geneve-ut-0485
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -4988,7 +5854,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0411
+Index: geneve-ut-0486
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5008,7 +5874,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0414
+Index: geneve-ut-0489
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -5021,7 +5887,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0415
+Index: geneve-ut-0490
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5057,13 +5923,20 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 ### Dumping Account Hashes via Built-In Commands
 
-Branch count: 8  
-Document count: 8  
-Index: geneve-ut-0416
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0491
 
 ```python
-process where host.os.type == "macos" and event.type in ("start", "process_started") and
- process.name in ("defaults", "mkpassdb") and process.args like~ ("ShadowHashData", "-dump")
+process where host.os.type == "macos" and event.type in ("start","process_started") and (
+  (process.name == "defaults" and process.args like~ "ShadowHashData") or
+  (process.name == "mkpassdb" and process.args == "-dump") or
+  (process.name == "dscl" and process.args like~ "ShadowHashData") or
+  (
+    process.name in ("plutil","cat","strings","xxd","head") and
+    process.args like "/var/db/dslocal/nodes/Default/users/*.plist"
+  )
+)
 ```
 
 
@@ -5072,7 +5945,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0417
+Index: geneve-ut-0492
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5085,7 +5958,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0418
+Index: geneve-ut-0493
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5108,7 +5981,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0420
+Index: geneve-ut-0495
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5139,7 +6012,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0421
+Index: geneve-ut-0496
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -5158,7 +6031,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0422
+Index: geneve-ut-0497
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -5201,7 +6074,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0423
+Index: geneve-ut-0498
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -5215,7 +6088,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0424
+Index: geneve-ut-0500
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5230,7 +6103,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0425
+Index: geneve-ut-0501
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5246,7 +6119,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0426
+Index: geneve-ut-0502
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5260,7 +6133,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0427
+Index: geneve-ut-0503
 
 ```python
 sequence by host.id with maxspan=3s
@@ -5286,7 +6159,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0428
+Index: geneve-ut-0504
 
 ```python
 process where event.type == "start" and
@@ -5324,7 +6197,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0435
+Index: geneve-ut-0511
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -5337,7 +6210,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0436
+Index: geneve-ut-0512
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5351,7 +6224,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0437
+Index: geneve-ut-0513
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -5373,7 +6246,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0438
+Index: geneve-ut-0514
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5408,7 +6281,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0439
+Index: geneve-ut-0515
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -5420,7 +6293,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0471
+Index: geneve-ut-0558
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -5432,7 +6305,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0493
+Index: geneve-ut-0582
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5446,7 +6319,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0496
+Index: geneve-ut-0585
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5473,7 +6346,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0499
+Index: geneve-ut-0588
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5494,7 +6367,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0500
+Index: geneve-ut-0589
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5524,7 +6397,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0503
+Index: geneve-ut-0592
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -5557,7 +6430,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0505
+Index: geneve-ut-0594
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -5574,7 +6447,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0506
+Index: geneve-ut-0595
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -5602,7 +6475,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0507
+Index: geneve-ut-0596
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -5615,7 +6488,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0509
+Index: geneve-ut-0598
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -5635,7 +6508,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0510
+Index: geneve-ut-0599
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5661,19 +6534,15 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0511
+Index: geneve-ut-0600
 
 ```python
 sequence with maxspan=2h
   [file where host.os.type == "windows" and event.type != "deletion" and file.extension : "exe" and
-     (process.name : "WINWORD.EXE" or
-      process.name : "EXCEL.EXE" or
-      process.name : "OUTLOOK.EXE" or
-      process.name : "POWERPNT.EXE" or
-      process.name : "eqnedt32.exe" or
-      process.name : "fltldr.exe" or
-      process.name : "MSPUB.EXE" or
-      process.name : "MSACCESS.EXE")
+    process.name : (
+      "WINWORD.EXE", "EXCEL.EXE", "OUTLOOK.EXE", "POWERPNT.EXE",
+      "eqnedt32.exe", "fltldr.exe", "MSPUB.EXE", "MSACCESS.EXE"
+    )
   ] by host.id, file.path
   [process where host.os.type == "windows" and event.type == "start" and 
    not (process.name : "NewOutlookInstaller.exe" and process.code_signature.subject_name : "Microsoft Corporation" and process.code_signature.trusted == true) and 
@@ -5687,7 +6556,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0512
+Index: geneve-ut-0601
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -5716,7 +6585,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0515
+Index: geneve-ut-0604
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5729,7 +6598,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0519
+Index: geneve-ut-0608
 
 ```python
 sequence by user.id with maxspan=5s
@@ -5744,7 +6613,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0520
+Index: geneve-ut-0609
 
 ```python
 process where event.type == "start" and
@@ -5766,7 +6635,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0522
+Index: geneve-ut-0611
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -5778,7 +6647,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0523
+Index: geneve-ut-0612
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5800,7 +6669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0525
+Index: geneve-ut-0614
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -5817,7 +6686,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0526
+Index: geneve-ut-0615
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5831,7 +6700,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0527
+Index: geneve-ut-0616
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -5844,7 +6713,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0528
+Index: geneve-ut-0617
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5856,7 +6725,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0529
+Index: geneve-ut-0618
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5868,7 +6737,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0530
+Index: geneve-ut-0619
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5882,7 +6751,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0531
+Index: geneve-ut-0620
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -5894,7 +6763,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 304  
 Document count: 304  
-Index: geneve-ut-0532
+Index: geneve-ut-0621
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -5916,7 +6785,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0536
+Index: geneve-ut-0625
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -5965,7 +6834,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0537
+Index: geneve-ut-0626
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -5982,7 +6851,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0538
+Index: geneve-ut-0627
 
 ```python
 sequence by host.id with maxspan=10s
@@ -5998,11 +6867,33 @@ sequence by host.id with maxspan=10s
 
 
 
+### File Download Detected via Defend for Containers
+
+Branch count: 40  
+Document count: 40  
+Index: geneve-ut-0632
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+  (
+    (process.name == "curl" or process.args in ("curl", "/bin/curl", "/usr/bin/curl", "/usr/local/bin/curl")) and
+    process.args in ("-o", "-O", "--output", "--remote-name", "--remote-name-all", "--output-dir")
+  ) or
+  (
+    (process.name == "wget" or process.args in ("wget", "/bin/wget", "/usr/bin/wget", "/usr/local/bin/wget")) and
+    process.args like ("-*O*", "--output-document=*", "--output-file=*")
+  )
+) 
+and container.id like "?*"
+```
+
+
+
 ### File Staged in Root Folder of Recycle Bin
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0546
+Index: geneve-ut-0635
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -6017,7 +6908,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0547
+Index: geneve-ut-0636
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6031,7 +6922,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0549
+Index: geneve-ut-0638
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6053,7 +6944,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0551
+Index: geneve-ut-0640
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -6074,7 +6965,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0552
+Index: geneve-ut-0641
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6100,7 +6991,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0553
+Index: geneve-ut-0642
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -6124,11 +7015,25 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Finder Sync Plugin Registered and Enabled
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0645
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
+  process.args == "-e" and process.args like~ "use" and process.args == "-i" and
+  (process.parent.name like~ ("python*", "node", "osascript", "bash", "sh", "zsh") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
 ### Full Disk Access Permission Check
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0591
+Index: geneve-ut-0680
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -6145,7 +7050,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0592
+Index: geneve-ut-0681
 
 ```python
 registry where host.os.type == "windows" and
@@ -6163,7 +7068,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0617
+Index: geneve-ut-0719
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -6202,7 +7107,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0618
+Index: geneve-ut-0720
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6229,7 +7134,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0619
+Index: geneve-ut-0721
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -6240,11 +7145,98 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 
 
+### GenAI CLI Started with Unsafe Permission Bypass
+
+Branch count: 267  
+Document count: 267  
+Index: geneve-ut-0722
+
+```python
+process where event.type == "start" and event.action in ("exec", "start") and
+(
+  (
+    process.args in (
+      "--dangerously-skip-permissions",
+      "--allow-dangerously-skip-permissions",
+      "--permission-mode=bypassPermissions"
+    ) or
+    (process.args == "--permission-mode" and process.args == "bypassPermissions")
+  ) and
+  (
+    process.name in ("claude", "claude.exe") or
+    process.executable : (
+      "*/.local/share/claude/versions/*",
+      "*/.claude/downloads/*",
+      "*Caskroom/claude-code/*",
+      "*\\Claude\\versions\\*"
+    ) or
+    (process.name in ("node", "node.exe") and process.args : "*@anthropic-ai/claude-code*")
+  )
+) or
+(
+  (
+    process.args in ("--dangerously-bypass-approvals-and-sandbox", "--full-auto", "--yolo") or
+    process.command_line : (
+      "* -s danger-full-access*",
+      "*--sandbox danger-full-access*",
+      "*--sandbox=danger-full-access*",
+      "*--ask-for-approval never*",
+      "*--ask-for-approval=never*"
+    )
+  ) and
+  (
+    process.name in (
+      "codex", "codex.exe", "codex-exec",
+      "codex-aarch64-apple-darwin", "codex-x86_64-apple-darwin",
+      "codex-linux-arm64", "codex-linux-x64"
+    ) or
+    (process.name in ("node", "node.exe") and process.args : ("*@openai/codex*", "*/codex", "*\\codex*"))
+  )
+) or
+(
+  (
+    process.args in ("--yolo", "-y") or
+    (process.args == "--approval-mode" and process.args == "yolo") or
+    process.args == "--approval-mode=yolo"
+  ) and
+  (
+    process.name in ("gemini", "gemini-cli", "gemini.exe", "gemini-cli.exe") or
+    (process.name in ("node", "node.exe") and process.args : ("*@google/gemini-cli*", "*/gemini", "*\\gemini*"))
+  )
+) or
+(
+  (
+    process.args in (
+      "--yolo",
+      "--autopilot",
+      "--allow-all",
+      "--allow-all-tools",
+      "--allow-all-paths",
+      "--allow-all-urls"
+    )
+  ) and
+  (
+    process.name in ("copilot", "copilot.exe") or
+    (process.name in ("node", "node.exe") and process.args : ("*@github/copilot*", "*/copilot", "*\\copilot*"))
+  )
+) or
+(
+  process.args == "--dangerously-skip-permissions" and
+  (
+    process.name in ("opencode", "opencode.exe", ".opencode") or
+    process.executable : ("*opencode-ai*", "*\\.opencode*") or
+    (process.name in ("node", "node.exe") and process.args : ("*opencode-ai*", "*/opencode", "*\\opencode*"))
+  )
+)
+```
+
+
+
 ### Git Hook Command Execution
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0627
+Index: geneve-ut-0730
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6262,7 +7254,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0628
+Index: geneve-ut-0731
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -6293,7 +7285,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0629
+Index: geneve-ut-0732
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6320,7 +7312,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0630
+Index: geneve-ut-0733
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -6340,7 +7332,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0634
+Index: geneve-ut-0737
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -6353,7 +7345,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0637
+Index: geneve-ut-0740
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -6365,7 +7357,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0640
+Index: geneve-ut-0743
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -6377,7 +7369,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0644
+Index: geneve-ut-0747
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -6389,7 +7381,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0646
+Index: geneve-ut-0749
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -6406,7 +7398,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0666
+Index: geneve-ut-0775
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6419,7 +7411,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0669
+Index: geneve-ut-0778
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -6443,7 +7435,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0670
+Index: geneve-ut-0779
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -6455,7 +7447,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0683
+Index: geneve-ut-0792
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6464,9 +7456,7 @@ sequence by process.entity_id with maxspan=5m
   /* Plan9FileSystem CLSID - WSL Host File System Worker */
  process.command_line : "*{DFB65C4C-B34F-435D-AFE9-A86218684AA8}*"]
 [file where host.os.type == "windows" and process.name : "dllhost.exe" and
-  not file.path : (
-        "?:\\Users\\*\\Downloads\\*",
-        "?:\\Windows\\Prefetch\\DLLHOST.exe-????????.pf")]
+  not file.path : "?:\\Windows\\Prefetch\\DLLHOST.exe-????????.pf"]
 ```
 
 
@@ -6475,7 +7465,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0684
+Index: geneve-ut-0793
 
 ```python
 any where process.executable != null and
@@ -6524,7 +7514,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0685
+Index: geneve-ut-0794
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6538,7 +7528,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0687
+Index: geneve-ut-0798
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6553,7 +7543,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0693
+Index: geneve-ut-0804
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6570,7 +7560,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0695
+Index: geneve-ut-0806
 
 ```python
 sequence with maxspan=1m
@@ -6589,12 +7579,12 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0696
+Index: geneve-ut-0807
 
 ```python
 sequence by host.id with maxspan=1m
  [network where host.os.type == "windows" and event.type == "start" and process.name : "mmc.exe" and source.port >= 49152 and
- destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
+  destination.port >= 49152 and source.ip != "127.0.0.1" and source.ip != "::1" and
   network.direction : ("incoming", "ingress") and network.transport == "tcp"
  ] by process.entity_id
  [process where host.os.type == "windows" and event.type == "start" and process.parent.name : "mmc.exe"
@@ -6607,7 +7597,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0697
+Index: geneve-ut-0808
 
 ```python
 sequence by host.id with maxspan=5s
@@ -6626,7 +7616,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0698
+Index: geneve-ut-0809
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -6642,7 +7632,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0699
+Index: geneve-ut-0810
 
 ```python
 sequence by host.id with maxspan=30s
@@ -6658,7 +7648,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0700
+Index: geneve-ut-0811
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6671,7 +7661,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0705
+Index: geneve-ut-0816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6688,7 +7678,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0707
+Index: geneve-ut-0818
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6701,7 +7691,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0708
+Index: geneve-ut-0819
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -6717,7 +7707,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0709
+Index: geneve-ut-0820
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6744,7 +7734,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0710
+Index: geneve-ut-0821
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6768,7 +7758,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0711
+Index: geneve-ut-0822
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6788,7 +7778,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-0713
+Index: geneve-ut-0824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -6816,7 +7806,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0717
+Index: geneve-ut-0828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6840,7 +7830,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0718
+Index: geneve-ut-0830
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6876,7 +7866,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0719
+Index: geneve-ut-0831
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -6888,7 +7878,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0720
+Index: geneve-ut-0832
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6902,7 +7892,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0721
+Index: geneve-ut-0833
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -6915,7 +7905,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0722
+Index: geneve-ut-0834
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -6974,7 +7964,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0723
+Index: geneve-ut-0835
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6987,7 +7977,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0724
+Index: geneve-ut-0836
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -7000,7 +7990,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0725
+Index: geneve-ut-0837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7021,7 +8011,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0726
+Index: geneve-ut-0838
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7039,7 +8029,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0727
+Index: geneve-ut-0839
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7071,27 +8061,35 @@ not (
 
 ### Kernel Module Load via Built-in Utility
 
-Branch count: 48  
-Document count: 48  
-Index: geneve-ut-0728
+Branch count: 8  
+Document count: 8  
+Index: geneve-ut-0840
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and
-event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "load_module" and
+(
   (process.name == "kmod" and process.args == "insmod" and process.args like~ "*.ko*") or
   (process.name == "kmod" and process.args == "modprobe" and not process.args in ("-r", "--remove")) or
   (process.name == "insmod" and process.args like~ "*.ko*") or
   (process.name == "modprobe" and not process.args in ("-r", "--remove"))
 ) and
 not (
-  ?process.parent.executable like ("/opt/ds_agent/*", "/opt/TrendMicro/vls_agent/*", "/opt/intel/oneapi/*") or
-  ?process.working_directory in ("/opt/vinchin/agent", "/var/opt/ds_agent/am", "/opt/ds_agent", "/var/opt/TrendMicro/vls_agent/am") or
-  ?process.parent.executable in (
+  process.parent.executable like ("/opt/ds_agent/*", "/opt/TrendMicro/vls_agent/*", "/opt/intel/oneapi/*") or
+  process.working_directory in ("/opt/vinchin/agent", "/var/opt/ds_agent/am", "/opt/ds_agent", "/var/opt/TrendMicro/vls_agent/am") or
+  process.parent.executable in (
     "/usr/lib/uptrack/ksplice-apply", "/opt/commvault/commvault/Base/linux_drv", "/opt/cisco/amp/bin/cisco-amp-helper",
     "/usr/bin/kcarectl", "/usr/share/ksplice/ksplice-apply", "/opt/commvault/Base/linux_drv", "/usr/sbin/veeamsnap-loader",
     "/bin/falcoctl"
   ) or
-  (?process.parent.name like ("python*", "platform-python*") and ?process.parent.args in ("--smart-update", "--auto-update"))
+  (process.parent.name like ("python*", "platform-python*") and process.parent.args in ("--smart-update", "--auto-update")) or
+  (
+    process.name == "modprobe" and process.args == "-q" and process.args == "--" and process.args in ("net-pf-10", "netdev-", "binfmt-464c")
+  ) or
+  (
+    process.name == "modprobe" and process.args == "-n" and process.args == "-v" and process.args in ("usb-storage", "dccp", "squashfs", "udf", "sctp", "cramfs", "hfsplus")
+  ) or
+  process.parent.executable like ("/sbin/iptables-multi*", "/var/ossec/bin/wazuh-modulesd", "/usr/sbin/mkinitramfs", "/usr/share/initramfs-tools/hooks/lvm2") or
+  process.parent.args like "/usr/share/initramfs-tools/hooks/*"
 )
 ```
 
@@ -7101,7 +8099,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0729
+Index: geneve-ut-0841
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7123,7 +8121,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0731
+Index: geneve-ut-0843
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7150,7 +8148,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0732
+Index: geneve-ut-0844
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7176,7 +8174,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0733
+Index: geneve-ut-0845
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -7192,7 +8190,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0734
+Index: geneve-ut-0846
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -7208,7 +8206,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0736
+Index: geneve-ut-0848
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -7220,7 +8218,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0737
+Index: geneve-ut-0849
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7248,7 +8246,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0739
+Index: geneve-ut-0851
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7264,7 +8262,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0741
+Index: geneve-ut-0853
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -7289,7 +8287,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0742
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -7303,7 +8301,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0744
+Index: geneve-ut-0856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7322,11 +8320,44 @@ process.name == "kubectl" and (
 
 
 
+### Kubelet API Connection Attempt to Internal IP
+
+Branch count: 204  
+Document count: 204  
+Index: geneve-ut-0857
+
+```python
+network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
+  event.action in ("connected-to", "connection_attempted") and (destination.port == 10250 or destination.port == 10255) and
+  cidrmatch(
+    destination.ip,
+    "127.0.0.0/8",
+    "10.0.0.0/8",
+    "172.16.0.0/12",
+    "192.168.0.0/16",
+    "169.254.0.0/16",
+    "100.64.0.0/10",
+    "::1/128",
+    "fc00::/7",
+    "fe80::/10"
+  ) and
+  (
+    process.name in ("curl", "wget", "nc", "ncat", "netcat", "socat", "openssl", "perl", "busybox") or 
+    process.name like ".*" or process.executable like "/*/.*" or 
+    process.name like ("python*", "ruby*", "node*", "java*", "lua*", "apache*", "php*", "nginx", "httpd*", "lighttpd", "caddy", "mongrel_rails", "gunicorn", 
+                       "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn", 
+                       "daphne", "twistd", "yaws", "webfsd", "flask", "rails", "mongrel", "catalina.sh", "hiawatha", "lswsctrl") or
+    process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/var/run/*", "/home/*", "/run/user/*", "/busybox/*")
+  )
+```
+
+
+
 ### Kubelet Certificate File Access Detected via Defend for Containers
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0745
+Index: geneve-ut-0858
 
 ```python
 any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
@@ -7349,11 +8380,59 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 
 
+### Kubernetes API Server Proxying Request to Kubelet
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0861
+
+```python
+kubernetes.audit.objectRef.subresource:"proxy" and
+kubernetes.audit.objectRef.resource:"nodes" and
+not kubernetes.audit.requestURI:(*metrics* or *healthz* or *stats/summary* or *elastic-agent* or *configz*) and
+not user.name:(
+  system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:serviceaccount\:kube-system\:* or
+  system\:node\:* or
+  eks\:* or aksService
+)
+```
+
+
+
+### Kubernetes Admission Webhook Created or Modified
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-0862
+
+```python
+kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
+kubernetes.audit.verb:("create" or "update" or "patch" or "delete") and
+kubernetes.audit.annotations.authorization_k8s_io/decision:"allow" and 
+user.name:(* and not 
+  (system\:kube-controller-manager or
+  system\:kube-scheduler or
+  system\:serviceaccount\:kube-system\:* or
+  eks\:* or aksService or masterclient or nodeclient or
+  system\:serviceaccount\:gke-managed-system\:* or
+  system\:serviceaccount\:cert-manager\:* or
+  system\:serviceaccount\:gatekeeper-system\:* or
+  system\:serviceaccount\:kyverno\:* or
+  system\:serviceaccount\:*\:*-operator)
+) and
+kubernetes.audit.objectRef.name:(* and not (pod-identity-webhook or vpc-resource-mutating-webhook or eks-* or gke-*)) and 
+not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kubernetes.audit.objectRef.name:"k8tz")
+```
+
+
+
 ### Kubernetes Direct API Request via Curl or Wget
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0754
+Index: geneve-ut-0872
 
 ```python
 process where event.type == "start" and
@@ -7375,7 +8454,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0768
+Index: geneve-ut-0898
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7394,7 +8473,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0771
+Index: geneve-ut-0901
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7434,11 +8513,36 @@ not (
 
 
 
+### Kubernetes Static Pod Manifest File Access
+
+Branch count: 116  
+Document count: 116  
+Index: geneve-ut-0903
+
+```python
+host.os.type:linux and event.category:process and event.action:(exec or executed) and 
+process.name:(
+  bash or sh or dash or zsh or 
+  cat or cp or mv or touch or tee or dd or
+  sed or awk or 
+  curl or wget or scp or
+  vi or vim or nano or echo or
+  busybox or
+  python* or perl* or ruby* or node or lua* or
+  openssl or base64 or xxd or
+  .*) and 
+  process.args:(*/etc/kubernetes/manifests/* and not (/etc/kubernetes/manifests/etcd* or /etc/kubernetes/manifests/kube-apiserver* or /etc/kubernetes/manifests/kube-scheduler* or /etc/kubernetes/manifests/kube-controller-manager*)) and 
+  not (process.args :printf* and process.working_directory :/home/*-svc-nessus) and 
+  not process.parent.executable :("/opt/nessus/sbin/nessusd" or "/opt/nessus_agent/sbin/nessus-agent-module")
+```
+
+
+
 ### LSASS Memory Dump Creation
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0778
+Index: geneve-ut-0911
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -7476,7 +8580,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0783
+Index: geneve-ut-0916
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -7494,7 +8598,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0784
+Index: geneve-ut-0917
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7508,7 +8612,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0788
+Index: geneve-ut-0922
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -7519,72 +8623,11 @@ process.args != "1"
 
 
 
-### Linux Restricted Shell Breakout via Linux Binary(s)
-
-Branch count: 303  
-Document count: 303  
-Index: geneve-ut-0790
-
-```python
-process where host.os.type == "linux" and event.type == "start" and process.executable != null and
-(
-  /* launching shell from capsh */
-  (process.name == "capsh" and process.args == "--" and not process.parent.executable == "/usr/bin/log4j-cve-2021-44228-hotpatch") or
-
-  /* launching shells from unusual parents or parent+arg combos */
-  (process.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and (
-    (process.parent.name : "*awk" and process.parent.args : "BEGIN {system(*)}") or
-    (process.parent.name == "git" and process.parent.args : ("!*sh", "exec *sh") and not process.name == "ssh" ) or
-    (process.parent.name : ("byebug", "ftp", "strace", "zip", "tar") and
-    (
-      process.parent.args : "BEGIN {system(*)}" or
-      (
-        (process.parent.args : "exec=*sh" or (process.parent.args : "-I" and process.parent.args : "*sh")) or
-        (process.args : "exec=*sh" or (process.args : "-I" and process.args : "*sh"))
-        )
-      )
-    ) or
-
-    /* shells specified in parent args */
-    /* nice rule is broken in 8.2 */
-    (process.parent.args : "*sh" and
-      (
-        (process.parent.name == "nice") or
-        (process.parent.name == "cpulimit" and process.parent.args == "-f") or
-        (process.parent.name == "find" and process.parent.args == "." and process.parent.args == "-exec" and
-         process.parent.args == ";" and process.parent.args : "/bin/*sh") or
-        (process.parent.name == "flock" and process.parent.args == "-u" and process.parent.args == "/")
-      )
-    )
-  )) or
-
-  /* shells specified in args */
-  (process.args : "*sh" and (
-    (process.parent.name == "crash" and process.parent.args == "-h") or
-    (process.name == "sensible-pager" and process.parent.name in ("apt", "apt-get") and process.parent.args == "changelog")
-    /* scope to include more sensible-pager invoked shells with different parent process to reduce noise and remove false positives */
-
-  )) or
-  (process.name == "busybox" and event.action == "exec" and process.args_count == 2 and process.args : "*sh" and not
-   process.executable : "/var/lib/docker/overlay2/*/merged/bin/busybox" and not (process.parent.args == "init" and
-   process.parent.args == "runc") and not process.parent.args in ("ls-remote", "push", "fetch") and not process.parent.name == "mkinitramfs" and
-   not process.parent.executable == "/bin/busybox") or
-  (process.name == "env" and process.args_count == 2 and process.args : "*sh") or
-  (process.parent.name in ("vi", "vim") and process.parent.args == "-c" and process.parent.args : ":!*sh") or
-  (process.parent.name in ("c89", "c99", "gcc") and process.parent.args : "*sh,-s" and process.parent.args == "-wrapper") or
-  (process.parent.name == "expect" and process.parent.args == "-c" and process.parent.args : "spawn *sh;interact") or
-  (process.parent.name == "mysql" and process.parent.args == "-e" and process.parent.args : "\\!*sh") or
-  (process.parent.name == "ssh" and process.parent.args == "-o" and process.parent.args : "ProxyCommand=;*sh 0<&2 1>&2")
-)
-```
-
-
-
 ### Linux SSH X11 Forwarding
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0804
+Index: geneve-ut-0937
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -7598,7 +8641,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0807
+Index: geneve-ut-0940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7612,7 +8655,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0809
+Index: geneve-ut-0942
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7631,9 +8674,9 @@ not (
 
 ### Linux User Added to Privileged Group
 
-Branch count: 360  
-Document count: 360  
-Index: geneve-ut-0810
+Branch count: 720  
+Document count: 720  
+Index: geneve-ut-0943
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7644,6 +8687,16 @@ process.executable != null and process.args in (
 (
   process.name in ("usermod", "adduser") or
   (process.name == "gpasswd" and process.args in ("-a", "--add", "-M", "--members"))
+) and
+not (
+  ?process.parent.executable like (
+    "/usr/lib/google/guest_agent/core_plugin", "/usr/libexec/platform-python*", "/usr/lib/google/guest_agent/GuestAgentCorePlugin/core_plugin",
+    "/usr/bin/google_guest_agent"
+  ) or
+  (
+    ?process.entry_leader.executable == "/usr/lib/venv-salt-minion/bin/python.original" and
+    ?process.entry_leader.args == "/usr/lib/venv-salt-minion/bin/salt-minion"
+  )
 )
 ```
 
@@ -7653,7 +8706,7 @@ process.executable != null and process.args in (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0814
+Index: geneve-ut-0947
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -7700,7 +8753,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0815
+Index: geneve-ut-0948
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7731,7 +8784,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 600  
 Document count: 1200  
-Index: geneve-ut-0816
+Index: geneve-ut-0949
 
 ```python
 sequence with maxspan=1m
@@ -7756,7 +8809,7 @@ sequence with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0818
+Index: geneve-ut-0951
 
 ```python
 event.dataset:o365.audit and
@@ -7769,7 +8822,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0820
+Index: geneve-ut-0953
 
 ```python
 event.dataset:o365.audit and
@@ -7782,7 +8835,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0821
+Index: geneve-ut-0954
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -7794,7 +8847,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0852
+Index: geneve-ut-0989
 
 ```python
 event.dataset:o365.audit and
@@ -7807,7 +8860,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0853
+Index: geneve-ut-0990
 
 ```python
 event.dataset:o365.audit and
@@ -7820,7 +8873,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0854
+Index: geneve-ut-0991
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -7832,7 +8885,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0855
+Index: geneve-ut-0992
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -7844,7 +8897,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0856
+Index: geneve-ut-0993
 
 ```python
 event.dataset:o365.audit and
@@ -7857,7 +8910,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0863
+Index: geneve-ut-1001
 
 ```python
 event.dataset: "o365.audit" and
@@ -7870,7 +8923,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0867
+Index: geneve-ut-1004
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7890,7 +8943,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0868
+Index: geneve-ut-1005
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -7902,7 +8955,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0869
+Index: geneve-ut-1006
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -7914,7 +8967,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0873
+Index: geneve-ut-1010
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7926,7 +8979,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0874
+Index: geneve-ut-1011
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -7938,7 +8991,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0876
+Index: geneve-ut-1013
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7950,7 +9003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0877
+Index: geneve-ut-1014
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7962,7 +9015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0878
+Index: geneve-ut-1015
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7987,7 +9040,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0879
+Index: geneve-ut-1016
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8007,7 +9060,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0880
+Index: geneve-ut-1017
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -8020,7 +9073,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-0881
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8035,7 +9088,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0883
+Index: geneve-ut-1020
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -8047,7 +9100,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0886
+Index: geneve-ut-1023
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -8059,7 +9112,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0887
+Index: geneve-ut-1024
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -8071,7 +9124,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0888
+Index: geneve-ut-1025
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -8105,7 +9158,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0891
+Index: geneve-ut-1028
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8119,7 +9172,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0892
+Index: geneve-ut-1029
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8140,7 +9193,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0893
+Index: geneve-ut-1030
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8154,7 +9207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0894
+Index: geneve-ut-1031
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8189,7 +9242,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0895
+Index: geneve-ut-1032
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -8214,7 +9267,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0896
+Index: geneve-ut-1033
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8229,14 +9282,14 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### Microsoft IIS Connection Strings Decryption
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0899
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1037
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   (process.name : "aspnet_regiis.exe" or ?process.pe.original_file_name == "aspnet_regiis.exe") and
-  process.args : "connectionStrings" and process.args : "-pdf"
+  process.args : "connectionStrings" and process.args : ("-pdf", "-pd")
 ```
 
 
@@ -8245,7 +9298,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0901
+Index: geneve-ut-1039
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8276,7 +9329,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0903
+Index: geneve-ut-1041
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -8330,7 +9383,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0904
+Index: geneve-ut-1042
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -8340,12 +9393,12 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 ### Modification of AmsiEnable Registry Key
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0906
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1044
 
 ```python
-registry where host.os.type == "windows" and event.type == "change" and
+registry where host.os.type == "windows" and event.type in ("creation", "change") and
   registry.value : "AmsiEnable" and registry.data.strings: ("0", "0x00000000")
 
   /*
@@ -8360,7 +9413,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0907
+Index: geneve-ut-1045
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8377,7 +9430,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0909
+Index: geneve-ut-1047
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8392,7 +9445,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0910
+Index: geneve-ut-1048
 
 ```python
 file where event.type != "deletion" and
@@ -8442,7 +9495,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0912
+Index: geneve-ut-1050
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8458,7 +9511,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0913
+Index: geneve-ut-1051
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -8472,7 +9525,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0915
+Index: geneve-ut-1053
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8495,7 +9548,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0916
+Index: geneve-ut-1054
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8523,7 +9576,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0917
+Index: geneve-ut-1055
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8545,7 +9598,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0918
+Index: geneve-ut-1056
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8562,9 +9615,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### MsBuild Making Network Connections
 
-Branch count: 8  
-Document count: 16  
-Index: geneve-ut-0919
+Branch count: 4  
+Document count: 8  
+Index: geneve-ut-1057
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -8582,10 +9635,6 @@ sequence by process.entity_id with maxspan=30s
   /* Exclude domains that are known to be benign */
   [network where host.os.type == "windows" and
     event.action: ("connection_attempted", "lookup_requested") and
-    (
-      process.pe.original_file_name: "MSBuild.exe" or
-      process.name: "MSBuild.exe"
-    ) and
     not user.id == "S-1-5-18" and
     not cidrmatch(destination.ip, "127.0.0.1", "::1") and
     not dns.question.name : (
@@ -8601,7 +9650,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0920
+Index: geneve-ut-1058
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -8619,7 +9668,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-0921
+Index: geneve-ut-1059
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8660,7 +9709,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-0932
+Index: geneve-ut-1072
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -8686,7 +9735,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0940
+Index: geneve-ut-1080
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -8710,7 +9759,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0943
+Index: geneve-ut-1083
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8722,9 +9771,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### NTDS or SAM Database File Copied
 
-Branch count: 210  
-Document count: 210  
-Index: geneve-ut-0944
+Branch count: 168  
+Document count: 168  
+Index: geneve-ut-1084
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8734,26 +9783,49 @@ process where host.os.type == "windows" and event.type == "start" and
     ) or
     ((?process.pe.original_file_name : "esentutl.exe" or process.name : "esentutl.exe") and process.args : ("*/y*", "*/vss*", "*/d*"))
   ) and
-  process.command_line : ("*\\ntds.dit*", "*\\config\\SAM*", "*\\*\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\*", "*/system32/config/SAM*", "*\\User Data\\*")
+  process.command_line : ("*\\ntds.dit*", "*\\config\\SAM*", "*\\*\\GLOBALROOT\\Device\\HarddiskVolumeShadowCopy*\\*", "*/system32/config/SAM*")
 ```
 
 
 
 ### Namespace Manipulation Using Unshare
 
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-0945
+Branch count: 12  
+Document count: 12  
+Index: geneve-ut-1085
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action : ("exec", "exec_event", "start") and
-process.executable: "/usr/bin/unshare" and not (
-  process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
-  process.args == "/usr/bin/snap" and not process.parent.name in ("zz-proxmox-boot", "java") or
-  process.parent.args like (
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
+process.name: "unshare" and not (
+  ?process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
+  ?process.args == "/usr/bin/snap" and not ?process.parent.name in ("zz-proxmox-boot", "java") or
+  ?process.parent.args like (
     "/etc/kernel/postinst.d/zz-proxmox-boot", "/opt/openssh/sbin/sshd", "/usr/sbin/sshd",
     "/snap/*", "/home/*/.local/share/JetBrains/Toolbox/*"
   )
+)
+```
+
+
+
+### Namespace Manipulation Using Unshare in a Container
+
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-1086
+
+```python
+process where event.type == "start" and event.action == "exec" and
+process.name == "unshare" and container.id like "?*" and not (
+  process.parent.executable: ("/usr/bin/udevadm", "*/lib/systemd/systemd-udevd", "/usr/bin/unshare") or
+  (process.args == "/usr/bin/snap" and not process.parent.name in ("zz-proxmox-boot", "java")) or
+  process.parent.args like (
+    "/etc/kernel/postinst.d/zz-proxmox-boot", "/opt/openssh/sbin/sshd", "/usr/sbin/sshd",
+    "/snap/*", "/home/*/.local/share/JetBrains/Toolbox/*"
+  ) or
+ (process.args == "--propagation" and process.args == "private" and process.args like "/etc/kernel/post*.d/zz-proxmox-boot") or 
+ (process.args == "--fork" and process.args == "--kill-child") or 
+  process.args like ("/usr/bin/os-prober", "/usr/bin/linux-boot-prober", "/opt/SIGOS/sitedata/exec/*")
 )
 ```
 
@@ -8763,7 +9835,7 @@ process.executable: "/usr/bin/unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0946
+Index: geneve-ut-1087
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8784,7 +9856,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0948
+Index: geneve-ut-1089
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8799,7 +9871,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0949
+Index: geneve-ut-1090
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8816,7 +9888,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0951
+Index: geneve-ut-1092
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -8836,11 +9908,57 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 
 
+### Network Connection Followed by File Creation
+
+Branch count: 112  
+Document count: 224  
+Index: geneve-ut-1094
+
+```python
+sequence by host.id, process.entity_id with maxspan=5s
+  [network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and
+  process.executable like (
+    "/boot/*", "/dev/shm/*", "/tmp/*", "/var/tmp/*", "/var/log/*", "/var/run/user/*", "/run/user/*"
+  ) and
+  not (
+    destination.ip == null or
+    destination.ip == "0.0.0.0" or 
+    cidrmatch(
+      destination.ip, "10.0.0.0/8", "127.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12",
+      "192.0.0.0/24", "192.0.0.0/29","192.0.0.8/32", "192.0.0.9/32", "192.0.0.10/32",
+      "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24",
+      "192.168.0.0/16", "192.88.99.0/24", "224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24",
+      "198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "240.0.0.0/4", "::1", "FE80::/10",
+      "FF00::/8", "FC00::/7"
+    )
+  )]
+  [file where host.os.type == "linux" and event.type == "creation" and process.executable like (
+    "/boot/*", "/dev/shm/*", "/tmp/*", "/var/tmp/*", "/var/log/*", "/boot/*", "/var/run/user/*", "/run/user/*"
+  ) and
+  not (
+    file.name like "tmp*" or file.extension in ("sqlite-journal", "db-journal", "lockfile", "tmp") or
+    file.path like (
+      "/loki/wal/*", "/dev/shm/.org.chromium.Chromium.*", "/opt/rapid7/nexpose/*",
+      "/usr/local/ltechagent*", "/var/lib/cloudendure/agent_keystore_temp", "/var/cache/yum/*",
+      "/run/aws-node/ipam.json.tmp*", "/run/systemd/journal/streams/.*"
+    ) or
+    (process.executable == "/tmp/terraform" and file.path like "/tmp/terraform-provider*") or 
+    process.name in ("podman", "minikube", "logrotate", "java", "aws-k8s-agent", "grafana", "postman") or
+    process.executable : (
+      "/etc/cron.daily/logrotate", "/etc/update-motd.d/50-motd-news", "/etc/cron.hourly/0yum-hourly.cron",
+      "/etc/cron.hourly/BitdefenderRedline", "/tmp/token_handler", "/tmp/.sentry-cli*.exe", 
+      "/etc/cron.daily/0yum-daily.cron", "/etc/init.d/fortiedr"
+    )
+  )]
+```
+
+
+
 ### Network Connection Initiated by Suspicious SSHD Child Process
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-0953
+Index: geneve-ut-1095
 
 ```python
 sequence by host.id with maxspan=1s
@@ -8882,7 +10000,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-0954
+Index: geneve-ut-1096
 
 ```python
 sequence by host.id with maxspan=10s
@@ -8899,7 +10017,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0956
+Index: geneve-ut-1098
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8914,7 +10032,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0957
+Index: geneve-ut-1099
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -8933,7 +10051,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0958
+Index: geneve-ut-1100
 
 ```python
 sequence by process.entity_id
@@ -8953,7 +10071,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0959
+Index: geneve-ut-1101
 
 ```python
 sequence by process.entity_id
@@ -8972,7 +10090,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-0961
+Index: geneve-ut-1103
 
 ```python
 sequence by host.id with maxspan=1m
@@ -9001,7 +10119,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-0962
+Index: geneve-ut-1104
 
 ```python
 sequence by process.entity_id
@@ -9026,7 +10144,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0963
+Index: geneve-ut-1105
 
 ```python
 sequence by process.entity_id
@@ -9048,7 +10166,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0964
+Index: geneve-ut-1106
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -9081,7 +10199,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0965
+Index: geneve-ut-1107
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9111,7 +10229,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0969
+Index: geneve-ut-1111
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -9128,7 +10246,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0970
+Index: geneve-ut-1112
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -9165,7 +10283,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0971
+Index: geneve-ut-1113
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9178,7 +10296,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0976
+Index: geneve-ut-1118
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -9190,7 +10308,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0979
+Index: geneve-ut-1121
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -9202,7 +10320,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-0988
+Index: geneve-ut-1130
 
 ```python
 sequence by host.id with maxspan=10s
@@ -9216,7 +10334,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0989
+Index: geneve-ut-1131
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9226,11 +10344,40 @@ process where host.os.type == "linux" and event.type == "start" and
 
 
 
+### Nsenter Execution with Target Flag Inside Container
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1132
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  (process.name == "nsenter" or process.args == "nsenter") and
+  container.id like "?*" and process.args like ("-t", "--target*")
+```
+
+
+
+### Nsenter to PID Namespace via Auditd
+
+Branch count: 32  
+Document count: 32  
+Index: geneve-ut-1133
+
+```python
+host.os.type:linux and 
+event.category:process and event.action:(executed or exec) and 
+(process.name:nsenter or process.args:nsenter) and 
+process.args:((--target* or -t) and not --net=/run/netns/* and not (--assertion and snap) and not (is-active and snap.*))
+```
+
+
+
 ### Office Test Registry Persistence
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0991
+Index: geneve-ut-1135
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -9243,7 +10390,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0992
+Index: geneve-ut-1136
 
 ```python
 event.dataset: "okta.system"
@@ -9258,7 +10405,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0994
+Index: geneve-ut-1138
 
 ```python
 sequence by user.name with maxspan=30m
@@ -9280,7 +10427,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1003
+Index: geneve-ut-1147
 
 ```python
 network where event.action == "connection_accepted" and
@@ -9307,7 +10454,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1004
+Index: geneve-ut-1148
 
 ```python
 network where event.action == "lookup_requested" and
@@ -9327,7 +10474,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1005
+Index: geneve-ut-1149
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9342,7 +10489,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1006
+Index: geneve-ut-1150
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -9369,7 +10516,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1007
+Index: geneve-ut-1151
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -9384,7 +10531,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1008
+Index: geneve-ut-1152
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -9400,7 +10547,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1009
+Index: geneve-ut-1153
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -9414,7 +10561,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1014
+Index: geneve-ut-1160
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -9429,7 +10576,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1015
+Index: geneve-ut-1161
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9443,7 +10590,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1016
+Index: geneve-ut-1162
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9462,7 +10609,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1017
+Index: geneve-ut-1163
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9474,7 +10621,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1018
+Index: geneve-ut-1164
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9486,7 +10633,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1019
+Index: geneve-ut-1165
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9504,7 +10651,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1020
+Index: geneve-ut-1166
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9517,7 +10664,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1021
+Index: geneve-ut-1167
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9532,7 +10679,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1022
+Index: geneve-ut-1168
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -9547,7 +10694,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1025
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -9565,9 +10712,9 @@ process where host.os.type == "macos" and event.type == "start" and
 
 ### Persistence via Microsoft Office AddIns
 
-Branch count: 36  
-Document count: 36  
-Index: geneve-ut-1026
+Branch count: 108  
+Document count: 108  
+Index: geneve-ut-1172
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9581,7 +10728,8 @@ file where host.os.type == "windows" and event.type != "deletion" and
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Word\\Startup\\*",
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\AddIns\\*",
     "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\Roaming\\Microsoft\\Excel\\XLSTART\\*"
- )
+ ) and
+ not (file.name : "~$*" and process.name : "excel.exe" and ?file.size in (0, 165))
 ```
 
 
@@ -9590,7 +10738,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1027
+Index: geneve-ut-1173
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9604,7 +10752,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1028
+Index: geneve-ut-1174
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9623,7 +10771,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1029
+Index: geneve-ut-1175
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9647,9 +10795,9 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 ### Persistence via Suspicious Launch Agent or Launch Daemon
 
-Branch count: 190  
-Document count: 190  
-Index: geneve-ut-1030
+Branch count: 380  
+Document count: 380  
+Index: geneve-ut-1176
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -9664,7 +10812,12 @@ file where host.os.type == "macos" and event.type != "deletion" and
   not process.executable like ("/System/*", "/Library/PrivilegedHelperTools/*") and
   not (process.code_signature.signing_id in ("com.apple.vim", "com.apple.cat", "com.apple.cfprefsd",
                                             "com.jetbrains.toolbox", "com.apple.pico", "com.apple.shove",
-                                            "com.sublimetext.4", "com.apple.ditto") and process.code_signature.trusted == true)
+                                            "com.sublimetext.4", "com.apple.ditto") and process.code_signature.trusted == true) and
+  not (file.path like ("/Library/LaunchDaemons/com.jumpcloud.*",
+                       "/Library/LaunchAgents/com.jumpcloud.*",
+                       "/Library/LaunchDaemons/com.wazuh.*",
+                       "/Library/LaunchDaemons/com.zscaler.service.plist") and
+       process.executable == "/bin/bash")
 ```
 
 
@@ -9673,7 +10826,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1031
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9692,7 +10845,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1032
+Index: geneve-ut-1178
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9720,7 +10873,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1033
+Index: geneve-ut-1179
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9735,7 +10888,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1034
+Index: geneve-ut-1180
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9798,7 +10951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1035
+Index: geneve-ut-1181
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -9819,7 +10972,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1036
+Index: geneve-ut-1182
 
 ```python
 any where host.os.type == "windows" and
@@ -9881,7 +11034,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1038
+Index: geneve-ut-1184
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -9910,7 +11063,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1039
+Index: geneve-ut-1185
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -9922,9 +11075,9 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 ### Pluggable Authentication Module (PAM) Version Discovery
 
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-1040
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1186
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9936,10 +11089,17 @@ process where host.os.type == "linux" and event.type == "start" and
 not (
   ?process.parent.name in ("dcservice", "inspectorssmplugin") or
   ?process.working_directory in ("/var/ossec", "/opt/msp-agent") or
+  ?process.entry_leader.executable in("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/usr/sbin/ScanAssistant") or
   ?process.parent.executable in (
     "/opt/CyberCNSAgent/cybercnsagent_linux", "/usr/local/manageengine/uems_agent/bin/dcpatchscan",
     "/usr/local/manageengine/uems_agent/bin/dcconfig", "/usr/share/vicarius/topiad",
-    "/etc/rc.d/init.d/sshd-chroot"
+    "/etc/rc.d/init.d/sshd-chroot", "/var/ossec/bin/wazuh-modulesd",
+    "/usr/lib/venv-salt-minion/bin/python.original"
+  ) or
+  (
+    process.executable == "/usr/bin/rpm" and
+    ?process.parent.name == "systemd" and
+    ?process.env_vars == "LD_LIBRARY_PATH=/usr/lib/venv-salt-minion/lib"
   )
 )
 ```
@@ -9950,7 +11110,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1043
+Index: geneve-ut-1189
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -9995,9 +11155,9 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 ### Polkit Version Discovery
 
-Branch count: 24  
-Document count: 24  
-Index: geneve-ut-1044
+Branch count: 48  
+Document count: 48  
+Index: geneve-ut-1190
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10009,7 +11169,12 @@ event.action in ("exec", "exec_event", "start", "ProcessRollup2", "process_start
 ) and
 not (
   ?process.working_directory in ("/opt/msp-agent", "/opt/CyberCNSAgent") or
-  ?process.parent.executable like ("/usr/local/cpanel/3rdparty/perl/*/bin/perl", "/usr/share/vicarius/topiad")
+  ?process.parent.executable like ("/usr/local/cpanel/3rdparty/perl/*/bin/perl", "/usr/share/vicarius/topiad") or
+  ?process.entry_leader.executable in ("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/sf/edr/agent/bin/edr_monitor") or
+  (
+    ?process.parent.args == "/usr/lib/venv-salt-minion/bin/python.original" and
+    ?process.parent.args == "/usr/lib/venv-salt-minion/bin/salt-minion"
+  )
 )
 ```
 
@@ -10019,7 +11184,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1045
+Index: geneve-ut-1191
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -10032,7 +11197,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1054
+Index: geneve-ut-1201
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10049,7 +11214,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1056
+Index: geneve-ut-1203
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -10074,7 +11239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1060
+Index: geneve-ut-1207
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/*/etc/nsswitch.conf" and
@@ -10091,7 +11256,7 @@ not file.path like (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1061
+Index: geneve-ut-1208
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10107,7 +11272,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1062
+Index: geneve-ut-1209
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10128,7 +11293,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1063
+Index: geneve-ut-1210
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10169,7 +11334,7 @@ event.action in ("exec", "exec_event", "start", "executed", "process_started", "
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1064
+Index: geneve-ut-1211
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -10186,7 +11351,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1065
+Index: geneve-ut-1212
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -10199,7 +11364,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1066
+Index: geneve-ut-1213
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10223,7 +11388,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1068
+Index: geneve-ut-1215
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -10248,11 +11413,38 @@ sequence by host.id, user.name with maxspan = 5s
 
 
 
+### Potential Container Escape via Kernel core_pattern Modification
+
+Branch count: 288  
+Document count: 288  
+Index: geneve-ut-1217
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
+process.args like ("*/proc/sys/kernel/core_pattern*", "*kernel.core_pattern*") and
+?process.parent.executable != null and
+(
+  process.name in ("tee", "cp", "mv", "dd") or
+  (
+    process.name == "sysctl" and
+    process.args like ("*-w*", "*core_pattern*")
+  ) or
+  (
+    process.name in ("bash", "dash", "sh", "zsh", "ksh", "fish", "ash", "mksh", "busybox") and
+    process.args == "-c" and process.args like ("*echo *", "*printf *")
+  )
+) and
+not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpctl", "/usr/sbin/abrtd", "/usr/bin/apport")
+```
+
+
+
 ### Potential Cookies Theft via Browser Debugging
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1070
+Index: geneve-ut-1218
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -10276,7 +11468,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1072
+Index: geneve-ut-1221
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -10292,18 +11484,18 @@ process where host.os.type == "windows" and event.code == "10" and
 
 ### Potential Credential Access via LSASS Memory Dump
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1073
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1222
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
   winlog.event_data.TargetImage : "?:\\WINDOWS\\system32\\lsass.exe" and
 
-   /* DLLs exporting MiniDumpWriteDump API to create an lsass mdmp*/
-  winlog.event_data.CallTrace : ("*dbghelp*", "*dbgcore*") and
+  /* dbgcore.dll hosts MiniDumpWriteDump on modern Windows; dbghelp-only traces are non-dump usage */
+  winlog.event_data.CallTrace : "*dbgcore*" and
 
-   /* case of lsass crashing */
+  /* crash handlers */
   not process.executable : (
         "?:\\Windows\\System32\\WerFault.exe",
         "?:\\Windows\\SysWOW64\\WerFault.exe",
@@ -10317,7 +11509,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1074
+Index: geneve-ut-1223
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -10370,17 +11562,33 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
+### Potential Credential Access via Renamed COM+ Services DLL
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1224
+
+```python
+sequence by process.entity_id with maxspan=1m
+ [process where host.os.type == "windows" and event.type == "start" and process.name : "rundll32.exe"]
+ [process where host.os.type == "windows" and event.code == "7" and
+   (file.pe.original_file_name : "COMSVCS.DLL" or file.pe.imphash : "EADBCCBB324829ACB5F2BBE87E5549A8") and
+   /* renamed COMSVCS */
+   not file.name : "COMSVCS.DLL"]
+```
+
+
+
 ### Potential Credential Access via Trusted Developer Utility
 
-Branch count: 16  
-Document count: 32  
-Index: geneve-ut-1076
+Branch count: 4  
+Document count: 8  
+Index: geneve-ut-1225
 
 ```python
 sequence by process.entity_id
  [process where host.os.type == "windows" and event.type == "start" and (process.name : "MSBuild.exe" or process.pe.original_file_name == "MSBuild.exe")]
- [any where host.os.type == "windows" and (event.category == "library" or (event.category == "process" and event.action : "Image loaded*")) and
-  (?dll.name : ("vaultcli.dll", "SAMLib.DLL") or file.name : ("vaultcli.dll", "SAMLib.DLL"))]
+ [library where host.os.type == "windows" and dll.name : ("vaultcli.dll", "SAMLib.DLL")]
 ```
 
 
@@ -10389,7 +11597,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1089
+Index: geneve-ut-1240
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10404,7 +11612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1090
+Index: geneve-ut-1241
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10435,7 +11643,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1091
+Index: geneve-ut-1242
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10449,7 +11657,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1092
+Index: geneve-ut-1243
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10462,7 +11670,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1093
+Index: geneve-ut-1244
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -10474,7 +11682,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1094
+Index: geneve-ut-1245
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10483,15 +11691,34 @@ process.parent.name == "proot"
 
 
 
+### Potential Direct Kubelet Access via Process Arguments
+
+Branch count: 136  
+Document count: 136  
+Index: geneve-ut-1247
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
+(
+  /* direct utility execution */
+  process.name like ("curl", "wget", "python*", "perl*", "php*", "node*", "java", "ruby*", "lua*", ".*") or
+
+  process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/var/run/*", "/home/*", "/run/user/*", "/busybox/*")
+) and
+process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:10255/*")
+```
+
+
+
 ### Potential Direct Kubelet Access via Process Arguments Detected via Defend for Containers
 
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-1096
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1248
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.args like "http*:10250*" and process.interactive == true and container.id like "?*"
+process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*") and container.id like "?*"
 ```
 
 
@@ -10500,7 +11727,7 @@ process.args like "http*:10250*" and process.interactive == true and container.i
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1097
+Index: geneve-ut-1249
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10521,7 +11748,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1098
+Index: geneve-ut-1250
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10535,7 +11762,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1101
+Index: geneve-ut-1253
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -10559,7 +11786,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1102
+Index: geneve-ut-1254
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -10575,7 +11802,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1103
+Index: geneve-ut-1255
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -10592,7 +11819,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1104
+Index: geneve-ut-1256
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10613,7 +11840,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1106
+Index: geneve-ut-1258
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -10626,7 +11853,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1108
+Index: geneve-ut-1260
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10654,7 +11881,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1111
+Index: geneve-ut-1263
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10670,7 +11897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1112
+Index: geneve-ut-1264
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10693,7 +11920,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1113
+Index: geneve-ut-1265
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10706,7 +11933,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1115
+Index: geneve-ut-1267
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10719,7 +11946,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1120
+Index: geneve-ut-1272
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10733,7 +11960,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1121
+Index: geneve-ut-1273
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10748,7 +11975,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1122
+Index: geneve-ut-1275
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -10771,7 +11998,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1125
+Index: geneve-ut-1278
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10814,7 +12041,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1126
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10832,7 +12059,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1127
+Index: geneve-ut-1280
 
 ```python
 host.os.type:"windows" and
@@ -10848,10 +12075,26 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1129
+Index: geneve-ut-1282
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
+```
+
+
+
+### Potential Kubeletctl Execution
+
+Branch count: 38  
+Document count: 38  
+Index: geneve-ut-1284
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
+(
+  process.name == "kubeletctl" or
+  (process.args in ("run", "exec", "scan", "pods", "runningpods", "attach", "portForward", "cri", "pid2pod") and process.args:("*:10250*", "*:10255*"))
+)
 ```
 
 
@@ -10860,7 +12103,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1131
+Index: geneve-ut-1285
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -10876,7 +12119,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1132
+Index: geneve-ut-1286
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10894,7 +12137,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1133
+Index: geneve-ut-1287
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -10908,7 +12151,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1135
+Index: geneve-ut-1289
 
 ```python
 sequence by host.id with maxspan=30s
@@ -10927,7 +12170,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1137
+Index: geneve-ut-1291
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -10943,7 +12186,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1138
+Index: geneve-ut-1292
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10956,7 +12199,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1139
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10986,7 +12229,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1145
+Index: geneve-ut-1299
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11009,7 +12252,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1146
+Index: geneve-ut-1300
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11028,7 +12271,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1151
+Index: geneve-ut-1305
 
 ```python
 process where host.os.type == "windows" and 
@@ -11170,7 +12413,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1152
+Index: geneve-ut-1306
 
 ```python
 process where host.os.type == "windows" and
@@ -11247,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1156
+Index: geneve-ut-1310
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -11264,7 +12507,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1157
+Index: geneve-ut-1311
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -11298,7 +12541,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1159
+Index: geneve-ut-1313
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -11310,7 +12553,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1160
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11349,7 +12592,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1162
+Index: geneve-ut-1316
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -11362,7 +12605,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1167
+Index: geneve-ut-1321
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11376,7 +12619,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1174
+Index: geneve-ut-1328
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -11404,7 +12647,8 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
       "/var/run/udev/ud.pid",
       "/var/run/udevd.pid"
     )
-  )
+  ) and
+  not file.path like ("/tmp/krb5cc*", "/tmp/ansible_*", "/storage/*", "/tmp/clearsigned.message.*", "/var/sftp/refinitiv/*", "/tmp/fileutil.message.*")
 ```
 
 
@@ -11413,7 +12657,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1175
+Index: geneve-ut-1329
 
 ```python
 network where host.os.type == "windows" and
@@ -11439,7 +12683,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1178
+Index: geneve-ut-1332
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11454,7 +12698,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1181
+Index: geneve-ut-1335
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -11468,7 +12712,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1182
+Index: geneve-ut-1336
 
 ```python
 file where host.os.type == "windows" and
@@ -11482,7 +12726,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1183
+Index: geneve-ut-1337
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11495,7 +12739,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1184
+Index: geneve-ut-1338
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11515,7 +12759,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1185
+Index: geneve-ut-1339
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11533,9 +12777,9 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 ### Potential PowerShell HackTool Script by Author
 
-Branch count: 45  
-Document count: 45  
-Index: geneve-ut-1187
+Branch count: 48  
+Document count: 48  
+Index: geneve-ut-1341
 
 ```python
 host.os.type:windows and event.category:process and
@@ -11562,7 +12806,8 @@ host.os.type:windows and event.category:process and
       "_nullbind" or "_tmenochet" or
       "jaredcatkinson" or "ChrisTruncer" or
       "monoxgas" or "TheRealWover" or
-      "splinter_code"
+      "splinter_code" or "samratashok" or
+      "leechristensen" or "nikhil_mitt"
   ) and
   not powershell.file.script_block_text : ("Get-UEFIDatabaseSigner" or "Posh-SSH")
 ```
@@ -11573,7 +12818,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1188
+Index: geneve-ut-1342
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11768,7 +13013,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1203
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11780,11 +13025,39 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 
 
+### Potential Privacy Control Bypass via TCCDB Modification
+
+Branch count: 16  
+Document count: 16  
+Index: geneve-ut-1358
+
+```python
+process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
+ process.args like "/*/Application Support/com.apple.TCC/TCC.db" and
+ (process.parent.name like~ ("osascript", "bash", "sh", "zsh", "Terminal", "Python*") or (process.parent.code_signature.exists == false or process.parent.code_signature.trusted == false))
+```
+
+
+
+### Potential Privilege Escalation in Container via Runc Init
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1359
+
+```python
+host.os.type:linux and event.category:process and 
+event.action:(executed or exec) and 
+process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
+```
+
+
+
 ### Potential Privilege Escalation through Writable Docker Socket
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1205
+Index: geneve-ut-1360
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -11801,7 +13074,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1206
+Index: geneve-ut-1361
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -11815,7 +13088,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1207
+Index: geneve-ut-1362
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11827,27 +13100,11 @@ process.interactive == true and process.parent.interactive == true
 
 
 
-### Potential Privilege Escalation via OverlayFS
-
-Branch count: 3  
-Document count: 6  
-Index: geneve-ut-1212
-
-```python
-sequence by process.parent.entity_id, host.id with maxspan=5s
-  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-    process.name == "unshare" and process.args : ("-r", "-rm", "m") and process.args : "*cap_setuid*"  and user.id != "0"]
-  [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
-    user.id == "0"]
-```
-
-
-
 ### Potential Privilege Escalation via PKEXEC
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1213
+Index: geneve-ut-1367
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -11859,7 +13116,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1214
+Index: geneve-ut-1368
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -11875,7 +13132,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1215
+Index: geneve-ut-1369
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11895,7 +13152,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1216
+Index: geneve-ut-1371
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11932,10 +13189,115 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1218
+Index: geneve-ut-1373
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
+```
+
+
+
+### Potential Privilege Escalation via a Parent Process Sequence
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1374
+
+```python
+sequence by host.id, process.parent.entity_id with maxspan=15s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )]
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")]
+```
+
+
+
+### Potential Privilege Escalation via a Parent/Child Process Sequence
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1375
+
+```python
+sequence by host.id with maxspan=15s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )] by process.entity_id
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")] by process.parent.entity_id
+```
+
+
+
+### Potential Privilege Escalation via a Suspicious UID Change
+
+Branch count: 14  
+Document count: 28  
+Index: geneve-ut-1376
+
+```python
+sequence by host.id, process.entity_id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+  user.id != "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  (
+    process.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*") or
+    process.parent.executable like (".*", "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/home/*/*", "/run/user/*", "/var/run/user/*")
+  )]
+  [process where host.os.type == "linux" and event.type == "change" and event.action == "uid_change" and
+  user.id == "0" and process.parent.user.id != "0" and process.parent.group.id != "0" and
+  not process.executable in ("/usr/bin/sudo", "/bin/sudo")]
+```
+
+
+
+### Potential Privilege Escalation via unshare Followed by Root Process
+
+Branch count: 341  
+Document count: 682  
+Index: geneve-ut-1377
+
+```python
+sequence by host.id, process.parent.pid with maxspan=30s
+ [process where host.os.type == "linux" and 
+  (
+   (auditd.data.syscall == "unshare" and auditd.data.class == "namespace" and auditd.data.a0 in ("10000000", "50000000", "70000000", "10020000", "50020000", "70020000")) or 
+
+   (process.name == "unshare" and  
+    (process.args in ("--user", "--map-root-user", "--map-current-user") or process.args like ("-*U*", "-*r*")))
+   ) and user.id != "0" and user.id != null]
+ [process where host.os.type == "linux" and 
+  user.id == "0" and user.id != null and 
+  (
+   process.name in ("su", "sudo", "pkexec", "passwd", "chsh", "newgrp", "doas", "run0", "sg", "dash", "sh", "bash", "zsh", "fish", 
+                    "ksh", "csh", "tcsh", "ash", "mksh", "busybox", "rbash", "rzsh", "rksh", "tmux", "screen", "node") or 
+   process.name like ("python*", "perl*", "ruby*", "php*", "lua*")
+  )]
+```
+
+
+
+### Potential Privilege Escalation via unshare and UID Change
+
+Branch count: 5  
+Document count: 10  
+Index: geneve-ut-1378
+
+```python
+sequence by process.parent.entity_id, host.id with maxspan=60s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+    process.name == "unshare" and process.args : ("-r", "-rm", "-m", "-U", "--user") and user.id != "0"]
+  [process where host.os.type == "linux" and event.action == "uid_change" and event.type == "change" and
+    user.id == "0"]
 ```
 
 
@@ -11944,7 +13306,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1219
+Index: geneve-ut-1379
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -11958,7 +13320,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1221
+Index: geneve-ut-1381
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -11981,7 +13343,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1223
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -11998,7 +13360,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1224
+Index: geneve-ut-1384
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -12021,7 +13383,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1225
+Index: geneve-ut-1385
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12034,7 +13396,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1226
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +13410,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1227
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12061,11 +13423,65 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Potential Proxy Execution via Systemd-run
+
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-1388
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started", "start", "ProcessRollup2") and
+process.name == "systemd-run" and ?process.parent.executable != null and
+not (
+  ?process.parent.executable in (
+    "/usr/lib/systemd", "/lib/systemd/systemd", "/opt/saltstack/salt/run/run", "/etc/update-motd.d/70-available-updates",
+    "/tmp/newroot/usr/libexec/ptyxis-agent", "/usr/local/sbin/clamscan.sh", "/opt/sentinelone/bin/sentinelone-agent",
+    "/usr/local/bin/salt-minion", "/var/vanta/launcher", "/opt/traps/bin/pmd", "/usr/sbin/gdm", "/usr/bin/salt-minion",
+    "/opt/GC_Ext/GC/gc_linux_service", "/usr/lib/plesk-task-manager", "/opt/forticlient/epctrl", "/usr/lib/snapd/snap-exec",
+    "/usr/bin/yay", "/usr/local/bin/hexnode_agent", "/opt/halcyon/halcyonar/agent", "/usr/local/bin/qsetup", "/usr/bin/pamac",
+    "/usr/bin/elephant", "/usr/bin/Hyprland"
+  ) or
+  ?process.parent.executable like (
+    "/opt/tableau/tableau_server/packages/scripts.*/after-install", "/opt/acronis/bin/acp-update-controller", "/snap/*",
+    "/var/lib/amagent/*", "/opt/msp-agent/msp-agent-core", "/opt/beyondtrust/*", "/var/lib/rancher/k3s/*/bin/k3s"
+  ) or
+  ?process.parent.name like "platform-python*" or
+  ?process.parent.name in (
+    "udevadm", "daemon.start", "snap", "systemd", "ptyxis-agent", "run-slack", "run-firefox", "dbus.service", "k3s-server",
+    "systemd-udevd", "kubelet", "hyperkube", "kthreadd", "gnome-shell", "xdg-desktop-portal", "firefox", "picus_updater",
+    "rpm-ostree", "prompt-agent"
+  ) or
+  ?process.command_line in (
+    "/usr/bin/systemd-run /usr/bin/systemctl start man-db-cache-update", "systemd-run env",
+    "systemd-run --user dnf-automatic-notifyonly.timer", "systemd-run --user systemctl suspend", "systemd-run /var/lib/aws-replication-agent/uninstall-agent.sh",
+    "systemd-run --on-active=10 --timer-property=AccuracySec=100ms --slice=system.slice systemctl start gc-agent",
+    "systemd-run --user --scope --unit=tmux-server -- tmux", "systemd-run bash -c sleep 60 && reboot"
+  ) or
+  ?process.command_line like~ (
+    "systemd-run --scope -p CPUQuota=10% rpm -qa*", "systemd-run --scope -p CPUQuota=10% dpkg -l*"
+  ) or
+  ?process.parent.command_line in ("runc init", "/usr/local/bin/main") or
+  ?process.parent.command_line like ("*/var/lib/waagent/*", "bash ./run.sh") or
+  process.args in (
+    "--help", "list-timers", "/usr/lib/udev/kdump-udev-throttler", "kubectl", "--unit=ngt_guest_agent_upgrade", "i3-zoom", "google-chrome",
+    "thunar", "/usr/bin/google-chrome-stable", "snap.lxd.workaround", "--unit=firefox", "--unit=slack", "--slice=zoom.slice",
+    "autorandr-launcher", "--unit=restart-dbus", "--unit=autorandr-debounce"
+  ) or
+  process.args like ("--unit=app-Hyprland-wezterm-*.scope", "--unit=app-Hyprland-swaybg-*.scope", "--unit=rmf_sim_*") or
+  ?process.working_directory == "/opt/Tychon/Endpoint/bin" or
+  (process.args in ("rpm", "dpkg") and process.args like~ "CPUQuota=*") or
+  (process.args == "--slice=app-graphical.slice" and process.args == "--description=xdg-terminal-exec")
+)
+```
+
+
+
 ### Potential REMCOS Trojan Execution
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1228
+Index: geneve-ut-1389
 
 ```python
 any where host.os.type == "windows" and
@@ -12092,7 +13508,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1231
+Index: geneve-ut-1395
 
 ```python
 file where host.os.type == "windows" and
@@ -12107,7 +13523,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1232
+Index: geneve-ut-1396
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -12124,8 +13540,10 @@ any where host.os.type == "windows" and
 
   ) or
   (event.category == "process" and event.type == "start" and
-     (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
-     (?process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
+    (
+      (process.name : ("RdpSaUacHelper.exe", "RdpSaProxy.exe") and process.parent.name : "svchost.exe") or
+      (?process.pe.original_file_name : "mstsc.exe" and process.args : "/shadow:*")
+    )
   )
 )
 ```
@@ -12136,7 +13554,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1233
+Index: geneve-ut-1397
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12150,7 +13568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1234
+Index: geneve-ut-1398
 
 ```python
 sequence with maxspan=1m
@@ -12190,18 +13608,25 @@ sequence with maxspan=1m
 
 ### Potential Remote Install via MsiExec
 
-Branch count: 200  
-Document count: 200  
-Index: geneve-ut-1235
+Branch count: 400  
+Document count: 400  
+Index: geneve-ut-1399
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
-  process.name : "msiexec.exe" and process.args : ("-i*", "/i*", "-p*", "/p*") and process.command_line : "*http*" and
+  process.name : "msiexec.exe" and process.args : ("-i*", "/i*", "-p*", "/p*") and
+  process.command_line : ("*http:*", "*https:*") and
   process.args : ("/qn", "-qn", "-q", "/q", "/quiet") and
-  process.parent.name : ("sihost.exe", "explorer.exe", "cmd.exe", "wscript.exe", "mshta.exe", "powershell.exe", "wmiprvse.exe", "pcalua.exe", "forfiles.exe", "conhost.exe") and
-  not process.command_line : ("*--set-server=*", "*UPGRADEADD=*" , "*--url=*",
-                              "*USESERVERCONFIG=*", "*RCTENTERPRISESERVER=*", "*app.ninjarmm.com*", "*zoom.us/client*",
-                              "*SUPPORTSERVERSTSURI=*", "*START_URL=*", "*AUTOCONFIG=*", "*awscli.amazonaws.com*")
+  process.parent.name : (
+    "sihost.exe", "explorer.exe", "cmd.exe", "wscript.exe", "mshta.exe",
+    "powershell.exe", "wmiprvse.exe", "pcalua.exe", "forfiles.exe", "conhost.exe"
+  ) and
+
+  not process.command_line : (
+        "*--set-server=*", "*UPGRADEADD=*" , "*--url=*", "*USESERVERCONFIG=*", "*RCTENTERPRISESERVER=*",
+        "*app.ninjarmm.com*", "*zoom.us/client*", "*SUPPORTSERVERSTSURI=*", "*START_URL=*", "*AUTOCONFIG=*",
+        "*awscli.amazonaws.com*", "*/i \"C:*", "*/i C:\\*"
+  )
 ```
 
 
@@ -12210,7 +13635,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1236
+Index: geneve-ut-1400
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12264,7 +13689,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1237
+Index: geneve-ut-1401
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12284,7 +13709,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1238
+Index: geneve-ut-1402
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -12305,7 +13730,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1239
+Index: geneve-ut-1403
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12320,7 +13745,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1240
+Index: geneve-ut-1404
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -12340,7 +13765,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1241
+Index: geneve-ut-1405
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12360,7 +13785,7 @@ sequence by host.id with maxspan=5s
    and not (
      process.parent.args in (
        "/usr/lib/jenkins/jenkins.war", "/etc/remote-iot/services/remoteiot.jar", "/opt/pentaho/data-integration/launcher/launcher.jar",
-       "/usr/share/java/jenkins.war", "/opt//tomcat/statistics/statistics.jar", "/usr/lib64/NetExtender.jar",
+       "/usr/share/java/jenkins.war", "/opt/tomcat/statistics/statistics.jar", "/usr/lib64/NetExtender.jar",
        "/var/lib/jenkins/workspace/MP-QA/tc_certified_copy*/tc_certified_copy_web_ui_test/target/surefire/surefirebooter*.jar",
        "-javaagent:/opt/opentelemetry/opentelemetry-javaagent-all.jar", "./lib/pipeline-job-executor*SNAPSHOT.jar",
        "./lib/worker-launcher-agent*SNAPSHOT.jar", "/opt/Seqrite_EndPoint_Security/wildfly/jboss-modules.jar",
@@ -12378,11 +13803,26 @@ sequence by host.id with maxspan=5s
 
 
 
+### Potential Root Effective Shell from Non-Standard Path via Auditd
+
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1409
+
+```python
+host.os.type:linux and event.category:process and 
+event.action:(exec or executed) and user.id:(* and not 0) and 
+process.executable:(* and not (/bin/* or /nix/store/*/bin/sudo or /run/wrappers/wrappers*/sudo or /sbin/* or /usr/bin/* or /usr/sbin/*)) and 
+user.effective.id:0 and process.args:-p
+```
+
+
+
 ### Potential SAP NetWeaver Exploitation
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1245
+Index: geneve-ut-1410
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -12417,7 +13857,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1246
+Index: geneve-ut-1411
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -12434,7 +13874,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1248
+Index: geneve-ut-1414
 
 ```python
 sequence by host.id with maxspan=3s
@@ -12448,7 +13888,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1250
+Index: geneve-ut-1417
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -12461,7 +13901,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1251
+Index: geneve-ut-1418
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -12473,12 +13913,13 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1252
+Index: geneve-ut-1419
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
   winlog.event_data.AttributeValue :B\:828* and
-  not winlog.event_data.SubjectUserName: MSOL_*
+  not winlog.event_data.SubjectUserName: MSOL_* and
+  not winlog.event_data.ObjectClass: "msDS-Device"
 ```
 
 
@@ -12487,7 +13928,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1254
+Index: geneve-ut-1421
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -12515,7 +13956,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1256
+Index: geneve-ut-1423
 
 ```python
 sequence by host.id with maxspan=1s
@@ -12540,7 +13981,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1260
+Index: geneve-ut-1427
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -12574,7 +14015,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1261
+Index: geneve-ut-1428
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12588,7 +14029,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1262
+Index: geneve-ut-1429
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -12604,7 +14045,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1263
+Index: geneve-ut-1430
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -12618,7 +14059,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1264
+Index: geneve-ut-1431
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -12648,15 +14089,16 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1265
+Index: geneve-ut-1432
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
-  file.name : ("winload.exe", "winlod.efi", "ntoskrnl.exe", "bootmgr") and
+  file.name : ("winload.exe", "winload.efi", "ntoskrnl.exe", "bootmgr") and
   file.path : ("?:\\Windows\\*", "\\Device\\HarddiskVolume*\\Windows\\*") and
   not process.executable : (
     "?:\\Windows\\System32\\poqexec.exe",
-    "?:\\Windows\\WinSxS\\amd64_microsoft-windows-servicingstack_*\\tiworker.exe"
+    "?:\\Windows\\System32\\wbengine.exe",
+    "?:\\Windows\\WinSxS\\???64_microsoft-windows-servicingstack_*\\tiworker.exe"
   ) and
   not file.path : (
     "?:\\Windows\\WinSxS\\Temp\\InFlight\\*",
@@ -12664,7 +14106,9 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
     "?:\\Windows\\WinSxS\\amd64_microsoft-windows*",
     "?:\\Windows\\SystemTemp\\*",
     "?:\\Windows\\Temp\\????????.???\\*",
-    "?:\\Windows\\Temp\\*\\amd64_microsoft-windows-*"
+    "?:\\Windows\\Temp\\*\\amd64_microsoft-windows-*",
+    "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download*",
+    "?:\\Windows\\Temp\\BootImages\\{*}\\mount\\Windows\\*"
   )
 ```
 
@@ -12674,7 +14118,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1266
+Index: geneve-ut-1433
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12690,7 +14134,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1267
+Index: geneve-ut-1434
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12704,7 +14148,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1268
+Index: geneve-ut-1435
 
 ```python
 file where host.os.type == "windows" and
@@ -12740,7 +14184,7 @@ file where host.os.type == "windows" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1271
+Index: geneve-ut-1438
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12754,7 +14198,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1272
+Index: geneve-ut-1439
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12774,7 +14218,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1274
+Index: geneve-ut-1441
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12791,7 +14235,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1275
+Index: geneve-ut-1442
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -12803,7 +14247,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1276
+Index: geneve-ut-1443
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -12820,7 +14264,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1277
+Index: geneve-ut-1444
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12838,7 +14282,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1283
+Index: geneve-ut-1451
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -12851,7 +14295,7 @@ file.name == "notify_on_release" and process.interactive == true and container.i
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1284
+Index: geneve-ut-1452
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12878,7 +14322,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1285
+Index: geneve-ut-1453
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -12891,7 +14335,7 @@ file.name == "release_agent" and process.interactive == true and container.id li
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1286
+Index: geneve-ut-1454
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -12905,7 +14349,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1288
+Index: geneve-ut-1456
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12920,9 +14364,9 @@ process where host.os.type == "linux" and event.type == "start" and
 
 ### PowerShell Invoke-NinjaCopy script
 
-Branch count: 21  
-Document count: 21  
-Index: geneve-ut-1289
+Branch count: 18  
+Document count: 18  
+Index: geneve-ut-1457
 
 ```python
 event.category:process and host.os.type:windows and
@@ -12932,11 +14376,9 @@ event.category:process and host.os.type:windows and
     "StealthCloseFileDelegate" or
     "StealthOpenFile" or
     "StealthCloseFile" or
-    "StealthReadFile" or
     "Invoke-NinjaCopy"
-   )
-  and not user.id : "S-1-5-18"
-  and not powershell.file.script_block_text : (
+   ) and
+  not powershell.file.script_block_text : (
     "sentinelbreakpoints" and "Set-PSBreakpoint" and "PowerSploitIndicators"
   )
 ```
@@ -12947,13 +14389,11 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1291
+Index: geneve-ut-1459
 
 ```python
 event.category:process and host.os.type:windows and
-  powershell.file.script_block_text : (
-    KerberosRequestorSecurityToken
-  ) and not user.id : ("S-1-5-18" or "S-1-5-20") and
+  powershell.file.script_block_text : "KerberosRequestorSecurityToken" and
   not powershell.file.script_block_text : (
     ("sentinelbreakpoints" and ("Set-PSBreakpoint" or "Set-HookFunctionTabs")) or
     ("function global" and "\\windows\\sentinel\\4")
@@ -12966,10 +14406,11 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1294
+Index: geneve-ut-1462
 
 ```python
-event.category:process and host.os.type:windows and powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory or pmuDetirWpmuDiniM) and not user.id : "S-1-5-18"
+event.category:process and host.os.type:windows and
+powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory or pmuDetirWpmuDiniM)
 ```
 
 
@@ -12978,7 +14419,7 @@ event.category:process and host.os.type:windows and powershell.file.script_block
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1296
+Index: geneve-ut-1464
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13002,7 +14443,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1297
+Index: geneve-ut-1465
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13030,7 +14471,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1313
+Index: geneve-ut-1481
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13051,7 +14492,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1316
+Index: geneve-ut-1484
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13088,7 +14529,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1317
+Index: geneve-ut-1485
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -13105,7 +14546,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1318
+Index: geneve-ut-1486
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13119,7 +14560,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1319
+Index: geneve-ut-1487
 
 ```python
 file where host.os.type == "windows" and
@@ -13138,7 +14579,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1320
+Index: geneve-ut-1488
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -13150,9 +14591,9 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 ### Privilege Escalation via SUID/SGID
 
-Branch count: 434  
-Document count: 434  
-Index: geneve-ut-1321
+Branch count: 450  
+Document count: 450  
+Index: geneve-ut-1489
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13183,9 +14624,11 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     "wc", "wget", "whiptail", "xargs", "xdotool", "xmodmap", "xmore", "xxd", "xz", "yash", "zsh",
     "zsoelim"
   ) or
+  (process.name like ".*" or process.executable like ("/tmp/.*", "/var/tmp/.*", "/dev/shm/.*", "/home/*"))  or 
   (process.name == "ip" and ((process.args == "-force" and process.args in ("-batch", "-b")) or (process.args == "exec"))) or
   (process.name == "find" and process.args in ("-exec", "-execdir")) or
-  (process.name in ("bash", "csh", "dash") and process.args in ("-p", "-b"))
+  (process.name in ("bash", "csh", "dash") and process.args in ("-p", "-b")) or
+  (process.name in ("su", "sudo", "pkexec") and process.args_count == 1)
 ) and not (
   process.parent.name == "spine" or
   process.parent.executable in (
@@ -13203,7 +14646,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1322
+Index: geneve-ut-1490
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13221,7 +14664,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1324
+Index: geneve-ut-1492
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -13239,7 +14682,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1327
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13253,7 +14696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1329
+Index: geneve-ut-1497
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13268,7 +14711,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1330
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -13291,7 +14734,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1332
+Index: geneve-ut-1500
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13335,7 +14778,6 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
                             "?:\\Windows\\Microsoft.NET\\Framework*\\*\\ngen.exe",
                             "?:\\Windows\\Microsoft.NET\\Framework*\\*\\aspnet_regiis.exe")) and
 
-
 /* Ignores additional parent executables that run with elevated privileges */
  not process.parent.executable :
                ("?:\\Windows\\System32\\AtBroker.exe",
@@ -13374,7 +14816,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1333
+Index: geneve-ut-1501
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -13395,7 +14837,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1334
+Index: geneve-ut-1502
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -13421,7 +14863,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1337
+Index: geneve-ut-1505
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13474,7 +14916,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1338
+Index: geneve-ut-1506
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13486,7 +14928,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1339
+Index: geneve-ut-1507
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13498,7 +14940,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1340
+Index: geneve-ut-1508
 
 ```python
 process where host.os.type == "windows" and
@@ -13513,7 +14955,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1341
+Index: geneve-ut-1509
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -13543,7 +14985,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1342
+Index: geneve-ut-1510
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -13603,7 +15045,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1345
+Index: geneve-ut-1513
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -13616,7 +15058,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1346
+Index: geneve-ut-1514
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +15090,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1347
+Index: geneve-ut-1515
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -13670,14 +15112,33 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 ### Proxy Execution via Console Window Host
 
-Branch count: 17  
-Document count: 17  
-Index: geneve-ut-1348
+Branch count: 68  
+Document count: 68  
+Index: geneve-ut-1517
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  process.name : "conhost.exe" and process.args : "--headless" and
-  process.command_line : ("*powershell*", "*cmd *", "*cmd.exe *", "*script*", "*mshta*", "*curl *", "*curl.exe *", "*^*^*^*", "*.bat*", "*.cmd*", "*schtasks*", "*@SSL*", "*http*", "* \\\\*", "*.vbs*", "*.js*", "*mhsta*")
+  process.command_line : (
+    "*powershell*", "*cmd *", "*cmd.exe *", "*script*", "*mshta*", "*curl *", "*curl.exe *", "*^*^*^*",
+    "*.bat*", "*.cmd*", "*schtasks*", "*@SSL*", "*http*", "* \\\\*", "*.vbs*", "*.js*", "*mhsta*"
+  ) and
+  not (
+    /* Winget-AutoUpdate via ServiceUI */
+    process.parent.executable : "?:\\Program Files\\winget-autoupdate*\\serviceui.exe" or
+    /* Winget-AutoUpdate notification via Task Scheduler */
+    (
+      process.parent.executable : "?:\\Windows\\System32\\svchost.exe" and process.parent.args : "-s" and
+      process.parent.args : "Schedule" and process.command_line : "*WAU-Notify.ps1*"
+    ) or
+    /* Windows OpenSSH console host — SSH-specific detection handled by 8cd49fbc-a35a-4418-8688-133cc3a1e548 */
+    process.parent.executable : (
+      "?:\\Windows\\System32\\OpenSSH\\sshd.exe",
+      "?:\\Windows\\System32\\OpenSSH\\sshd-session.exe",
+      "?:\\Program Files\\OpenSSH*\\sshd.exe",
+      "?:\\Program Files\\OpenSSH*\\sshd-session.exe"
+    )
+  )
 ```
 
 
@@ -13686,12 +15147,15 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1349
+Index: geneve-ut-1518
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
- process.command_line : ("*Command=*powershell*", "*schtasks*", "*Command=*@echo off*", "*Command=*http*", "*Command=*mshta*",  "*Command=*msiexec*",
-                          "*Command=*cmd /c*", "*Command=*cmd.exe*", "*Command=\"cmd /c*", "*LocalCommand=scp*&&*", "*LocalCommand=?scp*&&*", "*Command=*script*")
+  process.command_line : (
+    "*Command=*powershell*", "*schtasks*", "*Command=*@echo off*", "*Command=*http*",
+    "*Command=*mshta*", "*Command=*msiexec*", "*Command=*cmd /c*", "*Command=*cmd.exe*",
+    "*Command=\"cmd /c*", "*LocalCommand=scp*&&*", "*LocalCommand=?scp*&&*", "*Command=*script*"
+  )
 ```
 
 
@@ -13700,7 +15164,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1351
+Index: geneve-ut-1520
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -13729,7 +15193,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1352
+Index: geneve-ut-1521
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13743,7 +15207,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1353
+Index: geneve-ut-1522
 
 ```python
 sequence by process.entity_id
@@ -13768,7 +15232,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1354
+Index: geneve-ut-1523
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -13802,7 +15266,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1355
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -13830,7 +15294,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1356
+Index: geneve-ut-1525
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -13849,7 +15313,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1361
+Index: geneve-ut-1531
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13877,7 +15341,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1362
+Index: geneve-ut-1532
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -13896,7 +15360,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1366
+Index: geneve-ut-1536
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -13908,7 +15372,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1367
+Index: geneve-ut-1537
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13920,7 +15384,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1368
+Index: geneve-ut-1538
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -13932,7 +15396,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1369
+Index: geneve-ut-1539
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13944,7 +15408,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1380
+Index: geneve-ut-1550
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13957,7 +15421,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1381
+Index: geneve-ut-1551
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13995,7 +15459,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1383
+Index: geneve-ut-1553
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14010,7 +15474,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1384
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14029,7 +15493,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1385
+Index: geneve-ut-1555
 
 ```python
 sequence with maxspan=1m
@@ -14048,18 +15512,23 @@ sequence with maxspan=1m
               "ZOHO Corporation Private Limited",
               "BeyondTrust Corporation", 
               "CyberArk Software Ltd.", 
-              "Sophos Ltd"
+              "Sophos Ltd",
+              "AO Kaspersky Lab",
+              "Anthropic, PBC",
+              "Adobe Inc.",
+              "Netwrix Corporation"
         )
       ) or
       (
         process.executable : (
           "?:\\Windows\\ccmsetup\\ccmsetup.exe",
-          "?:\\Windows\\SoftwareDistribution\\Download\\Install\\AM_Delta*.exe",
-          "?:\\Windows\\CAInvokerService.exe"
+          "?:\\Windows\\SoftwareDistribution\\Download\\Install\\*.exe",
+          "?:\\Windows\\CAInvokerService.exe",
+          "?:\\Users\\*\\AppData\\Local\\Microsoft\\OneDrive\\*\\OneDriveSetup.exe"
         ) and process.code_signature.trusted == true
       ) or
       (
-        process.executable : "G:\\SMS_*\\srvboot.exe" and 
+        process.executable : "?:\\SMS_*\\srvboot.exe" and 
         process.code_signature.trusted == true and process.code_signature.subject_name : "Microsoft Corporation"
       )
     )
@@ -14072,7 +15541,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1387
+Index: geneve-ut-1557
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -14095,7 +15564,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1389
+Index: geneve-ut-1559
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14109,7 +15578,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1390
+Index: geneve-ut-1560
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14123,7 +15592,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1392
+Index: geneve-ut-1562
 
 ```python
 sequence by host.id, process.entity_id
@@ -14140,7 +15609,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1393
+Index: geneve-ut-1563
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14154,7 +15623,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1394
+Index: geneve-ut-1564
 
 ```python
 sequence by host.id with maxspan=1m
@@ -14172,17 +15641,29 @@ sequence by host.id with maxspan=1m
 
 ### Remote SSH Login Enabled via systemsetup Command
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1395
+Branch count: 10  
+Document count: 10  
+Index: geneve-ut-1565
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
- process.name == "systemsetup" and
- process.args like~ "-setremotelogin" and 
- process.args like~ "on" and
- process.parent.executable != null and
- not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xpcproxy", "/usr/bin/sudo")
+(
+  (
+    process.name == "systemsetup" and
+    process.args like~ "-setremotelogin" and
+    process.args like~ "on"
+  ) or
+  (
+    process.name == "launchctl" and
+    process.args in ("load", "bootstrap") and
+    (
+      process.command_line like~ "*/System/Library/LaunchDaemons/ssh.plist*" or
+      process.command_line like~ "*com.openssh.sshd*"
+    )
+  )
+) and
+process.parent.executable != null and
+not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xpcproxy", "/usr/bin/sudo")
 ```
 
 
@@ -14191,7 +15672,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1396
+Index: geneve-ut-1566
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -14211,7 +15692,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1397
+Index: geneve-ut-1567
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -14224,7 +15705,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1399
+Index: geneve-ut-1569
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -14266,7 +15747,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1400
+Index: geneve-ut-1570
 
 ```python
 sequence with maxspan=1m
@@ -14289,7 +15770,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1401
+Index: geneve-ut-1571
 
 ```python
 sequence with maxspan=1s
@@ -14337,7 +15818,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1402
+Index: geneve-ut-1572
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14354,7 +15835,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1404
+Index: geneve-ut-1574
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -14383,7 +15864,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1406
+Index: geneve-ut-1576
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14411,7 +15892,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1407
+Index: geneve-ut-1577
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -14428,7 +15909,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1409
+Index: geneve-ut-1579
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -14447,7 +15928,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1410
+Index: geneve-ut-1580
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -14468,7 +15949,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1418
+Index: geneve-ut-1589
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -14482,7 +15963,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1420
+Index: geneve-ut-1591
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -14501,7 +15982,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1421
+Index: geneve-ut-1592
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -14515,7 +15996,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1422
+Index: geneve-ut-1593
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -14535,7 +16016,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1424
+Index: geneve-ut-1595
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14553,7 +16034,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1425
+Index: geneve-ut-1596
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -14574,7 +16055,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1427
+Index: geneve-ut-1598
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14586,15 +16067,15 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 ### ScreenConnect Server Spawning Suspicious Processes
 
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-1428
+Branch count: 10  
+Document count: 10  
+Index: geneve-ut-1599
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.parent.name : "ScreenConnect.Service.exe" and
   (process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "powershell_ise.exe", "csc.exe") or
-  ?process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE", "pwsh.dll", "powershell_ise.EXE"))
+  ?process.pe.original_file_name in ("Cmd.Exe", "PowerShell.EXE", "pwsh.dll", "powershell_ise.EXE", "csc.exe"))
 ```
 
 
@@ -14603,7 +16084,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1429
+Index: geneve-ut-1600
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14644,7 +16125,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1431
+Index: geneve-ut-1602
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -14669,7 +16150,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1432
+Index: geneve-ut-1603
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -14708,7 +16189,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1433
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14722,7 +16203,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1434
+Index: geneve-ut-1605
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14746,7 +16227,12 @@ process.args like (
   ?process.parent.args in ("/opt/imperva/ragent/bin/get_sys_resources.sh", "/usr/sbin/lynis", "./terra_linux.sh") or
   process.args == "/usr/bin/coreutils" or
   (process.parent.name == "pwsh" and process.parent.command_line like "*Evaluate-STIG*") or
-  ?process.parent.executable == "/usr/sap/audit_scripts/auto_audit_gral.sh"
+  ?process.parent.executable like (
+    "/usr/sap/audit_scripts/auto_audit_gral.sh", "/opt/saltstack/salt/bin/python3*", "/opt/puppetlabs/puppet/bin/ruby"
+  ) or
+  ?process.entry_leader.executable like (
+    "/usr/sbin/ScanAssistant", "/opt/Tanium/TaniumClient/TaniumClient", "/tmp/CVU_*resource/exectask", "/opt/nessus/sbin/nessus-service"
+  )
 )
 ```
 
@@ -14756,7 +16242,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1435
+Index: geneve-ut-1606
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14770,7 +16256,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1436
+Index: geneve-ut-1607
 
 ```python
 process where event.type == "start" and
@@ -14842,7 +16328,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1439
+Index: geneve-ut-1611
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -14863,7 +16349,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1442
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14880,7 +16366,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1444
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14894,11 +16380,11 @@ process.command_line like~ (
 
 
 
-### Sensitive Privilege SeEnableDelegationPrivilege assigned to a User
+### Sensitive Privilege SeEnableDelegationPrivilege assigned to a Principal
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1445
+Index: geneve-ut-1618
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -14910,19 +16396,31 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1446
+Index: geneve-ut-1619
 
 ```python
-file where host.os.type == "windows" and 
- event.action == "open" and event.outcome == "success" and process.executable != null and 
+file where host.os.type == "windows" and
+ event.action == "open" and event.outcome == "success" and process.executable != null and
  file.path :
       ("?:\\Windows\\System32\\config\\RegBack\\SAM",
        "?:\\Windows\\System32\\config\\RegBack\\SECURITY",
-       "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and 
+       "?:\\Windows\\System32\\config\\RegBack\\SYSTEM") and
  not (
     user.id == "S-1-5-18" and process.executable : (
-        "?:\\Windows\\system32\\taskhostw.exe", "?:\\Windows\\system32\\taskhost.exe"
-    ))
+        "?:\\Windows\\system32\\taskhostw.exe",
+        "?:\\Windows\\system32\\taskhost.exe",
+        "?:\\Program Files\\Sophos\\Endpoint Defense\\SophosScanCoordinator.exe",
+        "?:\\Program Files\\Sophos\\Endpoint Defense\\SSPService.exe",
+        "?:\\Program Files\\Windows Defender Advanced Threat Protection\\MsSense.exe",
+        "?:\\Program Files\\Trend Micro\\AMSP\\coreServiceShell.exe",
+        "?:\\Program Files\\Symantec\\Symantec Endpoint Protection\\*\\Bin64\\ccSvcHst.exe",
+        "?:\\Program Files\\Bitdefender\\Endpoint Security\\EPSecurityService.exe",
+        "?:\\Program Files\\N-able Technologies\\AVDefender\\EPSecurityService.exe",
+        "?:\\Program Files\\Cylance\\Optics\\CyOptics.exe",
+        "?:\\Program Files\\Common Files\\McAfee\\AVSolution\\mcshield.exe",
+        "?:\\Program Files (x86)\\Padvish AV\\APCcSvc.exe"
+    )
+ )
 ```
 
 
@@ -14931,7 +16429,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1449
+Index: geneve-ut-1622
 
 ```python
 any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
@@ -14963,7 +16461,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1451
+Index: geneve-ut-1624
 
 ```python
 any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
@@ -14999,7 +16497,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1452
+Index: geneve-ut-1625
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -15016,7 +16514,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1453
+Index: geneve-ut-1626
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -15036,7 +16534,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1455
+Index: geneve-ut-1628
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15051,7 +16549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1456
+Index: geneve-ut-1629
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15072,7 +16570,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1457
+Index: geneve-ut-1630
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15095,7 +16593,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1458
+Index: geneve-ut-1631
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -15108,7 +16606,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1459
+Index: geneve-ut-1632
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15125,7 +16623,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1462
+Index: geneve-ut-1635
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -15150,7 +16648,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1464
+Index: geneve-ut-1638
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and process.interactive == true and container.id like "?*" and (
@@ -15181,7 +16679,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1465
+Index: geneve-ut-1639
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -15230,7 +16728,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1466
+Index: geneve-ut-1640
 
 ```python
 sequence by host.id with maxspan=10s
@@ -15240,11 +16738,26 @@ sequence by host.id with maxspan=10s
 
 
 
+### Shell Execution via Elastic Endpoint
+
+Branch count: 64  
+Document count: 64  
+Index: geneve-ut-1641
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
+process.parent.executable == "/opt/Elastic/Endpoint/elastic-endpoint" and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
+process.args in ("-c", "-cl", "-lc", "--command")
+```
+
+
+
 ### Shell History Clearing via Environment Variables
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1467
+Index: geneve-ut-1642
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15259,7 +16772,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1468
+Index: geneve-ut-1643
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -15281,7 +16794,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1469
+Index: geneve-ut-1644
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15302,7 +16815,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1473
+Index: geneve-ut-1648
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15316,7 +16829,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1474
+Index: geneve-ut-1649
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -15339,7 +16852,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1502
+Index: geneve-ut-1679
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -15364,7 +16877,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1503
+Index: geneve-ut-1680
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -15397,7 +16910,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1504
+Index: geneve-ut-1681
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -15456,7 +16969,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1506
+Index: geneve-ut-1683
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -15474,7 +16987,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1507
+Index: geneve-ut-1684
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -15486,7 +16999,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1510
+Index: geneve-ut-1687
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -15511,7 +17024,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1515
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15526,7 +17039,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1516
+Index: geneve-ut-1693
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -15549,7 +17062,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1519
+Index: geneve-ut-1696
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15563,7 +17076,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1521
+Index: geneve-ut-1698
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15585,7 +17098,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1523
+Index: geneve-ut-1700
 
 ```python
 sequence by host.id with maxspan=5s
@@ -15612,7 +17125,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1527
+Index: geneve-ut-1704
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -15624,6 +17137,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
     "?:\\Windows\\Syswow64\\amsi.dll",
     "?:\\$WINDOWS.~BT\\*\\amsi.dll",
     "?:\\Windows\\CbsTemp\\*\\amsi.dll",
+    "?:\\Windows\\SystemTemp\\*\\amsi.dll",
     "?:\\Windows\\SoftwareDistribution\\Download\\*",
     "?:\\Windows\\WinSxS\\*\\amsi.dll", 
     "?:\\Windows\\servicing\\*\\amsi.dll",
@@ -15638,7 +17152,8 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
     "\\Device\\HarddiskVolume*\\$SysReset\\CloudImage\\Package_for_RollupFix*\\amsi.dll",
     "\\Device\\HarddiskVolume*\\$WINDOWS.~BT\\*\\amsi.dll", 
     "\\Device\\HarddiskVolume*\\Windows\\SoftwareDistribution\\Download\\*\\amsi.dll", 
-    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll", 
+    "\\Device\\HarddiskVolume*\\Windows\\CbsTemp\\*\\amsi.dll",
+    "\\Device\\HarddiskVolume*\\Windows\\SystemTemp\\*\\amsi.dll", 
     "\\Device\\HarddiskVolume*\\Windows\\servicing\\*\\amsi.dll"
   )
 ```
@@ -15649,7 +17164,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1528
+Index: geneve-ut-1705
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -15672,7 +17187,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1529
+Index: geneve-ut-1706
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -15686,7 +17201,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1530
+Index: geneve-ut-1707
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15702,7 +17217,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1531
+Index: geneve-ut-1708
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -15718,7 +17233,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1532
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15732,7 +17247,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1534
+Index: geneve-ut-1711
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15755,7 +17270,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1535
+Index: geneve-ut-1712
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15770,7 +17285,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1536
+Index: geneve-ut-1715
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15793,11 +17308,42 @@ sequence by process.entity_id with maxspan=15s
 
 
 
+### Suspicious Container Runtime CLI Execution
+
+Branch count: 14  
+Document count: 14  
+Index: geneve-ut-1717
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+(
+  (
+    process.name in ("ctr", "crictl", "nerdctl") and
+    (
+      (process.args == "tasks" and process.args == "exec") or
+      (process.args == "run" and process.args in ("--privileged", "--rm", "--mount", "--net-host", "--pid-host")) or
+      (process.args == "snapshots" and process.args == "mount")
+    )
+  ) or
+  (
+    (process.executable like ("/dev/shm/*", "/tmp/*", "/var/tmp/*") or process.name : ".*") and
+    process.args like ("*containerd.sock*", "*k8s.io*")
+  )
+) and
+not process.parent.executable in (
+  "/usr/bin/kubelet", "/usr/local/bin/kubelet",
+  "/usr/bin/containerd", "/usr/sbin/containerd",
+  "/lib/systemd/systemd", "/usr/lib/systemd/systemd", "/sbin/init"
+)
+```
+
+
+
 ### Suspicious Content Extracted or Decompressed via Funzip
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1538
+Index: geneve-ut-1718
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -15813,7 +17359,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1539
+Index: geneve-ut-1719
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -15826,7 +17372,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1541
+Index: geneve-ut-1721
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15842,7 +17388,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1542
+Index: geneve-ut-1722
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -15858,7 +17404,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1543
+Index: geneve-ut-1723
 
 ```python
 any where host.os.type == "windows" and 
@@ -15925,7 +17471,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1545
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -15941,7 +17487,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1547
+Index: geneve-ut-1727
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15977,7 +17523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1548
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16015,7 +17561,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1549
+Index: geneve-ut-1729
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -16050,7 +17596,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1550
+Index: geneve-ut-1730
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16084,7 +17630,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1552
+Index: geneve-ut-1732
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -16105,7 +17651,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1557
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -16133,7 +17679,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1558
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16141,7 +17687,7 @@ process where host.os.type == "windows" and event.type == "start" and
 (process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or ?process.code_signature.subject_name : "OpenJS Foundation") and
 
 (
-  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume?\\\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
+  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
 
   (process.args : "-r" and process.parent.name : "powershell.exe") or
 
@@ -16155,7 +17701,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1559
+Index: geneve-ut-1739
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16179,7 +17725,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1561
+Index: geneve-ut-1741
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16200,7 +17746,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1564
+Index: geneve-ut-1744
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16215,7 +17761,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1567
+Index: geneve-ut-1747
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16228,7 +17774,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1568
+Index: geneve-ut-1748
 
 ```python
 any where host.os.type == "windows" and
@@ -16243,7 +17789,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1569
+Index: geneve-ut-1749
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16259,7 +17805,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1570
+Index: geneve-ut-1750
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -16273,7 +17819,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1572
+Index: geneve-ut-1754
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and
@@ -16330,7 +17876,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1573
+Index: geneve-ut-1755
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16344,19 +17890,28 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1575
+Index: geneve-ut-1757
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
  [network where host.os.type == "windows" and destination.port == 88 and
   process.executable != null and process.pid != 4 and 
-  not process.executable : 
-              ("?:\\Windows\\system32\\lsass.exe", 
-               "\\device\\harddiskvolume*\\windows\\system32\\lsass.exe", 
-               "\\device\\harddiskvolume*\\windows\\system32\\svchost.exe") and
-  not (process.executable : ("C:\\Windows\\System32\\svchost.exe", 
-                             "C:\\Program Files\\VMware\\VMware View\\Server\\bin\\ws_TomcatService.exe", 
-                             "F:\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe") and user.id in ("S-1-5-20", "S-1-5-18")) and   
+  not process.executable : (
+        "?:\\Windows\\system32\\lsass.exe",
+        "\\device\\harddiskvolume*\\windows\\system32\\lsass.exe",
+        "\\device\\harddiskvolume*\\windows\\system32\\svchost.exe"
+  ) and
+  not (
+    process.executable : (
+      "C:\\Windows\\System32\\svchost.exe",
+      "C:\\Program Files\\VMware\\VMware View\\Server\\bin\\ws_TomcatService.exe",
+      "C:\\Program Files\\Omnissa\\Horizon\\Server\\bin\\ws_TomcatService.exe",
+      "C:\\Program Files\\SysAidServer\\root\\WEB-INF\\domains\\NetworkDiscovery.exe",
+      "C:\\Program Files (x86)\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe",
+      "F:\\IGEL\\RemoteManager\\*\\bin\\tomcat10.exe"
+    ) and
+    user.id in ("S-1-5-20", "S-1-5-18")
+  ) and
   source.ip != "127.0.0.1" and destination.ip != "::1" and destination.ip != "127.0.0.1"]
  [authentication where host.os.type == "windows" and event.code in ("4768", "4769")]
 ```
@@ -16367,7 +17922,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1577
+Index: geneve-ut-1759
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -16380,7 +17935,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1578
+Index: geneve-ut-1760
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16389,7 +17944,7 @@ process where host.os.type == "windows" and event.code == "10" and
    /* seclogon service accessing lsass */
   winlog.event_data.CallTrace : "*seclogon.dll*" and process.name : "svchost.exe" and
 
-   /* PROCESS_CREATE_PROCESS & PROCESS_DUP_HANDLE & PROCESS_QUERY_INFORMATION */
+   /* PROCESS_CREATE_PROCESS & PROCESS_DUP_HANDLE & PROCESS_QUERY_INFORMATION & PROCESS_QUERY_LIMITED_INFORMATION */
   winlog.event_data.GrantedAccess == "0x14c0"
 ```
 
@@ -16399,7 +17954,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1579
+Index: geneve-ut-1761
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16445,7 +18000,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1581
+Index: geneve-ut-1763
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16466,7 +18021,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1582
+Index: geneve-ut-1764
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16486,7 +18041,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1583
+Index: geneve-ut-1765
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16500,7 +18055,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1584
+Index: geneve-ut-1766
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16528,28 +18083,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Suspicious Microsoft HTML Application Child Process
-
-Branch count: 12  
-Document count: 12  
-Index: geneve-ut-1586
-
-```python
-process where host.os.type == "windows" and event.type == "start" and
- process.parent.name : "mshta.exe" and
- (
-  process.name : ("cmd.exe", "powershell.exe", "certutil.exe", "bitsadmin.exe", "curl.exe", "msiexec.exe", "schtasks.exe", "reg.exe", "wscript.exe", "rundll32.exe") or
-  process.executable : ("C:\\Users\\*\\*.exe", "\\Device\\HarddiskVolume*\\Users\\*\\*.exe")
-  )
-```
-
-
-
 ### Suspicious Mining Process Creation Event
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1587
+Index: geneve-ut-1769
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -16568,80 +18106,101 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 ### Suspicious Module Loaded by LSASS
 
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-1589
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1771
 
 ```python
-any where event.category in ("library", "driver") and host.os.type == "windows" and
+library where host.os.type == "windows" and event.action == "load" and
   process.executable : "?:\\Windows\\System32\\lsass.exe" and
-  not (dll.code_signature.subject_name :
-               ("Microsoft Windows",
-                "Microsoft Corporation",
-                "Microsoft Windows Publisher",
-                "Microsoft Windows Software Compatibility Publisher",
-                "Microsoft Windows Hardware Compatibility Publisher",
-                "McAfee, Inc.",
-                "SecMaker AB",
-                "HID Global Corporation",
-                "HID Global",
-                "Apple Inc.",
-                "Citrix Systems, Inc.",
-                "Dell Inc",
-                "Hewlett-Packard Company",
-                "Symantec Corporation",
-                "National Instruments Corporation",
-                "DigitalPersona, Inc.",
-                "Novell, Inc.",
-                "gemalto",
-                "EasyAntiCheat Oy",
-                "Entrust Datacard Corporation",
-                "AuriStor, Inc.",
-                "LogMeIn, Inc.",
-                "VMware, Inc.",
-                "Istituto Poligrafico e Zecca dello Stato S.p.A.",
-                "Nubeva Technologies Ltd",
-                "Micro Focus (US), Inc.",
-                "Yubico AB",
-                "GEMALTO SA",
-                "Secure Endpoints, Inc.",
-                "Sophos Ltd",
-                "Morphisec Information Security 2014 Ltd",
-                "Entrust, Inc.",
-                "Nubeva Technologies Ltd",
-                "Micro Focus (US), Inc.",
-                "F5 Networks Inc",
-                "Bit4id",
-                "Thales DIS CPL USA, Inc.",
-                "Micro Focus International plc",
-                "HYPR Corp",
-                "Intel(R) Software Development Products",
-                "PGP Corporation",
-                "Parallels International GmbH",
-                "FrontRange Solutions Deutschland GmbH",
-                "SecureLink, Inc.",
-                "Tidexa OU",
-                "Amazon Web Services, Inc.",
-                "SentryBay Limited",
-                "Audinate Pty Ltd",
-                "CyberArk Software Ltd.",
-                "McAfeeSysPrep",
-                "NVIDIA Corporation PE Sign v2016",
-                "Trend Micro, Inc.",
-                "Fortinet Technologies (Canada) Inc.",
-                "Carbon Black, Inc.") and
-       dll.code_signature.status : ("trusted", "errorExpired", "errorCode_endpoint*", "errorChaining")) and
+  not (
+        dll.code_signature.subject_name : (
+            "Algorithmic Research LTD.",
+            "Amazon Web Services, Inc.",
+            "Apple Inc.",
+            "Audinate Pty Ltd",
+            "AuriStor, Inc.",
+            "Bit4id",
+            "Carbon Black, Inc.",
+            "Check Point Software Technologies Ltd.",
+            "Citrix Systems, Inc.",
+            "CyberArk Software Ltd.",
+            "Dell Inc",
+            "DigitalPersona, Inc.",
+            "EasyAntiCheat Oy",
+            "Entrust Corporation",
+            "Entrust Datacard Corporation",
+            "Entrust, Inc.",
+            "F5 Networks Inc",
+            "Fortinet, Inc.",
+            "Fortinet Technologies (Canada) Inc.",
+            "FrontRange Solutions Deutschland GmbH",
+            "GEMALTO SA",
+            "gemalto",
+            "Hewlett-Packard Company",
+            "HID Global",
+            "HID Global Corporation",
+            "HYPR Corp",
+            "IDEMIA IDENTITY & SECURITY FRANCE SAS",
+            "IDEMIA France SAS",
+            "Intel(R) Software Development Products",
+            "Istituto Poligrafico e Zecca dello Stato S.p.A.",
+            "LogMeIn, Inc.",
+            "McAfee, Inc.",
+            "McAfeeSysPrep",
+            "Micro Focus (US), Inc.",
+            "Micro Focus International plc",
+            "Microsoft Corporation",
+            "Microsoft Windows",
+            "Microsoft Windows Hardware Compatibility Publisher",
+            "Microsoft Windows Publisher",
+            "Microsoft Windows Software Compatibility Publisher",
+            "Morphisec Information Security 2014 Ltd",
+            "Musarubra US LLC",
+            "National Instruments Corporation",
+            "Novell, Inc.",
+            "Nubeva Technologies Ltd",
+            "NVIDIA Corporation PE Sign v2016",
+            "Palo Alto Networks (Netherlands) B.V.",
+            "Parallels International GmbH",
+            "PGP Corporation",
+            "QUEST SOFTWARE INC.",
+            "SecMaker AB",
+            "Secure Endpoints, Inc.",
+            "SecureLink, Inc.",
+            "SentinelOne Inc.",
+            "SentryBay Limited",
+            "Sophos Ltd",
+            "Symantec Corporation",
+            "Thales DIS CPL USA, Inc.",
+            "Tidexa OU",
+            "Trend Micro, Inc.",
+            "VMware, Inc.",
+            "Yubico AB"
+        ) and
+        dll.code_signature.status : ("trusted", "errorExpired", "errorCode_endpoint*", "errorChaining")
+  ) and
 
-     not dll.hash.sha256 :
-                ("811a03a5d7c03802676d2613d741be690b3461022ea925eb6b2651a5be740a4c",
-                 "1181542d9cfd63fb00c76242567446513e6773ea37db6211545629ba2ecf26a1",
-                 "ed6e735aa6233ed262f50f67585949712f1622751035db256811b4088c214ce3",
-                 "26be2e4383728eebe191c0ab19706188f0e9592add2e0bf86b37442083ae5e12",
-                 "9367e78b84ef30cf38ab27776605f2645e52e3f6e93369c674972b668a444faa",
-                 "d46cc934765c5ecd53867070f540e8d6f7701e834831c51c2b0552aba871921b",
-                 "0f77a3826d7a5cd0533990be0269d951a88a5c277bc47cff94553330b715ec61",
-                 "4aca034d3d85a9e9127b5d7a10882c2ef4c3e0daa3329ae2ac1d0797398695fb",
-                 "86031e69914d9d33c34c2f4ac4ae523cef855254d411f88ac26684265c981d95")
+  not dll.hash.sha256 : (
+          "811a03a5d7c03802676d2613d741be690b3461022ea925eb6b2651a5be740a4c",
+          "1181542d9cfd63fb00c76242567446513e6773ea37db6211545629ba2ecf26a1",
+          "ed6e735aa6233ed262f50f67585949712f1622751035db256811b4088c214ce3",
+          "26be2e4383728eebe191c0ab19706188f0e9592add2e0bf86b37442083ae5e12",
+          "9367e78b84ef30cf38ab27776605f2645e52e3f6e93369c674972b668a444faa",
+          "d46cc934765c5ecd53867070f540e8d6f7701e834831c51c2b0552aba871921b",
+          "0f77a3826d7a5cd0533990be0269d951a88a5c277bc47cff94553330b715ec61",
+          "4aca034d3d85a9e9127b5d7a10882c2ef4c3e0daa3329ae2ac1d0797398695fb",
+          "86031e69914d9d33c34c2f4ac4ae523cef855254d411f88ac26684265c981d95",
+          "4af1fee3369d9a993a84f54eafb72a661633c33e9e12fb3dd151a6a2cddbd404"
+  ) and
+  not dll.path : (
+        "C:\\Windows\\System32\\CertPolEng.dll",
+        "C:\\Windows\\System32\\FWPUCLNT.DLL",
+        "C:\\Windows\\System32\\keyiso.dll",
+        "C:\\Windows\\System32\\ngcpopkeysrv.dll",
+        "C:\\Windows\\System32\\SecureTimeAggregator.dll",
+        "C:\\Windows\\System32\\vaultsvc.dll"
+  )
 ```
 
 
@@ -16650,7 +18209,7 @@ any where event.category in ("library", "driver") and host.os.type == "windows" 
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1593
+Index: geneve-ut-1775
 
 ```python
 sequence by host.id with maxspan=5s
@@ -16698,7 +18257,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1596
+Index: geneve-ut-1778
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16724,7 +18283,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1597
+Index: geneve-ut-1779
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16769,7 +18328,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1598
+Index: geneve-ut-1780
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16793,7 +18352,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1599
+Index: geneve-ut-1781
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -16809,7 +18368,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1601
+Index: geneve-ut-1783
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -16834,7 +18393,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1602
+Index: geneve-ut-1784
 
 ```python
 event.category:process and host.os.type:windows and
@@ -16849,7 +18408,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1605
+Index: geneve-ut-1787
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -16863,7 +18422,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1606
+Index: geneve-ut-1788
 
 ```python
 sequence by host.id with maxspan=30s
@@ -16883,7 +18442,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1607
+Index: geneve-ut-1789
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16918,7 +18477,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1611
+Index: geneve-ut-1793
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -16936,7 +18495,7 @@ process where event.type == "start" and event.action == "exec" and process.inter
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1612
+Index: geneve-ut-1794
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16949,7 +18508,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1615
+Index: geneve-ut-1797
 
 ```python
 any where host.os.type == "windows" and
@@ -16982,7 +18541,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1617
+Index: geneve-ut-1799
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -17000,7 +18559,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1618
+Index: geneve-ut-1800
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -17018,11 +18577,50 @@ and not (
 
 
 
+### Suspicious SUID Binary Execution (Auditd Sequence)
+
+Branch count: 414  
+Document count: 828  
+Index: geneve-ut-1803
+
+```python
+sequence by host.id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action == "executed" and
+   user.id != "0" and user.effective.id != "0" and
+   (
+     process.name like ("python*", "perl*", "ruby*", "php*", "lua*", ".*") or
+     process.name in ("node", "bun", "java") or
+     process.executable like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/user/*", "/var/run/user/*", "/home/*/*") or
+     (
+       process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "mksh") and
+       process.args in ("-c", "--command", "-ic", "-ci", "-cl", "-lc")
+     )
+   )
+  ] by process.pid
+
+  [process where host.os.type == "linux" and event.type == "start" and
+   event.action == "executed" and
+   user.effective.id == "0" and user.id != "0" and
+   (
+     (process.name in ("sudo", "pkexec") and
+      not process.args like "-*" and
+      not process.args : ("/usr/*", "/bin/*", "/sbin/*", "/opt/*")) or
+     (process.name == "su" and
+      not process.args in ("--command", "-c", "--shell", "-s")) or
+     (process.name in ("passwd", "chsh", "newgrp") and
+      not process.args in ("--shell", "-s", "--help"))
+   )
+  ] by process.parent.pid
+```
+
+
+
 ### Suspicious ScreenConnect Client Child Process
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1620
+Index: geneve-ut-1804
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17041,7 +18639,7 @@ process where host.os.type == "windows" and event.type == "start" and
    (process.name : "rundll32.exe" and not process.args : "url.dll,FileProtocolHandler") or
    (process.name : "msiexec.exe" and process.args : ("/i", "-i") and
     process.args : ("/q", "/quiet", "/qn", "-q", "-quiet", "-qn", "-Q+")) or
-   process.name : ("mshta.exe", "certutil.exe", "bistadmin.exe", "certreq.exe", "wscript.exe", "cscript.exe", "curl.exe",
+   process.name : ("mshta.exe", "certutil.exe", "bitsadmin.exe", "certreq.exe", "wscript.exe", "cscript.exe", "curl.exe",
                    "ssh.exe", "scp.exe", "wevtutil.exe", "wget.exe", "wmic.exe")
    )
 ```
@@ -17052,7 +18650,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1621
+Index: geneve-ut-1805
 
 ```python
 any where host.os.type == "windows" and
@@ -17086,7 +18684,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1622
+Index: geneve-ut-1806
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -17100,7 +18698,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1625
+Index: geneve-ut-1809
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17131,13 +18729,13 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1626
+Index: geneve-ut-1810
 
 ```python
 any where host.os.type == "windows" and
 (
  (event.category == "library" and
-  process.executable : ("C:\\Program Files\\WebHelpDesk\\*\\java.exe", "C:\\Program Files (x86)\\WebHelpDesk\\*\\java.exe") and
+  process.executable : ("C:\\Program Files\\WebHelpDesk\\*\\java*.exe", "C:\\Program Files (x86)\\WebHelpDesk\\*\\java*.exe") and
   (dll.path : "\\Device\\Mup\\*" or dll.code_signature.trusted == false or ?dll.code_signature.exists == false)) or
 
  (event.category == "process" and process.name : ("cmd.exe", "powershell.exe", "rundll32.exe") and
@@ -17151,7 +18749,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1627
+Index: geneve-ut-1811
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17192,7 +18790,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1628
+Index: geneve-ut-1812
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -17208,7 +18806,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1629
+Index: geneve-ut-1813
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17238,7 +18836,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1633
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -17251,7 +18849,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1634
+Index: geneve-ut-1818
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -17275,7 +18873,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1636
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17293,7 +18891,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1638
+Index: geneve-ut-1822
 
 ```python
 any where host.os.type == "windows" and
@@ -17308,7 +18906,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1639
+Index: geneve-ut-1823
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -17326,7 +18924,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1640
+Index: geneve-ut-1824
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -17338,7 +18936,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
                   "Login Data") and
  ((process.code_signature.trusted == false or process.code_signature.exists == false) or process.name == "osascript") and
  not process.code_signature.signing_id == "org.mozilla.firefox" and
- not Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
+not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoint.app/Contents/MacOS/elastic-endpoint"
 ```
 
 
@@ -17347,7 +18945,7 @@ file where event.action == "open" and host.os.type == "macos" and process.execut
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1641
+Index: geneve-ut-1825
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17366,7 +18964,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1644
+Index: geneve-ut-1828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17391,7 +18989,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1645
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17404,7 +19002,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1647
+Index: geneve-ut-1831
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -17417,7 +19015,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1649
+Index: geneve-ut-1833
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17440,7 +19038,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1651
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17459,7 +19057,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1652
+Index: geneve-ut-1836
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -17481,7 +19079,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1653
+Index: geneve-ut-1837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -17514,7 +19112,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1655
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17532,7 +19130,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1656
+Index: geneve-ut-1840
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -17546,7 +19144,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1657
+Index: geneve-ut-1841
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17570,7 +19168,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1658
+Index: geneve-ut-1842
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -17593,7 +19191,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1659
+Index: geneve-ut-1843
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -17612,7 +19210,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1662
+Index: geneve-ut-1846
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and
@@ -17631,7 +19229,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1664
+Index: geneve-ut-1848
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -17666,7 +19264,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1665
+Index: geneve-ut-1849
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17683,7 +19281,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1666
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17703,7 +19301,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1667
+Index: geneve-ut-1851
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -17743,7 +19341,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1668
+Index: geneve-ut-1852
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -17759,7 +19357,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1669
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17773,7 +19371,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1670
+Index: geneve-ut-1854
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17811,7 +19409,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1671
+Index: geneve-ut-1855
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17861,11 +19459,39 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 
 
+### Systemd Service Override Configuration File Created
+
+Branch count: 24  
+Document count: 24  
+Index: geneve-ut-1856
+
+```python
+file where host.os.type == "linux" and event.action in ("rename", "creation") and
+file.extension == "conf" and file.path like (
+  "/etc/systemd/system/*.d/*.conf", "/etc/systemd/user/*.d/*.conf", "/usr/local/lib/systemd/system/*.d/*.conf",
+  "/lib/systemd/system/*.d/*.conf", "/usr/lib/systemd/system/*.d/*.conf", "/usr/lib/systemd/user/*.d/*.conf",
+  "/home/*/.config/systemd/user/*.d/*.conf", "/home/*/.local/share/systemd/user/*.d/*.conf",
+  "/root/.config/systemd/user/*.d/*.conf", "/root/.local/share/systemd/user/*.d/*.conf",
+  "/run/systemd/system/*.d/*.conf", "/var/run/systemd/system/*.d/*.conf"
+) and
+not process.executable in (
+  "/bin/dpkg", "/usr/bin/dpkg", "/bin/dockerd", "/usr/bin/dockerd", "/usr/sbin/dockerd", "/bin/microdnf",
+  "/usr/bin/microdnf", "/bin/rpm", "/usr/bin/rpm", "/bin/snapd", "/usr/bin/snapd", "/bin/yum", "/usr/bin/yum",
+  "/bin/dnf", "/usr/bin/dnf", "/bin/podman", "/usr/bin/podman", "/bin/dnf-automatic", "/usr/bin/dnf-automatic",
+  "/usr/bin/dpkg-divert", "/bin/dpkg-divert", "/sbin/apk", "/usr/sbin/apk", "/usr/local/sbin/apk", "/usr/bin/dnf5",
+  "/usr/bin/apt", "/usr/bin/puppet", "/bin/puppet", "/opt/puppetlabs/puppet/bin/puppet", "/usr/bin/pacman",
+  "/usr/bin/chef-client", "/bin/chef-client", "/usr/bin/pamac-daemon", "/bin/pamac-daemon", "/usr/local/bin/dockerd",
+  "/usr/bin/crio", "/usr/bin/podman", "/usr/bin/tdnf", "/usr/bin/apk"
+)
+```
+
+
+
 ### Systemd Shell Execution During Boot
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1673
+Index: geneve-ut-1858
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -17879,7 +19505,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1674
+Index: geneve-ut-1859
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17925,7 +19551,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1675
+Index: geneve-ut-1860
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -17964,7 +19590,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1676
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -17977,7 +19603,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1680
+Index: geneve-ut-1865
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -18010,7 +19636,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1681
+Index: geneve-ut-1866
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -18024,7 +19650,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1682
+Index: geneve-ut-1867
 
 ```python
 sequence by host.id with maxspan=1s
@@ -18038,7 +19664,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1683
+Index: geneve-ut-1868
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -18052,7 +19678,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1684
+Index: geneve-ut-1869
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18091,7 +19717,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1691
+Index: geneve-ut-1876
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -18133,7 +19759,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1693
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
@@ -18155,7 +19781,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1695
+Index: geneve-ut-1880
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -18168,7 +19794,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1698
+Index: geneve-ut-1883
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18185,7 +19811,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1699
+Index: geneve-ut-1884
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -18201,7 +19827,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1700
+Index: geneve-ut-1885
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18214,7 +19840,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1701
+Index: geneve-ut-1886
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -18229,7 +19855,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1702
+Index: geneve-ut-1887
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18250,15 +19876,16 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### UAC Bypass via ICMLuaUtil Elevated COM Interface
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1703
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1888
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
  process.parent.name == "dllhost.exe" and
  process.parent.args in ("/Processid:{3E5FC7F9-9A51-4367-9063-A120244FBEC7}", "/Processid:{D2E7041B-2927-42FB-8E9F-7CE93B6DC937}") and
- process.pe.original_file_name != "WerFault.exe"
+ process.pe.original_file_name != "WerFault.exe" and
+ not (process.executable : "?:\\Program Files\\WireGuard\\wireguard.exe" and process.args : "/installmanagerservice")
 ```
 
 
@@ -18267,7 +19894,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1704
+Index: geneve-ut-1889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18279,38 +19906,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Uncommon Destination Port Connection by Web Server
-
-Branch count: 45  
-Document count: 45  
-Index: geneve-ut-1708
-
-```python
-network where host.os.type == "linux" and event.type == "start" and event.action == "connection_attempted" and (
-  process.name like (
-    "apache", "nginx", "apache2", "httpd", "lighttpd", "caddy", "mongrel_rails", "gunicorn",
-    "uwsgi", "openresty", "cherokee", "h2o", "resin", "puma", "unicorn", "traefik", "tornado", "hypercorn",
-    "daphne", "twistd", "yaws", "webfsd", "httpd.worker", "flask", "rails", "mongrel", "php-fpm*", "php-cgi",
-    "php-fcgi", "php-cgi.cagefs", "catalina.sh", "hiawatha", "lswsctrl"
-  ) or
-  user.name in ("apache", "www-data", "httpd", "nginx", "lighttpd", "tomcat", "tomcat8", "tomcat9") or
-  user.id in ("33", "498", "48") or
-  (process.name == "java" and process.working_directory like "/u0?/*")
-) and
-network.direction == "egress" and destination.ip != null and
-not destination.port in (80, 443, 8080, 8443, 8000, 8888, 3128, 3306, 5432, 8220, 8082) and
-not cidrmatch(destination.ip, "127.0.0.0/8", "::1","FE80::/10", "FF00::/8", "10.0.0.0/8", "169.254.0.0/16", "172.16.0.0/12", "192.0.0.0/24", "192.0.0.0/29", "192.0.0.8/32", "192.0.0.9/32",
-"192.0.0.10/32", "192.0.0.170/32", "192.0.0.171/32", "192.0.2.0/24", "192.31.196.0/24", "192.52.193.0/24", "192.168.0.0/16", "192.88.99.0/24",
-"224.0.0.0/4", "100.64.0.0/10", "192.175.48.0/24","198.18.0.0/15", "198.51.100.0/24", "203.0.113.0/24", "224.0.0.0/4", "240.0.0.0/4")
-```
-
-
-
 ### Unexpected Child Process of macOS Screensaver Engine
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1710
+Index: geneve-ut-1895
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -18322,7 +19922,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1711
+Index: geneve-ut-1896
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18351,7 +19951,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1713
+Index: geneve-ut-1898
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -18361,36 +19961,22 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 
 
-### Untrusted DLL Loaded by Azure AD Sync Service
+### Untrusted DLL Loaded by Azure AD Connect Authentication Agent
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1718
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1903
 
 ```python
-any where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
-(
- (event.category == "library" and event.action == "load") or
- (event.category == "process" and event.action : "Image loaded*")
-) and
+library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
 
-not (?dll.code_signature.trusted == true or file.code_signature.status == "Valid") and not
-
-  (
-   /* Elastic defend DLL path */
-   ?dll.path :
-         ("?:\\Windows\\assembly\\NativeImages*",
-          "?:\\Windows\\Microsoft.NET\\*",
-          "?:\\Windows\\WinSxS\\*",
-          "?:\\Windows\\System32\\DriverStore\\FileRepository\\*") or
-
-   /* Sysmon DLL path is mapped to file.path */
-   file.path :
-         ("?:\\Windows\\assembly\\NativeImages*",
-          "?:\\Windows\\Microsoft.NET\\*",
-          "?:\\Windows\\WinSxS\\*",
-          "?:\\Windows\\System32\\DriverStore\\FileRepository\\*")
-  )
+not dll.code_signature.trusted == true and
+not dll.path : (
+    "?:\\Windows\\assembly\\NativeImages*",
+    "?:\\Windows\\Microsoft.NET\\*",
+    "?:\\Windows\\WinSxS\\*",
+    "?:\\Windows\\System32\\DriverStore\\FileRepository\\*"
+)
 ```
 
 
@@ -18399,12 +19985,23 @@ not (?dll.code_signature.trusted == true or file.code_signature.status == "Valid
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1719
+Index: geneve-ut-1904
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
   (dll.code_signature.trusted == false or dll.code_signature.exists == false) and
-  not dll.code_signature.status : ("errorExpired", "errorRevoked", "errorCode_endpoint:*")
+  /* errorExpired and errorRevoked are handled by d12bac54-ab2a-4159-933f-d7bcefa7b61d */
+  not dll.code_signature.status : ("errorExpired", "errorRevoked", "errorCode_endpoint:*") and
+
+  not dll.hash.sha256 : (
+        /* HP DOT4 printer driver family FPs (Dot4.sys, Dot4Prt.sys, Dot4usb.sys, Dot4Scan.sys) */
+        "f21c1d478180bc5e932bb2c2e4618e3ed463ca87acedeb139682d218435f82f1",
+        "7e2f2a139e897eae56038b920bda9381094bc0ae9e626f6634e6b444b8b0c91f",
+        "12ffdf5f48a79b1b4adbb88ba2cb6c59dd6719554e8ea6beefe99b3e3c66f1ac",
+        "dbc6afaf80141e2480e19878f581edfe9c2b018da2ec527c4025ff04d5587afd",
+        /* (dc3d.sys, test-signed) */
+        "ca8f9564733ded4c3895cf7150bb254995d66889e6be08d6654e4f897e4ff7a4"
+  )
 ```
 
 
@@ -18413,7 +20010,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1724
+Index: geneve-ut-1910
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18427,16 +20024,18 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1725
+Index: geneve-ut-1911
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.parent.name : "dns.exe" and
   not process.executable : (
     "?:\\Windows\\System32\\conhost.exe",
+    "?:\\Windows\\System32\\dns.exe",
 
     /* Crowdstrike specific exclusion as it uses NT Object paths */
     "\\Device\\HarddiskVolume*\\Windows\\System32\\conhost.exe",
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\dns.exe",
     "\\Device\\HarddiskVolume*\\Program Files\\ReasonLabs\\*"
   ) and
   not ?process.parent.executable : "?:\\Program Files\\ReasonLabs\\DNS\\ui\\DNS.exe"
@@ -18448,7 +20047,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1734
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -18482,7 +20081,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1736
+Index: geneve-ut-1922
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18497,37 +20096,15 @@ process.group_leader.name != null and not (
 
 
 
-### Unusual Executable File Creation by a System Critical Process
-
-Branch count: 18  
-Document count: 18  
-Index: geneve-ut-1739
-
-```python
-file where host.os.type == "windows" and event.type != "deletion" and
-  file.extension : ("exe", "dll") and
-  process.name : ("smss.exe",
-                  "autochk.exe",
-                  "csrss.exe",
-                  "wininit.exe",
-                  "services.exe",
-                  "lsass.exe",
-                  "winlogon.exe",
-                  "userinit.exe",
-                  "LogonUI.exe")
-```
-
-
-
 ### Unusual File Creation - Alternate Data Stream
 
-Branch count: 186  
-Document count: 186  
-Index: geneve-ut-1743
+Branch count: 248  
+Document count: 248  
+Index: geneve-ut-1929
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
-   process.name : ("cmd.exe", "powershell.exe", "mshta.exe", "wscript.exe", "node.exe", "python*.exe") and
+   process.name : ("cmd.exe", "powershell.exe", "pwsh.exe", "mshta.exe", "wscript.exe", "cscript.exe", "node.exe", "python*.exe") and
    file.extension in~ (
     "pdf", "dll", "exe", "dat", "com", "bat", "cmd", "sys", "vbs", "vbe", "ps1", "hta", "txt", "js", "jse",
     "wsh", "wsf", "sct", "docx", "doc", "xlsx", "xls", "pptx", "ppt", "rtf", "gif", "jpg", "png", "bmp", "img", "iso"
@@ -18538,128 +20115,11 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 
 
-### Unusual Instance Metadata Service (IMDS) API Request
-
-Branch count: 141  
-Document count: 282  
-Index: geneve-ut-1755
-
-```python
-sequence by host.id, process.parent.entity_id with maxspan=3s
-[
-    process
-    where host.os.type == "linux"
-        and event.type == "start"
-        and event.action == "exec"
-        and process.parent.executable != null
-
-        // common tooling / suspicious names (keep broad)
-        and (
-            process.name : (
-                "curl", "wget", "python*", "perl*", "php*", "ruby*", "lua*", "telnet", "pwsh",
-                "openssl", "nc", "ncat", "netcat", "awk", "gawk", "mawk", "nawk", "socat", "node",
-                "bash", "sh"
-            )
-            or
-            // suspicious execution locations (dropped binaries / temp execution)
-            process.executable : (
-                "./*", "/tmp/*", "/var/tmp/*", "/var/www/*", "/dev/shm/*", "/etc/init.d/*", "/etc/rc*.d/*",
-                "/etc/cron*", "/etc/update-motd.d/*", "/boot/*", "/srv/*", "/run/*", "/etc/rc.local"
-            )
-            or
-            // threat-relevant IMDS / metadata endpoints (inclusion list)
-            process.command_line : (
-                "*169.254.169.254/latest/api/token*",
-                "*169.254.169.254/latest/meta-data/iam/security-credentials*",
-                "*169.254.169.254/latest/meta-data/local-ipv4*",
-                "*169.254.169.254/latest/meta-data/local-hostname*",
-                "*169.254.169.254/latest/meta-data/public-ipv4*",
-                "*169.254.169.254/latest/user-data*",
-                "*169.254.169.254/latest/dynamic/instance-identity/document*",
-                "*169.254.169.254/latest/meta-data/instance-id*",
-                "*169.254.169.254/latest/meta-data/public-keys*",
-                "*computeMetadata/v1/instance/service-accounts/*/token*",
-                "*/metadata/identity/oauth2/token*",
-                "*169.254.169.254/opc/v*/instance*",
-                "*169.254.169.254/opc/v*/vnics*"
-            )
-        )
-
-        // global working-dir / executable / parent exclusions for known benign agents
-        and not process.working_directory : (
-            "/opt/rapid7*",
-            "/opt/nessus*",
-            "/snap/amazon-ssm-agent*",
-            "/var/snap/amazon-ssm-agent/*",
-            "/var/log/amazon/ssm/*",
-            "/srv/snp/docker/overlay2*",
-            "/opt/nessus_agent/var/nessus/*"
-        )
-
-        and not process.executable : (
-            "/opt/rumble/bin/rumble-agent*",
-            "/opt/aws/inspector/bin/inspectorssmplugin",
-            "/snap/oracle-cloud-agent/*",
-            "/lusr/libexec/oracle-cloud-agent/*"
-        )
-
-        and not process.parent.executable : (
-            "/usr/bin/setup-policy-routes",
-            "/usr/share/ec2-instance-connect/*",
-            "/var/lib/amazon/ssm/*",
-            "/etc/update-motd.d/30-banner",
-            "/usr/sbin/dhclient-script",
-            "/usr/local/bin/uwsgi",
-            "/usr/lib/skylight/al-extras",
-            "/usr/bin/cloud-init",
-            "/usr/sbin/waagent",
-            "/usr/bin/google_osconfig_agent",
-            "/usr/bin/docker",
-            "/usr/bin/containerd-shim",
-            "/usr/bin/runc"
-        )
-
-        and not process.entry_leader.executable : (
-            "/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent",
-            "/opt/Elastic/Agent/data/elastic-agent-*/elastic-agent",
-            "/opt/nessus_agent/sbin/nessus-service"
-        )
-
-        // carve-out: safe /usr/bin/curl usage (suppress noisy, legitimate agent patterns)
-        and not (
-            process.executable == "/usr/bin/curl"
-            and (
-                // AWS IMDSv2 token PUT that includes ttl header
-                (process.command_line : "*-X PUT*169.254.169.254/latest/api/token*" and process.command_line : "*X-aws-ec2-metadata-token-ttl-seconds*")
-                or
-                // Any IMDSv2 GET that includes token header for any /latest/* path
-                process.command_line : "*-H X-aws-ec2-metadata-token:*169.254.169.254/latest/*"
-                or
-                // Common amazon tooling UA
-                process.command_line : "*-A amazon-ec2-net-utils/*"
-                or
-                // Azure metadata legitimate header
-                process.command_line : "*-H Metadata:true*169.254.169.254/metadata/*"
-                or
-                // Oracle IMDS legitimate header
-                process.command_line : "*-H Authorization:*Oracle*169.254.169.254/opc/*"
-            )
-        )
-]
-[
-    network where host.os.type == "linux"
-        and event.action == "connection_attempted"
-        and destination.ip == "169.254.169.254"
-]
-```
-
-
-
 ### Unusual Kill Signal
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1758
+Index: geneve-ut-1943
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -18676,7 +20136,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1761
+Index: geneve-ut-1946
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -18693,7 +20153,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1777
+Index: geneve-ut-1962
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -18710,13 +20170,13 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 ### Unusual Parent-Child Relationship
 
-Branch count: 32  
-Document count: 32  
-Index: geneve-ut-1781
+Branch count: 66  
+Document count: 66  
+Index: geneve-ut-1966
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
-process.parent.name != null and
+process.parent.name != null and process.parent.executable like ("?:\\*", "\\Device\\*") and
  (
    /* suspicious parent processes */
    (process.name:"autochk.exe" and not process.parent.name:"smss.exe") or
@@ -18739,11 +20199,12 @@ process.parent.name != null and
    (process.name:"userinit.exe" and not process.parent.name:("dwm.exe", "winlogon.exe", "KUsrInit.exe")) or
    (process.name:("wmiprvse.exe", "wsmprovhost.exe", "winrshost.exe") and not process.parent.name:"svchost.exe") or
    /* suspicious child processes */
-   (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe")) or
+   (process.parent.name:("SearchProtocolHost.exe", "taskhost.exe", "csrss.exe") and not process.name:("werfault.exe", "wermgr.exe", "WerFaultSecure.exe", "conhost.exe", "ngentask.exe", "SearchProtocolHost.exe")) or
    (process.parent.name:"autochk.exe" and not process.name:("chkdsk.exe", "doskey.exe", "WerFault.exe")) or
    (process.parent.name:"smss.exe" and not process.name:("autochk.exe", "smss.exe", "csrss.exe", "wininit.exe", "winlogon.exe", "setupcl.exe", "WerFault.exe", "wpbbin.exe", "PvsVmBoot.exe", "SophosNA.exe", "omnissa-ic-nga.exe", "icarus_rvrt.exe", "poqexec.exe")) or
-   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe")) or
-   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe"))
+   (process.parent.name:"wermgr.exe" and not process.name:("WerFaultSecure.exe", "wermgr.exe", "WerFault.exe") and
+     not (process.name:"rundll32.exe" and process.command_line : "*WerConCpl.dll*LaunchErcApp*")) or
+   (process.parent.name:"conhost.exe" and not process.name:("mscorsvw.exe", "wermgr.exe", "WerFault.exe", "WerFaultSecure.exe", "conhost.exe"))
   )
 ```
 
@@ -18753,7 +20214,7 @@ process.parent.name != null and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1782
+Index: geneve-ut-1967
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18798,7 +20259,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1785
+Index: geneve-ut-1970
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18836,11 +20297,39 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### Unusual Process Connection to Docker or Containerd Socket
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1972
+
+```python
+host.os.type:"linux" and 
+event.category:"network" and
+event.action:"connected-to" and network.direction:"egress" and 
+destination.address:("/run/containerd/containerd.sock" or "/var/run/containerd/containerd.sock" or "/var/run/docker.sock" or "/run/docker.sock") and
+process.executable:(* and not 
+  ("/usr/bin/kubelet" or
+  "/usr/local/bin/kubelet" or
+  "/usr/bin/containerd" or
+  "/usr/sbin/containerd" or
+  "/usr/bin/containerd-shim" or
+  "/usr/bin/containerd-shim-runc-v2" or
+  "/usr/local/bin/containerd-shim-runc-v2" or
+  "/usr/bin/dockerd" or
+  "/usr/sbin/dockerd" or  
+   /var/lib/*/usr/bin/dockerd or 
+  "/usr/bin/docker-proxy")
+)
+```
+
+
+
 ### Unusual Process Execution on WBEM Path
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1790
+Index: geneve-ut-1976
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18864,7 +20353,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1791
+Index: geneve-ut-1977
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18904,7 +20393,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1792
+Index: geneve-ut-1978
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -18951,7 +20440,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1796
+Index: geneve-ut-1982
 
 ```python
 sequence by process.entity_id
@@ -18988,7 +20477,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1830
+Index: geneve-ut-2014
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19002,7 +20491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1831
+Index: geneve-ut-2015
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -19045,7 +20534,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1832
+Index: geneve-ut-2016
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -19058,7 +20547,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1835
+Index: geneve-ut-2019
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -19072,7 +20561,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1836
+Index: geneve-ut-2020
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -19081,29 +20570,11 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 
 
-### Veeam Backup Library Loaded by Unusual Process
-
-Branch count: 10  
-Document count: 10  
-Index: geneve-ut-1839
-
-```python
-library where host.os.type == "windows" and event.action == "load" and
-  (dll.name : "Veeam.Backup.Common.dll" or dll.pe.original_file_name : "Veeam.Backup.Common.dll") and
-  (
-    process.code_signature.trusted == false or
-    process.code_signature.exists == false or
-    process.name : ("powershell.exe", "pwsh.exe", "powershell_ise.exe")
-  )
-```
-
-
-
 ### Virtual Machine Fingerprinting
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1840
+Index: geneve-ut-2024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -19128,7 +20599,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1841
+Index: geneve-ut-2025
 
 ```python
 process where event.type == "start" and
@@ -19143,7 +20614,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1842
+Index: geneve-ut-2026
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19160,7 +20631,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1843
+Index: geneve-ut-2027
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19174,7 +20645,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1844
+Index: geneve-ut-2028
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19190,7 +20661,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1845
+Index: geneve-ut-2029
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19204,7 +20675,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1846
+Index: geneve-ut-2030
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -19217,8 +20688,12 @@ file where host.os.type == "windows" and event.action != "deletion" and
   ) and
   not process.executable : (
     "C:\\Windows\\System32\\poqexec.exe",
-    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe"
-  )
+    "\\Device\\HarddiskVolume*\\Windows\\System32\\poqexec.exe",
+    "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+    "?:\\Windows\\System32\\omadmclient.exe"
+  ) and
+  /* System / ntoskrnl.exe (PID 4) */
+  not process.pid == 4
 ```
 
 
@@ -19227,7 +20702,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1848
+Index: geneve-ut-2032
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -19239,7 +20714,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1849
+Index: geneve-ut-2033
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19255,7 +20730,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1850
+Index: geneve-ut-2034
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -19278,7 +20753,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1851
+Index: geneve-ut-2035
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -19291,7 +20766,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1853
+Index: geneve-ut-2037
 
 ```python
 http.response.status_code:403 and http.request.method:post
@@ -19303,7 +20778,7 @@ http.response.status_code:403 and http.request.method:post
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1854
+Index: geneve-ut-2038
 
 ```python
 http.response.status_code:405
@@ -19315,7 +20790,7 @@ http.response.status_code:405
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1855
+Index: geneve-ut-2039
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -19323,22 +20798,101 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 
 
-### Web Server Potential SQL Injection Request
+### Web Server Cloud Metadata SSRF Request
 
-Branch count: 61  
-Document count: 61  
-Index: geneve-ut-1861
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-2040
 
 ```python
-any where url.original like~ (
-  "*%20order%20by%*", "*dbms_pipe.receive_message%28chr%*", "*waitfor%20delay%20*", "*%28select%20*from%20pg_sleep%285*", "*%28select%28sleep%285*", "*%3bselect%20pg_sleep%285*",
-  "*select%20concat%28concat*", "*xp_cmdshell*", "*select*case*when*", "*and*extractvalue*select*", "*from*information_schema.tables*", "*boolean*mode*having*", "*extractvalue*concat*",
-  "*case*when*sleep*", "*select*sleep*", "*dbms_lock.sleep*", "*and*sleep*", "*like*sleep*", "*csleep*", "*pgsleep*", "*char*char*char*", "*union*select*", "*concat*select*",
-  "*select*else*drop*", "*having*like*", "*case*else*end*", "*if*sleep*", "*where*and*select*", "*or*1=1*", "*\"1\"=\"1\"*", "*or*'a'='a*", "*into*outfile*", "*pga_sleep*",
-  "*into%20outfile*", "*into*dumpfile*", "*load_file%28*", "*load%5ffile%28*", "*cast%28*", "*convert%28*", "*cast%28%*", "*convert%28%*", "*@@version*", "*@@version_comment*",
-  "*version%28*", "*user%28*", "*current_user%28*", "*database%28*", "*schema_name%28*", "*information_schema.columns*", "*information_schema.columns*", "*table_schema*",
-  "*column_name*", "*dbms_pipe*", "*dbms_lock%2e*sleep*", "*dbms_lock.sleep*", "*sp_executesql*", "*sp_executesql*", "*load%20data*", "*information_schema*",  "*pg_slp*",
-  "*information_schema.tables*"
+web where (
+  url.original : (
+    "*169.254.169.254*", "*169%2e254%2e169%2e254*", "*0xa9fea9fe*", "*0xa9.0xfe.0xa9.0xfe*", 
+    "*2852039166*", "*0251.0376.0251.0376*", "*::ffff:169.254.169.254*", "*::ffff:a9fe:a9fe*", "*fd00:ec2::254*",
+    "*100.100.100.200*", "*169.254.170.2*", "*metadata.google.internal*", "*metadata.goog*", "*computeMetadata/v1*",
+    "*meta-data/iam/security-credentials*", "*meta-data%2Fiam%2Fsecurity-credentials*",
+    "*latest/meta-data*", "*latest/api/token*"
+  )
+  or
+  url.query : (
+    "*169.254.169.254*", "*169%2e254%2e169%2e254*", "*0xa9fea9fe*", "*0xa9.0xfe.0xa9.0xfe*", 
+    "*2852039166*", "*0251.0376.0251.0376*", "*::ffff:169.254.169.254*", "*::ffff:a9fe:a9fe*", "*fd00:ec2::254*",
+    "*100.100.100.200*", "*169.254.170.2*", "*metadata.google.internal*", "*metadata.goog*", "*computeMetadata/v1*",
+    "*meta-data/iam/security-credentials*", "*meta-data%2Fiam%2Fsecurity-credentials*",
+    "*latest/meta-data*", "*latest/api/token*"
+  )
+)
+```
+
+
+
+### Web Server Potential SQL Injection Request
+
+Branch count: 91  
+Document count: 91  
+Index: geneve-ut-2046
+
+```python
+any where (
+url.original like~ (
+    "*dbms_pipe.receive_message%28chr%*",
+    "*waitfor%20delay%20%270%3a0%3a*",
+    "*%28select%28sleep%285*", "*%28select%20*from%20pg_sleep%285*", "*%3bselect%20pg_sleep%285*",
+    "*and%20sleep%28*%29*", "*or%20sleep%28*%29*", "*case%20when*then%20sleep%28*", "*if%28sleep%28*%29*",
+    "*benchmark%28*%2c*md5%28*",
+    "*convert%28int%2c%28select%20char%28*",
+    "*char%28*char%28*char%28*char%28*",
+    "*concat%28concat%28char%28*",
+    "*case%20when%20%28*%3d*%29%20then*else*end*",
+    "*elt%28*%3d*%2c1%29%29*",
+    "*union%20select%20null%2cnull*", "*union%20all%20select%20null*",
+    "*union%20all%20select%20*concat%28md5%28*",
+    "*extractvalue%28*concat%280x*", "*updatexml%28*concat%280x*",
+    "*procedure%2f%2a%2a%2fanalyse%28extractvalue%28*",
+    "*gtid_subset%28concat%280x*", "*gtid_subtract%28concat%280x*",
+    "*mid%28ifnull%28session_user%28%29*",
+    "*'qq'%2b%28%28select%20@@version%29%29%2b'qq'*",
+    "*%27%20or%20%271%27%3d%271*", "*%22%20or%20%221%22%3d%221*", "*%27%20or%20%27a%27%3d%27a*",
+    "*and%201%3d1--*", "*and%201%3d2--*",
+    "*%29%3bselect*if%28%28ord%28mid%28*",
+    "*xp_cmdshell*",
+    "*select%20*into%20outfile*", "*select%20*into%20dumpfile*",
+    "*load_file%28*", "*load%5ffile%28*",
+    "*select%20*from%20information_schema.tables*", "*from%20information_schema.columns%20where%20table_schema*",
+    "*dbms_pipe%2ereceive_message*", "*dbms_lock%2esleep*",
+    "*select%20@@version*", "*select%20user%28%29*", "*select%20current_user%28%29*", "*select%20database%28%29*",
+    "*sp_executesql%20*exec%20*", "*xp_dirtree*"
+  )
+  or
+  url.query like~ (
+    "*dbms_pipe.receive_message(chr*",
+    "*waitfor delay '0:0:*",
+    "*(select(sleep(5*", "*(select*from pg_sleep(5*", "*;select pg_sleep(5*",
+    "*and sleep(*)*", "*or sleep(*)*", "*case when*then sleep(*", "*if(sleep(*)*",
+    "*benchmark(*,*md5(*",
+    "*convert(int,(select char(*",
+    "*char(*char(*char(*char(*",
+    "*concat(concat(char(*",
+    "*case when (*=*) then*else*end*",
+    "*elt(*=*,1))*",
+    "*union select null,null*", "*union all select null*",
+    "*union all select*concat(md5(*",
+    "*extractvalue(*concat(0x*", "*updatexml(*concat(0x*",
+    "*procedure/**/analyse(extractvalue(*",
+    "*gtid_subset(concat(0x*", "*gtid_subtract(concat(0x*",
+    "*mid(ifnull(session_user()*",
+    "*'qq'+((select @@version))+'qq'*",
+    "*' or '1'='1*", "*\" or \"1\"=\"1*", "*' or 'a'='a*",
+    "*and 1=1--*", "*and 1=2--*",
+    "*);select*if((ord(mid(*",
+    "*xp_cmdshell*",
+    "*select*into outfile*", "*select*into dumpfile*",
+    "*load_file(*",
+    "*select*from information_schema.tables*", "*from information_schema.columns where table_schema*",
+    "*dbms_pipe.receive_message*", "*dbms_lock.sleep*",
+    "*select @@version*", "*select user()*", "*select current_user()*", "*select database()*",
+    "*sp_executesql*exec*", "*xp_dirtree*"
+  )
 )
 ```
 
@@ -19348,7 +20902,7 @@ any where url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1863
+Index: geneve-ut-2048
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19369,7 +20923,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1866
+Index: geneve-ut-2051
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -19383,7 +20937,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1867
+Index: geneve-ut-2052
 
 ```python
 file where event.type == "deletion" and
@@ -19400,7 +20954,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1868
+Index: geneve-ut-2053
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19418,7 +20972,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1871
+Index: geneve-ut-2056
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19456,7 +21010,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1873
+Index: geneve-ut-2058
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19493,7 +21047,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1874
+Index: geneve-ut-2059
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19508,7 +21062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1875
+Index: geneve-ut-2060
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -19521,7 +21075,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1876
+Index: geneve-ut-2061
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19540,7 +21094,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-1877
+Index: geneve-ut-2062
 
 ```python
 sequence with maxspan=1m
@@ -19565,7 +21119,7 @@ sequence with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1878
+Index: geneve-ut-2063
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19591,7 +21145,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1879
+Index: geneve-ut-2064
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -19613,7 +21167,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1880
+Index: geneve-ut-2065
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19630,7 +21184,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-1882
+Index: geneve-ut-2067
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -19649,7 +21203,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-1883
+Index: geneve-ut-2068
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -19689,7 +21243,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1884
+Index: geneve-ut-2069
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19706,7 +21260,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1886
+Index: geneve-ut-2071
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -19719,7 +21273,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1887
+Index: geneve-ut-2072
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -19733,7 +21287,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1888
+Index: geneve-ut-2073
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19761,7 +21315,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1889
+Index: geneve-ut-2074
 
 ```python
 process where event.type == "start" and
@@ -19786,7 +21340,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1890
+Index: geneve-ut-2075
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19796,11 +21350,27 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
+### XDG-Open Command Execution
+
+Branch count: 25  
+Document count: 25  
+Index: geneve-ut-2076
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2") and (
+  process.name == "xdg-open" or
+  process.args in ("/bin/xdg-open", "/usr/bin/xdg-open", "/usr/local/bin/xdg-open", "xdg-open")
+)
+```
+
+
+
 ### Yum Package Manager Plugin File Creation
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1891
+Index: geneve-ut-2077
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19835,7 +21405,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1892
+Index: geneve-ut-2078
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19853,7 +21423,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1895
+Index: geneve-ut-2081
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/documents_from_rules-8.19.md
+++ b/tests/reports/documents_from_rules-8.19.md
@@ -5,41 +5,62 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.22
+Rules version: 8.19.27
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (184)](#unsupported-rule-type-new_terms-184)
-      1. [Unsupported rule type: esql (138)](#unsupported-rule-type-esql-138)
+      1. [Unsupported rule type: new_terms (212)](#unsupported-rule-type-new_terms-212)
+      1. [Unsupported rule type: esql (165)](#unsupported-rule-type-esql-165)
       1. [Unsupported rule type: machine_learning (95)](#unsupported-rule-type-machine_learning-95)
-      1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
+      1. [Unsupported rule type: threshold (27)](#unsupported-rule-type-threshold-27)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Unsupported query language: lucene (4)](#unsupported-query-language-lucene-4)
+      1. [Unsupported query language: lucene (5)](#unsupported-query-language-lucene-5)
+      1. [Error at line:37,column:3
+Invalid syntax
+  *confluence/conf/server.xml
+  */.config/gcloud/application_default_credentials.json or
+  ^ (1)](#error-at-line37column3
+invalid-syntax
+--confluenceconfserverxml
+--configgcloudapplication_default_credentialsjson-or
+---1)
+      1. [Error at line:7,column:19
+Invalid syntax
+  process.name:(curl or wget) or
+  process.args:(* curl* or */bin/curl* or *wget*)
+                  ^ (1)](#error-at-line7column19
+invalid-syntax
+--processnamecurl-or-wget-or
+--processargs-curl-or-bincurl-or-wget
+-------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (274)](#field-type-solver-constant_keyword-274)
-      1. [Unsupported function: match (32)](#unsupported-function-match-32)
-      1. [Unsupported function: stringContains (23)](#unsupported-function-stringcontains-23)
-      1. [Root with too many branches (limit: 10000) (18)](#root-with-too-many-branches-limit-10000-18)
+      1. [Field type solver: constant_keyword (341)](#field-type-solver-constant_keyword-341)
+      1. [Unsupported function: match (33)](#unsupported-function-match-33)
+      1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
+      1. [Root with too many branches (limit: 10000) (20)](#root-with-too-many-branches-limit-10000-20)
       1. [Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)](#unsupported-lhs-type-class-eqlastfunctioncall-11)
-      1. [Root without branches (8)](#root-without-branches-8)
-      1. [Unsupported argument type(s): <class 'eql.ast.Field'> (8)](#unsupported-argument-types-class-eqlastfield-8)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (6)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-6)
+      1. [Unsupported argument type(s): <class 'eql.ast.Field'> (10)](#unsupported-argument-types-class-eqlastfield-10)
+      1. [Root without branches (9)](#root-without-branches-9)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-7)
       1. [Unsupported function: startsWith (4)](#unsupported-function-startswith-4)
       1. [<class 'eql.ast.Sample'> (3)](#class-eqlastsample-3)
+      1. [Field type solver: match_only_text (3)](#field-type-solver-match_only_text-3)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
       1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
-      1. [Field type solver: match_only_text (2)](#field-type-solver-match_only_text-2)
       1. [Unsolvable constraints: event.category & event.type (empty intersection) (2)](#unsolvable-constraints-eventcategory--eventtype-empty-intersection-2)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)](#unsolvable-constraints-processname-excluded-by-stringspython-python-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'rundll32.exe'}): ('rundll32.exe')) (2)](#unsolvable-constraints-processname-excluded-by-stringsrundll32exe-rundll32exe-2)
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
+      1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
-      1. [Cannot choose from an empty set (1)](#cannot-choose-from-an-empty-set-1)
       1. [Unsolvable constraints: file.Ext.header_bytes (excluded by Strings({'504B0304*'}): ('504B0304*')) (1)](#unsolvable-constraints-fileextheader_bytes-excluded-by-strings504b0304-504b0304-1)
       1. [Unsolvable constraints: file.extension (cannot be non-null) (1)](#unsolvable-constraints-fileextension-cannot-be-non-null-1)
+      1. [Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)](#unsolvable-constraints-filename-excluded-by-stringslocal-state-local-state-1)
       1. [Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)](#unsolvable-constraints-filename-not-in-stringsso-so-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringsswipuploadashx-post-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringschild_process-exec-1)
@@ -56,6 +77,7 @@ Rules version: 8.19.22
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'LsaCallAuthenticationPackage'}): ('KerbRetrieveEncodedTicketMessage')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringslsacallauthenticationpackage-kerbretrieveencodedticketmessage-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'Microsoft.Office.Interop.Outlook'}): ('MAPI')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsmicrosoftofficeinteropoutlook-mapi-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NTLMSSPNegotiate'}): ('NegotiateSMB')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsntlmsspnegotiate-negotiatesmb-1)
+      1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NdrClientCall'}): ('GetProcAddress')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsndrclientcall-getprocaddress-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'New-MailboxExportRequest'}): ('-FilePath')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsnew-mailboxexportrequest--filepath-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'STARTUPINFOEX'}): ('UpdateProcThreadAttribute')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsstartupinfoex-updateprocthreadattribute-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'Set-MpPreference'}): ('DisableArchiveScanning')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsset-mppreference-disablearchivescanning-1)
@@ -83,6 +105,7 @@ Rules version: 8.19.22
       1. [Unsolvable constraints: process.command_line (not in Strings({'*net.ipv4.ip_forward*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsnetipv4ip_forward-echo--1)
       1. [Unsolvable constraints: process.command_line (not in Strings({'*vm.swappiness*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsvmswappiness-echo--1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'arp.exe'}): ('arp.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsarpexe-arpexe-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (1)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)](#unsolvable-constraints-processname-excluded-by-stringscp-cp-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselevation_serviceexe-elevation_serviceexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (1)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-1)
@@ -91,12 +114,8 @@ Rules version: 8.19.22
       1. [Unsolvable constraints: process.name (excluded by Strings({'nc.traditional'}): ('nc.traditional')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnctraditional-nctraditional-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'net1.exe'}): ('net1.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnet1exe-net1exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nohup'}): ('nohup')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnohup-nohup-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (1)](#unsolvable-constraints-processname-excluded-by-stringspython-python-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsscexe-scexe-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)](#unsolvable-constraints-processname-excluded-by-stringssh-sh-1)
-      1. [Unsolvable constraints: process.name (not in Strings({'java'}): ('.*')) (1)](#unsolvable-constraints-processname-not-in-stringsjava--1)
-      1. [Unsolvable constraints: process.name (not in Strings({'pluginkit'}): ('python*')) (1)](#unsolvable-constraints-processname-not-in-stringspluginkit-python-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringssmssexe-smssexe-1)
       1. [Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)](#unsolvable-constraints-processname-not-in-stringsrundll32exe-mshtaexe-1)
       1. [Unsolvable constraints: process.parent.args (excluded by Strings({'WdiSystemHost'}): ('WdiSystemHost')) (1)](#unsolvable-constraints-processparentargs-excluded-by-stringswdisystemhost-wdisystemhost-1)
       1. [Unsolvable constraints: process.parent.name (excluded by Strings({'dllhost.exe'}): ('dllhost.exe')) (1)](#unsolvable-constraints-processparentname-excluded-by-stringsdllhostexe-dllhostexe-1)
@@ -110,6 +129,7 @@ Rules version: 8.19.22
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*42B5FAAE-6536-11D2-AE5A-0000F87571E3*'}): ('*40B66650-4972-11D1-A7CA-0000F87571E3*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-strings42b5faae-6536-11d2-ae5a-0000f87571e3-40b66650-4972-11d1-a7ca-0000f87571e3-1)
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*827D319E-6EAC-11D2-A4EA-00C04F79F83A*'}): ('*803E14A0-B4FB-11D0-A0D0-00A0C90F574B*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-strings827d319e-6eac-11d2-a4ea-00c04f79f83a-803e14a0-b4fb-11d0-a0d0-00a0c90f574b-1)
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*CAB54552-DEEA-4691-817E-ED4A4D1AFC72*'}): ('*AADCED64-746C-4633-A97C-D61349046527*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-stringscab54552-deea-4691-817e-ed4a4d1afc72-aadced64-746c-4633-a97c-d61349046527-1)
+      1. [Unsolvable constraints: winlog.event_data.param1 (not in Strings({'*FullControl*'}): ('*setsharingmode*')) (1)](#unsolvable-constraints-winlogevent_dataparam1-not-in-stringsfullcontrol-setsharingmode-1)
       1. [Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: < (1)](#unsupported-keyword-dllextrelative_file_creation_time-constraint--1)
       1. [Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: <= (1)](#unsupported-keyword-dllextrelative_file_creation_time-constraint--1)
       1. [Unsupported &keyword 'file.Ext.entropy' constraint: >= (1)](#unsupported-keyword-fileextentropy-constraint--1)
@@ -118,18 +138,24 @@ Rules version: 8.19.22
       1. [Unsupported &keyword 'powershell.file.script_block_length' constraint: > (1)](#unsupported-keyword-powershellfilescript_block_length-constraint--1)
       1. [Unsupported &keyword 'problemchild.prediction_probability' constraint: <= (1)](#unsupported-keyword-problemchildprediction_probability-constraint--1)
       1. [Unsupported &keyword 'problemchild.prediction_probability' constraint: > (1)](#unsupported-keyword-problemchildprediction_probability-constraint--1)
-      1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (1)](#unsupported-keyword-processextrelative_file_creation_time-constraint--1)
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (184)
+### Unsupported rule type: new_terms (212)
 
-184 rules:
+212 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
+* AWS Bedrock Agent or Action Group Manipulation
+* AWS Bedrock Knowledge Base or RAG Data Source Tampering
+* AWS Bedrock Resource-Based Policy Modified or Deleted
+* AWS Bedrock Third-Party or External Knowledge Base Associated to Agent
 * AWS CLI Command with Custom Endpoint URL
+* AWS Discovery API Calls from VPN ASN for the First Time by Identity
 * AWS DynamoDB Scan by Unusual User
 * AWS DynamoDB Table Exported to S3
+* AWS EC2 CreateKeyPair by New Principal from Non-Cloud AS Organization
+* AWS EC2 Role GetCallerIdentity from New Source AS Organization
 * AWS EC2 Route Table Created
 * AWS EC2 Route Table Modified or Deleted
 * AWS EC2 Unauthorized Admin Credential Fetch via Assumed Role
@@ -141,6 +167,8 @@ Rules version: 8.19.22
 * AWS IAM Customer-Managed Policy Attached to Role by Rare User
 * AWS IAM Long-Term Access Key First Seen from Source IP
 * AWS IAM OIDC Provider Created by Rare User
+* AWS Lambda Function Invoked by an Unusual Principal
+* AWS Lambda Function Invoked from an Unusual Source ASN
 * AWS S3 Unauthenticated Bucket Access by Rare Source
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
@@ -160,9 +188,12 @@ Rules version: 8.19.22
 * Abnormal Process ID or Lock File Created
 * Account or Group Discovery via Built-In Tools
 * Authentication via Unusual PAM Grantor
+* Azure AD Graph Access with Unusual Client and User
+* Azure AD Graph Access with Unusual User and ASN
 * Azure Arc Cluster Credential Access by Identity from Unusual Source
 * Azure Compute Restore Point Collection Deleted by Unusual User
 * Azure Compute Snapshot Deletion by Unusual User and Resource Group
+* Azure Compute VM Command Executed
 * Azure Diagnostic Settings Deleted
 * Azure Key Vault Modified
 * Azure Key Vault Unusual Secret Key Usage
@@ -170,12 +201,17 @@ Rules version: 8.19.22
 * Azure Storage Account Deletion by Unusual User
 * Azure Storage Account Keys Accessed by Privileged User
 * Azure Storage Blob Retrieval via AzCopy
+* Azure VM Extension CRUD Operation with Unusual Source ASN
+* Azure VM Managed Run Command Created or Updated with Unusual Principal
+* Azure VM Serial Console Connection with Unusual User and ASN
 * DPKG Package Installed by Unusual Parent Process
 * Delegated Managed Service Account Modification by an Unusual User
 * Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
+* Deprecated TLS Version or Weak Cipher Negotiated Externally
 * Discovery of Internet Capabilities via Built-in Tools
 * Entra ID Conditional Access Policy (CAP) Modified
+* Entra ID Device with ROADtools Default OS Build (Entity Analytics)
 * Entra ID Elevated Access to User Access Administrator
 * Entra ID External Authentication Methods (EAM) Modified
 * Entra ID OAuth Authorization Code Grant for Unusual User, App, and Resource
@@ -211,22 +247,27 @@ Rules version: 8.19.22
 * First Time Python Created a LaunchAgent or LaunchDaemon
 * First Time Python Spawned a Shell on Host
 * First Time Seen AWS Secret Value Accessed in Secrets Manager
+* First Time Seen Account Performing DCSync
 * First Time Seen Driver Loaded
 * First Time Seen Google Workspace OAuth Login from Third-Party Application
 * First Time Seen NewCredentials Logon Process
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
-* FirstTime Seen Account Performing DCSync
 * FortiGate Administrator Account Creation from Unusual Source
+* GKE Secrets List from Unusual Source AS Organization
+* GKE User Exec into Pod
 * GenAI Process Connection to Unusual Domain
 * GitHub Actions Unusual Bot Push to Repository
 * Github Activity on a Private Repository from an Unusual IP
+* Google Workspace User Login with Unusual ASN
+* Google Workspace User Sign-in from Atypical Device Type
 * Interactive Shell Launched via Unusual Parent Process in a Container
 * Kernel Object File Creation
 * Kill Command Execution
 * Kubernetes Anonymous Request Authorized by Unusual User Agent
 * Kubernetes Denied Service Account Request via Unusual User Agent
 * Kubernetes Forbidden Request from Unusual User Agent
+* Kubernetes Pod Creation Using Common Debug or Base Images
 * Kubernetes Secret Access via Unusual User Agent
 * Kubernetes Suspicious Self-Subject Review via Unusual User Agent
 * Kubernetes Unusual Decision by User Agent
@@ -239,7 +280,9 @@ Rules version: 8.19.22
 * M365 Exchange Inbox Phishing Evasion Rule Created
 * M365 Exchange Mailbox Accessed by Unusual Client
 * M365 Exchange Mailbox High-Risk Permission Delegated
-* M365 Identity Login from Atypical Travel Location
+* M365 Identity Device Code Grant by an Unusual User (Non-Compliant Device)
+* M365 Identity Device Code Grant with Unusual User and ASN
+* M365 Identity Login from Atypical Region
 * M365 Identity OAuth Illicit Consent Grant by Rare Client and User
 * M365 Identity Unusual SSO Authentication Errors for User
 * M365 SharePoint/OneDrive File Access via PowerShell
@@ -254,6 +297,7 @@ Rules version: 8.19.22
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
+* Potential ICMP Tunneling Activity to the Internet
 * Potential Pass-the-Hash (PtH) Attempt
 * Potential Privilege Escalation via Linux DAC permissions
 * Potential Shadow File Read via Command Line Utilities
@@ -264,6 +308,7 @@ Rules version: 8.19.22
 * RPM Package Installed by Unusual Parent Process
 * Rare SMB Connection to the Internet
 * Remote File Creation in World Writeable Directory
+* SMB (Windows File Sharing) Activity from the Internet
 * SMB (Windows File Sharing) Activity to the Internet
 * SSH Authorized Keys File Activity
 * Sensitive Files Compression
@@ -272,6 +317,7 @@ Rules version: 8.19.22
 * Successful SSH Authentication from Unusual IP Address
 * Successful SSH Authentication from Unusual SSH Public Key
 * Successful SSH Authentication from Unusual User
+* Suspicious Instance Metadata Service (IMDS) API Request
 * Suspicious Modprobe File Event
 * Suspicious Named Pipe Creation
 * Suspicious Network Activity to the Internet by Previously Unknown Executable
@@ -288,6 +334,8 @@ Rules version: 8.19.22
 * Unauthorized Scope for Public App OAuth2 Token Grant with Client Credentials
 * Unknown Execution of Binary with RWX Memory Region
 * Unusual AWS S3 Object Encryption with SSE-C
+* Unusual Child Execution via Web Server
+* Unusual Command Execution via Web Server
 * Unusual Discovery Signal Alert with Unusual Process Command Line
 * Unusual Discovery Signal Alert with Unusual Process Executable
 * Unusual Execution from Kernel Thread (kthreadd) Parent
@@ -307,36 +355,47 @@ Rules version: 8.19.22
 * Unusual SSHD Child Process
 * Unusual Scheduled Task Update
 * Unusual Web Config File Access
-* Unusual Web Server Command Execution
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (138)
+### Unsupported rule type: esql (165)
 
-138 rules:
+165 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock Detected Multiple Attempts to use Denied Models by a Single User
 * AWS Bedrock Detected Multiple Validation Exception Errors by a Single User
 * AWS Bedrock Guardrails Detected Multiple Policy Violations Within a Single Blocked Request
 * AWS Bedrock Guardrails Detected Multiple Violations by a Single User Over a Session
+* AWS Bedrock High-Frequency Single-Model Inference API Probing
 * AWS Bedrock Invocations without Guardrails Detected by a Single User Over a Session
 * AWS Credentials Used from GitHub Actions and Non-CI/CD Infrastructure
 * AWS Discovery API Calls via CLI from a Single Resource
 * AWS EC2 LOLBin Execution via SSM SendCommand
 * AWS EC2 Multi-Region DescribeInstances API Calls
+* AWS EC2 Stop, Start, and User Data Modification Correlation
+* AWS ECR Repository or Registry Policy Granted Public Access
+* AWS IAM User Console Login from Multiple Geolocations
 * AWS IAM User Created Access Keys For Another User
+* AWS Lambda Function High-Frequency Invocation by a Single Principal
+* AWS Lambda Function Invoked Cross-Account
+* AWS Lateral Movement from Kubernetes SA via AssumeRoleWithWebIdentity
 * AWS Rare Source AS Organization Activity
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
 * Agent Spoofing - Multiple Hosts Using Same Agent
 * Alerts From Multiple Integrations by Destination Address
 * Alerts From Multiple Integrations by Source Address
 * Alerts From Multiple Integrations by User Name
 * Alerts in Different ATT&CK Tactics by Host
+* Azure AD Graph Access with Suspicious User-Agent
+* Azure AD Graph High 4xx Error Ratio from User
+* Azure AD Graph Potential Enumeration (ROADrecon)
 * Azure Key Vault Excessive Secret or Key Retrieved
 * Azure OpenAI Insecure Output Handling
+* Azure Run Command Correlated with Process Execution
 * Command Line Obfuscation via Whitespace Padding
 * Correlated Alerts on Similar User Identities
 * Detection Alert on a Process Exhibiting CPU Spike
@@ -358,30 +417,43 @@ Rules version: 8.19.22
 * First-Time FortiGate Administrator Login
 * FortiGate Administrator Login from Multiple IP Addresses
 * FortiGate FortiCloud SSO Login from Unusual Source
+* GKE API Request Failure Burst by User
 * GitHub Actions Workflow Modification Blocked
 * GitHub Exfiltration via High Number of Repository Clones by User
+* Google Workspace Device Registration Burst for Single User
 * High Number of Closed Pull Requests by User
 * High Number of Egress Network Connections from Unusual Executable
 * High Number of Protected Branch Force Pushes by User
 * Kubernetes Creation or Modification of Sensitive Role
+* Kubernetes Multi-Resource Discovery
+* Kubernetes Pod Exec Cloud Instance Metadata Access
+* Kubernetes Pod Exec Potential Reverse Shell
+* Kubernetes Pod Exec Sensitive File or Credential Path Access
+* Kubernetes Pod Exec with Curl or Wget to HTTPS
 * Kubernetes Potential Endpoint Permission Enumeration Attempt Detected
 * Kubernetes Potential Endpoint Permission Enumeration Attempt by Anonymous User Detected
+* Kubernetes RBAC Wildcard Elevation on Existing Role
+* Kubernetes Rapid Secret GET Activity Against Multiple Objects
 * Kubernetes Secret or ConfigMap Access via Azure Arc Proxy
 * LSASS Process Access via Windows API
 * Lateral Movement Alerts from a Newly Observed Source Address
 * Lateral Movement Alerts from a Newly Observed User
 * Long Base64 Encoded Command via Scripting Interpreter
 * M365 Azure Monitor Alert Email with Financial or Billing Theme
+* M365 Exchange Inbox Rule with Obfuscated Name
 * M365 Identity OAuth Flow by First-Party Microsoft App from Multiple IPs
 * M365 Identity User Account Lockouts
 * M365 Identity User Brute Force Attempted
 * M365 OneDrive/SharePoint Excessive File Downloads
 * M365 or Entra ID Identity Sign-in from a Suspicious Source
 * Microsoft Entra ID Exccessive Account Lockouts Detected
+* Microsoft Graph Multi-Category Reconnaissance Burst
+* Multi-Cloud CLI Token and Credential Access Commands
 * Multiple Alerts Involving a User
 * Multiple Alerts in Same ATT&CK Tactic by Host
 * Multiple Alerts on a Host Exhibiting CPU Spike
 * Multiple Cloud Secrets Accessed by Source Address
+* Multiple DHCP Servers Responding to the Same Transaction
 * Multiple Device Token Hashes for Single Okta Session
 * Multiple Elastic Defend Alerts by Agent
 * Multiple Elastic Defend Alerts from a Single Process Tree
@@ -406,6 +478,8 @@ Rules version: 8.19.22
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
 * Potential Credential Discovery via Recursive Grep
+* Potential DHCP Starvation via High Client MAC Cardinality
+* Potential DNS Exfiltration via Excessive Chunked Queries
 * Potential Denial of Azure OpenAI ML Service
 * Potential Dynamic IEX Reconstruction via Environment Variables
 * Potential Linux Local Account Brute Force Detected
@@ -430,6 +504,7 @@ Rules version: 8.19.22
 * Potential PowerShell Obfuscation via String Concatenation
 * Potential PowerShell Obfuscation via String Reordering
 * Potential Ransomware Behavior - Note Files by System
+* Potential SQL Injection Against Microsoft SQL Server
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
 * Potential Widespread Malware Infection Across Multiple Hosts
@@ -437,18 +512,17 @@ Rules version: 8.19.22
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
 * Several Failed Protected Branch Force Pushes by User
+* Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
 * Suspected Lateral Movement from Compromised Host
 * Suspicious AWS S3 Connection via Script Interpreter
 * Suspicious Python Shell Command Execution
 * Suspicious TCC Access Granted for User Folders
 * Unusual Base64 Encoding/Decoding Activity
-* Unusual Command Execution from Web Server Parent
 * Unusual File Creation by Web Server
 * Unusual High Confidence Content Filter Blocks Detected
 * Unusual High Denied Sensitive Information Policy Blocks Detected
 * Unusual High Denied Topic Blocks Detected
 * Unusual High Word Policy Blocks Detected
-* Unusual Process Spawned from Web Server Parent
 * Web Server Discovery or Fuzzing Activity
 * Web Server Potential Command Injection Request
 * Web Server Potential Spike in Error Response Codes
@@ -554,9 +628,9 @@ Rules version: 8.19.22
 * Unusual Windows Username
 * User Detected with Suspicious Windows Process(es)
 
-### Unsupported rule type: threshold (28)
+### Unsupported rule type: threshold (27)
 
-28 rules:
+27 rules:
 
 * AWS IAM Principal Enumeration via UpdateAssumeRolePolicy
 * AWS Management Console Brute Force of Root User Identity
@@ -566,7 +640,6 @@ Rules version: 8.19.22
 * Azure Compute Restore Point Collections Deleted
 * Azure Compute Snapshot Deletions by User
 * Azure Storage Account Deletions by User
-* Deprecated - Sudo Heap-Based Buffer Overflow Attempt
 * Excessive AWS S3 Object Encryption with SSE-C
 * GitHub UEBA - Multiple Alerts from a GitHub Account
 * High Number of Cloned GitHub Repos From PAT
@@ -598,20 +671,54 @@ Rules version: 8.19.22
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Unsupported query language: lucene (4)
+### Unsupported query language: lucene (5)
 
-4 rules:
+5 rules:
 
 * Cobalt Strike Command and Control Beacon
 * Halfbaked Command and Control Beacon
 * Inbound Connection to an Unsecure Elasticsearch Node
 * Possible FIN7 DGA Command and Control Behavior
+* Potential cPanel WHM CRLF Authentication Bypass (CVE-2026-41940)
+
+### Error at line:37,column:3
+Invalid syntax
+  *confluence/conf/server.xml
+  */.config/gcloud/application_default_credentials.json or
+  ^ (1)
+
+1 rules:
+
+* Kubernetes and Cloud Credential Path Access via Process Arguments
+
+### Error at line:7,column:19
+Invalid syntax
+  process.name:(curl or wget) or
+  process.args:(* curl* or */bin/curl* or *wget*)
+                  ^ (1)
+
+1 rules:
+
+* Curl or Wget Execution from Container Context
 
 ## Generation errors
 
-### Field type solver: constant_keyword (274)
+### Field type solver: constant_keyword (341)
 
-274 rules:
+341 rules:
+* AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
+* AWS Backup Recovery Point Deleted
+* AWS Backup Vault Deleted or Vault Lock Removed
+* AWS Bedrock Agent Created by IAM User or Root
+* AWS Bedrock Automated Reasoning Safety Policy Tampering
+* AWS Bedrock Foundation Model Access Enabled or Entitlement Granted
+* AWS Bedrock Foundation Model Enumeration Followed by Invocation via Long-Term Key
+* AWS Bedrock Guardrail Deleted or Weakened
+* AWS Bedrock Model Invocation Logging Disabled or Modified
+* AWS Bedrock Provisioned Model Throughput Tampering
+* AWS Bedrock Unauthorized Foundation Model Access Attempt
+* AWS Bedrock Unauthorized Resource-Based Policy Modification Attempt
+* AWS Bedrock Untrusted Model Imported or Marketplace Endpoint Registered
 * AWS CloudShell Environment Created
 * AWS CloudTrail Log Created
 * AWS CloudTrail Log Deleted
@@ -634,18 +741,29 @@ Rules version: 8.19.22
 * AWS EC2 Security Group Configuration Change
 * AWS EC2 Serial Console Access Enabled
 * AWS EFS File System Deleted
+* AWS EKS Access Entry Granted Cluster Admin Policy
+* AWS EKS Access Entry Modified
+* AWS EKS Control Plane Logging Disabled
 * AWS EventBridge Rule Disabled or Deleted
 * AWS GuardDuty Detector Deletion
 * AWS GuardDuty Member Account Manipulation
+* AWS IAM Account Password Policy Deleted
 * AWS IAM Deactivation of MFA Device
 * AWS IAM Group Creation
 * AWS IAM Group Deletion
+* AWS IAM Inline Policy Added to a Group
+* AWS IAM Login Profile Created or Modified for an IAM User
+* AWS IAM Permissions Boundary Modified or Removed
 * AWS IAM Roles Anywhere Profile Creation
 * AWS IAM SAML Provider Created
 * AWS IAM SAML Provider Updated
 * AWS IAM User Addition to Group
 * AWS KMS Customer Managed Key Disabled or Scheduled for Deletion
+* AWS KMS Imported Key Material Deleted
+* AWS Lambda Event Source Mapping Creation
+* AWS Lambda Function Deletion
 * AWS Lambda Layer Added to Existing Function
+* AWS Lambda Layer Shared Externally
 * AWS Management Console Root Login
 * AWS RDS DB Instance Restored
 * AWS RDS DB Instance or Cluster Deleted
@@ -655,6 +773,7 @@ Rules version: 8.19.22
 * AWS Route 53 Private Hosted Zone Associated With a VPC
 * AWS Route 53 Resolver Query Log Configuration Deleted
 * AWS S3 Bucket Configuration Deletion
+* AWS S3 Credential File Retrieved from Bucket
 * AWS SQS Queue Purge
 * AWS Sensitive IAM Operations Performed via CloudShell
 * AWS Sign-In Console Login with Federated User
@@ -689,7 +808,6 @@ Rules version: 8.19.22
 * Azure Automation Webhook Created
 * Azure Blob Storage Container Access Level Modified
 * Azure Blob Storage Permissions Modified
-* Azure Compute VM Command Executed
 * Azure Diagnostic Settings Alert Suppression Rule Created or Modified
 * Azure Event Hub Authorization Rule Created or Updated
 * Azure Event Hub Deleted
@@ -700,10 +818,13 @@ Rules version: 8.19.22
 * Azure Resource Group Deleted
 * Azure Service Principal Sign-In Followed by Arc Cluster Credential Access
 * Azure Storage Account Key Regenerated
+* Azure VM Boot Diagnostics Retrieved
+* Azure VM Extension Deployment by User
 * Azure VNet Firewall Front Door WAF Policy Deleted
 * Azure VNet Firewall Policy Deleted
 * Azure VNet Full Network Packet Capture Enabled
 * Azure VNet Network Watcher Deleted
+* Azure Virtual Machine Configuration Modified
 * Command and Scripting Interpreter via Windows Scripts
 * CrowdStrike External Alerts
 * CyberArk Privileged Access Security Error
@@ -716,21 +837,33 @@ Rules version: 8.19.22
 * Deprecated - M365 Security Compliance User Restricted from Sending Email
 * Deprecated - M365 Teams External Access Enabled
 * Deprecated - M365 Teams Guest Access Enabled
+* Deprecated - MFA Disabled for Google Workspace Organization
 * Domain Added to Google Workspace Trusted Domains
+* EKS Authentication Configuration Modified
 * Elastic Security External Alerts
 * Entra ID ADRS Token Request by Microsoft Authentication Broker
 * Entra ID Application Credential Modified
 * Entra ID Custom Domain Added or Verified
+* Entra ID Device Registration with ROADtools Default OS Build
 * Entra ID Domain Federation Configuration Change
 * Entra ID External Guest User Invited
 * Entra ID Global Administrator Role Assigned
 * Entra ID Global Administrator Role Assigned (PIM User)
+* Entra ID Guest Account Promoted to Member
 * Entra ID High Risk Sign-in
 * Entra ID High Risk User Sign-in Heuristic
+* Entra ID Kali365 Default User-Agent Detected
 * Entra ID MFA Disabled for User
+* Entra ID Microsoft Authentication Broker DRS Sign-In from Suspicious ASN
+* Entra ID Microsoft Authentication Broker Sign-In to Unusual Resource
+* Entra ID Microsoft Authentication Broker Sign-In with Non-Standard User Agent
+* Entra ID OAuth Application Redirect URI Modified
 * Entra ID OAuth Device Code Grant by Microsoft Authentication Broker
+* Entra ID OAuth Device Code Phishing via AiTM
+* Entra ID OAuth Device Code Sign-in to Azure AD Graph Enumeration
 * Entra ID OAuth PRT Issuance to Non-Managed Device Detected
 * Entra ID OAuth Phishing via First-Party Microsoft Application
+* Entra ID Potential AiTM Sign-In via OfficeHome (Tycoon2FA)
 * Entra ID PowerShell Sign-in
 * Entra ID Privileged Identity Management (PIM) Role Modified
 * Entra ID Protection - Risk Detection - Sign-in Risk
@@ -738,8 +871,10 @@ Rules version: 8.19.22
 * Entra ID Protection Admin Confirmed Compromise
 * Entra ID Protection Alerts for User Detected
 * Entra ID Protection User Alert and Device Registration
+* Entra ID Register Device with Unusual User Agent (Azure AD Join)
 * Entra ID Service Principal Created
 * Entra ID Sign-in TeamFiltration User-Agent Detected
+* Entra ID Temporary Access Pass Created for User
 * Entra ID Unusual Cloud Device Registration
 * Entra ID User Added as Registered Application Owner
 * Entra ID User Added as Service Principal Owner
@@ -776,23 +911,35 @@ Rules version: 8.19.22
 * GCP Virtual Private Cloud Network Deletion
 * GCP Virtual Private Cloud Route Creation
 * GCP Virtual Private Cloud Route Deletion
+* GKE Admission Webhook Created or Modified
+* GKE Cluster-Admin Role Binding Created or Modified
+* GKE Container Created with Excessive Linux Capabilities
+* GKE Pod Created With HostIPC
+* GKE Pod Created With HostNetwork
+* GKE Pod Created With HostPID
+* GKE Pod Created with a Sensitive hostPath Volume
+* GKE Privileged Pod Created
+* GKE Secret get or list with Suspicious User Agent
+* GKE Suspicious Self-Subject Review via Service Account
 * GitHub App Deleted
 * GitHub Owner Role Granted To User
 * GitHub Private Repository Turned Public
 * GitHub Protected Branch Settings Changed
 * GitHub Repository Deleted
 * GitHub Secret Scanning Disabled
-* Google Drive Ownership Transferred via Google Workspace
 * Google SecOps External Alerts
-* Google Workspace 2SV Policy Disabled
+* Google Workspace 2SV Policy Disabled By User
 * Google Workspace API Access Granted via Domain-Wide Delegation
-* Google Workspace Admin Role Assigned to a User
+* Google Workspace Admin Role Assigned to a User or Group
 * Google Workspace Admin Role Deletion
 * Google Workspace Bitlocker Setting Disabled
 * Google Workspace Custom Admin Role Created
-* Google Workspace Custom Gmail Route Created or Modified
+* Google Workspace Device Registration After OAuth from Suspicious ASN
+* Google Workspace Drive Data Transfer or Takeout Export Initiated
 * Google Workspace Drive Encryption Key(s) Accessed from Anonymous User
-* Google Workspace MFA Enforcement Disabled
+* Google Workspace Gmail Routing or Forwarding Rule Created or Modified
+* Google Workspace Login Flagged Suspicious
+* Google Workspace MFA Enforcement Disabled For Organization
 * Google Workspace Object Copied to External Drive with App Consent
 * Google Workspace Password Policy Modified
 * Google Workspace Restrictions for Marketplace Modified to Allow Any App
@@ -800,12 +947,18 @@ Rules version: 8.19.22
 * Google Workspace Suspended User Account Renewed
 * Google Workspace User Organizational Unit Changed
 * IBM QRadar External Alerts
+* ICMP Redirect Message from Internal Host
+* ICMP Timestamp or Information Request from the Internet
 * IPSEC NAT Traversal Port Activity
 * Initial Access via File Upload Followed by GET Request
 * Insecure AWS EC2 VPC Security Group Ingress Rule Added
+* Kubernetes API Request Impersonating Privileged Identity
 * Kubernetes Anonymous User Create/Update/Patch Pods Request
+* Kubernetes Client Certificate Signing Request Created or Approved
 * Kubernetes Cluster-Admin Role Binding Created
+* Kubernetes CoreDNS or Kube-DNS Configuration Modified
 * Kubernetes Creation of a RoleBinding Referencing a ServiceAccount
+* Kubernetes Ephemeral Container Added to Pod
 * Kubernetes Events Deleted
 * Kubernetes Exposed Service Created With Type NodePort
 * Kubernetes Forbidden Creation Request
@@ -814,8 +967,11 @@ Rules version: 8.19.22
 * Kubernetes Pod Created With HostPID
 * Kubernetes Pod Created with a Sensitive hostPath Volume
 * Kubernetes Privileged Pod Created
+* Kubernetes Secret get or list from Node or Pod Service Account
+* Kubernetes Secret get or list with Suspicious User Agent
 * Kubernetes Sensitive RBAC Change Followed by Workload Modification
 * Kubernetes Service Account Modified RBAC Objects
+* Kubernetes Service Account Token Created via TokenRequest API
 * Kubernetes Suspicious Assignment of Controller Service Account
 * Kubernetes User Exec into Pod
 * M365 Exchange Anti-Phish Policy Deleted
@@ -836,12 +992,13 @@ Rules version: 8.19.22
 * M365 Identity OAuth Flow by User Sign-in to Device Registration
 * M365 Identity OAuth Phishing via First-Party Microsoft Application
 * M365 OneDrive Malware File Upload
+* M365 Potential AiTM UserLoggedIn via Office App (Tycoon2FA)
 * M365 SharePoint Malware File Detected
 * M365 SharePoint Search for Sensitive Content
 * M365 SharePoint Site Administrator Added
 * M365 SharePoint Site Sharing Policy Weakened
 * M365 Teams Custom Application Interaction Enabled
-* MFA Disabled for Google Workspace Organization
+* M365 Teams Rogue Help Desk Chat Created
 * Microsoft Sentinel External Alerts
 * Modification or Removal of an Okta Application Sign-On Policy
 * New GitHub App Installed
@@ -853,10 +1010,12 @@ Rules version: 8.19.22
 * Okta User Assigned Administrator Role
 * Okta User Session Impersonation
 * Possible Okta DoS Attack
-* Potential Credential Access via Renamed COM+ Services DLL
 * Potential DLL Side-Loading via Trusted Microsoft Programs
 * Potential File Transfer via Curl for Windows
 * Potential Persistence via File Modification
+* Potential Redis CONFIG SET Cron Directory Persistence (RedisRaider)
+* Potential Redis CONFIG SET SSH Authorized Key Injection
+* Potential Redis Lua Use-After-Free RCE Attempt (CVE-2025-49844 / RediShell)
 * Potential Toolshell Initial Exploit (CVE-2025-53770 & CVE-2025-53771)
 * Potential VIEWSTATE RCE Attempt on SharePoint/IIS
 * Potential Webshell Deployed via Apache Struts CVE-2023-50164 Exploitation
@@ -867,9 +1026,11 @@ Rules version: 8.19.22
 * RPC (Remote Procedure Call) to the Internet
 * React2Shell Network Security Alert
 * Roshal Archive (RAR) or PowerShell File Downloaded from the Internet
-* SMTP on Port 26/TCP
+* SMTP to the Internet on Port 26/TCP
+* Sensitive Identity File Open by Suspicious Process via Auditd
 * SentinelOne Alert External Alerts
 * SentinelOne Threat External Alerts
+* Splunk Enterprise PostgreSQL Recovery Endpoint Injection Artifacts
 * Splunk External Alerts
 * Stolen Credentials Used to Login to Okta Account After MFA Reset
 * Suricata and Elastic Defend Network Correlation
@@ -887,9 +1048,9 @@ Rules version: 8.19.22
 * Whoami Process Activity
 * Zoom Meeting with no Passcode
 
-### Unsupported function: match (32)
+### Unsupported function: match (33)
 
-32 rules:
+33 rules:
 * Alternate Data Stream Creation/Execution at Volume Root Directory
 * Command Obfuscation via Unicode Modifier Letters
 * Creation of Hidden Files and Directories via CommandLine
@@ -907,6 +1068,7 @@ Rules version: 8.19.22
 * Potential Exploitation of an Unquoted Service Path Vulnerability
 * Potential Linux Tunneling and/or Port Forwarding
 * Potential Linux Tunneling and/or Port Forwarding via Command Line
+* Potential SSH Reverse Port Forwarding
 * Potential Windows Error Manager Masquerading
 * Process Created with a Duplicated Token
 * Process Started from Process ID (PID) File
@@ -923,9 +1085,9 @@ Rules version: 8.19.22
 * Unusual Network Connection via RunDLL32
 * Unusual Process Execution Path - Alternate Data Stream
 
-### Unsupported function: stringContains (23)
+### Unsupported function: stringContains (25)
 
-23 rules:
+25 rules:
 * AWS EC2 EBS Snapshot Access Removed
 * AWS EC2 EBS Snapshot Shared or Made Public
 * AWS EC2 Instance Console Login via Assumed Role
@@ -936,7 +1098,9 @@ Rules version: 8.19.22
 * AWS IAM CompromisedKeyQuarantine Policy Attached to User
 * AWS IAM Login Profile Added for Root
 * AWS IAM Roles Anywhere Trust Anchor Created with External CA
+* AWS Lambda Function Policy Updated to Allow Cross-Account Invocation
 * AWS Lambda Function Policy Updated to Allow Public Invocation
+* AWS Lambda Function URL Created with Public Access
 * AWS RDS DB Instance Made Public
 * AWS RDS DB Instance or Cluster Deletion Protection Disabled
 * AWS RDS DB Instance or Cluster Password Modified
@@ -950,15 +1114,15 @@ Rules version: 8.19.22
 * AWS S3 Object Versioning Suspended
 * AWS Suspicious User Agent Fingerprint
 
-### Root with too many branches (limit: 10000) (18)
+### Root with too many branches (limit: 10000) (20)
 
-18 rules:
+20 rules:
 * Connection to Common Large Language Model Endpoints
 * Connection to Commonly Abused Web Services
 * Execution from Unusual Directory - Command Line
 * External IP Lookup from Non-Browser Process
-* GenAI Process Accessing Sensitive Files
 * GenAI or MCP Server Child Process Execution
+* Potential Copy Fail (CVE-2026-31431) Exploitation via AF_ALG Socket
 * Potential DNS Tunneling via NsLookup
 * Potential Evasion via Windows Filtering Platform
 * Potential External Linux SSH Brute Force Detected
@@ -969,6 +1133,8 @@ Rules version: 8.19.22
 * Potential Reverse Shell via Suspicious Binary
 * Potential Reverse Shell via Suspicious Child Process
 * Potential Successful SSH Brute Force Attack
+* Suspicious Child Execution via Web Server
+* Suspicious Command Execution via Web Server
 * Suspicious React Server Child Process
 * Unusual User Privilege Enumeration via id
 
@@ -987,37 +1153,41 @@ Rules version: 8.19.22
 * Suspicious Process Access via Direct System Call
 * Uncommon Registry Persistence Change
 
-### Root without branches (8)
+### Unsupported argument type(s): <class 'eql.ast.Field'> (10)
 
-8 rules:
-* Initramfs Extraction via CPIO
-* Interactive Terminal Spawned via Perl
-* Kubectl Configuration Discovery
-* Linux User or Group Deletion
-* Linux init (PID 1) Secret Dump via GDB
-* Potential Docker Escape via Nsenter
-* Potential Linux Backdoor User Account Creation
-* Suspicious Data Encryption via OpenSSL Utility
-
-### Unsupported argument type(s): <class 'eql.ast.Field'> (8)
-
-8 rules:
+10 rules:
 * External User Added to Google Workspace Group
 * Image Loaded with Invalid Signature
 * Interactive Logon by an Unusual Process
 * M365 Exchange Inbox Forwarding Rule Created
+* Payload Downloaded by Interpreter and Piped to Interpreter
+* Potential Privilege Escalation via SUID/SGID
 * Potential Ransomware Note File Dropped via SMB
 * Suspicious File Renamed via SMB
 * Unusual Network Activity from a Windows System Binary
 * Windows Service Installed via an Unusual Client
 
-### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (6)
+### Root without branches (9)
 
-6 rules:
+9 rules:
+* Initramfs Extraction via CPIO
+* Interactive Terminal Spawned via Perl
+* Kubectl Configuration Discovery
+* Linux User or Group Deletion
+* Linux init (PID 1) Secret Dump via GDB
+* Passwordless Sudo Probing
+* Potential Docker Escape via Nsenter
+* Potential Linux Backdoor User Account Creation
+* Suspicious Data Encryption via OpenSSL Utility
+
+### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)
+
+7 rules:
 * Execution via MS VisualStudio Pre/Post Build Events
 * Suspicious Execution from VS Code Extension
 * Suspicious Execution from a WebDav Share
 * Suspicious JetBrains TeamCity Child Process
+* Suspicious Microsoft HTML Application Child Process
 * Suspicious Shell Execution via Velociraptor
 * Suspicious Windows Command Shell Arguments
 
@@ -1035,6 +1205,20 @@ Rules version: 8.19.22
 * Network Connection from Binary with RWX Memory Region
 * Potential Meterpreter Reverse Shell
 * Potential Reverse Shell via UDP
+
+### Field type solver: match_only_text (3)
+
+3 rules:
+* Segfault Detected
+* Segfault from Sensitive Process Detected
+* Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)
+
+### Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)
+
+3 rules:
+* AWS SSM Session Manager Child Process Execution
+* Delayed Execution via Ping
+* Veeam Backup Library Loaded by Unusual Process
 
 ### Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)
 
@@ -1057,17 +1241,17 @@ Rules version: 8.19.22
 * Potential Machine Account Relay Attack via SMB
 * Unusual Execution via Microsoft Common Console File
 
-### Field type solver: match_only_text (2)
-
-2 rules:
-* Segfault Detected
-* Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)
-
 ### Unsolvable constraints: event.category & event.type (empty intersection) (2)
 
 2 rules:
 * File with Right-to-Left Override Character (RTLO) Created/Executed
 * Unsigned DLL loaded by DNS Service
+
+### Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)
+
+2 rules:
+* Base64 Decoded Payload Piped to Interpreter
+* Shared Object Load via LoLBin
 
 ### Unsolvable constraints: process.name (excluded by Strings({'rundll32.exe'}): ('rundll32.exe')) (2)
 
@@ -1080,6 +1264,12 @@ Rules version: 8.19.22
 2 rules:
 * Downloaded Shortcut Files
 * File with Suspicious Extension Downloaded
+
+### Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)
+
+2 rules:
+* Java Dropped and Executed With DNS Lookup
+* Suspicious Inter-Process Communication via Outlook
 
 ### Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)
 
@@ -1103,11 +1293,6 @@ Rules version: 8.19.22
 1 rules:
 * Potential Okta MFA Bombing via Push Notifications
 
-### Cannot choose from an empty set (1)
-
-1 rules:
-* DNS Request for IP Lookup Service via Unsigned Binary
-
 ### Unsolvable constraints: file.Ext.header_bytes (excluded by Strings({'504B0304*'}): ('504B0304*')) (1)
 
 1 rules:
@@ -1117,6 +1302,11 @@ Rules version: 8.19.22
 
 1 rules:
 * Pluggable Authentication Module or Configuration Creation
+
+### Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)
+
+1 rules:
+* GenAI Process Accessing Sensitive Files
 
 ### Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)
 
@@ -1197,6 +1387,11 @@ Rules version: 8.19.22
 
 1 rules:
 * Potential PowerShell Pass-the-Hash/Relay Script
+
+### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NdrClientCall'}): ('GetProcAddress')) (1)
+
+1 rules:
+* Potential AMSI Bypass via RPC Runtime Hooking
 
 ### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'New-MailboxExportRequest'}): ('-FilePath')) (1)
 
@@ -1333,6 +1528,11 @@ Rules version: 8.19.22
 1 rules:
 * Remote System Discovery Commands
 
+### Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (1)
+
+1 rules:
+* Suspicious macOS MS Office Child Process
+
 ### Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)
 
 1 rules:
@@ -1373,35 +1573,15 @@ Rules version: 8.19.22
 1 rules:
 * Curl or Wget Egress Network Connection via LoLBin
 
-### Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (1)
-
-1 rules:
-* Delayed Execution via Ping
-
-### Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (1)
-
-1 rules:
-* Base64 Decoded Payload Piped to Interpreter
-
 ### Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)
 
 1 rules:
 * Enumeration Command Spawned via WMIPrvSE
 
-### Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)
+### Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)
 
 1 rules:
-* Suspicious macOS MS Office Child Process
-
-### Unsolvable constraints: process.name (not in Strings({'java'}): ('.*')) (1)
-
-1 rules:
-* Suspicious Child Execution via Web Server
-
-### Unsolvable constraints: process.name (not in Strings({'pluginkit'}): ('python*')) (1)
-
-1 rules:
-* Finder Sync Plugin Registered and Enabled
+* Unusual Executable File Creation by a System Critical Process
 
 ### Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)
 
@@ -1468,6 +1648,11 @@ Rules version: 8.19.22
 1 rules:
 * Scheduled Task Execution at Scale via GPO
 
+### Unsolvable constraints: winlog.event_data.param1 (not in Strings({'*FullControl*'}): ('*setsharingmode*')) (1)
+
+1 rules:
+* Quick Assist Full Control Sharing Mode Enabled
+
 ### Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: < (1)
 
 1 rules:
@@ -1507,8 +1692,3 @@ Rules version: 8.19.22
 
 1 rules:
 * Machine Learning Detected a Suspicious Windows Event with a High Malicious Probability Score
-
-### Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (1)
-
-1 rules:
-* Suspicious Inter-Process Communication via Outlook

--- a/tests/reports/documents_from_rules-9.2.md
+++ b/tests/reports/documents_from_rules-9.2.md
@@ -5,41 +5,62 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.2.14
+Rules version: 9.2.19
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (186)](#unsupported-rule-type-new_terms-186)
-      1. [Unsupported rule type: esql (142)](#unsupported-rule-type-esql-142)
+      1. [Unsupported rule type: new_terms (214)](#unsupported-rule-type-new_terms-214)
+      1. [Unsupported rule type: esql (169)](#unsupported-rule-type-esql-169)
       1. [Unsupported rule type: machine_learning (95)](#unsupported-rule-type-machine_learning-95)
-      1. [Unsupported rule type: threshold (29)](#unsupported-rule-type-threshold-29)
+      1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Unsupported query language: lucene (4)](#unsupported-query-language-lucene-4)
+      1. [Unsupported query language: lucene (5)](#unsupported-query-language-lucene-5)
+      1. [Error at line:37,column:3
+Invalid syntax
+  *confluence/conf/server.xml
+  */.config/gcloud/application_default_credentials.json or
+  ^ (1)](#error-at-line37column3
+invalid-syntax
+--confluenceconfserverxml
+--configgcloudapplication_default_credentialsjson-or
+---1)
+      1. [Error at line:7,column:19
+Invalid syntax
+  process.name:(curl or wget) or
+  process.args:(* curl* or */bin/curl* or *wget*)
+                  ^ (1)](#error-at-line7column19
+invalid-syntax
+--processnamecurl-or-wget-or
+--processargs-curl-or-bincurl-or-wget
+-------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (274)](#field-type-solver-constant_keyword-274)
-      1. [Unsupported function: match (32)](#unsupported-function-match-32)
-      1. [Unsupported function: stringContains (23)](#unsupported-function-stringcontains-23)
-      1. [Root with too many branches (limit: 10000) (19)](#root-with-too-many-branches-limit-10000-19)
+      1. [Field type solver: constant_keyword (341)](#field-type-solver-constant_keyword-341)
+      1. [Unsupported function: match (33)](#unsupported-function-match-33)
+      1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
+      1. [Root with too many branches (limit: 10000) (21)](#root-with-too-many-branches-limit-10000-21)
       1. [Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)](#unsupported-lhs-type-class-eqlastfunctioncall-11)
-      1. [Root without branches (8)](#root-without-branches-8)
-      1. [Unsupported argument type(s): <class 'eql.ast.Field'> (8)](#unsupported-argument-types-class-eqlastfield-8)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (6)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-6)
+      1. [Unsupported argument type(s): <class 'eql.ast.Field'> (10)](#unsupported-argument-types-class-eqlastfield-10)
+      1. [Root without branches (9)](#root-without-branches-9)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-7)
       1. [Unsupported function: startsWith (4)](#unsupported-function-startswith-4)
       1. [<class 'eql.ast.Sample'> (3)](#class-eqlastsample-3)
+      1. [Field type solver: match_only_text (3)](#field-type-solver-match_only_text-3)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
       1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
-      1. [Field type solver: match_only_text (2)](#field-type-solver-match_only_text-2)
       1. [Unsolvable constraints: event.category & event.type (empty intersection) (2)](#unsolvable-constraints-eventcategory--eventtype-empty-intersection-2)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)](#unsolvable-constraints-processname-excluded-by-stringspython-python-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'rundll32.exe'}): ('rundll32.exe')) (2)](#unsolvable-constraints-processname-excluded-by-stringsrundll32exe-rundll32exe-2)
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
+      1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
-      1. [Cannot choose from an empty set (1)](#cannot-choose-from-an-empty-set-1)
       1. [Unsolvable constraints: file.Ext.header_bytes (excluded by Strings({'504B0304*'}): ('504B0304*')) (1)](#unsolvable-constraints-fileextheader_bytes-excluded-by-strings504b0304-504b0304-1)
       1. [Unsolvable constraints: file.extension (cannot be non-null) (1)](#unsolvable-constraints-fileextension-cannot-be-non-null-1)
+      1. [Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)](#unsolvable-constraints-filename-excluded-by-stringslocal-state-local-state-1)
       1. [Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)](#unsolvable-constraints-filename-not-in-stringsso-so-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringsswipuploadashx-post-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringschild_process-exec-1)
@@ -56,6 +77,7 @@ Rules version: 9.2.14
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'LsaCallAuthenticationPackage'}): ('KerbRetrieveEncodedTicketMessage')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringslsacallauthenticationpackage-kerbretrieveencodedticketmessage-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'Microsoft.Office.Interop.Outlook'}): ('MAPI')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsmicrosoftofficeinteropoutlook-mapi-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NTLMSSPNegotiate'}): ('NegotiateSMB')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsntlmsspnegotiate-negotiatesmb-1)
+      1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NdrClientCall'}): ('GetProcAddress')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsndrclientcall-getprocaddress-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'New-MailboxExportRequest'}): ('-FilePath')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsnew-mailboxexportrequest--filepath-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'STARTUPINFOEX'}): ('UpdateProcThreadAttribute')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsstartupinfoex-updateprocthreadattribute-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'Set-MpPreference'}): ('DisableArchiveScanning')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsset-mppreference-disablearchivescanning-1)
@@ -83,6 +105,7 @@ Rules version: 9.2.14
       1. [Unsolvable constraints: process.command_line (not in Strings({'*net.ipv4.ip_forward*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsnetipv4ip_forward-echo--1)
       1. [Unsolvable constraints: process.command_line (not in Strings({'*vm.swappiness*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsvmswappiness-echo--1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'arp.exe'}): ('arp.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsarpexe-arpexe-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (1)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)](#unsolvable-constraints-processname-excluded-by-stringscp-cp-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselevation_serviceexe-elevation_serviceexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (1)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-1)
@@ -91,12 +114,8 @@ Rules version: 9.2.14
       1. [Unsolvable constraints: process.name (excluded by Strings({'nc.traditional'}): ('nc.traditional')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnctraditional-nctraditional-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'net1.exe'}): ('net1.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnet1exe-net1exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nohup'}): ('nohup')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnohup-nohup-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (1)](#unsolvable-constraints-processname-excluded-by-stringspython-python-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsscexe-scexe-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)](#unsolvable-constraints-processname-excluded-by-stringssh-sh-1)
-      1. [Unsolvable constraints: process.name (not in Strings({'java'}): ('.*')) (1)](#unsolvable-constraints-processname-not-in-stringsjava--1)
-      1. [Unsolvable constraints: process.name (not in Strings({'pluginkit'}): ('python*')) (1)](#unsolvable-constraints-processname-not-in-stringspluginkit-python-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringssmssexe-smssexe-1)
       1. [Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)](#unsolvable-constraints-processname-not-in-stringsrundll32exe-mshtaexe-1)
       1. [Unsolvable constraints: process.parent.args (excluded by Strings({'WdiSystemHost'}): ('WdiSystemHost')) (1)](#unsolvable-constraints-processparentargs-excluded-by-stringswdisystemhost-wdisystemhost-1)
       1. [Unsolvable constraints: process.parent.name (excluded by Strings({'dllhost.exe'}): ('dllhost.exe')) (1)](#unsolvable-constraints-processparentname-excluded-by-stringsdllhostexe-dllhostexe-1)
@@ -110,6 +129,7 @@ Rules version: 9.2.14
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*42B5FAAE-6536-11D2-AE5A-0000F87571E3*'}): ('*40B66650-4972-11D1-A7CA-0000F87571E3*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-strings42b5faae-6536-11d2-ae5a-0000f87571e3-40b66650-4972-11d1-a7ca-0000f87571e3-1)
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*827D319E-6EAC-11D2-A4EA-00C04F79F83A*'}): ('*803E14A0-B4FB-11D0-A0D0-00A0C90F574B*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-strings827d319e-6eac-11d2-a4ea-00c04f79f83a-803e14a0-b4fb-11d0-a0d0-00a0c90f574b-1)
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*CAB54552-DEEA-4691-817E-ED4A4D1AFC72*'}): ('*AADCED64-746C-4633-A97C-D61349046527*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-stringscab54552-deea-4691-817e-ed4a4d1afc72-aadced64-746c-4633-a97c-d61349046527-1)
+      1. [Unsolvable constraints: winlog.event_data.param1 (not in Strings({'*FullControl*'}): ('*setsharingmode*')) (1)](#unsolvable-constraints-winlogevent_dataparam1-not-in-stringsfullcontrol-setsharingmode-1)
       1. [Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: < (1)](#unsupported-keyword-dllextrelative_file_creation_time-constraint--1)
       1. [Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: <= (1)](#unsupported-keyword-dllextrelative_file_creation_time-constraint--1)
       1. [Unsupported &keyword 'file.Ext.entropy' constraint: >= (1)](#unsupported-keyword-fileextentropy-constraint--1)
@@ -118,19 +138,25 @@ Rules version: 9.2.14
       1. [Unsupported &keyword 'powershell.file.script_block_length' constraint: > (1)](#unsupported-keyword-powershellfilescript_block_length-constraint--1)
       1. [Unsupported &keyword 'problemchild.prediction_probability' constraint: <= (1)](#unsupported-keyword-problemchildprediction_probability-constraint--1)
       1. [Unsupported &keyword 'problemchild.prediction_probability' constraint: > (1)](#unsupported-keyword-problemchildprediction_probability-constraint--1)
-      1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (1)](#unsupported-keyword-processextrelative_file_creation_time-constraint--1)
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (186)
+### Unsupported rule type: new_terms (214)
 
-186 rules:
+214 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
+* AWS Bedrock Agent or Action Group Manipulation
+* AWS Bedrock Knowledge Base or RAG Data Source Tampering
+* AWS Bedrock Resource-Based Policy Modified or Deleted
+* AWS Bedrock Third-Party or External Knowledge Base Associated to Agent
 * AWS CLI Command with Custom Endpoint URL
+* AWS Discovery API Calls from VPN ASN for the First Time by Identity
 * AWS DynamoDB Scan by Unusual User
 * AWS DynamoDB Table Exported to S3
+* AWS EC2 CreateKeyPair by New Principal from Non-Cloud AS Organization
+* AWS EC2 Role GetCallerIdentity from New Source AS Organization
 * AWS EC2 Route Table Created
 * AWS EC2 Route Table Modified or Deleted
 * AWS EC2 Unauthorized Admin Credential Fetch via Assumed Role
@@ -142,6 +168,8 @@ Rules version: 9.2.14
 * AWS IAM Customer-Managed Policy Attached to Role by Rare User
 * AWS IAM Long-Term Access Key First Seen from Source IP
 * AWS IAM OIDC Provider Created by Rare User
+* AWS Lambda Function Invoked by an Unusual Principal
+* AWS Lambda Function Invoked from an Unusual Source ASN
 * AWS S3 Unauthenticated Bucket Access by Rare Source
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
@@ -161,9 +189,12 @@ Rules version: 9.2.14
 * Abnormal Process ID or Lock File Created
 * Account or Group Discovery via Built-In Tools
 * Authentication via Unusual PAM Grantor
+* Azure AD Graph Access with Unusual Client and User
+* Azure AD Graph Access with Unusual User and ASN
 * Azure Arc Cluster Credential Access by Identity from Unusual Source
 * Azure Compute Restore Point Collection Deleted by Unusual User
 * Azure Compute Snapshot Deletion by Unusual User and Resource Group
+* Azure Compute VM Command Executed
 * Azure Diagnostic Settings Deleted
 * Azure Key Vault Modified
 * Azure Key Vault Unusual Secret Key Usage
@@ -171,12 +202,17 @@ Rules version: 9.2.14
 * Azure Storage Account Deletion by Unusual User
 * Azure Storage Account Keys Accessed by Privileged User
 * Azure Storage Blob Retrieval via AzCopy
+* Azure VM Extension CRUD Operation with Unusual Source ASN
+* Azure VM Managed Run Command Created or Updated with Unusual Principal
+* Azure VM Serial Console Connection with Unusual User and ASN
 * DPKG Package Installed by Unusual Parent Process
 * Delegated Managed Service Account Modification by an Unusual User
 * Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
+* Deprecated TLS Version or Weak Cipher Negotiated Externally
 * Discovery of Internet Capabilities via Built-in Tools
 * Entra ID Conditional Access Policy (CAP) Modified
+* Entra ID Device with ROADtools Default OS Build (Entity Analytics)
 * Entra ID Elevated Access to User Access Administrator
 * Entra ID External Authentication Methods (EAM) Modified
 * Entra ID OAuth Authorization Code Grant for Unusual User, App, and Resource
@@ -212,22 +248,27 @@ Rules version: 9.2.14
 * First Time Python Created a LaunchAgent or LaunchDaemon
 * First Time Python Spawned a Shell on Host
 * First Time Seen AWS Secret Value Accessed in Secrets Manager
+* First Time Seen Account Performing DCSync
 * First Time Seen Driver Loaded
 * First Time Seen Google Workspace OAuth Login from Third-Party Application
 * First Time Seen NewCredentials Logon Process
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
-* FirstTime Seen Account Performing DCSync
 * FortiGate Administrator Account Creation from Unusual Source
+* GKE Secrets List from Unusual Source AS Organization
+* GKE User Exec into Pod
 * GenAI Process Connection to Unusual Domain
 * GitHub Actions Unusual Bot Push to Repository
 * Github Activity on a Private Repository from an Unusual IP
+* Google Workspace User Login with Unusual ASN
+* Google Workspace User Sign-in from Atypical Device Type
 * Interactive Shell Launched via Unusual Parent Process in a Container
 * Kernel Object File Creation
 * Kill Command Execution
 * Kubernetes Anonymous Request Authorized by Unusual User Agent
 * Kubernetes Denied Service Account Request via Unusual User Agent
 * Kubernetes Forbidden Request from Unusual User Agent
+* Kubernetes Pod Creation Using Common Debug or Base Images
 * Kubernetes Secret Access via Unusual User Agent
 * Kubernetes Suspicious Self-Subject Review via Unusual User Agent
 * Kubernetes Unusual Decision by User Agent
@@ -240,7 +281,9 @@ Rules version: 9.2.14
 * M365 Exchange Inbox Phishing Evasion Rule Created
 * M365 Exchange Mailbox Accessed by Unusual Client
 * M365 Exchange Mailbox High-Risk Permission Delegated
-* M365 Identity Login from Atypical Travel Location
+* M365 Identity Device Code Grant by an Unusual User (Non-Compliant Device)
+* M365 Identity Device Code Grant with Unusual User and ASN
+* M365 Identity Login from Atypical Region
 * M365 Identity OAuth Illicit Consent Grant by Rare Client and User
 * M365 Identity Unusual SSO Authentication Errors for User
 * M365 SharePoint/OneDrive File Access via PowerShell
@@ -256,6 +299,7 @@ Rules version: 9.2.14
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
+* Potential ICMP Tunneling Activity to the Internet
 * Potential Pass-the-Hash (PtH) Attempt
 * Potential Privilege Escalation via Linux DAC permissions
 * Potential Shadow File Read via Command Line Utilities
@@ -266,6 +310,7 @@ Rules version: 9.2.14
 * RPM Package Installed by Unusual Parent Process
 * Rare SMB Connection to the Internet
 * Remote File Creation in World Writeable Directory
+* SMB (Windows File Sharing) Activity from the Internet
 * SMB (Windows File Sharing) Activity to the Internet
 * SSH Authorized Keys File Activity
 * Sensitive Files Compression
@@ -274,6 +319,7 @@ Rules version: 9.2.14
 * Successful SSH Authentication from Unusual IP Address
 * Successful SSH Authentication from Unusual SSH Public Key
 * Successful SSH Authentication from Unusual User
+* Suspicious Instance Metadata Service (IMDS) API Request
 * Suspicious Modprobe File Event
 * Suspicious Named Pipe Creation
 * Suspicious Network Activity to the Internet by Previously Unknown Executable
@@ -290,6 +336,8 @@ Rules version: 9.2.14
 * Unauthorized Scope for Public App OAuth2 Token Grant with Client Credentials
 * Unknown Execution of Binary with RWX Memory Region
 * Unusual AWS S3 Object Encryption with SSE-C
+* Unusual Child Execution via Web Server
+* Unusual Command Execution via Web Server
 * Unusual Discovery Signal Alert with Unusual Process Command Line
 * Unusual Discovery Signal Alert with Unusual Process Executable
 * Unusual Execution from Kernel Thread (kthreadd) Parent
@@ -309,38 +357,49 @@ Rules version: 9.2.14
 * Unusual SSHD Child Process
 * Unusual Scheduled Task Update
 * Unusual Web Config File Access
-* Unusual Web Server Command Execution
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (142)
+### Unsupported rule type: esql (169)
 
-142 rules:
+169 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock Detected Multiple Attempts to use Denied Models by a Single User
 * AWS Bedrock Detected Multiple Validation Exception Errors by a Single User
 * AWS Bedrock Guardrails Detected Multiple Policy Violations Within a Single Blocked Request
 * AWS Bedrock Guardrails Detected Multiple Violations by a Single User Over a Session
+* AWS Bedrock High-Frequency Single-Model Inference API Probing
 * AWS Bedrock Invocations without Guardrails Detected by a Single User Over a Session
 * AWS Credentials Used from GitHub Actions and Non-CI/CD Infrastructure
 * AWS Discovery API Calls via CLI from a Single Resource
 * AWS EC2 LOLBin Execution via SSM SendCommand
 * AWS EC2 Multi-Region DescribeInstances API Calls
+* AWS EC2 Stop, Start, and User Data Modification Correlation
+* AWS ECR Repository or Registry Policy Granted Public Access
 * AWS IAM Long-Term Access Key Correlated with Elevated Detection Alerts
+* AWS IAM User Console Login from Multiple Geolocations
 * AWS IAM User Created Access Keys For Another User
+* AWS Lambda Function High-Frequency Invocation by a Single Principal
+* AWS Lambda Function Invoked Cross-Account
+* AWS Lateral Movement from Kubernetes SA via AssumeRoleWithWebIdentity
 * AWS Rare Source AS Organization Activity
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
 * Agent Spoofing - Multiple Hosts Using Same Agent
 * Alerts From Multiple Integrations by Destination Address
 * Alerts From Multiple Integrations by Source Address
 * Alerts From Multiple Integrations by User Name
 * Alerts in Different ATT&CK Tactics by Host
+* Azure AD Graph Access with Suspicious User-Agent
+* Azure AD Graph High 4xx Error Ratio from User
+* Azure AD Graph Potential Enumeration (ROADrecon)
 * Azure Key Vault Excessive Secret or Key Retrieved
 * Azure OpenAI Insecure Output Handling
+* Azure Run Command Correlated with Process Execution
 * Command Line Obfuscation via Whitespace Padding
 * Correlated Alerts on Similar User Identities
 * Detection Alert on a Process Exhibiting CPU Spike
@@ -362,29 +421,42 @@ Rules version: 9.2.14
 * First-Time FortiGate Administrator Login
 * FortiGate Administrator Login from Multiple IP Addresses
 * FortiGate FortiCloud SSO Login from Unusual Source
+* GKE API Request Failure Burst by User
 * GitHub Actions Workflow Modification Blocked
 * GitHub Exfiltration via High Number of Repository Clones by User
+* Google Workspace Device Registration Burst for Single User
 * High Number of Closed Pull Requests by User
 * High Number of Egress Network Connections from Unusual Executable
 * High Number of Protected Branch Force Pushes by User
 * Kubernetes Creation or Modification of Sensitive Role
+* Kubernetes Multi-Resource Discovery
+* Kubernetes Pod Exec Cloud Instance Metadata Access
+* Kubernetes Pod Exec Potential Reverse Shell
+* Kubernetes Pod Exec Sensitive File or Credential Path Access
+* Kubernetes Pod Exec with Curl or Wget to HTTPS
 * Kubernetes Potential Endpoint Permission Enumeration Attempt Detected
 * Kubernetes Potential Endpoint Permission Enumeration Attempt by Anonymous User Detected
+* Kubernetes RBAC Wildcard Elevation on Existing Role
+* Kubernetes Rapid Secret GET Activity Against Multiple Objects
 * Kubernetes Secret or ConfigMap Access via Azure Arc Proxy
 * LSASS Process Access via Windows API
 * Lateral Movement Alerts from a Newly Observed Source Address
 * Lateral Movement Alerts from a Newly Observed User
 * Long Base64 Encoded Command via Scripting Interpreter
 * M365 Azure Monitor Alert Email with Financial or Billing Theme
+* M365 Exchange Inbox Rule with Obfuscated Name
 * M365 Identity OAuth Flow by First-Party Microsoft App from Multiple IPs
 * M365 Identity User Account Lockouts
 * M365 Identity User Brute Force Attempted
 * M365 OneDrive/SharePoint Excessive File Downloads
 * M365 or Entra ID Identity Sign-in from a Suspicious Source
+* Microsoft Graph Multi-Category Reconnaissance Burst
+* Multi-Cloud CLI Token and Credential Access Commands
 * Multiple Alerts Involving a User
 * Multiple Alerts in Same ATT&CK Tactic by Host
 * Multiple Alerts on a Host Exhibiting CPU Spike
 * Multiple Cloud Secrets Accessed by Source Address
+* Multiple DHCP Servers Responding to the Same Transaction
 * Multiple Device Token Hashes for Single Okta Session
 * Multiple Elastic Defend Alerts by Agent
 * Multiple Elastic Defend Alerts from a Single Process Tree
@@ -409,6 +481,8 @@ Rules version: 9.2.14
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
 * Potential Credential Discovery via Recursive Grep
+* Potential DHCP Starvation via High Client MAC Cardinality
+* Potential DNS Exfiltration via Excessive Chunked Queries
 * Potential Denial of Azure OpenAI ML Service
 * Potential Dynamic IEX Reconstruction via Environment Variables
 * Potential Linux Local Account Brute Force Detected
@@ -434,6 +508,7 @@ Rules version: 9.2.14
 * Potential PowerShell Obfuscation via String Concatenation
 * Potential PowerShell Obfuscation via String Reordering
 * Potential Ransomware Behavior - Note Files by System
+* Potential SQL Injection Against Microsoft SQL Server
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
 * Potential Widespread Malware Infection Across Multiple Hosts
@@ -441,18 +516,17 @@ Rules version: 9.2.14
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
 * Several Failed Protected Branch Force Pushes by User
+* Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
 * Suspected Lateral Movement from Compromised Host
 * Suspicious AWS S3 Connection via Script Interpreter
 * Suspicious Python Shell Command Execution
 * Suspicious TCC Access Granted for User Folders
 * Unusual Base64 Encoding/Decoding Activity
-* Unusual Command Execution from Web Server Parent
 * Unusual File Creation by Web Server
 * Unusual High Confidence Content Filter Blocks Detected
 * Unusual High Denied Sensitive Information Policy Blocks Detected
 * Unusual High Denied Topic Blocks Detected
 * Unusual High Word Policy Blocks Detected
-* Unusual Process Spawned from Web Server Parent
 * Web Server Discovery or Fuzzing Activity
 * Web Server Local File Inclusion Activity
 * Web Server Potential Command Injection Request
@@ -560,9 +634,9 @@ Rules version: 9.2.14
 * Unusual Windows Username
 * User Detected with Suspicious Windows Process(es)
 
-### Unsupported rule type: threshold (29)
+### Unsupported rule type: threshold (28)
 
-29 rules:
+28 rules:
 
 * AWS IAM Principal Enumeration via UpdateAssumeRolePolicy
 * AWS Management Console Brute Force of Root User Identity
@@ -572,7 +646,6 @@ Rules version: 9.2.14
 * Azure Compute Restore Point Collections Deleted
 * Azure Compute Snapshot Deletions by User
 * Azure Storage Account Deletions by User
-* Deprecated - Sudo Heap-Based Buffer Overflow Attempt
 * Entra ID Excessive Account Lockouts Detected
 * Excessive AWS S3 Object Encryption with SSE-C
 * GitHub UEBA - Multiple Alerts from a GitHub Account
@@ -605,20 +678,54 @@ Rules version: 9.2.14
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Unsupported query language: lucene (4)
+### Unsupported query language: lucene (5)
 
-4 rules:
+5 rules:
 
 * Cobalt Strike Command and Control Beacon
 * Halfbaked Command and Control Beacon
 * Inbound Connection to an Unsecure Elasticsearch Node
 * Possible FIN7 DGA Command and Control Behavior
+* Potential cPanel WHM CRLF Authentication Bypass (CVE-2026-41940)
+
+### Error at line:37,column:3
+Invalid syntax
+  *confluence/conf/server.xml
+  */.config/gcloud/application_default_credentials.json or
+  ^ (1)
+
+1 rules:
+
+* Kubernetes and Cloud Credential Path Access via Process Arguments
+
+### Error at line:7,column:19
+Invalid syntax
+  process.name:(curl or wget) or
+  process.args:(* curl* or */bin/curl* or *wget*)
+                  ^ (1)
+
+1 rules:
+
+* Curl or Wget Execution from Container Context
 
 ## Generation errors
 
-### Field type solver: constant_keyword (274)
+### Field type solver: constant_keyword (341)
 
-274 rules:
+341 rules:
+* AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
+* AWS Backup Recovery Point Deleted
+* AWS Backup Vault Deleted or Vault Lock Removed
+* AWS Bedrock Agent Created by IAM User or Root
+* AWS Bedrock Automated Reasoning Safety Policy Tampering
+* AWS Bedrock Foundation Model Access Enabled or Entitlement Granted
+* AWS Bedrock Foundation Model Enumeration Followed by Invocation via Long-Term Key
+* AWS Bedrock Guardrail Deleted or Weakened
+* AWS Bedrock Model Invocation Logging Disabled or Modified
+* AWS Bedrock Provisioned Model Throughput Tampering
+* AWS Bedrock Unauthorized Foundation Model Access Attempt
+* AWS Bedrock Unauthorized Resource-Based Policy Modification Attempt
+* AWS Bedrock Untrusted Model Imported or Marketplace Endpoint Registered
 * AWS CloudShell Environment Created
 * AWS CloudTrail Log Created
 * AWS CloudTrail Log Deleted
@@ -641,18 +748,29 @@ Rules version: 9.2.14
 * AWS EC2 Security Group Configuration Change
 * AWS EC2 Serial Console Access Enabled
 * AWS EFS File System Deleted
+* AWS EKS Access Entry Granted Cluster Admin Policy
+* AWS EKS Access Entry Modified
+* AWS EKS Control Plane Logging Disabled
 * AWS EventBridge Rule Disabled or Deleted
 * AWS GuardDuty Detector Deletion
 * AWS GuardDuty Member Account Manipulation
+* AWS IAM Account Password Policy Deleted
 * AWS IAM Deactivation of MFA Device
 * AWS IAM Group Creation
 * AWS IAM Group Deletion
+* AWS IAM Inline Policy Added to a Group
+* AWS IAM Login Profile Created or Modified for an IAM User
+* AWS IAM Permissions Boundary Modified or Removed
 * AWS IAM Roles Anywhere Profile Creation
 * AWS IAM SAML Provider Created
 * AWS IAM SAML Provider Updated
 * AWS IAM User Addition to Group
 * AWS KMS Customer Managed Key Disabled or Scheduled for Deletion
+* AWS KMS Imported Key Material Deleted
+* AWS Lambda Event Source Mapping Creation
+* AWS Lambda Function Deletion
 * AWS Lambda Layer Added to Existing Function
+* AWS Lambda Layer Shared Externally
 * AWS Management Console Root Login
 * AWS RDS DB Instance Restored
 * AWS RDS DB Instance or Cluster Deleted
@@ -662,6 +780,7 @@ Rules version: 9.2.14
 * AWS Route 53 Private Hosted Zone Associated With a VPC
 * AWS Route 53 Resolver Query Log Configuration Deleted
 * AWS S3 Bucket Configuration Deletion
+* AWS S3 Credential File Retrieved from Bucket
 * AWS SQS Queue Purge
 * AWS Sensitive IAM Operations Performed via CloudShell
 * AWS Sign-In Console Login with Federated User
@@ -696,7 +815,6 @@ Rules version: 9.2.14
 * Azure Automation Webhook Created
 * Azure Blob Storage Container Access Level Modified
 * Azure Blob Storage Permissions Modified
-* Azure Compute VM Command Executed
 * Azure Diagnostic Settings Alert Suppression Rule Created or Modified
 * Azure Event Hub Authorization Rule Created or Updated
 * Azure Event Hub Deleted
@@ -707,10 +825,13 @@ Rules version: 9.2.14
 * Azure Resource Group Deleted
 * Azure Service Principal Sign-In Followed by Arc Cluster Credential Access
 * Azure Storage Account Key Regenerated
+* Azure VM Boot Diagnostics Retrieved
+* Azure VM Extension Deployment by User
 * Azure VNet Firewall Front Door WAF Policy Deleted
 * Azure VNet Firewall Policy Deleted
 * Azure VNet Full Network Packet Capture Enabled
 * Azure VNet Network Watcher Deleted
+* Azure Virtual Machine Configuration Modified
 * Command and Scripting Interpreter via Windows Scripts
 * CrowdStrike External Alerts
 * CyberArk Privileged Access Security Error
@@ -723,21 +844,33 @@ Rules version: 9.2.14
 * Deprecated - M365 Security Compliance User Restricted from Sending Email
 * Deprecated - M365 Teams External Access Enabled
 * Deprecated - M365 Teams Guest Access Enabled
+* Deprecated - MFA Disabled for Google Workspace Organization
 * Domain Added to Google Workspace Trusted Domains
+* EKS Authentication Configuration Modified
 * Elastic Security External Alerts
 * Entra ID ADRS Token Request by Microsoft Authentication Broker
 * Entra ID Application Credential Modified
 * Entra ID Custom Domain Added or Verified
+* Entra ID Device Registration with ROADtools Default OS Build
 * Entra ID Domain Federation Configuration Change
 * Entra ID External Guest User Invited
 * Entra ID Global Administrator Role Assigned
 * Entra ID Global Administrator Role Assigned (PIM User)
+* Entra ID Guest Account Promoted to Member
 * Entra ID High Risk Sign-in
 * Entra ID High Risk User Sign-in Heuristic
+* Entra ID Kali365 Default User-Agent Detected
 * Entra ID MFA Disabled for User
+* Entra ID Microsoft Authentication Broker DRS Sign-In from Suspicious ASN
+* Entra ID Microsoft Authentication Broker Sign-In to Unusual Resource
+* Entra ID Microsoft Authentication Broker Sign-In with Non-Standard User Agent
+* Entra ID OAuth Application Redirect URI Modified
 * Entra ID OAuth Device Code Grant by Microsoft Authentication Broker
+* Entra ID OAuth Device Code Phishing via AiTM
+* Entra ID OAuth Device Code Sign-in to Azure AD Graph Enumeration
 * Entra ID OAuth PRT Issuance to Non-Managed Device Detected
 * Entra ID OAuth Phishing via First-Party Microsoft Application
+* Entra ID Potential AiTM Sign-In via OfficeHome (Tycoon2FA)
 * Entra ID PowerShell Sign-in
 * Entra ID Privileged Identity Management (PIM) Role Modified
 * Entra ID Protection - Risk Detection - Sign-in Risk
@@ -745,8 +878,10 @@ Rules version: 9.2.14
 * Entra ID Protection Admin Confirmed Compromise
 * Entra ID Protection Alerts for User Detected
 * Entra ID Protection User Alert and Device Registration
+* Entra ID Register Device with Unusual User Agent (Azure AD Join)
 * Entra ID Service Principal Created
 * Entra ID Sign-in TeamFiltration User-Agent Detected
+* Entra ID Temporary Access Pass Created for User
 * Entra ID Unusual Cloud Device Registration
 * Entra ID User Added as Registered Application Owner
 * Entra ID User Added as Service Principal Owner
@@ -783,36 +918,54 @@ Rules version: 9.2.14
 * GCP Virtual Private Cloud Network Deletion
 * GCP Virtual Private Cloud Route Creation
 * GCP Virtual Private Cloud Route Deletion
+* GKE Admission Webhook Created or Modified
+* GKE Cluster-Admin Role Binding Created or Modified
+* GKE Container Created with Excessive Linux Capabilities
+* GKE Pod Created With HostIPC
+* GKE Pod Created With HostNetwork
+* GKE Pod Created With HostPID
+* GKE Pod Created with a Sensitive hostPath Volume
+* GKE Privileged Pod Created
+* GKE Secret get or list with Suspicious User Agent
+* GKE Suspicious Self-Subject Review via Service Account
 * GitHub App Deleted
 * GitHub Owner Role Granted To User
 * GitHub Private Repository Turned Public
 * GitHub Protected Branch Settings Changed
 * GitHub Repository Deleted
 * GitHub Secret Scanning Disabled
-* Google Drive Ownership Transferred via Google Workspace
 * Google SecOps External Alerts
-* Google Workspace 2SV Policy Disabled
+* Google Workspace 2SV Policy Disabled By User
 * Google Workspace API Access Granted via Domain-Wide Delegation
-* Google Workspace Admin Role Assigned to a User
+* Google Workspace Admin Role Assigned to a User or Group
 * Google Workspace Admin Role Deletion
 * Google Workspace Bitlocker Setting Disabled
 * Google Workspace Custom Admin Role Created
-* Google Workspace Custom Gmail Route Created or Modified
+* Google Workspace Device Registration After OAuth from Suspicious ASN
+* Google Workspace Drive Data Transfer or Takeout Export Initiated
 * Google Workspace Drive Encryption Key(s) Accessed from Anonymous User
-* Google Workspace MFA Enforcement Disabled
-* Google Workspace Object Copied to External Drive with App Consent
+* Google Workspace Gmail Routing or Forwarding Rule Created or Modified
+* Google Workspace Login Flagged Suspicious
+* Google Workspace MFA Enforcement Disabled For Organization
+* Google Workspace Object Copied from External Drive with App Consent
 * Google Workspace Password Policy Modified
 * Google Workspace Restrictions for Marketplace Modified to Allow Any App
 * Google Workspace Role Modified
 * Google Workspace Suspended User Account Renewed
 * Google Workspace User Organizational Unit Changed
 * IBM QRadar External Alerts
+* ICMP Redirect Message from Internal Host
+* ICMP Timestamp or Information Request from the Internet
 * IPSEC NAT Traversal Port Activity
 * Initial Access via File Upload Followed by GET Request
 * Insecure AWS EC2 VPC Security Group Ingress Rule Added
+* Kubernetes API Request Impersonating Privileged Identity
 * Kubernetes Anonymous User Create/Update/Patch Pods Request
+* Kubernetes Client Certificate Signing Request Created or Approved
 * Kubernetes Cluster-Admin Role Binding Created
+* Kubernetes CoreDNS or Kube-DNS Configuration Modified
 * Kubernetes Creation of a RoleBinding Referencing a ServiceAccount
+* Kubernetes Ephemeral Container Added to Pod
 * Kubernetes Events Deleted
 * Kubernetes Exposed Service Created With Type NodePort
 * Kubernetes Forbidden Creation Request
@@ -821,8 +974,11 @@ Rules version: 9.2.14
 * Kubernetes Pod Created With HostPID
 * Kubernetes Pod Created with a Sensitive hostPath Volume
 * Kubernetes Privileged Pod Created
+* Kubernetes Secret get or list from Node or Pod Service Account
+* Kubernetes Secret get or list with Suspicious User Agent
 * Kubernetes Sensitive RBAC Change Followed by Workload Modification
 * Kubernetes Service Account Modified RBAC Objects
+* Kubernetes Service Account Token Created via TokenRequest API
 * Kubernetes Suspicious Assignment of Controller Service Account
 * Kubernetes User Exec into Pod
 * M365 Exchange Anti-Phish Policy Deleted
@@ -843,12 +999,13 @@ Rules version: 9.2.14
 * M365 Identity OAuth Flow by User Sign-in to Device Registration
 * M365 Identity OAuth Phishing via First-Party Microsoft Application
 * M365 OneDrive Malware File Upload
+* M365 Potential AiTM UserLoggedIn via Office App (Tycoon2FA)
 * M365 SharePoint Malware File Detected
 * M365 SharePoint Search for Sensitive Content
 * M365 SharePoint Site Administrator Added
 * M365 SharePoint Site Sharing Policy Weakened
 * M365 Teams Custom Application Interaction Enabled
-* MFA Disabled for Google Workspace Organization
+* M365 Teams Rogue Help Desk Chat Created
 * Microsoft Sentinel External Alerts
 * Modification or Removal of an Okta Application Sign-On Policy
 * New GitHub App Installed
@@ -860,10 +1017,12 @@ Rules version: 9.2.14
 * Okta User Assigned Administrator Role
 * Okta User Session Impersonation
 * Possible Okta DoS Attack
-* Potential Credential Access via Renamed COM+ Services DLL
 * Potential DLL Side-Loading via Trusted Microsoft Programs
 * Potential File Transfer via Curl for Windows
 * Potential Persistence via File Modification
+* Potential Redis CONFIG SET Cron Directory Persistence (RedisRaider)
+* Potential Redis CONFIG SET SSH Authorized Key Injection
+* Potential Redis Lua Use-After-Free RCE Attempt (CVE-2025-49844 / RediShell)
 * Potential Toolshell Initial Exploit (CVE-2025-53770 & CVE-2025-53771)
 * Potential VIEWSTATE RCE Attempt on SharePoint/IIS
 * Potential Webshell Deployed via Apache Struts CVE-2023-50164 Exploitation
@@ -874,9 +1033,11 @@ Rules version: 9.2.14
 * RPC (Remote Procedure Call) to the Internet
 * React2Shell Network Security Alert
 * Roshal Archive (RAR) or PowerShell File Downloaded from the Internet
-* SMTP on Port 26/TCP
+* SMTP to the Internet on Port 26/TCP
+* Sensitive Identity File Open by Suspicious Process via Auditd
 * SentinelOne Alert External Alerts
 * SentinelOne Threat External Alerts
+* Splunk Enterprise PostgreSQL Recovery Endpoint Injection Artifacts
 * Splunk External Alerts
 * Stolen Credentials Used to Login to Okta Account After MFA Reset
 * Suricata and Elastic Defend Network Correlation
@@ -894,9 +1055,9 @@ Rules version: 9.2.14
 * Whoami Process Activity
 * Zoom Meeting with no Passcode
 
-### Unsupported function: match (32)
+### Unsupported function: match (33)
 
-32 rules:
+33 rules:
 * Alternate Data Stream Creation/Execution at Volume Root Directory
 * Command Obfuscation via Unicode Modifier Letters
 * Creation of Hidden Files and Directories via CommandLine
@@ -914,6 +1075,7 @@ Rules version: 9.2.14
 * Potential Exploitation of an Unquoted Service Path Vulnerability
 * Potential Linux Tunneling and/or Port Forwarding
 * Potential Linux Tunneling and/or Port Forwarding via Command Line
+* Potential SSH Reverse Port Forwarding
 * Potential Windows Error Manager Masquerading
 * Process Created with a Duplicated Token
 * Process Started from Process ID (PID) File
@@ -930,9 +1092,9 @@ Rules version: 9.2.14
 * Unusual Network Connection via RunDLL32
 * Unusual Process Execution Path - Alternate Data Stream
 
-### Unsupported function: stringContains (23)
+### Unsupported function: stringContains (25)
 
-23 rules:
+25 rules:
 * AWS EC2 EBS Snapshot Access Removed
 * AWS EC2 EBS Snapshot Shared or Made Public
 * AWS EC2 Instance Console Login via Assumed Role
@@ -943,7 +1105,9 @@ Rules version: 9.2.14
 * AWS IAM CompromisedKeyQuarantine Policy Attached to User
 * AWS IAM Login Profile Added for Root
 * AWS IAM Roles Anywhere Trust Anchor Created with External CA
+* AWS Lambda Function Policy Updated to Allow Cross-Account Invocation
 * AWS Lambda Function Policy Updated to Allow Public Invocation
+* AWS Lambda Function URL Created with Public Access
 * AWS RDS DB Instance Made Public
 * AWS RDS DB Instance or Cluster Deletion Protection Disabled
 * AWS RDS DB Instance or Cluster Password Modified
@@ -957,16 +1121,16 @@ Rules version: 9.2.14
 * AWS S3 Object Versioning Suspended
 * AWS Suspicious User Agent Fingerprint
 
-### Root with too many branches (limit: 10000) (19)
+### Root with too many branches (limit: 10000) (21)
 
-19 rules:
+21 rules:
 * Connection to Common Large Language Model Endpoints
 * Connection to Commonly Abused Web Services
 * Execution from Unusual Directory - Command Line
 * Execution of a Downloaded Windows Script
 * External IP Lookup from Non-Browser Process
-* GenAI Process Accessing Sensitive Files
 * GenAI or MCP Server Child Process Execution
+* Potential Copy Fail (CVE-2026-31431) Exploitation via AF_ALG Socket
 * Potential DNS Tunneling via NsLookup
 * Potential Evasion via Windows Filtering Platform
 * Potential External Linux SSH Brute Force Detected
@@ -977,6 +1141,8 @@ Rules version: 9.2.14
 * Potential Reverse Shell via Suspicious Binary
 * Potential Reverse Shell via Suspicious Child Process
 * Potential Successful SSH Brute Force Attack
+* Suspicious Child Execution via Web Server
+* Suspicious Command Execution via Web Server
 * Suspicious React Server Child Process
 * Unusual User Privilege Enumeration via id
 
@@ -995,37 +1161,41 @@ Rules version: 9.2.14
 * Suspicious Process Access via Direct System Call
 * Uncommon Registry Persistence Change
 
-### Root without branches (8)
+### Unsupported argument type(s): <class 'eql.ast.Field'> (10)
 
-8 rules:
-* Initramfs Extraction via CPIO
-* Interactive Terminal Spawned via Perl
-* Kubectl Configuration Discovery
-* Linux User or Group Deletion
-* Linux init (PID 1) Secret Dump via GDB
-* Potential Docker Escape via Nsenter
-* Potential Linux Backdoor User Account Creation
-* Suspicious Data Encryption via OpenSSL Utility
-
-### Unsupported argument type(s): <class 'eql.ast.Field'> (8)
-
-8 rules:
+10 rules:
 * External User Added to Google Workspace Group
 * Image Loaded with Invalid Signature
 * Interactive Logon by an Unusual Process
 * M365 Exchange Inbox Forwarding Rule Created
+* Payload Downloaded by Interpreter and Piped to Interpreter
+* Potential Privilege Escalation via SUID/SGID
 * Potential Ransomware Note File Dropped via SMB
 * Suspicious File Renamed via SMB
 * Unusual Network Activity from a Windows System Binary
 * Windows Service Installed via an Unusual Client
 
-### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (6)
+### Root without branches (9)
 
-6 rules:
+9 rules:
+* Initramfs Extraction via CPIO
+* Interactive Terminal Spawned via Perl
+* Kubectl Configuration Discovery
+* Linux User or Group Deletion
+* Linux init (PID 1) Secret Dump via GDB
+* Passwordless Sudo Probing
+* Potential Docker Escape via Nsenter
+* Potential Linux Backdoor User Account Creation
+* Suspicious Data Encryption via OpenSSL Utility
+
+### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)
+
+7 rules:
 * Execution via MS VisualStudio Pre/Post Build Events
 * Suspicious Execution from VS Code Extension
 * Suspicious Execution from a WebDav Share
 * Suspicious JetBrains TeamCity Child Process
+* Suspicious Microsoft HTML Application Child Process
 * Suspicious Shell Execution via Velociraptor
 * Suspicious Windows Command Shell Arguments
 
@@ -1043,6 +1213,20 @@ Rules version: 9.2.14
 * Network Connection from Binary with RWX Memory Region
 * Potential Meterpreter Reverse Shell
 * Potential Reverse Shell via UDP
+
+### Field type solver: match_only_text (3)
+
+3 rules:
+* Segfault Detected
+* Segfault from Sensitive Process Detected
+* Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)
+
+### Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)
+
+3 rules:
+* AWS SSM Session Manager Child Process Execution
+* Delayed Execution via Ping
+* Veeam Backup Library Loaded by Unusual Process
 
 ### Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)
 
@@ -1065,17 +1249,17 @@ Rules version: 9.2.14
 * Potential Machine Account Relay Attack via SMB
 * Unusual Execution via Microsoft Common Console File
 
-### Field type solver: match_only_text (2)
-
-2 rules:
-* Segfault Detected
-* Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)
-
 ### Unsolvable constraints: event.category & event.type (empty intersection) (2)
 
 2 rules:
 * File with Right-to-Left Override Character (RTLO) Created/Executed
 * Unsigned DLL loaded by DNS Service
+
+### Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)
+
+2 rules:
+* Base64 Decoded Payload Piped to Interpreter
+* Shared Object Load via LoLBin
 
 ### Unsolvable constraints: process.name (excluded by Strings({'rundll32.exe'}): ('rundll32.exe')) (2)
 
@@ -1088,6 +1272,12 @@ Rules version: 9.2.14
 2 rules:
 * Downloaded Shortcut Files
 * File with Suspicious Extension Downloaded
+
+### Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)
+
+2 rules:
+* Java Dropped and Executed With DNS Lookup
+* Suspicious Inter-Process Communication via Outlook
 
 ### Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)
 
@@ -1111,11 +1301,6 @@ Rules version: 9.2.14
 1 rules:
 * Potential Okta MFA Bombing via Push Notifications
 
-### Cannot choose from an empty set (1)
-
-1 rules:
-* DNS Request for IP Lookup Service via Unsigned Binary
-
 ### Unsolvable constraints: file.Ext.header_bytes (excluded by Strings({'504B0304*'}): ('504B0304*')) (1)
 
 1 rules:
@@ -1125,6 +1310,11 @@ Rules version: 9.2.14
 
 1 rules:
 * Pluggable Authentication Module or Configuration Creation
+
+### Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)
+
+1 rules:
+* GenAI Process Accessing Sensitive Files
 
 ### Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)
 
@@ -1205,6 +1395,11 @@ Rules version: 9.2.14
 
 1 rules:
 * Potential PowerShell Pass-the-Hash/Relay Script
+
+### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NdrClientCall'}): ('GetProcAddress')) (1)
+
+1 rules:
+* Potential AMSI Bypass via RPC Runtime Hooking
 
 ### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'New-MailboxExportRequest'}): ('-FilePath')) (1)
 
@@ -1341,6 +1536,11 @@ Rules version: 9.2.14
 1 rules:
 * Remote System Discovery Commands
 
+### Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (1)
+
+1 rules:
+* Suspicious macOS MS Office Child Process
+
 ### Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)
 
 1 rules:
@@ -1381,35 +1581,15 @@ Rules version: 9.2.14
 1 rules:
 * Curl or Wget Egress Network Connection via LoLBin
 
-### Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (1)
-
-1 rules:
-* Delayed Execution via Ping
-
-### Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (1)
-
-1 rules:
-* Base64 Decoded Payload Piped to Interpreter
-
 ### Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)
 
 1 rules:
 * Enumeration Command Spawned via WMIPrvSE
 
-### Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)
+### Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)
 
 1 rules:
-* Suspicious macOS MS Office Child Process
-
-### Unsolvable constraints: process.name (not in Strings({'java'}): ('.*')) (1)
-
-1 rules:
-* Suspicious Child Execution via Web Server
-
-### Unsolvable constraints: process.name (not in Strings({'pluginkit'}): ('python*')) (1)
-
-1 rules:
-* Finder Sync Plugin Registered and Enabled
+* Unusual Executable File Creation by a System Critical Process
 
 ### Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)
 
@@ -1476,6 +1656,11 @@ Rules version: 9.2.14
 1 rules:
 * Scheduled Task Execution at Scale via GPO
 
+### Unsolvable constraints: winlog.event_data.param1 (not in Strings({'*FullControl*'}): ('*setsharingmode*')) (1)
+
+1 rules:
+* Quick Assist Full Control Sharing Mode Enabled
+
 ### Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: < (1)
 
 1 rules:
@@ -1515,8 +1700,3 @@ Rules version: 9.2.14
 
 1 rules:
 * Machine Learning Detected a Suspicious Windows Event with a High Malicious Probability Score
-
-### Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (1)
-
-1 rules:
-* Suspicious Inter-Process Communication via Outlook

--- a/tests/reports/documents_from_rules-9.3.md
+++ b/tests/reports/documents_from_rules-9.3.md
@@ -5,43 +5,64 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.10
+Rules version: 9.3.15
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (186)](#unsupported-rule-type-new_terms-186)
-      1. [Unsupported rule type: esql (148)](#unsupported-rule-type-esql-148)
+      1. [Unsupported rule type: new_terms (215)](#unsupported-rule-type-new_terms-215)
+      1. [Unsupported rule type: esql (175)](#unsupported-rule-type-esql-175)
       1. [Unsupported rule type: machine_learning (105)](#unsupported-rule-type-machine_learning-105)
-      1. [Unsupported rule type: threshold (29)](#unsupported-rule-type-threshold-29)
+      1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Unsupported query language: lucene (4)](#unsupported-query-language-lucene-4)
+      1. [Unsupported query language: lucene (5)](#unsupported-query-language-lucene-5)
+      1. [Error at line:37,column:3
+Invalid syntax
+  *confluence/conf/server.xml
+  */.config/gcloud/application_default_credentials.json or
+  ^ (1)](#error-at-line37column3
+invalid-syntax
+--confluenceconfserverxml
+--configgcloudapplication_default_credentialsjson-or
+---1)
+      1. [Error at line:7,column:19
+Invalid syntax
+  process.name:(curl or wget) or
+  process.args:(* curl* or */bin/curl* or *wget*)
+                  ^ (1)](#error-at-line7column19
+invalid-syntax
+--processnamecurl-or-wget-or
+--processargs-curl-or-bincurl-or-wget
+-------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (278)](#field-type-solver-constant_keyword-278)
+      1. [Field type solver: constant_keyword (345)](#field-type-solver-constant_keyword-345)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
-      1. [Unsupported function: stringContains (23)](#unsupported-function-stringcontains-23)
-      1. [Root with too many branches (limit: 10000) (22)](#root-with-too-many-branches-limit-10000-22)
+      1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
+      1. [Root with too many branches (limit: 10000) (24)](#root-with-too-many-branches-limit-10000-24)
+      1. [Root without branches (11)](#root-without-branches-11)
       1. [Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)](#unsupported-lhs-type-class-eqlastfunctioncall-11)
-      1. [Root without branches (10)](#root-without-branches-10)
-      1. [Unsupported argument type(s): <class 'eql.ast.Field'> (8)](#unsupported-argument-types-class-eqlastfield-8)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (6)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-6)
+      1. [Unsupported argument type(s): <class 'eql.ast.Field'> (10)](#unsupported-argument-types-class-eqlastfield-10)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-7)
       1. [Unsupported function: startsWith (4)](#unsupported-function-startswith-4)
       1. [<class 'eql.ast.Sample'> (3)](#class-eqlastsample-3)
+      1. [Field type solver: match_only_text (3)](#field-type-solver-match_only_text-3)
       1. [Unsolvable constraints: event.category & event.type (empty intersection) (3)](#unsolvable-constraints-eventcategory--eventtype-empty-intersection-3)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
       1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
-      1. [Field type solver: match_only_text (2)](#field-type-solver-match_only_text-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nc.traditional'}): ('nc.traditional')) (2)](#unsolvable-constraints-processname-excluded-by-stringsnctraditional-nctraditional-2)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)](#unsolvable-constraints-processname-excluded-by-stringspython-python-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'rundll32.exe'}): ('rundll32.exe')) (2)](#unsolvable-constraints-processname-excluded-by-stringsrundll32exe-rundll32exe-2)
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
+      1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
-      1. [Cannot choose from an empty set (1)](#cannot-choose-from-an-empty-set-1)
       1. [Unsolvable constraints: file.Ext.header_bytes (excluded by Strings({'504B0304*'}): ('504B0304*')) (1)](#unsolvable-constraints-fileextheader_bytes-excluded-by-strings504b0304-504b0304-1)
       1. [Unsolvable constraints: file.extension (cannot be non-null) (1)](#unsolvable-constraints-fileextension-cannot-be-non-null-1)
+      1. [Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)](#unsolvable-constraints-filename-excluded-by-stringslocal-state-local-state-1)
       1. [Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)](#unsolvable-constraints-filename-not-in-stringsso-so-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringsswipuploadashx-post-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringschild_process-exec-1)
@@ -58,6 +79,7 @@ Rules version: 9.3.10
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'LsaCallAuthenticationPackage'}): ('KerbRetrieveEncodedTicketMessage')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringslsacallauthenticationpackage-kerbretrieveencodedticketmessage-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'Microsoft.Office.Interop.Outlook'}): ('MAPI')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsmicrosoftofficeinteropoutlook-mapi-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NTLMSSPNegotiate'}): ('NegotiateSMB')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsntlmsspnegotiate-negotiatesmb-1)
+      1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NdrClientCall'}): ('GetProcAddress')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsndrclientcall-getprocaddress-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'New-MailboxExportRequest'}): ('-FilePath')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsnew-mailboxexportrequest--filepath-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'STARTUPINFOEX'}): ('UpdateProcThreadAttribute')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsstartupinfoex-updateprocthreadattribute-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'Set-MpPreference'}): ('DisableArchiveScanning')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsset-mppreference-disablearchivescanning-1)
@@ -85,18 +107,15 @@ Rules version: 9.3.10
       1. [Unsolvable constraints: process.command_line (not in Strings({'*net.ipv4.ip_forward*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsnetipv4ip_forward-echo--1)
       1. [Unsolvable constraints: process.command_line (not in Strings({'*vm.swappiness*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsvmswappiness-echo--1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'arp.exe'}): ('arp.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsarpexe-arpexe-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (1)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)](#unsolvable-constraints-processname-excluded-by-stringscp-cp-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselevation_serviceexe-elevation_serviceexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msdt.exe'}): ('msdt.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsdtexe-msdtexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msedgewebview2.exe'}): ('msedgewebview2.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsedgewebview2exe-msedgewebview2exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'net1.exe'}): ('net1.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnet1exe-net1exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nohup'}): ('nohup')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnohup-nohup-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (1)](#unsolvable-constraints-processname-excluded-by-stringspython-python-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsscexe-scexe-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)](#unsolvable-constraints-processname-excluded-by-stringssh-sh-1)
-      1. [Unsolvable constraints: process.name (not in Strings({'java'}): ('.*')) (1)](#unsolvable-constraints-processname-not-in-stringsjava--1)
-      1. [Unsolvable constraints: process.name (not in Strings({'pluginkit'}): ('python*')) (1)](#unsolvable-constraints-processname-not-in-stringspluginkit-python-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringssmssexe-smssexe-1)
       1. [Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)](#unsolvable-constraints-processname-not-in-stringsrundll32exe-mshtaexe-1)
       1. [Unsolvable constraints: process.parent.args (excluded by Strings({'WdiSystemHost'}): ('WdiSystemHost')) (1)](#unsolvable-constraints-processparentargs-excluded-by-stringswdisystemhost-wdisystemhost-1)
       1. [Unsolvable constraints: process.parent.name (excluded by Strings({'dllhost.exe'}): ('dllhost.exe')) (1)](#unsolvable-constraints-processparentname-excluded-by-stringsdllhostexe-dllhostexe-1)
@@ -110,6 +129,7 @@ Rules version: 9.3.10
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*42B5FAAE-6536-11D2-AE5A-0000F87571E3*'}): ('*40B66650-4972-11D1-A7CA-0000F87571E3*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-strings42b5faae-6536-11d2-ae5a-0000f87571e3-40b66650-4972-11d1-a7ca-0000f87571e3-1)
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*827D319E-6EAC-11D2-A4EA-00C04F79F83A*'}): ('*803E14A0-B4FB-11D0-A0D0-00A0C90F574B*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-strings827d319e-6eac-11d2-a4ea-00c04f79f83a-803e14a0-b4fb-11d0-a0d0-00a0c90f574b-1)
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*CAB54552-DEEA-4691-817E-ED4A4D1AFC72*'}): ('*AADCED64-746C-4633-A97C-D61349046527*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-stringscab54552-deea-4691-817e-ed4a4d1afc72-aadced64-746c-4633-a97c-d61349046527-1)
+      1. [Unsolvable constraints: winlog.event_data.param1 (not in Strings({'*FullControl*'}): ('*setsharingmode*')) (1)](#unsolvable-constraints-winlogevent_dataparam1-not-in-stringsfullcontrol-setsharingmode-1)
       1. [Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: < (1)](#unsupported-keyword-dllextrelative_file_creation_time-constraint--1)
       1. [Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: <= (1)](#unsupported-keyword-dllextrelative_file_creation_time-constraint--1)
       1. [Unsupported &keyword 'file.Ext.entropy' constraint: >= (1)](#unsupported-keyword-fileextentropy-constraint--1)
@@ -118,19 +138,25 @@ Rules version: 9.3.10
       1. [Unsupported &keyword 'powershell.file.script_block_length' constraint: > (1)](#unsupported-keyword-powershellfilescript_block_length-constraint--1)
       1. [Unsupported &keyword 'problemchild.prediction_probability' constraint: <= (1)](#unsupported-keyword-problemchildprediction_probability-constraint--1)
       1. [Unsupported &keyword 'problemchild.prediction_probability' constraint: > (1)](#unsupported-keyword-problemchildprediction_probability-constraint--1)
-      1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (1)](#unsupported-keyword-processextrelative_file_creation_time-constraint--1)
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (186)
+### Unsupported rule type: new_terms (215)
 
-186 rules:
+215 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
+* AWS Bedrock Agent or Action Group Manipulation
+* AWS Bedrock Knowledge Base or RAG Data Source Tampering
+* AWS Bedrock Resource-Based Policy Modified or Deleted
+* AWS Bedrock Third-Party or External Knowledge Base Associated to Agent
 * AWS CLI Command with Custom Endpoint URL
+* AWS Discovery API Calls from VPN ASN for the First Time by Identity
 * AWS DynamoDB Scan by Unusual User
 * AWS DynamoDB Table Exported to S3
+* AWS EC2 CreateKeyPair by New Principal from Non-Cloud AS Organization
+* AWS EC2 Role GetCallerIdentity from New Source AS Organization
 * AWS EC2 Route Table Created
 * AWS EC2 Route Table Modified or Deleted
 * AWS EC2 Unauthorized Admin Credential Fetch via Assumed Role
@@ -142,6 +168,8 @@ Rules version: 9.3.10
 * AWS IAM Customer-Managed Policy Attached to Role by Rare User
 * AWS IAM Long-Term Access Key First Seen from Source IP
 * AWS IAM OIDC Provider Created by Rare User
+* AWS Lambda Function Invoked by an Unusual Principal
+* AWS Lambda Function Invoked from an Unusual Source ASN
 * AWS S3 Unauthenticated Bucket Access by Rare Source
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
@@ -161,9 +189,12 @@ Rules version: 9.3.10
 * Abnormal Process ID or Lock File Created
 * Account or Group Discovery via Built-In Tools
 * Authentication via Unusual PAM Grantor
+* Azure AD Graph Access with Unusual Client and User
+* Azure AD Graph Access with Unusual User and ASN
 * Azure Arc Cluster Credential Access by Identity from Unusual Source
 * Azure Compute Restore Point Collection Deleted by Unusual User
 * Azure Compute Snapshot Deletion by Unusual User and Resource Group
+* Azure Compute VM Command Executed
 * Azure Diagnostic Settings Deleted
 * Azure Key Vault Modified
 * Azure Key Vault Unusual Secret Key Usage
@@ -171,12 +202,17 @@ Rules version: 9.3.10
 * Azure Storage Account Deletion by Unusual User
 * Azure Storage Account Keys Accessed by Privileged User
 * Azure Storage Blob Retrieval via AzCopy
+* Azure VM Extension CRUD Operation with Unusual Source ASN
+* Azure VM Managed Run Command Created or Updated with Unusual Principal
+* Azure VM Serial Console Connection with Unusual User and ASN
 * DPKG Package Installed by Unusual Parent Process
 * Delegated Managed Service Account Modification by an Unusual User
 * Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
+* Deprecated TLS Version or Weak Cipher Negotiated Externally
 * Discovery of Internet Capabilities via Built-in Tools
 * Entra ID Conditional Access Policy (CAP) Modified
+* Entra ID Device with ROADtools Default OS Build (Entity Analytics)
 * Entra ID Elevated Access to User Access Administrator
 * Entra ID External Authentication Methods (EAM) Modified
 * Entra ID OAuth Authorization Code Grant for Unusual User, App, and Resource
@@ -212,22 +248,27 @@ Rules version: 9.3.10
 * First Time Python Created a LaunchAgent or LaunchDaemon
 * First Time Python Spawned a Shell on Host
 * First Time Seen AWS Secret Value Accessed in Secrets Manager
+* First Time Seen Account Performing DCSync
 * First Time Seen Driver Loaded
 * First Time Seen Google Workspace OAuth Login from Third-Party Application
 * First Time Seen NewCredentials Logon Process
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
-* FirstTime Seen Account Performing DCSync
 * FortiGate Administrator Account Creation from Unusual Source
+* GKE Secrets List from Unusual Source AS Organization
+* GKE User Exec into Pod
 * GenAI Process Connection to Unusual Domain
 * GitHub Actions Unusual Bot Push to Repository
 * Github Activity on a Private Repository from an Unusual IP
+* Google Workspace User Login with Unusual ASN
+* Google Workspace User Sign-in from Atypical Device Type
 * Interactive Shell Launched via Unusual Parent Process in a Container
 * Kernel Object File Creation
 * Kill Command Execution
 * Kubernetes Anonymous Request Authorized by Unusual User Agent
 * Kubernetes Denied Service Account Request via Unusual User Agent
 * Kubernetes Forbidden Request from Unusual User Agent
+* Kubernetes Pod Creation Using Common Debug or Base Images
 * Kubernetes Secret Access via Unusual User Agent
 * Kubernetes Suspicious Self-Subject Review via Unusual User Agent
 * Kubernetes Unusual Decision by User Agent
@@ -240,7 +281,9 @@ Rules version: 9.3.10
 * M365 Exchange Inbox Phishing Evasion Rule Created
 * M365 Exchange Mailbox Accessed by Unusual Client
 * M365 Exchange Mailbox High-Risk Permission Delegated
-* M365 Identity Login from Atypical Travel Location
+* M365 Identity Device Code Grant by an Unusual User (Non-Compliant Device)
+* M365 Identity Device Code Grant with Unusual User and ASN
+* M365 Identity Login from Atypical Region
 * M365 Identity OAuth Illicit Consent Grant by Rare Client and User
 * M365 Identity Unusual SSO Authentication Errors for User
 * M365 SharePoint/OneDrive File Access via PowerShell
@@ -256,6 +299,7 @@ Rules version: 9.3.10
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
+* Potential ICMP Tunneling Activity to the Internet
 * Potential Pass-the-Hash (PtH) Attempt
 * Potential Privilege Escalation via Linux DAC permissions
 * Potential Shadow File Read via Command Line Utilities
@@ -266,6 +310,7 @@ Rules version: 9.3.10
 * RPM Package Installed by Unusual Parent Process
 * Rare SMB Connection to the Internet
 * Remote File Creation in World Writeable Directory
+* SMB (Windows File Sharing) Activity from the Internet
 * SMB (Windows File Sharing) Activity to the Internet
 * SSH Authorized Keys File Activity
 * Sensitive Files Compression
@@ -274,6 +319,7 @@ Rules version: 9.3.10
 * Successful SSH Authentication from Unusual IP Address
 * Successful SSH Authentication from Unusual SSH Public Key
 * Successful SSH Authentication from Unusual User
+* Suspicious Instance Metadata Service (IMDS) API Request
 * Suspicious Modprobe File Event
 * Suspicious Named Pipe Creation
 * Suspicious Network Activity to the Internet by Previously Unknown Executable
@@ -288,8 +334,11 @@ Rules version: 9.3.10
 * Systemd Service Started by Unusual Parent Process
 * UID Elevation from Previously Unknown Executable
 * Unauthorized Scope for Public App OAuth2 Token Grant with Client Credentials
+* Uncommon DNS Request via Bun or Node.js
 * Unknown Execution of Binary with RWX Memory Region
 * Unusual AWS S3 Object Encryption with SSE-C
+* Unusual Child Execution via Web Server
+* Unusual Command Execution via Web Server
 * Unusual Discovery Signal Alert with Unusual Process Command Line
 * Unusual Discovery Signal Alert with Unusual Process Executable
 * Unusual Execution from Kernel Thread (kthreadd) Parent
@@ -309,38 +358,49 @@ Rules version: 9.3.10
 * Unusual SSHD Child Process
 * Unusual Scheduled Task Update
 * Unusual Web Config File Access
-* Unusual Web Server Command Execution
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (148)
+### Unsupported rule type: esql (175)
 
-148 rules:
+175 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock Detected Multiple Attempts to use Denied Models by a Single User
 * AWS Bedrock Detected Multiple Validation Exception Errors by a Single User
 * AWS Bedrock Guardrails Detected Multiple Policy Violations Within a Single Blocked Request
 * AWS Bedrock Guardrails Detected Multiple Violations by a Single User Over a Session
+* AWS Bedrock High-Frequency Single-Model Inference API Probing
 * AWS Bedrock Invocations without Guardrails Detected by a Single User Over a Session
 * AWS Credentials Used from GitHub Actions and Non-CI/CD Infrastructure
 * AWS Discovery API Calls via CLI from a Single Resource
 * AWS EC2 LOLBin Execution via SSM SendCommand
 * AWS EC2 Multi-Region DescribeInstances API Calls
+* AWS EC2 Stop, Start, and User Data Modification Correlation
+* AWS ECR Repository or Registry Policy Granted Public Access
 * AWS IAM Long-Term Access Key Correlated with Elevated Detection Alerts
+* AWS IAM User Console Login from Multiple Geolocations
 * AWS IAM User Created Access Keys For Another User
+* AWS Lambda Function High-Frequency Invocation by a Single Principal
+* AWS Lambda Function Invoked Cross-Account
+* AWS Lateral Movement from Kubernetes SA via AssumeRoleWithWebIdentity
 * AWS Rare Source AS Organization Activity
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
 * Agent Spoofing - Multiple Hosts Using Same Agent
 * Alerts From Multiple Integrations by Destination Address
 * Alerts From Multiple Integrations by Source Address
 * Alerts From Multiple Integrations by User Name
 * Alerts in Different ATT&CK Tactics by Host
+* Azure AD Graph Access with Suspicious User-Agent
+* Azure AD Graph High 4xx Error Ratio from User
+* Azure AD Graph Potential Enumeration (ROADrecon)
 * Azure Key Vault Excessive Secret or Key Retrieved
 * Azure OpenAI Insecure Output Handling
+* Azure Run Command Correlated with Process Execution
 * Command Line Obfuscation via Whitespace Padding
 * Correlated Alerts on Similar User Identities
 * Detection Alert on a Process Exhibiting CPU Spike
@@ -364,14 +424,23 @@ Rules version: 9.3.10
 * First-Time FortiGate Administrator Login
 * FortiGate Administrator Login from Multiple IP Addresses
 * FortiGate FortiCloud SSO Login from Unusual Source
+* GKE API Request Failure Burst by User
 * GitHub Actions Workflow Modification Blocked
 * GitHub Exfiltration via High Number of Repository Clones by User
+* Google Workspace Device Registration Burst for Single User
 * High Number of Closed Pull Requests by User
 * High Number of Egress Network Connections from Unusual Executable
 * High Number of Protected Branch Force Pushes by User
 * Kubernetes Creation or Modification of Sensitive Role
+* Kubernetes Multi-Resource Discovery
+* Kubernetes Pod Exec Cloud Instance Metadata Access
+* Kubernetes Pod Exec Potential Reverse Shell
+* Kubernetes Pod Exec Sensitive File or Credential Path Access
+* Kubernetes Pod Exec with Curl or Wget to HTTPS
 * Kubernetes Potential Endpoint Permission Enumeration Attempt Detected
 * Kubernetes Potential Endpoint Permission Enumeration Attempt by Anonymous User Detected
+* Kubernetes RBAC Wildcard Elevation on Existing Role
+* Kubernetes Rapid Secret GET Activity Against Multiple Objects
 * Kubernetes Secret or ConfigMap Access via Azure Arc Proxy
 * LLM-Based Attack Chain Triage by Host
 * LLM-Based Compromised User Triage by User
@@ -380,15 +449,19 @@ Rules version: 9.3.10
 * Lateral Movement Alerts from a Newly Observed User
 * Long Base64 Encoded Command via Scripting Interpreter
 * M365 Azure Monitor Alert Email with Financial or Billing Theme
+* M365 Exchange Inbox Rule with Obfuscated Name
 * M365 Identity OAuth Flow by First-Party Microsoft App from Multiple IPs
 * M365 Identity User Account Lockouts
 * M365 Identity User Brute Force Attempted
 * M365 OneDrive/SharePoint Excessive File Downloads
 * M365 or Entra ID Identity Sign-in from a Suspicious Source
+* Microsoft Graph Multi-Category Reconnaissance Burst
+* Multi-Cloud CLI Token and Credential Access Commands
 * Multiple Alerts Involving a User
 * Multiple Alerts in Same ATT&CK Tactic by Host
 * Multiple Alerts on a Host Exhibiting CPU Spike
 * Multiple Cloud Secrets Accessed by Source Address
+* Multiple DHCP Servers Responding to the Same Transaction
 * Multiple Device Token Hashes for Single Okta Session
 * Multiple Elastic Defend Alerts by Agent
 * Multiple Elastic Defend Alerts from a Single Process Tree
@@ -414,6 +487,8 @@ Rules version: 9.3.10
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
 * Potential Credential Discovery via Recursive Grep
+* Potential DHCP Starvation via High Client MAC Cardinality
+* Potential DNS Exfiltration via Excessive Chunked Queries
 * Potential Denial of Azure OpenAI ML Service
 * Potential Dynamic IEX Reconstruction via Environment Variables
 * Potential Linux Local Account Brute Force Detected
@@ -439,6 +514,7 @@ Rules version: 9.3.10
 * Potential PowerShell Obfuscation via String Concatenation
 * Potential PowerShell Obfuscation via String Reordering
 * Potential Ransomware Behavior - Note Files by System
+* Potential SQL Injection Against Microsoft SQL Server
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
 * Potential Widespread Malware Infection Across Multiple Hosts
@@ -447,18 +523,17 @@ Rules version: 9.3.10
 * Rare Connection to WebDAV Target
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
+* Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
 * Suspected Lateral Movement from Compromised Host
 * Suspicious AWS S3 Connection via Script Interpreter
 * Suspicious Python Shell Command Execution
 * Suspicious TCC Access Granted for User Folders
 * Unusual Base64 Encoding/Decoding Activity
-* Unusual Command Execution from Web Server Parent
 * Unusual File Creation by Web Server
 * Unusual High Confidence Content Filter Blocks Detected
 * Unusual High Denied Sensitive Information Policy Blocks Detected
 * Unusual High Denied Topic Blocks Detected
 * Unusual High Word Policy Blocks Detected
-* Unusual Process Spawned from Web Server Parent
 * Web Server Discovery or Fuzzing Activity
 * Web Server Local File Inclusion Activity
 * Web Server Potential Command Injection Request
@@ -576,9 +651,9 @@ Rules version: 9.3.10
 * Unusual Windows Username
 * User Detected with Suspicious Windows Process(es)
 
-### Unsupported rule type: threshold (29)
+### Unsupported rule type: threshold (28)
 
-29 rules:
+28 rules:
 
 * AWS IAM Principal Enumeration via UpdateAssumeRolePolicy
 * AWS Management Console Brute Force of Root User Identity
@@ -588,7 +663,6 @@ Rules version: 9.3.10
 * Azure Compute Restore Point Collections Deleted
 * Azure Compute Snapshot Deletions by User
 * Azure Storage Account Deletions by User
-* Deprecated - Sudo Heap-Based Buffer Overflow Attempt
 * Entra ID Excessive Account Lockouts Detected
 * Excessive AWS S3 Object Encryption with SSE-C
 * GitHub UEBA - Multiple Alerts from a GitHub Account
@@ -621,20 +695,54 @@ Rules version: 9.3.10
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Unsupported query language: lucene (4)
+### Unsupported query language: lucene (5)
 
-4 rules:
+5 rules:
 
 * Cobalt Strike Command and Control Beacon
 * Halfbaked Command and Control Beacon
 * Inbound Connection to an Unsecure Elasticsearch Node
 * Possible FIN7 DGA Command and Control Behavior
+* Potential cPanel WHM CRLF Authentication Bypass (CVE-2026-41940)
+
+### Error at line:37,column:3
+Invalid syntax
+  *confluence/conf/server.xml
+  */.config/gcloud/application_default_credentials.json or
+  ^ (1)
+
+1 rules:
+
+* Kubernetes and Cloud Credential Path Access via Process Arguments
+
+### Error at line:7,column:19
+Invalid syntax
+  process.name:(curl or wget) or
+  process.args:(* curl* or */bin/curl* or *wget*)
+                  ^ (1)
+
+1 rules:
+
+* Curl or Wget Execution from Container Context
 
 ## Generation errors
 
-### Field type solver: constant_keyword (278)
+### Field type solver: constant_keyword (345)
 
-278 rules:
+345 rules:
+* AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
+* AWS Backup Recovery Point Deleted
+* AWS Backup Vault Deleted or Vault Lock Removed
+* AWS Bedrock Agent Created by IAM User or Root
+* AWS Bedrock Automated Reasoning Safety Policy Tampering
+* AWS Bedrock Foundation Model Access Enabled or Entitlement Granted
+* AWS Bedrock Foundation Model Enumeration Followed by Invocation via Long-Term Key
+* AWS Bedrock Guardrail Deleted or Weakened
+* AWS Bedrock Model Invocation Logging Disabled or Modified
+* AWS Bedrock Provisioned Model Throughput Tampering
+* AWS Bedrock Unauthorized Foundation Model Access Attempt
+* AWS Bedrock Unauthorized Resource-Based Policy Modification Attempt
+* AWS Bedrock Untrusted Model Imported or Marketplace Endpoint Registered
 * AWS CloudShell Environment Created
 * AWS CloudTrail Log Created
 * AWS CloudTrail Log Deleted
@@ -657,18 +765,29 @@ Rules version: 9.3.10
 * AWS EC2 Security Group Configuration Change
 * AWS EC2 Serial Console Access Enabled
 * AWS EFS File System Deleted
+* AWS EKS Access Entry Granted Cluster Admin Policy
+* AWS EKS Access Entry Modified
+* AWS EKS Control Plane Logging Disabled
 * AWS EventBridge Rule Disabled or Deleted
 * AWS GuardDuty Detector Deletion
 * AWS GuardDuty Member Account Manipulation
+* AWS IAM Account Password Policy Deleted
 * AWS IAM Deactivation of MFA Device
 * AWS IAM Group Creation
 * AWS IAM Group Deletion
+* AWS IAM Inline Policy Added to a Group
+* AWS IAM Login Profile Created or Modified for an IAM User
+* AWS IAM Permissions Boundary Modified or Removed
 * AWS IAM Roles Anywhere Profile Creation
 * AWS IAM SAML Provider Created
 * AWS IAM SAML Provider Updated
 * AWS IAM User Addition to Group
 * AWS KMS Customer Managed Key Disabled or Scheduled for Deletion
+* AWS KMS Imported Key Material Deleted
+* AWS Lambda Event Source Mapping Creation
+* AWS Lambda Function Deletion
 * AWS Lambda Layer Added to Existing Function
+* AWS Lambda Layer Shared Externally
 * AWS Management Console Root Login
 * AWS RDS DB Instance Restored
 * AWS RDS DB Instance or Cluster Deleted
@@ -678,6 +797,7 @@ Rules version: 9.3.10
 * AWS Route 53 Private Hosted Zone Associated With a VPC
 * AWS Route 53 Resolver Query Log Configuration Deleted
 * AWS S3 Bucket Configuration Deletion
+* AWS S3 Credential File Retrieved from Bucket
 * AWS SQS Queue Purge
 * AWS Sensitive IAM Operations Performed via CloudShell
 * AWS Sign-In Console Login with Federated User
@@ -712,7 +832,6 @@ Rules version: 9.3.10
 * Azure Automation Webhook Created
 * Azure Blob Storage Container Access Level Modified
 * Azure Blob Storage Permissions Modified
-* Azure Compute VM Command Executed
 * Azure Diagnostic Settings Alert Suppression Rule Created or Modified
 * Azure Event Hub Authorization Rule Created or Updated
 * Azure Event Hub Deleted
@@ -723,10 +842,13 @@ Rules version: 9.3.10
 * Azure Resource Group Deleted
 * Azure Service Principal Sign-In Followed by Arc Cluster Credential Access
 * Azure Storage Account Key Regenerated
+* Azure VM Boot Diagnostics Retrieved
+* Azure VM Extension Deployment by User
 * Azure VNet Firewall Front Door WAF Policy Deleted
 * Azure VNet Firewall Policy Deleted
 * Azure VNet Full Network Packet Capture Enabled
 * Azure VNet Network Watcher Deleted
+* Azure Virtual Machine Configuration Modified
 * Command and Scripting Interpreter via Windows Scripts
 * CrowdStrike External Alerts
 * CyberArk Privileged Access Security Error
@@ -739,23 +861,35 @@ Rules version: 9.3.10
 * Deprecated - M365 Security Compliance User Restricted from Sending Email
 * Deprecated - M365 Teams External Access Enabled
 * Deprecated - M365 Teams Guest Access Enabled
+* Deprecated - MFA Disabled for Google Workspace Organization
 * Direct Interactive Kubernetes API Request by Common Utilities
 * Direct Interactive Kubernetes API Request by Unusual Utilities
 * Domain Added to Google Workspace Trusted Domains
+* EKS Authentication Configuration Modified
 * Elastic Security External Alerts
 * Entra ID ADRS Token Request by Microsoft Authentication Broker
 * Entra ID Application Credential Modified
 * Entra ID Custom Domain Added or Verified
+* Entra ID Device Registration with ROADtools Default OS Build
 * Entra ID Domain Federation Configuration Change
 * Entra ID External Guest User Invited
 * Entra ID Global Administrator Role Assigned
 * Entra ID Global Administrator Role Assigned (PIM User)
+* Entra ID Guest Account Promoted to Member
 * Entra ID High Risk Sign-in
 * Entra ID High Risk User Sign-in Heuristic
+* Entra ID Kali365 Default User-Agent Detected
 * Entra ID MFA Disabled for User
+* Entra ID Microsoft Authentication Broker DRS Sign-In from Suspicious ASN
+* Entra ID Microsoft Authentication Broker Sign-In to Unusual Resource
+* Entra ID Microsoft Authentication Broker Sign-In with Non-Standard User Agent
+* Entra ID OAuth Application Redirect URI Modified
 * Entra ID OAuth Device Code Grant by Microsoft Authentication Broker
+* Entra ID OAuth Device Code Phishing via AiTM
+* Entra ID OAuth Device Code Sign-in to Azure AD Graph Enumeration
 * Entra ID OAuth PRT Issuance to Non-Managed Device Detected
 * Entra ID OAuth Phishing via First-Party Microsoft Application
+* Entra ID Potential AiTM Sign-In via OfficeHome (Tycoon2FA)
 * Entra ID PowerShell Sign-in
 * Entra ID Privileged Identity Management (PIM) Role Modified
 * Entra ID Protection - Risk Detection - Sign-in Risk
@@ -763,8 +897,10 @@ Rules version: 9.3.10
 * Entra ID Protection Admin Confirmed Compromise
 * Entra ID Protection Alerts for User Detected
 * Entra ID Protection User Alert and Device Registration
+* Entra ID Register Device with Unusual User Agent (Azure AD Join)
 * Entra ID Service Principal Created
 * Entra ID Sign-in TeamFiltration User-Agent Detected
+* Entra ID Temporary Access Pass Created for User
 * Entra ID Unusual Cloud Device Registration
 * Entra ID User Added as Registered Application Owner
 * Entra ID User Added as Service Principal Owner
@@ -802,36 +938,54 @@ Rules version: 9.3.10
 * GCP Virtual Private Cloud Network Deletion
 * GCP Virtual Private Cloud Route Creation
 * GCP Virtual Private Cloud Route Deletion
+* GKE Admission Webhook Created or Modified
+* GKE Cluster-Admin Role Binding Created or Modified
+* GKE Container Created with Excessive Linux Capabilities
+* GKE Pod Created With HostIPC
+* GKE Pod Created With HostNetwork
+* GKE Pod Created With HostPID
+* GKE Pod Created with a Sensitive hostPath Volume
+* GKE Privileged Pod Created
+* GKE Secret get or list with Suspicious User Agent
+* GKE Suspicious Self-Subject Review via Service Account
 * GitHub App Deleted
 * GitHub Owner Role Granted To User
 * GitHub Private Repository Turned Public
 * GitHub Protected Branch Settings Changed
 * GitHub Repository Deleted
 * GitHub Secret Scanning Disabled
-* Google Drive Ownership Transferred via Google Workspace
 * Google SecOps External Alerts
-* Google Workspace 2SV Policy Disabled
+* Google Workspace 2SV Policy Disabled By User
 * Google Workspace API Access Granted via Domain-Wide Delegation
-* Google Workspace Admin Role Assigned to a User
+* Google Workspace Admin Role Assigned to a User or Group
 * Google Workspace Admin Role Deletion
 * Google Workspace Bitlocker Setting Disabled
 * Google Workspace Custom Admin Role Created
-* Google Workspace Custom Gmail Route Created or Modified
+* Google Workspace Device Registration After OAuth from Suspicious ASN
+* Google Workspace Drive Data Transfer or Takeout Export Initiated
 * Google Workspace Drive Encryption Key(s) Accessed from Anonymous User
-* Google Workspace MFA Enforcement Disabled
-* Google Workspace Object Copied to External Drive with App Consent
+* Google Workspace Gmail Routing or Forwarding Rule Created or Modified
+* Google Workspace Login Flagged Suspicious
+* Google Workspace MFA Enforcement Disabled For Organization
+* Google Workspace Object Copied from External Drive with App Consent
 * Google Workspace Password Policy Modified
 * Google Workspace Restrictions for Marketplace Modified to Allow Any App
 * Google Workspace Role Modified
 * Google Workspace Suspended User Account Renewed
 * Google Workspace User Organizational Unit Changed
 * IBM QRadar External Alerts
+* ICMP Redirect Message from Internal Host
+* ICMP Timestamp or Information Request from the Internet
 * IPSEC NAT Traversal Port Activity
 * Initial Access via File Upload Followed by GET Request
 * Insecure AWS EC2 VPC Security Group Ingress Rule Added
+* Kubernetes API Request Impersonating Privileged Identity
 * Kubernetes Anonymous User Create/Update/Patch Pods Request
+* Kubernetes Client Certificate Signing Request Created or Approved
 * Kubernetes Cluster-Admin Role Binding Created
+* Kubernetes CoreDNS or Kube-DNS Configuration Modified
 * Kubernetes Creation of a RoleBinding Referencing a ServiceAccount
+* Kubernetes Ephemeral Container Added to Pod
 * Kubernetes Events Deleted
 * Kubernetes Exposed Service Created With Type NodePort
 * Kubernetes Forbidden Creation Request
@@ -840,8 +994,11 @@ Rules version: 9.3.10
 * Kubernetes Pod Created With HostPID
 * Kubernetes Pod Created with a Sensitive hostPath Volume
 * Kubernetes Privileged Pod Created
+* Kubernetes Secret get or list from Node or Pod Service Account
+* Kubernetes Secret get or list with Suspicious User Agent
 * Kubernetes Sensitive RBAC Change Followed by Workload Modification
 * Kubernetes Service Account Modified RBAC Objects
+* Kubernetes Service Account Token Created via TokenRequest API
 * Kubernetes Suspicious Assignment of Controller Service Account
 * Kubernetes User Exec into Pod
 * M365 Exchange Anti-Phish Policy Deleted
@@ -862,12 +1019,13 @@ Rules version: 9.3.10
 * M365 Identity OAuth Flow by User Sign-in to Device Registration
 * M365 Identity OAuth Phishing via First-Party Microsoft Application
 * M365 OneDrive Malware File Upload
+* M365 Potential AiTM UserLoggedIn via Office App (Tycoon2FA)
 * M365 SharePoint Malware File Detected
 * M365 SharePoint Search for Sensitive Content
 * M365 SharePoint Site Administrator Added
 * M365 SharePoint Site Sharing Policy Weakened
 * M365 Teams Custom Application Interaction Enabled
-* MFA Disabled for Google Workspace Organization
+* M365 Teams Rogue Help Desk Chat Created
 * Microsoft Sentinel External Alerts
 * Modification or Removal of an Okta Application Sign-On Policy
 * New GitHub App Installed
@@ -879,10 +1037,12 @@ Rules version: 9.3.10
 * Okta User Assigned Administrator Role
 * Okta User Session Impersonation
 * Possible Okta DoS Attack
-* Potential Credential Access via Renamed COM+ Services DLL
 * Potential DLL Side-Loading via Trusted Microsoft Programs
 * Potential File Transfer via Curl for Windows
 * Potential Persistence via File Modification
+* Potential Redis CONFIG SET Cron Directory Persistence (RedisRaider)
+* Potential Redis CONFIG SET SSH Authorized Key Injection
+* Potential Redis Lua Use-After-Free RCE Attempt (CVE-2025-49844 / RediShell)
 * Potential Toolshell Initial Exploit (CVE-2025-53770 & CVE-2025-53771)
 * Potential VIEWSTATE RCE Attempt on SharePoint/IIS
 * Potential Webshell Deployed via Apache Struts CVE-2023-50164 Exploitation
@@ -893,10 +1053,12 @@ Rules version: 9.3.10
 * RPC (Remote Procedure Call) to the Internet
 * React2Shell Network Security Alert
 * Roshal Archive (RAR) or PowerShell File Downloaded from the Internet
-* SMTP on Port 26/TCP
+* SMTP to the Internet on Port 26/TCP
+* Sensitive Identity File Open by Suspicious Process via Auditd
 * SentinelOne Alert External Alerts
 * SentinelOne Threat External Alerts
 * Service Account Token or Certificate Access Followed by Kubernetes API Request
+* Splunk Enterprise PostgreSQL Recovery Endpoint Injection Artifacts
 * Splunk External Alerts
 * Stolen Credentials Used to Login to Okta Account After MFA Reset
 * Suricata and Elastic Defend Network Correlation
@@ -923,7 +1085,6 @@ Rules version: 9.3.10
 * Entra ID Sign-in BloodHound Suite User-Agent Detected
 * Executable File Creation with Multiple Extensions
 * File Deletion via Shred
-* File Download Detected via Defend for Containers
 * GenAI Process Connection to Suspicious Top Level Domain
 * Masquerading Space After Filename
 * Network Activity to a Suspicious Top Level Domain
@@ -935,6 +1096,7 @@ Rules version: 9.3.10
 * Potential Exploitation of an Unquoted Service Path Vulnerability
 * Potential Linux Tunneling and/or Port Forwarding
 * Potential Linux Tunneling and/or Port Forwarding via Command Line
+* Potential SSH Reverse Port Forwarding
 * Potential Windows Error Manager Masquerading
 * Process Created with a Duplicated Token
 * Process Started from Process ID (PID) File
@@ -953,9 +1115,9 @@ Rules version: 9.3.10
 * Unusual Process Execution Path - Alternate Data Stream
 * Web Server Exploitation Detected via Defend for Containers
 
-### Unsupported function: stringContains (23)
+### Unsupported function: stringContains (25)
 
-23 rules:
+25 rules:
 * AWS EC2 EBS Snapshot Access Removed
 * AWS EC2 EBS Snapshot Shared or Made Public
 * AWS EC2 Instance Console Login via Assumed Role
@@ -966,7 +1128,9 @@ Rules version: 9.3.10
 * AWS IAM CompromisedKeyQuarantine Policy Attached to User
 * AWS IAM Login Profile Added for Root
 * AWS IAM Roles Anywhere Trust Anchor Created with External CA
+* AWS Lambda Function Policy Updated to Allow Cross-Account Invocation
 * AWS Lambda Function Policy Updated to Allow Public Invocation
+* AWS Lambda Function URL Created with Public Access
 * AWS RDS DB Instance Made Public
 * AWS RDS DB Instance or Cluster Deletion Protection Disabled
 * AWS RDS DB Instance or Cluster Password Modified
@@ -980,19 +1144,19 @@ Rules version: 9.3.10
 * AWS S3 Object Versioning Suspended
 * AWS Suspicious User Agent Fingerprint
 
-### Root with too many branches (limit: 10000) (22)
+### Root with too many branches (limit: 10000) (24)
 
-22 rules:
+24 rules:
 * Connection to Common Large Language Model Endpoints
 * Connection to Commonly Abused Web Services
 * Decoded Payload Piped to Interpreter Detected via Defend for Containers
 * Execution from Unusual Directory - Command Line
 * Execution of a Downloaded Windows Script
 * External IP Lookup from Non-Browser Process
-* GenAI Process Accessing Sensitive Files
 * GenAI or MCP Server Child Process Execution
 * Ingress Tool Transfer Followed by Execution and Deletion Detected via Defend for Containers
 * Kubelet Pod Discovery Detected via Defend for Containers
+* Potential Copy Fail (CVE-2026-31431) Exploitation via AF_ALG Socket
 * Potential DNS Tunneling via NsLookup
 * Potential Evasion via Windows Filtering Platform
 * Potential External Linux SSH Brute Force Detected
@@ -1003,8 +1167,25 @@ Rules version: 9.3.10
 * Potential Reverse Shell via Suspicious Binary
 * Potential Reverse Shell via Suspicious Child Process
 * Potential Successful SSH Brute Force Attack
+* Suspicious Child Execution via Web Server
+* Suspicious Command Execution via Web Server
 * Suspicious React Server Child Process
 * Unusual User Privilege Enumeration via id
+
+### Root without branches (11)
+
+11 rules:
+* Initramfs Extraction via CPIO
+* Interactive Shell Spawn Detected via Defend for Containers
+* Interactive Terminal Spawned via Perl
+* Kubectl Configuration Discovery
+* Kubectl Secrets Enumeration Across All Namespaces
+* Linux User or Group Deletion
+* Linux init (PID 1) Secret Dump via GDB
+* Passwordless Sudo Probing
+* Potential Docker Escape via Nsenter
+* Potential Linux Backdoor User Account Creation
+* Suspicious Data Encryption via OpenSSL Utility
 
 ### Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)
 
@@ -1021,39 +1202,28 @@ Rules version: 9.3.10
 * Suspicious Process Access via Direct System Call
 * Uncommon Registry Persistence Change
 
-### Root without branches (10)
+### Unsupported argument type(s): <class 'eql.ast.Field'> (10)
 
 10 rules:
-* Initramfs Extraction via CPIO
-* Interactive Shell Spawn Detected via Defend for Containers
-* Interactive Terminal Spawned via Perl
-* Kubectl Configuration Discovery
-* Kubectl Secrets Enumeration Across All Namespaces
-* Linux User or Group Deletion
-* Linux init (PID 1) Secret Dump via GDB
-* Potential Docker Escape via Nsenter
-* Potential Linux Backdoor User Account Creation
-* Suspicious Data Encryption via OpenSSL Utility
-
-### Unsupported argument type(s): <class 'eql.ast.Field'> (8)
-
-8 rules:
 * External User Added to Google Workspace Group
 * Image Loaded with Invalid Signature
 * Interactive Logon by an Unusual Process
 * M365 Exchange Inbox Forwarding Rule Created
+* Payload Downloaded by Interpreter and Piped to Interpreter
+* Potential Privilege Escalation via SUID/SGID
 * Potential Ransomware Note File Dropped via SMB
 * Suspicious File Renamed via SMB
 * Unusual Network Activity from a Windows System Binary
 * Windows Service Installed via an Unusual Client
 
-### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (6)
+### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)
 
-6 rules:
+7 rules:
 * Execution via MS VisualStudio Pre/Post Build Events
 * Suspicious Execution from VS Code Extension
 * Suspicious Execution from a WebDav Share
 * Suspicious JetBrains TeamCity Child Process
+* Suspicious Microsoft HTML Application Child Process
 * Suspicious Shell Execution via Velociraptor
 * Suspicious Windows Command Shell Arguments
 
@@ -1072,12 +1242,26 @@ Rules version: 9.3.10
 * Potential Meterpreter Reverse Shell
 * Potential Reverse Shell via UDP
 
+### Field type solver: match_only_text (3)
+
+3 rules:
+* Segfault Detected
+* Segfault from Sensitive Process Detected
+* Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)
+
 ### Unsolvable constraints: event.category & event.type (empty intersection) (3)
 
 3 rules:
 * File Execution Permission Modification Detected via Defend for Containers
 * File with Right-to-Left Override Character (RTLO) Created/Executed
 * Unsigned DLL loaded by DNS Service
+
+### Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)
+
+3 rules:
+* AWS SSM Session Manager Child Process Execution
+* Delayed Execution via Ping
+* Veeam Backup Library Loaded by Unusual Process
 
 ### Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)
 
@@ -1100,12 +1284,6 @@ Rules version: 9.3.10
 * Potential Machine Account Relay Attack via SMB
 * Unusual Execution via Microsoft Common Console File
 
-### Field type solver: match_only_text (2)
-
-2 rules:
-* Segfault Detected
-* Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)
-
 ### Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)
 
 2 rules:
@@ -1118,6 +1296,12 @@ Rules version: 9.3.10
 * Suspicious Network Tool Launch Detected via Defend for Containers
 * Suspicious Network Tool Launched Inside A Container
 
+### Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)
+
+2 rules:
+* Base64 Decoded Payload Piped to Interpreter
+* Shared Object Load via LoLBin
+
 ### Unsolvable constraints: process.name (excluded by Strings({'rundll32.exe'}): ('rundll32.exe')) (2)
 
 2 rules:
@@ -1129,6 +1313,12 @@ Rules version: 9.3.10
 2 rules:
 * Downloaded Shortcut Files
 * File with Suspicious Extension Downloaded
+
+### Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)
+
+2 rules:
+* Java Dropped and Executed With DNS Lookup
+* Suspicious Inter-Process Communication via Outlook
 
 ### Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)
 
@@ -1152,11 +1342,6 @@ Rules version: 9.3.10
 1 rules:
 * Potential Okta MFA Bombing via Push Notifications
 
-### Cannot choose from an empty set (1)
-
-1 rules:
-* DNS Request for IP Lookup Service via Unsigned Binary
-
 ### Unsolvable constraints: file.Ext.header_bytes (excluded by Strings({'504B0304*'}): ('504B0304*')) (1)
 
 1 rules:
@@ -1166,6 +1351,11 @@ Rules version: 9.3.10
 
 1 rules:
 * Pluggable Authentication Module or Configuration Creation
+
+### Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)
+
+1 rules:
+* GenAI Process Accessing Sensitive Files
 
 ### Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)
 
@@ -1246,6 +1436,11 @@ Rules version: 9.3.10
 
 1 rules:
 * Potential PowerShell Pass-the-Hash/Relay Script
+
+### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NdrClientCall'}): ('GetProcAddress')) (1)
+
+1 rules:
+* Potential AMSI Bypass via RPC Runtime Hooking
 
 ### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'New-MailboxExportRequest'}): ('-FilePath')) (1)
 
@@ -1382,6 +1577,11 @@ Rules version: 9.3.10
 1 rules:
 * Remote System Discovery Commands
 
+### Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (1)
+
+1 rules:
+* Suspicious macOS MS Office Child Process
+
 ### Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)
 
 1 rules:
@@ -1412,35 +1612,15 @@ Rules version: 9.3.10
 1 rules:
 * Curl or Wget Egress Network Connection via LoLBin
 
-### Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (1)
-
-1 rules:
-* Delayed Execution via Ping
-
-### Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (1)
-
-1 rules:
-* Base64 Decoded Payload Piped to Interpreter
-
 ### Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)
 
 1 rules:
 * Enumeration Command Spawned via WMIPrvSE
 
-### Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)
+### Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)
 
 1 rules:
-* Suspicious macOS MS Office Child Process
-
-### Unsolvable constraints: process.name (not in Strings({'java'}): ('.*')) (1)
-
-1 rules:
-* Suspicious Child Execution via Web Server
-
-### Unsolvable constraints: process.name (not in Strings({'pluginkit'}): ('python*')) (1)
-
-1 rules:
-* Finder Sync Plugin Registered and Enabled
+* Unusual Executable File Creation by a System Critical Process
 
 ### Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)
 
@@ -1507,6 +1687,11 @@ Rules version: 9.3.10
 1 rules:
 * Scheduled Task Execution at Scale via GPO
 
+### Unsolvable constraints: winlog.event_data.param1 (not in Strings({'*FullControl*'}): ('*setsharingmode*')) (1)
+
+1 rules:
+* Quick Assist Full Control Sharing Mode Enabled
+
 ### Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: < (1)
 
 1 rules:
@@ -1546,8 +1731,3 @@ Rules version: 9.3.10
 
 1 rules:
 * Machine Learning Detected a Suspicious Windows Event with a High Malicious Probability Score
-
-### Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (1)
-
-1 rules:
-* Suspicious Inter-Process Communication via Outlook

--- a/tests/reports/documents_from_rules-9.4.md
+++ b/tests/reports/documents_from_rules-9.4.md
@@ -5,44 +5,65 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.2
+Rules version: 9.4.7
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (186)](#unsupported-rule-type-new_terms-186)
-      1. [Unsupported rule type: esql (148)](#unsupported-rule-type-esql-148)
-      1. ['types.SimpleNamespace' object has no attribute 'type' (111)](#typessimplenamespace-object-has-no-attribute-type-111)
+      1. [Unsupported rule type: new_terms (215)](#unsupported-rule-type-new_terms-215)
+      1. [Unsupported rule type: esql (176)](#unsupported-rule-type-esql-176)
+      1. ['types.SimpleNamespace' object has no attribute 'type' (117)](#typessimplenamespace-object-has-no-attribute-type-117)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
-      1. [Unsupported rule type: threshold (29)](#unsupported-rule-type-threshold-29)
+      1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Unsupported query language: lucene (4)](#unsupported-query-language-lucene-4)
+      1. [Unsupported query language: lucene (5)](#unsupported-query-language-lucene-5)
+      1. [Error at line:37,column:3
+Invalid syntax
+  *confluence/conf/server.xml
+  */.config/gcloud/application_default_credentials.json or
+  ^ (1)](#error-at-line37column3
+invalid-syntax
+--confluenceconfserverxml
+--configgcloudapplication_default_credentialsjson-or
+---1)
+      1. [Error at line:7,column:19
+Invalid syntax
+  process.name:(curl or wget) or
+  process.args:(* curl* or */bin/curl* or *wget*)
+                  ^ (1)](#error-at-line7column19
+invalid-syntax
+--processnamecurl-or-wget-or
+--processargs-curl-or-bincurl-or-wget
+-------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (278)](#field-type-solver-constant_keyword-278)
+      1. [Field type solver: constant_keyword (345)](#field-type-solver-constant_keyword-345)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
-      1. [Unsupported function: stringContains (23)](#unsupported-function-stringcontains-23)
-      1. [Root with too many branches (limit: 10000) (22)](#root-with-too-many-branches-limit-10000-22)
+      1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
+      1. [Root with too many branches (limit: 10000) (24)](#root-with-too-many-branches-limit-10000-24)
+      1. [Root without branches (11)](#root-without-branches-11)
       1. [Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)](#unsupported-lhs-type-class-eqlastfunctioncall-11)
-      1. [Root without branches (10)](#root-without-branches-10)
-      1. [Unsupported argument type(s): <class 'eql.ast.Field'> (8)](#unsupported-argument-types-class-eqlastfield-8)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (6)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-6)
+      1. [Unsupported argument type(s): <class 'eql.ast.Field'> (10)](#unsupported-argument-types-class-eqlastfield-10)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-7)
       1. [Unsupported function: startsWith (4)](#unsupported-function-startswith-4)
       1. [<class 'eql.ast.Sample'> (3)](#class-eqlastsample-3)
+      1. [Field type solver: match_only_text (3)](#field-type-solver-match_only_text-3)
       1. [Unsolvable constraints: event.category & event.type (empty intersection) (3)](#unsolvable-constraints-eventcategory--eventtype-empty-intersection-3)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
       1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
-      1. [Field type solver: match_only_text (2)](#field-type-solver-match_only_text-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nc.traditional'}): ('nc.traditional')) (2)](#unsolvable-constraints-processname-excluded-by-stringsnctraditional-nctraditional-2)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)](#unsolvable-constraints-processname-excluded-by-stringspython-python-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'rundll32.exe'}): ('rundll32.exe')) (2)](#unsolvable-constraints-processname-excluded-by-stringsrundll32exe-rundll32exe-2)
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
+      1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
-      1. [Cannot choose from an empty set (1)](#cannot-choose-from-an-empty-set-1)
       1. [Unsolvable constraints: file.Ext.header_bytes (excluded by Strings({'504B0304*'}): ('504B0304*')) (1)](#unsolvable-constraints-fileextheader_bytes-excluded-by-strings504b0304-504b0304-1)
       1. [Unsolvable constraints: file.extension (cannot be non-null) (1)](#unsolvable-constraints-fileextension-cannot-be-non-null-1)
+      1. [Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)](#unsolvable-constraints-filename-excluded-by-stringslocal-state-local-state-1)
       1. [Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)](#unsolvable-constraints-filename-not-in-stringsso-so-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringsswipuploadashx-post-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringschild_process-exec-1)
@@ -59,6 +80,7 @@ Rules version: 9.4.2
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'LsaCallAuthenticationPackage'}): ('KerbRetrieveEncodedTicketMessage')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringslsacallauthenticationpackage-kerbretrieveencodedticketmessage-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'Microsoft.Office.Interop.Outlook'}): ('MAPI')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsmicrosoftofficeinteropoutlook-mapi-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NTLMSSPNegotiate'}): ('NegotiateSMB')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsntlmsspnegotiate-negotiatesmb-1)
+      1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NdrClientCall'}): ('GetProcAddress')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsndrclientcall-getprocaddress-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'New-MailboxExportRequest'}): ('-FilePath')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsnew-mailboxexportrequest--filepath-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'STARTUPINFOEX'}): ('UpdateProcThreadAttribute')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsstartupinfoex-updateprocthreadattribute-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'Set-MpPreference'}): ('DisableArchiveScanning')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsset-mppreference-disablearchivescanning-1)
@@ -86,18 +108,15 @@ Rules version: 9.4.2
       1. [Unsolvable constraints: process.command_line (not in Strings({'*net.ipv4.ip_forward*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsnetipv4ip_forward-echo--1)
       1. [Unsolvable constraints: process.command_line (not in Strings({'*vm.swappiness*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsvmswappiness-echo--1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'arp.exe'}): ('arp.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsarpexe-arpexe-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (1)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)](#unsolvable-constraints-processname-excluded-by-stringscp-cp-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselevation_serviceexe-elevation_serviceexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msdt.exe'}): ('msdt.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsdtexe-msdtexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msedgewebview2.exe'}): ('msedgewebview2.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsedgewebview2exe-msedgewebview2exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'net1.exe'}): ('net1.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnet1exe-net1exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nohup'}): ('nohup')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnohup-nohup-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (1)](#unsolvable-constraints-processname-excluded-by-stringspython-python-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsscexe-scexe-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)](#unsolvable-constraints-processname-excluded-by-stringssh-sh-1)
-      1. [Unsolvable constraints: process.name (not in Strings({'java'}): ('.*')) (1)](#unsolvable-constraints-processname-not-in-stringsjava--1)
-      1. [Unsolvable constraints: process.name (not in Strings({'pluginkit'}): ('python*')) (1)](#unsolvable-constraints-processname-not-in-stringspluginkit-python-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringssmssexe-smssexe-1)
       1. [Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)](#unsolvable-constraints-processname-not-in-stringsrundll32exe-mshtaexe-1)
       1. [Unsolvable constraints: process.parent.args (excluded by Strings({'WdiSystemHost'}): ('WdiSystemHost')) (1)](#unsolvable-constraints-processparentargs-excluded-by-stringswdisystemhost-wdisystemhost-1)
       1. [Unsolvable constraints: process.parent.name (excluded by Strings({'dllhost.exe'}): ('dllhost.exe')) (1)](#unsolvable-constraints-processparentname-excluded-by-stringsdllhostexe-dllhostexe-1)
@@ -111,6 +130,7 @@ Rules version: 9.4.2
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*42B5FAAE-6536-11D2-AE5A-0000F87571E3*'}): ('*40B66650-4972-11D1-A7CA-0000F87571E3*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-strings42b5faae-6536-11d2-ae5a-0000f87571e3-40b66650-4972-11d1-a7ca-0000f87571e3-1)
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*827D319E-6EAC-11D2-A4EA-00C04F79F83A*'}): ('*803E14A0-B4FB-11D0-A0D0-00A0C90F574B*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-strings827d319e-6eac-11d2-a4ea-00c04f79f83a-803e14a0-b4fb-11d0-a0d0-00a0c90f574b-1)
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*CAB54552-DEEA-4691-817E-ED4A4D1AFC72*'}): ('*AADCED64-746C-4633-A97C-D61349046527*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-stringscab54552-deea-4691-817e-ed4a4d1afc72-aadced64-746c-4633-a97c-d61349046527-1)
+      1. [Unsolvable constraints: winlog.event_data.param1 (not in Strings({'*FullControl*'}): ('*setsharingmode*')) (1)](#unsolvable-constraints-winlogevent_dataparam1-not-in-stringsfullcontrol-setsharingmode-1)
       1. [Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: < (1)](#unsupported-keyword-dllextrelative_file_creation_time-constraint--1)
       1. [Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: <= (1)](#unsupported-keyword-dllextrelative_file_creation_time-constraint--1)
       1. [Unsupported &keyword 'file.Ext.entropy' constraint: >= (1)](#unsupported-keyword-fileextentropy-constraint--1)
@@ -119,19 +139,25 @@ Rules version: 9.4.2
       1. [Unsupported &keyword 'powershell.file.script_block_length' constraint: > (1)](#unsupported-keyword-powershellfilescript_block_length-constraint--1)
       1. [Unsupported &keyword 'problemchild.prediction_probability' constraint: <= (1)](#unsupported-keyword-problemchildprediction_probability-constraint--1)
       1. [Unsupported &keyword 'problemchild.prediction_probability' constraint: > (1)](#unsupported-keyword-problemchildprediction_probability-constraint--1)
-      1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (1)](#unsupported-keyword-processextrelative_file_creation_time-constraint--1)
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (186)
+### Unsupported rule type: new_terms (215)
 
-186 rules:
+215 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
+* AWS Bedrock Agent or Action Group Manipulation
+* AWS Bedrock Knowledge Base or RAG Data Source Tampering
+* AWS Bedrock Resource-Based Policy Modified or Deleted
+* AWS Bedrock Third-Party or External Knowledge Base Associated to Agent
 * AWS CLI Command with Custom Endpoint URL
+* AWS Discovery API Calls from VPN ASN for the First Time by Identity
 * AWS DynamoDB Scan by Unusual User
 * AWS DynamoDB Table Exported to S3
+* AWS EC2 CreateKeyPair by New Principal from Non-Cloud AS Organization
+* AWS EC2 Role GetCallerIdentity from New Source AS Organization
 * AWS EC2 Route Table Created
 * AWS EC2 Route Table Modified or Deleted
 * AWS EC2 Unauthorized Admin Credential Fetch via Assumed Role
@@ -143,6 +169,8 @@ Rules version: 9.4.2
 * AWS IAM Customer-Managed Policy Attached to Role by Rare User
 * AWS IAM Long-Term Access Key First Seen from Source IP
 * AWS IAM OIDC Provider Created by Rare User
+* AWS Lambda Function Invoked by an Unusual Principal
+* AWS Lambda Function Invoked from an Unusual Source ASN
 * AWS S3 Unauthenticated Bucket Access by Rare Source
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
@@ -162,9 +190,12 @@ Rules version: 9.4.2
 * Abnormal Process ID or Lock File Created
 * Account or Group Discovery via Built-In Tools
 * Authentication via Unusual PAM Grantor
+* Azure AD Graph Access with Unusual Client and User
+* Azure AD Graph Access with Unusual User and ASN
 * Azure Arc Cluster Credential Access by Identity from Unusual Source
 * Azure Compute Restore Point Collection Deleted by Unusual User
 * Azure Compute Snapshot Deletion by Unusual User and Resource Group
+* Azure Compute VM Command Executed
 * Azure Diagnostic Settings Deleted
 * Azure Key Vault Modified
 * Azure Key Vault Unusual Secret Key Usage
@@ -172,12 +203,17 @@ Rules version: 9.4.2
 * Azure Storage Account Deletion by Unusual User
 * Azure Storage Account Keys Accessed by Privileged User
 * Azure Storage Blob Retrieval via AzCopy
+* Azure VM Extension CRUD Operation with Unusual Source ASN
+* Azure VM Managed Run Command Created or Updated with Unusual Principal
+* Azure VM Serial Console Connection with Unusual User and ASN
 * DPKG Package Installed by Unusual Parent Process
 * Delegated Managed Service Account Modification by an Unusual User
 * Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
+* Deprecated TLS Version or Weak Cipher Negotiated Externally
 * Discovery of Internet Capabilities via Built-in Tools
 * Entra ID Conditional Access Policy (CAP) Modified
+* Entra ID Device with ROADtools Default OS Build (Entity Analytics)
 * Entra ID Elevated Access to User Access Administrator
 * Entra ID External Authentication Methods (EAM) Modified
 * Entra ID OAuth Authorization Code Grant for Unusual User, App, and Resource
@@ -213,22 +249,27 @@ Rules version: 9.4.2
 * First Time Python Created a LaunchAgent or LaunchDaemon
 * First Time Python Spawned a Shell on Host
 * First Time Seen AWS Secret Value Accessed in Secrets Manager
+* First Time Seen Account Performing DCSync
 * First Time Seen Driver Loaded
 * First Time Seen Google Workspace OAuth Login from Third-Party Application
 * First Time Seen NewCredentials Logon Process
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
-* FirstTime Seen Account Performing DCSync
 * FortiGate Administrator Account Creation from Unusual Source
+* GKE Secrets List from Unusual Source AS Organization
+* GKE User Exec into Pod
 * GenAI Process Connection to Unusual Domain
 * GitHub Actions Unusual Bot Push to Repository
 * Github Activity on a Private Repository from an Unusual IP
+* Google Workspace User Login with Unusual ASN
+* Google Workspace User Sign-in from Atypical Device Type
 * Interactive Shell Launched via Unusual Parent Process in a Container
 * Kernel Object File Creation
 * Kill Command Execution
 * Kubernetes Anonymous Request Authorized by Unusual User Agent
 * Kubernetes Denied Service Account Request via Unusual User Agent
 * Kubernetes Forbidden Request from Unusual User Agent
+* Kubernetes Pod Creation Using Common Debug or Base Images
 * Kubernetes Secret Access via Unusual User Agent
 * Kubernetes Suspicious Self-Subject Review via Unusual User Agent
 * Kubernetes Unusual Decision by User Agent
@@ -241,7 +282,9 @@ Rules version: 9.4.2
 * M365 Exchange Inbox Phishing Evasion Rule Created
 * M365 Exchange Mailbox Accessed by Unusual Client
 * M365 Exchange Mailbox High-Risk Permission Delegated
-* M365 Identity Login from Atypical Travel Location
+* M365 Identity Device Code Grant by an Unusual User (Non-Compliant Device)
+* M365 Identity Device Code Grant with Unusual User and ASN
+* M365 Identity Login from Atypical Region
 * M365 Identity OAuth Illicit Consent Grant by Rare Client and User
 * M365 Identity Unusual SSO Authentication Errors for User
 * M365 SharePoint/OneDrive File Access via PowerShell
@@ -257,6 +300,7 @@ Rules version: 9.4.2
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
+* Potential ICMP Tunneling Activity to the Internet
 * Potential Pass-the-Hash (PtH) Attempt
 * Potential Privilege Escalation via Linux DAC permissions
 * Potential Shadow File Read via Command Line Utilities
@@ -267,6 +311,7 @@ Rules version: 9.4.2
 * RPM Package Installed by Unusual Parent Process
 * Rare SMB Connection to the Internet
 * Remote File Creation in World Writeable Directory
+* SMB (Windows File Sharing) Activity from the Internet
 * SMB (Windows File Sharing) Activity to the Internet
 * SSH Authorized Keys File Activity
 * Sensitive Files Compression
@@ -275,6 +320,7 @@ Rules version: 9.4.2
 * Successful SSH Authentication from Unusual IP Address
 * Successful SSH Authentication from Unusual SSH Public Key
 * Successful SSH Authentication from Unusual User
+* Suspicious Instance Metadata Service (IMDS) API Request
 * Suspicious Modprobe File Event
 * Suspicious Named Pipe Creation
 * Suspicious Network Activity to the Internet by Previously Unknown Executable
@@ -289,8 +335,11 @@ Rules version: 9.4.2
 * Systemd Service Started by Unusual Parent Process
 * UID Elevation from Previously Unknown Executable
 * Unauthorized Scope for Public App OAuth2 Token Grant with Client Credentials
+* Uncommon DNS Request via Bun or Node.js
 * Unknown Execution of Binary with RWX Memory Region
 * Unusual AWS S3 Object Encryption with SSE-C
+* Unusual Child Execution via Web Server
+* Unusual Command Execution via Web Server
 * Unusual Discovery Signal Alert with Unusual Process Command Line
 * Unusual Discovery Signal Alert with Unusual Process Executable
 * Unusual Execution from Kernel Thread (kthreadd) Parent
@@ -310,38 +359,49 @@ Rules version: 9.4.2
 * Unusual SSHD Child Process
 * Unusual Scheduled Task Update
 * Unusual Web Config File Access
-* Unusual Web Server Command Execution
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (148)
+### Unsupported rule type: esql (176)
 
-148 rules:
+176 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock Detected Multiple Attempts to use Denied Models by a Single User
 * AWS Bedrock Detected Multiple Validation Exception Errors by a Single User
 * AWS Bedrock Guardrails Detected Multiple Policy Violations Within a Single Blocked Request
 * AWS Bedrock Guardrails Detected Multiple Violations by a Single User Over a Session
+* AWS Bedrock High-Frequency Single-Model Inference API Probing
 * AWS Bedrock Invocations without Guardrails Detected by a Single User Over a Session
 * AWS Credentials Used from GitHub Actions and Non-CI/CD Infrastructure
 * AWS Discovery API Calls via CLI from a Single Resource
 * AWS EC2 LOLBin Execution via SSM SendCommand
 * AWS EC2 Multi-Region DescribeInstances API Calls
+* AWS EC2 Stop, Start, and User Data Modification Correlation
+* AWS ECR Repository or Registry Policy Granted Public Access
 * AWS IAM Long-Term Access Key Correlated with Elevated Detection Alerts
+* AWS IAM User Console Login from Multiple Geolocations
 * AWS IAM User Created Access Keys For Another User
+* AWS Lambda Function High-Frequency Invocation by a Single Principal
+* AWS Lambda Function Invoked Cross-Account
+* AWS Lateral Movement from Kubernetes SA via AssumeRoleWithWebIdentity
 * AWS Rare Source AS Organization Activity
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
 * Agent Spoofing - Multiple Hosts Using Same Agent
 * Alerts From Multiple Integrations by Destination Address
 * Alerts From Multiple Integrations by Source Address
 * Alerts From Multiple Integrations by User Name
 * Alerts in Different ATT&CK Tactics by Host
+* Azure AD Graph Access with Suspicious User-Agent
+* Azure AD Graph High 4xx Error Ratio from User
+* Azure AD Graph Potential Enumeration (ROADrecon)
 * Azure Key Vault Excessive Secret or Key Retrieved
 * Azure OpenAI Insecure Output Handling
+* Azure Run Command Correlated with Process Execution
 * Command Line Obfuscation via Whitespace Padding
 * Correlated Alerts on Similar User Identities
 * Detection Alert on a Process Exhibiting CPU Spike
@@ -365,14 +425,24 @@ Rules version: 9.4.2
 * First-Time FortiGate Administrator Login
 * FortiGate Administrator Login from Multiple IP Addresses
 * FortiGate FortiCloud SSO Login from Unusual Source
+* GKE API Request Failure Burst by User
 * GitHub Actions Workflow Modification Blocked
 * GitHub Exfiltration via High Number of Repository Clones by User
+* Google Workspace Device Registration Burst for Single User
+* Google Workspace Impossible Travel Login
 * High Number of Closed Pull Requests by User
 * High Number of Egress Network Connections from Unusual Executable
 * High Number of Protected Branch Force Pushes by User
 * Kubernetes Creation or Modification of Sensitive Role
+* Kubernetes Multi-Resource Discovery
+* Kubernetes Pod Exec Cloud Instance Metadata Access
+* Kubernetes Pod Exec Potential Reverse Shell
+* Kubernetes Pod Exec Sensitive File or Credential Path Access
+* Kubernetes Pod Exec with Curl or Wget to HTTPS
 * Kubernetes Potential Endpoint Permission Enumeration Attempt Detected
 * Kubernetes Potential Endpoint Permission Enumeration Attempt by Anonymous User Detected
+* Kubernetes RBAC Wildcard Elevation on Existing Role
+* Kubernetes Rapid Secret GET Activity Against Multiple Objects
 * Kubernetes Secret or ConfigMap Access via Azure Arc Proxy
 * LLM-Based Attack Chain Triage by Host
 * LLM-Based Compromised User Triage by User
@@ -381,15 +451,19 @@ Rules version: 9.4.2
 * Lateral Movement Alerts from a Newly Observed User
 * Long Base64 Encoded Command via Scripting Interpreter
 * M365 Azure Monitor Alert Email with Financial or Billing Theme
+* M365 Exchange Inbox Rule with Obfuscated Name
 * M365 Identity OAuth Flow by First-Party Microsoft App from Multiple IPs
 * M365 Identity User Account Lockouts
 * M365 Identity User Brute Force Attempted
 * M365 OneDrive/SharePoint Excessive File Downloads
 * M365 or Entra ID Identity Sign-in from a Suspicious Source
+* Microsoft Graph Multi-Category Reconnaissance Burst
+* Multi-Cloud CLI Token and Credential Access Commands
 * Multiple Alerts Involving a User
 * Multiple Alerts in Same ATT&CK Tactic by Host
 * Multiple Alerts on a Host Exhibiting CPU Spike
 * Multiple Cloud Secrets Accessed by Source Address
+* Multiple DHCP Servers Responding to the Same Transaction
 * Multiple Device Token Hashes for Single Okta Session
 * Multiple Elastic Defend Alerts by Agent
 * Multiple Elastic Defend Alerts from a Single Process Tree
@@ -415,6 +489,8 @@ Rules version: 9.4.2
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
 * Potential Credential Discovery via Recursive Grep
+* Potential DHCP Starvation via High Client MAC Cardinality
+* Potential DNS Exfiltration via Excessive Chunked Queries
 * Potential Denial of Azure OpenAI ML Service
 * Potential Dynamic IEX Reconstruction via Environment Variables
 * Potential Linux Local Account Brute Force Detected
@@ -440,6 +516,7 @@ Rules version: 9.4.2
 * Potential PowerShell Obfuscation via String Concatenation
 * Potential PowerShell Obfuscation via String Reordering
 * Potential Ransomware Behavior - Note Files by System
+* Potential SQL Injection Against Microsoft SQL Server
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
 * Potential Widespread Malware Infection Across Multiple Hosts
@@ -448,18 +525,17 @@ Rules version: 9.4.2
 * Rare Connection to WebDAV Target
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
+* Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
 * Suspected Lateral Movement from Compromised Host
 * Suspicious AWS S3 Connection via Script Interpreter
 * Suspicious Python Shell Command Execution
 * Suspicious TCC Access Granted for User Folders
 * Unusual Base64 Encoding/Decoding Activity
-* Unusual Command Execution from Web Server Parent
 * Unusual File Creation by Web Server
 * Unusual High Confidence Content Filter Blocks Detected
 * Unusual High Denied Sensitive Information Policy Blocks Detected
 * Unusual High Denied Topic Blocks Detected
 * Unusual High Word Policy Blocks Detected
-* Unusual Process Spawned from Web Server Parent
 * Web Server Discovery or Fuzzing Activity
 * Web Server Local File Inclusion Activity
 * Web Server Potential Command Injection Request
@@ -467,9 +543,9 @@ Rules version: 9.4.2
 * Web Server Potential Spike in Error Response Codes
 * Web Server Suspicious User Agent Requests
 
-### 'types.SimpleNamespace' object has no attribute 'type' (111)
+### 'types.SimpleNamespace' object has no attribute 'type' (117)
 
-111 rules:
+117 rules:
 
 * AWS RDS Snapshot Export
 * Attempt to Disable IPTables or Firewall
@@ -495,8 +571,10 @@ Rules version: 9.4.2
 * Deprecated - Azure Virtual Network Device Modified or Deleted
 * Deprecated - CAP_SYS_ADMIN Assigned to Binary
 * Deprecated - Creation of Kernel Module
+* Deprecated - EggShell Backdoor Execution
 * Deprecated - Execution of File Written or Modified by PDF Reader
 * Deprecated - LaunchDaemon Creation or Modification and Immediate Loading
+* Deprecated - Linux Restricted Shell Breakout via Linux Binary(s)
 * Deprecated - Modification of Standard Authentication Module or Configuration
 * Deprecated - Network Connection via Sudo Binary
 * Deprecated - Potential DNS Tunneling via Iodine
@@ -516,11 +594,15 @@ Rules version: 9.4.2
 * Deprecated - SSH Connection Established Inside A Running Container
 * Deprecated - SSH Process Launched From Inside A Container
 * Deprecated - SSH Process Launched From Inside A Container via Elastic Defend
+* Deprecated - Sudo Heap-Based Buffer Overflow Attempt
 * Deprecated - Suspicious File Creation in /etc for Persistence
 * Deprecated - Suspicious JAVA Child Process
 * Deprecated - Suspicious Renaming of ESXI index.html File
 * Deprecated - Threat Intel Filebeat Module (v8.x) Indicator Match
 * Deprecated - Threat Intel Indicator Match
+* Deprecated - Uncommon Destination Port Connection by Web Server
+* Deprecated - Unusual Command Execution from Web Server Parent
+* Deprecated - Unusual Process Spawned from Web Server Parent
 * Execution via Regsvcs/Regasm
 * FTP (File Transfer Protocol) Activity to the Internet
 * File and Directory Discovery
@@ -694,9 +776,9 @@ Rules version: 9.4.2
 * Unusual Windows Username
 * User Detected with Suspicious Windows Process(es)
 
-### Unsupported rule type: threshold (29)
+### Unsupported rule type: threshold (28)
 
-29 rules:
+28 rules:
 
 * AWS IAM Principal Enumeration via UpdateAssumeRolePolicy
 * AWS Management Console Brute Force of Root User Identity
@@ -706,7 +788,6 @@ Rules version: 9.4.2
 * Azure Compute Restore Point Collections Deleted
 * Azure Compute Snapshot Deletions by User
 * Azure Storage Account Deletions by User
-* Deprecated - Sudo Heap-Based Buffer Overflow Attempt
 * Entra ID Excessive Account Lockouts Detected
 * Excessive AWS S3 Object Encryption with SSE-C
 * GitHub UEBA - Multiple Alerts from a GitHub Account
@@ -739,20 +820,54 @@ Rules version: 9.4.2
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Unsupported query language: lucene (4)
+### Unsupported query language: lucene (5)
 
-4 rules:
+5 rules:
 
 * Cobalt Strike Command and Control Beacon
 * Halfbaked Command and Control Beacon
 * Inbound Connection to an Unsecure Elasticsearch Node
 * Possible FIN7 DGA Command and Control Behavior
+* Potential cPanel WHM CRLF Authentication Bypass (CVE-2026-41940)
+
+### Error at line:37,column:3
+Invalid syntax
+  *confluence/conf/server.xml
+  */.config/gcloud/application_default_credentials.json or
+  ^ (1)
+
+1 rules:
+
+* Kubernetes and Cloud Credential Path Access via Process Arguments
+
+### Error at line:7,column:19
+Invalid syntax
+  process.name:(curl or wget) or
+  process.args:(* curl* or */bin/curl* or *wget*)
+                  ^ (1)
+
+1 rules:
+
+* Curl or Wget Execution from Container Context
 
 ## Generation errors
 
-### Field type solver: constant_keyword (278)
+### Field type solver: constant_keyword (345)
 
-278 rules:
+345 rules:
+* AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
+* AWS Backup Recovery Point Deleted
+* AWS Backup Vault Deleted or Vault Lock Removed
+* AWS Bedrock Agent Created by IAM User or Root
+* AWS Bedrock Automated Reasoning Safety Policy Tampering
+* AWS Bedrock Foundation Model Access Enabled or Entitlement Granted
+* AWS Bedrock Foundation Model Enumeration Followed by Invocation via Long-Term Key
+* AWS Bedrock Guardrail Deleted or Weakened
+* AWS Bedrock Model Invocation Logging Disabled or Modified
+* AWS Bedrock Provisioned Model Throughput Tampering
+* AWS Bedrock Unauthorized Foundation Model Access Attempt
+* AWS Bedrock Unauthorized Resource-Based Policy Modification Attempt
+* AWS Bedrock Untrusted Model Imported or Marketplace Endpoint Registered
 * AWS CloudShell Environment Created
 * AWS CloudTrail Log Created
 * AWS CloudTrail Log Deleted
@@ -775,18 +890,29 @@ Rules version: 9.4.2
 * AWS EC2 Security Group Configuration Change
 * AWS EC2 Serial Console Access Enabled
 * AWS EFS File System Deleted
+* AWS EKS Access Entry Granted Cluster Admin Policy
+* AWS EKS Access Entry Modified
+* AWS EKS Control Plane Logging Disabled
 * AWS EventBridge Rule Disabled or Deleted
 * AWS GuardDuty Detector Deletion
 * AWS GuardDuty Member Account Manipulation
+* AWS IAM Account Password Policy Deleted
 * AWS IAM Deactivation of MFA Device
 * AWS IAM Group Creation
 * AWS IAM Group Deletion
+* AWS IAM Inline Policy Added to a Group
+* AWS IAM Login Profile Created or Modified for an IAM User
+* AWS IAM Permissions Boundary Modified or Removed
 * AWS IAM Roles Anywhere Profile Creation
 * AWS IAM SAML Provider Created
 * AWS IAM SAML Provider Updated
 * AWS IAM User Addition to Group
 * AWS KMS Customer Managed Key Disabled or Scheduled for Deletion
+* AWS KMS Imported Key Material Deleted
+* AWS Lambda Event Source Mapping Creation
+* AWS Lambda Function Deletion
 * AWS Lambda Layer Added to Existing Function
+* AWS Lambda Layer Shared Externally
 * AWS Management Console Root Login
 * AWS RDS DB Instance Restored
 * AWS RDS DB Instance or Cluster Deleted
@@ -796,6 +922,7 @@ Rules version: 9.4.2
 * AWS Route 53 Private Hosted Zone Associated With a VPC
 * AWS Route 53 Resolver Query Log Configuration Deleted
 * AWS S3 Bucket Configuration Deletion
+* AWS S3 Credential File Retrieved from Bucket
 * AWS SQS Queue Purge
 * AWS Sensitive IAM Operations Performed via CloudShell
 * AWS Sign-In Console Login with Federated User
@@ -830,7 +957,6 @@ Rules version: 9.4.2
 * Azure Automation Webhook Created
 * Azure Blob Storage Container Access Level Modified
 * Azure Blob Storage Permissions Modified
-* Azure Compute VM Command Executed
 * Azure Diagnostic Settings Alert Suppression Rule Created or Modified
 * Azure Event Hub Authorization Rule Created or Updated
 * Azure Event Hub Deleted
@@ -841,10 +967,13 @@ Rules version: 9.4.2
 * Azure Resource Group Deleted
 * Azure Service Principal Sign-In Followed by Arc Cluster Credential Access
 * Azure Storage Account Key Regenerated
+* Azure VM Boot Diagnostics Retrieved
+* Azure VM Extension Deployment by User
 * Azure VNet Firewall Front Door WAF Policy Deleted
 * Azure VNet Firewall Policy Deleted
 * Azure VNet Full Network Packet Capture Enabled
 * Azure VNet Network Watcher Deleted
+* Azure Virtual Machine Configuration Modified
 * Command and Scripting Interpreter via Windows Scripts
 * CrowdStrike External Alerts
 * CyberArk Privileged Access Security Error
@@ -857,23 +986,35 @@ Rules version: 9.4.2
 * Deprecated - M365 Security Compliance User Restricted from Sending Email
 * Deprecated - M365 Teams External Access Enabled
 * Deprecated - M365 Teams Guest Access Enabled
+* Deprecated - MFA Disabled for Google Workspace Organization
 * Direct Interactive Kubernetes API Request by Common Utilities
 * Direct Interactive Kubernetes API Request by Unusual Utilities
 * Domain Added to Google Workspace Trusted Domains
+* EKS Authentication Configuration Modified
 * Elastic Security External Alerts
 * Entra ID ADRS Token Request by Microsoft Authentication Broker
 * Entra ID Application Credential Modified
 * Entra ID Custom Domain Added or Verified
+* Entra ID Device Registration with ROADtools Default OS Build
 * Entra ID Domain Federation Configuration Change
 * Entra ID External Guest User Invited
 * Entra ID Global Administrator Role Assigned
 * Entra ID Global Administrator Role Assigned (PIM User)
+* Entra ID Guest Account Promoted to Member
 * Entra ID High Risk Sign-in
 * Entra ID High Risk User Sign-in Heuristic
+* Entra ID Kali365 Default User-Agent Detected
 * Entra ID MFA Disabled for User
+* Entra ID Microsoft Authentication Broker DRS Sign-In from Suspicious ASN
+* Entra ID Microsoft Authentication Broker Sign-In to Unusual Resource
+* Entra ID Microsoft Authentication Broker Sign-In with Non-Standard User Agent
+* Entra ID OAuth Application Redirect URI Modified
 * Entra ID OAuth Device Code Grant by Microsoft Authentication Broker
+* Entra ID OAuth Device Code Phishing via AiTM
+* Entra ID OAuth Device Code Sign-in to Azure AD Graph Enumeration
 * Entra ID OAuth PRT Issuance to Non-Managed Device Detected
 * Entra ID OAuth Phishing via First-Party Microsoft Application
+* Entra ID Potential AiTM Sign-In via OfficeHome (Tycoon2FA)
 * Entra ID PowerShell Sign-in
 * Entra ID Privileged Identity Management (PIM) Role Modified
 * Entra ID Protection - Risk Detection - Sign-in Risk
@@ -881,8 +1022,10 @@ Rules version: 9.4.2
 * Entra ID Protection Admin Confirmed Compromise
 * Entra ID Protection Alerts for User Detected
 * Entra ID Protection User Alert and Device Registration
+* Entra ID Register Device with Unusual User Agent (Azure AD Join)
 * Entra ID Service Principal Created
 * Entra ID Sign-in TeamFiltration User-Agent Detected
+* Entra ID Temporary Access Pass Created for User
 * Entra ID Unusual Cloud Device Registration
 * Entra ID User Added as Registered Application Owner
 * Entra ID User Added as Service Principal Owner
@@ -920,36 +1063,54 @@ Rules version: 9.4.2
 * GCP Virtual Private Cloud Network Deletion
 * GCP Virtual Private Cloud Route Creation
 * GCP Virtual Private Cloud Route Deletion
+* GKE Admission Webhook Created or Modified
+* GKE Cluster-Admin Role Binding Created or Modified
+* GKE Container Created with Excessive Linux Capabilities
+* GKE Pod Created With HostIPC
+* GKE Pod Created With HostNetwork
+* GKE Pod Created With HostPID
+* GKE Pod Created with a Sensitive hostPath Volume
+* GKE Privileged Pod Created
+* GKE Secret get or list with Suspicious User Agent
+* GKE Suspicious Self-Subject Review via Service Account
 * GitHub App Deleted
 * GitHub Owner Role Granted To User
 * GitHub Private Repository Turned Public
 * GitHub Protected Branch Settings Changed
 * GitHub Repository Deleted
 * GitHub Secret Scanning Disabled
-* Google Drive Ownership Transferred via Google Workspace
 * Google SecOps External Alerts
-* Google Workspace 2SV Policy Disabled
+* Google Workspace 2SV Policy Disabled By User
 * Google Workspace API Access Granted via Domain-Wide Delegation
-* Google Workspace Admin Role Assigned to a User
+* Google Workspace Admin Role Assigned to a User or Group
 * Google Workspace Admin Role Deletion
 * Google Workspace Bitlocker Setting Disabled
 * Google Workspace Custom Admin Role Created
-* Google Workspace Custom Gmail Route Created or Modified
+* Google Workspace Device Registration After OAuth from Suspicious ASN
+* Google Workspace Drive Data Transfer or Takeout Export Initiated
 * Google Workspace Drive Encryption Key(s) Accessed from Anonymous User
-* Google Workspace MFA Enforcement Disabled
-* Google Workspace Object Copied to External Drive with App Consent
+* Google Workspace Gmail Routing or Forwarding Rule Created or Modified
+* Google Workspace Login Flagged Suspicious
+* Google Workspace MFA Enforcement Disabled For Organization
+* Google Workspace Object Copied from External Drive with App Consent
 * Google Workspace Password Policy Modified
 * Google Workspace Restrictions for Marketplace Modified to Allow Any App
 * Google Workspace Role Modified
 * Google Workspace Suspended User Account Renewed
 * Google Workspace User Organizational Unit Changed
 * IBM QRadar External Alerts
+* ICMP Redirect Message from Internal Host
+* ICMP Timestamp or Information Request from the Internet
 * IPSEC NAT Traversal Port Activity
 * Initial Access via File Upload Followed by GET Request
 * Insecure AWS EC2 VPC Security Group Ingress Rule Added
+* Kubernetes API Request Impersonating Privileged Identity
 * Kubernetes Anonymous User Create/Update/Patch Pods Request
+* Kubernetes Client Certificate Signing Request Created or Approved
 * Kubernetes Cluster-Admin Role Binding Created
+* Kubernetes CoreDNS or Kube-DNS Configuration Modified
 * Kubernetes Creation of a RoleBinding Referencing a ServiceAccount
+* Kubernetes Ephemeral Container Added to Pod
 * Kubernetes Events Deleted
 * Kubernetes Exposed Service Created With Type NodePort
 * Kubernetes Forbidden Creation Request
@@ -958,8 +1119,11 @@ Rules version: 9.4.2
 * Kubernetes Pod Created With HostPID
 * Kubernetes Pod Created with a Sensitive hostPath Volume
 * Kubernetes Privileged Pod Created
+* Kubernetes Secret get or list from Node or Pod Service Account
+* Kubernetes Secret get or list with Suspicious User Agent
 * Kubernetes Sensitive RBAC Change Followed by Workload Modification
 * Kubernetes Service Account Modified RBAC Objects
+* Kubernetes Service Account Token Created via TokenRequest API
 * Kubernetes Suspicious Assignment of Controller Service Account
 * Kubernetes User Exec into Pod
 * M365 Exchange Anti-Phish Policy Deleted
@@ -980,12 +1144,13 @@ Rules version: 9.4.2
 * M365 Identity OAuth Flow by User Sign-in to Device Registration
 * M365 Identity OAuth Phishing via First-Party Microsoft Application
 * M365 OneDrive Malware File Upload
+* M365 Potential AiTM UserLoggedIn via Office App (Tycoon2FA)
 * M365 SharePoint Malware File Detected
 * M365 SharePoint Search for Sensitive Content
 * M365 SharePoint Site Administrator Added
 * M365 SharePoint Site Sharing Policy Weakened
 * M365 Teams Custom Application Interaction Enabled
-* MFA Disabled for Google Workspace Organization
+* M365 Teams Rogue Help Desk Chat Created
 * Microsoft Sentinel External Alerts
 * Modification or Removal of an Okta Application Sign-On Policy
 * New GitHub App Installed
@@ -997,10 +1162,12 @@ Rules version: 9.4.2
 * Okta User Assigned Administrator Role
 * Okta User Session Impersonation
 * Possible Okta DoS Attack
-* Potential Credential Access via Renamed COM+ Services DLL
 * Potential DLL Side-Loading via Trusted Microsoft Programs
 * Potential File Transfer via Curl for Windows
 * Potential Persistence via File Modification
+* Potential Redis CONFIG SET Cron Directory Persistence (RedisRaider)
+* Potential Redis CONFIG SET SSH Authorized Key Injection
+* Potential Redis Lua Use-After-Free RCE Attempt (CVE-2025-49844 / RediShell)
 * Potential Toolshell Initial Exploit (CVE-2025-53770 & CVE-2025-53771)
 * Potential VIEWSTATE RCE Attempt on SharePoint/IIS
 * Potential Webshell Deployed via Apache Struts CVE-2023-50164 Exploitation
@@ -1011,10 +1178,12 @@ Rules version: 9.4.2
 * RPC (Remote Procedure Call) to the Internet
 * React2Shell Network Security Alert
 * Roshal Archive (RAR) or PowerShell File Downloaded from the Internet
-* SMTP on Port 26/TCP
+* SMTP to the Internet on Port 26/TCP
+* Sensitive Identity File Open by Suspicious Process via Auditd
 * SentinelOne Alert External Alerts
 * SentinelOne Threat External Alerts
 * Service Account Token or Certificate Access Followed by Kubernetes API Request
+* Splunk Enterprise PostgreSQL Recovery Endpoint Injection Artifacts
 * Splunk External Alerts
 * Stolen Credentials Used to Login to Okta Account After MFA Reset
 * Suricata and Elastic Defend Network Correlation
@@ -1041,7 +1210,6 @@ Rules version: 9.4.2
 * Entra ID Sign-in BloodHound Suite User-Agent Detected
 * Executable File Creation with Multiple Extensions
 * File Deletion via Shred
-* File Download Detected via Defend for Containers
 * GenAI Process Connection to Suspicious Top Level Domain
 * Masquerading Space After Filename
 * Network Activity to a Suspicious Top Level Domain
@@ -1053,6 +1221,7 @@ Rules version: 9.4.2
 * Potential Exploitation of an Unquoted Service Path Vulnerability
 * Potential Linux Tunneling and/or Port Forwarding
 * Potential Linux Tunneling and/or Port Forwarding via Command Line
+* Potential SSH Reverse Port Forwarding
 * Potential Windows Error Manager Masquerading
 * Process Created with a Duplicated Token
 * Process Started from Process ID (PID) File
@@ -1071,9 +1240,9 @@ Rules version: 9.4.2
 * Unusual Process Execution Path - Alternate Data Stream
 * Web Server Exploitation Detected via Defend for Containers
 
-### Unsupported function: stringContains (23)
+### Unsupported function: stringContains (25)
 
-23 rules:
+25 rules:
 * AWS EC2 EBS Snapshot Access Removed
 * AWS EC2 EBS Snapshot Shared or Made Public
 * AWS EC2 Instance Console Login via Assumed Role
@@ -1084,7 +1253,9 @@ Rules version: 9.4.2
 * AWS IAM CompromisedKeyQuarantine Policy Attached to User
 * AWS IAM Login Profile Added for Root
 * AWS IAM Roles Anywhere Trust Anchor Created with External CA
+* AWS Lambda Function Policy Updated to Allow Cross-Account Invocation
 * AWS Lambda Function Policy Updated to Allow Public Invocation
+* AWS Lambda Function URL Created with Public Access
 * AWS RDS DB Instance Made Public
 * AWS RDS DB Instance or Cluster Deletion Protection Disabled
 * AWS RDS DB Instance or Cluster Password Modified
@@ -1098,19 +1269,19 @@ Rules version: 9.4.2
 * AWS S3 Object Versioning Suspended
 * AWS Suspicious User Agent Fingerprint
 
-### Root with too many branches (limit: 10000) (22)
+### Root with too many branches (limit: 10000) (24)
 
-22 rules:
+24 rules:
 * Connection to Common Large Language Model Endpoints
 * Connection to Commonly Abused Web Services
 * Decoded Payload Piped to Interpreter Detected via Defend for Containers
 * Execution from Unusual Directory - Command Line
 * Execution of a Downloaded Windows Script
 * External IP Lookup from Non-Browser Process
-* GenAI Process Accessing Sensitive Files
 * GenAI or MCP Server Child Process Execution
 * Ingress Tool Transfer Followed by Execution and Deletion Detected via Defend for Containers
 * Kubelet Pod Discovery Detected via Defend for Containers
+* Potential Copy Fail (CVE-2026-31431) Exploitation via AF_ALG Socket
 * Potential DNS Tunneling via NsLookup
 * Potential Evasion via Windows Filtering Platform
 * Potential External Linux SSH Brute Force Detected
@@ -1121,8 +1292,25 @@ Rules version: 9.4.2
 * Potential Reverse Shell via Suspicious Binary
 * Potential Reverse Shell via Suspicious Child Process
 * Potential Successful SSH Brute Force Attack
+* Suspicious Child Execution via Web Server
+* Suspicious Command Execution via Web Server
 * Suspicious React Server Child Process
 * Unusual User Privilege Enumeration via id
+
+### Root without branches (11)
+
+11 rules:
+* Initramfs Extraction via CPIO
+* Interactive Shell Spawn Detected via Defend for Containers
+* Interactive Terminal Spawned via Perl
+* Kubectl Configuration Discovery
+* Kubectl Secrets Enumeration Across All Namespaces
+* Linux User or Group Deletion
+* Linux init (PID 1) Secret Dump via GDB
+* Passwordless Sudo Probing
+* Potential Docker Escape via Nsenter
+* Potential Linux Backdoor User Account Creation
+* Suspicious Data Encryption via OpenSSL Utility
 
 ### Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)
 
@@ -1139,39 +1327,28 @@ Rules version: 9.4.2
 * Suspicious Process Access via Direct System Call
 * Uncommon Registry Persistence Change
 
-### Root without branches (10)
+### Unsupported argument type(s): <class 'eql.ast.Field'> (10)
 
 10 rules:
-* Initramfs Extraction via CPIO
-* Interactive Shell Spawn Detected via Defend for Containers
-* Interactive Terminal Spawned via Perl
-* Kubectl Configuration Discovery
-* Kubectl Secrets Enumeration Across All Namespaces
-* Linux User or Group Deletion
-* Linux init (PID 1) Secret Dump via GDB
-* Potential Docker Escape via Nsenter
-* Potential Linux Backdoor User Account Creation
-* Suspicious Data Encryption via OpenSSL Utility
-
-### Unsupported argument type(s): <class 'eql.ast.Field'> (8)
-
-8 rules:
 * External User Added to Google Workspace Group
 * Image Loaded with Invalid Signature
 * Interactive Logon by an Unusual Process
 * M365 Exchange Inbox Forwarding Rule Created
+* Payload Downloaded by Interpreter and Piped to Interpreter
+* Potential Privilege Escalation via SUID/SGID
 * Potential Ransomware Note File Dropped via SMB
 * Suspicious File Renamed via SMB
 * Unusual Network Activity from a Windows System Binary
 * Windows Service Installed via an Unusual Client
 
-### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (6)
+### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)
 
-6 rules:
+7 rules:
 * Execution via MS VisualStudio Pre/Post Build Events
 * Suspicious Execution from VS Code Extension
 * Suspicious Execution from a WebDav Share
 * Suspicious JetBrains TeamCity Child Process
+* Suspicious Microsoft HTML Application Child Process
 * Suspicious Shell Execution via Velociraptor
 * Suspicious Windows Command Shell Arguments
 
@@ -1190,12 +1367,26 @@ Rules version: 9.4.2
 * Potential Meterpreter Reverse Shell
 * Potential Reverse Shell via UDP
 
+### Field type solver: match_only_text (3)
+
+3 rules:
+* Segfault Detected
+* Segfault from Sensitive Process Detected
+* Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)
+
 ### Unsolvable constraints: event.category & event.type (empty intersection) (3)
 
 3 rules:
 * File Execution Permission Modification Detected via Defend for Containers
 * File with Right-to-Left Override Character (RTLO) Created/Executed
 * Unsigned DLL loaded by DNS Service
+
+### Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)
+
+3 rules:
+* AWS SSM Session Manager Child Process Execution
+* Delayed Execution via Ping
+* Veeam Backup Library Loaded by Unusual Process
 
 ### Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)
 
@@ -1218,12 +1409,6 @@ Rules version: 9.4.2
 * Potential Machine Account Relay Attack via SMB
 * Unusual Execution via Microsoft Common Console File
 
-### Field type solver: match_only_text (2)
-
-2 rules:
-* Segfault Detected
-* Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)
-
 ### Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)
 
 2 rules:
@@ -1236,6 +1421,12 @@ Rules version: 9.4.2
 * Suspicious Network Tool Launch Detected via Defend for Containers
 * Suspicious Network Tool Launched Inside A Container
 
+### Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)
+
+2 rules:
+* Base64 Decoded Payload Piped to Interpreter
+* Shared Object Load via LoLBin
+
 ### Unsolvable constraints: process.name (excluded by Strings({'rundll32.exe'}): ('rundll32.exe')) (2)
 
 2 rules:
@@ -1247,6 +1438,12 @@ Rules version: 9.4.2
 2 rules:
 * Downloaded Shortcut Files
 * File with Suspicious Extension Downloaded
+
+### Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)
+
+2 rules:
+* Java Dropped and Executed With DNS Lookup
+* Suspicious Inter-Process Communication via Outlook
 
 ### Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)
 
@@ -1270,11 +1467,6 @@ Rules version: 9.4.2
 1 rules:
 * Potential Okta MFA Bombing via Push Notifications
 
-### Cannot choose from an empty set (1)
-
-1 rules:
-* DNS Request for IP Lookup Service via Unsigned Binary
-
 ### Unsolvable constraints: file.Ext.header_bytes (excluded by Strings({'504B0304*'}): ('504B0304*')) (1)
 
 1 rules:
@@ -1284,6 +1476,11 @@ Rules version: 9.4.2
 
 1 rules:
 * Pluggable Authentication Module or Configuration Creation
+
+### Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)
+
+1 rules:
+* GenAI Process Accessing Sensitive Files
 
 ### Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)
 
@@ -1364,6 +1561,11 @@ Rules version: 9.4.2
 
 1 rules:
 * Potential PowerShell Pass-the-Hash/Relay Script
+
+### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NdrClientCall'}): ('GetProcAddress')) (1)
+
+1 rules:
+* Potential AMSI Bypass via RPC Runtime Hooking
 
 ### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'New-MailboxExportRequest'}): ('-FilePath')) (1)
 
@@ -1500,6 +1702,11 @@ Rules version: 9.4.2
 1 rules:
 * Remote System Discovery Commands
 
+### Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (1)
+
+1 rules:
+* Suspicious macOS MS Office Child Process
+
 ### Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)
 
 1 rules:
@@ -1530,35 +1737,15 @@ Rules version: 9.4.2
 1 rules:
 * Curl or Wget Egress Network Connection via LoLBin
 
-### Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (1)
-
-1 rules:
-* Delayed Execution via Ping
-
-### Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (1)
-
-1 rules:
-* Base64 Decoded Payload Piped to Interpreter
-
 ### Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)
 
 1 rules:
 * Enumeration Command Spawned via WMIPrvSE
 
-### Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)
+### Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)
 
 1 rules:
-* Suspicious macOS MS Office Child Process
-
-### Unsolvable constraints: process.name (not in Strings({'java'}): ('.*')) (1)
-
-1 rules:
-* Suspicious Child Execution via Web Server
-
-### Unsolvable constraints: process.name (not in Strings({'pluginkit'}): ('python*')) (1)
-
-1 rules:
-* Finder Sync Plugin Registered and Enabled
+* Unusual Executable File Creation by a System Critical Process
 
 ### Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)
 
@@ -1625,6 +1812,11 @@ Rules version: 9.4.2
 1 rules:
 * Scheduled Task Execution at Scale via GPO
 
+### Unsolvable constraints: winlog.event_data.param1 (not in Strings({'*FullControl*'}): ('*setsharingmode*')) (1)
+
+1 rules:
+* Quick Assist Full Control Sharing Mode Enabled
+
 ### Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: < (1)
 
 1 rules:
@@ -1664,8 +1856,3 @@ Rules version: 9.4.2
 
 1 rules:
 * Machine Learning Detected a Suspicious Windows Event with a High Malicious Probability Score
-
-### Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (1)
-
-1 rules:
-* Suspicious Inter-Process Communication via Outlook

--- a/tests/reports/documents_from_rules-serverless.md
+++ b/tests/reports/documents_from_rules-serverless.md
@@ -5,44 +5,65 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.2
+Rules version: 9.4.7
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (186)](#unsupported-rule-type-new_terms-186)
-      1. [Unsupported rule type: esql (148)](#unsupported-rule-type-esql-148)
-      1. ['types.SimpleNamespace' object has no attribute 'type' (111)](#typessimplenamespace-object-has-no-attribute-type-111)
+      1. [Unsupported rule type: new_terms (215)](#unsupported-rule-type-new_terms-215)
+      1. [Unsupported rule type: esql (176)](#unsupported-rule-type-esql-176)
+      1. ['types.SimpleNamespace' object has no attribute 'type' (117)](#typessimplenamespace-object-has-no-attribute-type-117)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
-      1. [Unsupported rule type: threshold (29)](#unsupported-rule-type-threshold-29)
+      1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Unsupported query language: lucene (4)](#unsupported-query-language-lucene-4)
+      1. [Unsupported query language: lucene (5)](#unsupported-query-language-lucene-5)
+      1. [Error at line:37,column:3
+Invalid syntax
+  *confluence/conf/server.xml
+  */.config/gcloud/application_default_credentials.json or
+  ^ (1)](#error-at-line37column3
+invalid-syntax
+--confluenceconfserverxml
+--configgcloudapplication_default_credentialsjson-or
+---1)
+      1. [Error at line:7,column:19
+Invalid syntax
+  process.name:(curl or wget) or
+  process.args:(* curl* or */bin/curl* or *wget*)
+                  ^ (1)](#error-at-line7column19
+invalid-syntax
+--processnamecurl-or-wget-or
+--processargs-curl-or-bincurl-or-wget
+-------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (278)](#field-type-solver-constant_keyword-278)
+      1. [Field type solver: constant_keyword (345)](#field-type-solver-constant_keyword-345)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
-      1. [Unsupported function: stringContains (23)](#unsupported-function-stringcontains-23)
-      1. [Root with too many branches (limit: 10000) (22)](#root-with-too-many-branches-limit-10000-22)
+      1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
+      1. [Root with too many branches (limit: 10000) (24)](#root-with-too-many-branches-limit-10000-24)
+      1. [Root without branches (11)](#root-without-branches-11)
       1. [Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)](#unsupported-lhs-type-class-eqlastfunctioncall-11)
-      1. [Root without branches (10)](#root-without-branches-10)
-      1. [Unsupported argument type(s): <class 'eql.ast.Field'> (8)](#unsupported-argument-types-class-eqlastfield-8)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (6)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-6)
+      1. [Unsupported argument type(s): <class 'eql.ast.Field'> (10)](#unsupported-argument-types-class-eqlastfield-10)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-7)
       1. [Unsupported function: startsWith (4)](#unsupported-function-startswith-4)
       1. [<class 'eql.ast.Sample'> (3)](#class-eqlastsample-3)
+      1. [Field type solver: match_only_text (3)](#field-type-solver-match_only_text-3)
       1. [Unsolvable constraints: event.category & event.type (empty intersection) (3)](#unsolvable-constraints-eventcategory--eventtype-empty-intersection-3)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
       1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
-      1. [Field type solver: match_only_text (2)](#field-type-solver-match_only_text-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nc.traditional'}): ('nc.traditional')) (2)](#unsolvable-constraints-processname-excluded-by-stringsnctraditional-nctraditional-2)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)](#unsolvable-constraints-processname-excluded-by-stringspython-python-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'rundll32.exe'}): ('rundll32.exe')) (2)](#unsolvable-constraints-processname-excluded-by-stringsrundll32exe-rundll32exe-2)
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
+      1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
-      1. [Cannot choose from an empty set (1)](#cannot-choose-from-an-empty-set-1)
       1. [Unsolvable constraints: file.Ext.header_bytes (excluded by Strings({'504B0304*'}): ('504B0304*')) (1)](#unsolvable-constraints-fileextheader_bytes-excluded-by-strings504b0304-504b0304-1)
       1. [Unsolvable constraints: file.extension (cannot be non-null) (1)](#unsolvable-constraints-fileextension-cannot-be-non-null-1)
+      1. [Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)](#unsolvable-constraints-filename-excluded-by-stringslocal-state-local-state-1)
       1. [Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)](#unsolvable-constraints-filename-not-in-stringsso-so-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringsswipuploadashx-post-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringschild_process-exec-1)
@@ -59,6 +80,7 @@ Rules version: 9.4.2
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'LsaCallAuthenticationPackage'}): ('KerbRetrieveEncodedTicketMessage')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringslsacallauthenticationpackage-kerbretrieveencodedticketmessage-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'Microsoft.Office.Interop.Outlook'}): ('MAPI')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsmicrosoftofficeinteropoutlook-mapi-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NTLMSSPNegotiate'}): ('NegotiateSMB')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsntlmsspnegotiate-negotiatesmb-1)
+      1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NdrClientCall'}): ('GetProcAddress')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsndrclientcall-getprocaddress-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'New-MailboxExportRequest'}): ('-FilePath')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsnew-mailboxexportrequest--filepath-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'STARTUPINFOEX'}): ('UpdateProcThreadAttribute')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsstartupinfoex-updateprocthreadattribute-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'Set-MpPreference'}): ('DisableArchiveScanning')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsset-mppreference-disablearchivescanning-1)
@@ -86,18 +108,15 @@ Rules version: 9.4.2
       1. [Unsolvable constraints: process.command_line (not in Strings({'*net.ipv4.ip_forward*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsnetipv4ip_forward-echo--1)
       1. [Unsolvable constraints: process.command_line (not in Strings({'*vm.swappiness*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsvmswappiness-echo--1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'arp.exe'}): ('arp.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsarpexe-arpexe-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (1)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)](#unsolvable-constraints-processname-excluded-by-stringscp-cp-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselevation_serviceexe-elevation_serviceexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msdt.exe'}): ('msdt.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsdtexe-msdtexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msedgewebview2.exe'}): ('msedgewebview2.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsedgewebview2exe-msedgewebview2exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'net1.exe'}): ('net1.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnet1exe-net1exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nohup'}): ('nohup')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnohup-nohup-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (1)](#unsolvable-constraints-processname-excluded-by-stringspython-python-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsscexe-scexe-1)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)](#unsolvable-constraints-processname-excluded-by-stringssh-sh-1)
-      1. [Unsolvable constraints: process.name (not in Strings({'java'}): ('.*')) (1)](#unsolvable-constraints-processname-not-in-stringsjava--1)
-      1. [Unsolvable constraints: process.name (not in Strings({'pluginkit'}): ('python*')) (1)](#unsolvable-constraints-processname-not-in-stringspluginkit-python-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringssmssexe-smssexe-1)
       1. [Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)](#unsolvable-constraints-processname-not-in-stringsrundll32exe-mshtaexe-1)
       1. [Unsolvable constraints: process.parent.args (excluded by Strings({'WdiSystemHost'}): ('WdiSystemHost')) (1)](#unsolvable-constraints-processparentargs-excluded-by-stringswdisystemhost-wdisystemhost-1)
       1. [Unsolvable constraints: process.parent.name (excluded by Strings({'dllhost.exe'}): ('dllhost.exe')) (1)](#unsolvable-constraints-processparentname-excluded-by-stringsdllhostexe-dllhostexe-1)
@@ -111,6 +130,7 @@ Rules version: 9.4.2
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*42B5FAAE-6536-11D2-AE5A-0000F87571E3*'}): ('*40B66650-4972-11D1-A7CA-0000F87571E3*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-strings42b5faae-6536-11d2-ae5a-0000f87571e3-40b66650-4972-11d1-a7ca-0000f87571e3-1)
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*827D319E-6EAC-11D2-A4EA-00C04F79F83A*'}): ('*803E14A0-B4FB-11D0-A0D0-00A0C90F574B*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-strings827d319e-6eac-11d2-a4ea-00c04f79f83a-803e14a0-b4fb-11d0-a0d0-00a0c90f574b-1)
       1. [Unsolvable constraints: winlog.event_data.AttributeValue (not in Strings({'*CAB54552-DEEA-4691-817E-ED4A4D1AFC72*'}): ('*AADCED64-746C-4633-A97C-D61349046527*')) (1)](#unsolvable-constraints-winlogevent_dataattributevalue-not-in-stringscab54552-deea-4691-817e-ed4a4d1afc72-aadced64-746c-4633-a97c-d61349046527-1)
+      1. [Unsolvable constraints: winlog.event_data.param1 (not in Strings({'*FullControl*'}): ('*setsharingmode*')) (1)](#unsolvable-constraints-winlogevent_dataparam1-not-in-stringsfullcontrol-setsharingmode-1)
       1. [Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: < (1)](#unsupported-keyword-dllextrelative_file_creation_time-constraint--1)
       1. [Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: <= (1)](#unsupported-keyword-dllextrelative_file_creation_time-constraint--1)
       1. [Unsupported &keyword 'file.Ext.entropy' constraint: >= (1)](#unsupported-keyword-fileextentropy-constraint--1)
@@ -119,19 +139,25 @@ Rules version: 9.4.2
       1. [Unsupported &keyword 'powershell.file.script_block_length' constraint: > (1)](#unsupported-keyword-powershellfilescript_block_length-constraint--1)
       1. [Unsupported &keyword 'problemchild.prediction_probability' constraint: <= (1)](#unsupported-keyword-problemchildprediction_probability-constraint--1)
       1. [Unsupported &keyword 'problemchild.prediction_probability' constraint: > (1)](#unsupported-keyword-problemchildprediction_probability-constraint--1)
-      1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (1)](#unsupported-keyword-processextrelative_file_creation_time-constraint--1)
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (186)
+### Unsupported rule type: new_terms (215)
 
-186 rules:
+215 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
+* AWS Bedrock Agent or Action Group Manipulation
+* AWS Bedrock Knowledge Base or RAG Data Source Tampering
+* AWS Bedrock Resource-Based Policy Modified or Deleted
+* AWS Bedrock Third-Party or External Knowledge Base Associated to Agent
 * AWS CLI Command with Custom Endpoint URL
+* AWS Discovery API Calls from VPN ASN for the First Time by Identity
 * AWS DynamoDB Scan by Unusual User
 * AWS DynamoDB Table Exported to S3
+* AWS EC2 CreateKeyPair by New Principal from Non-Cloud AS Organization
+* AWS EC2 Role GetCallerIdentity from New Source AS Organization
 * AWS EC2 Route Table Created
 * AWS EC2 Route Table Modified or Deleted
 * AWS EC2 Unauthorized Admin Credential Fetch via Assumed Role
@@ -143,6 +169,8 @@ Rules version: 9.4.2
 * AWS IAM Customer-Managed Policy Attached to Role by Rare User
 * AWS IAM Long-Term Access Key First Seen from Source IP
 * AWS IAM OIDC Provider Created by Rare User
+* AWS Lambda Function Invoked by an Unusual Principal
+* AWS Lambda Function Invoked from an Unusual Source ASN
 * AWS S3 Unauthenticated Bucket Access by Rare Source
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
@@ -162,9 +190,12 @@ Rules version: 9.4.2
 * Abnormal Process ID or Lock File Created
 * Account or Group Discovery via Built-In Tools
 * Authentication via Unusual PAM Grantor
+* Azure AD Graph Access with Unusual Client and User
+* Azure AD Graph Access with Unusual User and ASN
 * Azure Arc Cluster Credential Access by Identity from Unusual Source
 * Azure Compute Restore Point Collection Deleted by Unusual User
 * Azure Compute Snapshot Deletion by Unusual User and Resource Group
+* Azure Compute VM Command Executed
 * Azure Diagnostic Settings Deleted
 * Azure Key Vault Modified
 * Azure Key Vault Unusual Secret Key Usage
@@ -172,12 +203,17 @@ Rules version: 9.4.2
 * Azure Storage Account Deletion by Unusual User
 * Azure Storage Account Keys Accessed by Privileged User
 * Azure Storage Blob Retrieval via AzCopy
+* Azure VM Extension CRUD Operation with Unusual Source ASN
+* Azure VM Managed Run Command Created or Updated with Unusual Principal
+* Azure VM Serial Console Connection with Unusual User and ASN
 * DPKG Package Installed by Unusual Parent Process
 * Delegated Managed Service Account Modification by an Unusual User
 * Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
+* Deprecated TLS Version or Weak Cipher Negotiated Externally
 * Discovery of Internet Capabilities via Built-in Tools
 * Entra ID Conditional Access Policy (CAP) Modified
+* Entra ID Device with ROADtools Default OS Build (Entity Analytics)
 * Entra ID Elevated Access to User Access Administrator
 * Entra ID External Authentication Methods (EAM) Modified
 * Entra ID OAuth Authorization Code Grant for Unusual User, App, and Resource
@@ -213,22 +249,27 @@ Rules version: 9.4.2
 * First Time Python Created a LaunchAgent or LaunchDaemon
 * First Time Python Spawned a Shell on Host
 * First Time Seen AWS Secret Value Accessed in Secrets Manager
+* First Time Seen Account Performing DCSync
 * First Time Seen Driver Loaded
 * First Time Seen Google Workspace OAuth Login from Third-Party Application
 * First Time Seen NewCredentials Logon Process
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
-* FirstTime Seen Account Performing DCSync
 * FortiGate Administrator Account Creation from Unusual Source
+* GKE Secrets List from Unusual Source AS Organization
+* GKE User Exec into Pod
 * GenAI Process Connection to Unusual Domain
 * GitHub Actions Unusual Bot Push to Repository
 * Github Activity on a Private Repository from an Unusual IP
+* Google Workspace User Login with Unusual ASN
+* Google Workspace User Sign-in from Atypical Device Type
 * Interactive Shell Launched via Unusual Parent Process in a Container
 * Kernel Object File Creation
 * Kill Command Execution
 * Kubernetes Anonymous Request Authorized by Unusual User Agent
 * Kubernetes Denied Service Account Request via Unusual User Agent
 * Kubernetes Forbidden Request from Unusual User Agent
+* Kubernetes Pod Creation Using Common Debug or Base Images
 * Kubernetes Secret Access via Unusual User Agent
 * Kubernetes Suspicious Self-Subject Review via Unusual User Agent
 * Kubernetes Unusual Decision by User Agent
@@ -241,7 +282,9 @@ Rules version: 9.4.2
 * M365 Exchange Inbox Phishing Evasion Rule Created
 * M365 Exchange Mailbox Accessed by Unusual Client
 * M365 Exchange Mailbox High-Risk Permission Delegated
-* M365 Identity Login from Atypical Travel Location
+* M365 Identity Device Code Grant by an Unusual User (Non-Compliant Device)
+* M365 Identity Device Code Grant with Unusual User and ASN
+* M365 Identity Login from Atypical Region
 * M365 Identity OAuth Illicit Consent Grant by Rare Client and User
 * M365 Identity Unusual SSO Authentication Errors for User
 * M365 SharePoint/OneDrive File Access via PowerShell
@@ -257,6 +300,7 @@ Rules version: 9.4.2
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
+* Potential ICMP Tunneling Activity to the Internet
 * Potential Pass-the-Hash (PtH) Attempt
 * Potential Privilege Escalation via Linux DAC permissions
 * Potential Shadow File Read via Command Line Utilities
@@ -267,6 +311,7 @@ Rules version: 9.4.2
 * RPM Package Installed by Unusual Parent Process
 * Rare SMB Connection to the Internet
 * Remote File Creation in World Writeable Directory
+* SMB (Windows File Sharing) Activity from the Internet
 * SMB (Windows File Sharing) Activity to the Internet
 * SSH Authorized Keys File Activity
 * Sensitive Files Compression
@@ -275,6 +320,7 @@ Rules version: 9.4.2
 * Successful SSH Authentication from Unusual IP Address
 * Successful SSH Authentication from Unusual SSH Public Key
 * Successful SSH Authentication from Unusual User
+* Suspicious Instance Metadata Service (IMDS) API Request
 * Suspicious Modprobe File Event
 * Suspicious Named Pipe Creation
 * Suspicious Network Activity to the Internet by Previously Unknown Executable
@@ -289,8 +335,11 @@ Rules version: 9.4.2
 * Systemd Service Started by Unusual Parent Process
 * UID Elevation from Previously Unknown Executable
 * Unauthorized Scope for Public App OAuth2 Token Grant with Client Credentials
+* Uncommon DNS Request via Bun or Node.js
 * Unknown Execution of Binary with RWX Memory Region
 * Unusual AWS S3 Object Encryption with SSE-C
+* Unusual Child Execution via Web Server
+* Unusual Command Execution via Web Server
 * Unusual Discovery Signal Alert with Unusual Process Command Line
 * Unusual Discovery Signal Alert with Unusual Process Executable
 * Unusual Execution from Kernel Thread (kthreadd) Parent
@@ -310,38 +359,49 @@ Rules version: 9.4.2
 * Unusual SSHD Child Process
 * Unusual Scheduled Task Update
 * Unusual Web Config File Access
-* Unusual Web Server Command Execution
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (148)
+### Unsupported rule type: esql (176)
 
-148 rules:
+176 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock Detected Multiple Attempts to use Denied Models by a Single User
 * AWS Bedrock Detected Multiple Validation Exception Errors by a Single User
 * AWS Bedrock Guardrails Detected Multiple Policy Violations Within a Single Blocked Request
 * AWS Bedrock Guardrails Detected Multiple Violations by a Single User Over a Session
+* AWS Bedrock High-Frequency Single-Model Inference API Probing
 * AWS Bedrock Invocations without Guardrails Detected by a Single User Over a Session
 * AWS Credentials Used from GitHub Actions and Non-CI/CD Infrastructure
 * AWS Discovery API Calls via CLI from a Single Resource
 * AWS EC2 LOLBin Execution via SSM SendCommand
 * AWS EC2 Multi-Region DescribeInstances API Calls
+* AWS EC2 Stop, Start, and User Data Modification Correlation
+* AWS ECR Repository or Registry Policy Granted Public Access
 * AWS IAM Long-Term Access Key Correlated with Elevated Detection Alerts
+* AWS IAM User Console Login from Multiple Geolocations
 * AWS IAM User Created Access Keys For Another User
+* AWS Lambda Function High-Frequency Invocation by a Single Principal
+* AWS Lambda Function Invoked Cross-Account
+* AWS Lateral Movement from Kubernetes SA via AssumeRoleWithWebIdentity
 * AWS Rare Source AS Organization Activity
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
 * Agent Spoofing - Multiple Hosts Using Same Agent
 * Alerts From Multiple Integrations by Destination Address
 * Alerts From Multiple Integrations by Source Address
 * Alerts From Multiple Integrations by User Name
 * Alerts in Different ATT&CK Tactics by Host
+* Azure AD Graph Access with Suspicious User-Agent
+* Azure AD Graph High 4xx Error Ratio from User
+* Azure AD Graph Potential Enumeration (ROADrecon)
 * Azure Key Vault Excessive Secret or Key Retrieved
 * Azure OpenAI Insecure Output Handling
+* Azure Run Command Correlated with Process Execution
 * Command Line Obfuscation via Whitespace Padding
 * Correlated Alerts on Similar User Identities
 * Detection Alert on a Process Exhibiting CPU Spike
@@ -365,14 +425,24 @@ Rules version: 9.4.2
 * First-Time FortiGate Administrator Login
 * FortiGate Administrator Login from Multiple IP Addresses
 * FortiGate FortiCloud SSO Login from Unusual Source
+* GKE API Request Failure Burst by User
 * GitHub Actions Workflow Modification Blocked
 * GitHub Exfiltration via High Number of Repository Clones by User
+* Google Workspace Device Registration Burst for Single User
+* Google Workspace Impossible Travel Login
 * High Number of Closed Pull Requests by User
 * High Number of Egress Network Connections from Unusual Executable
 * High Number of Protected Branch Force Pushes by User
 * Kubernetes Creation or Modification of Sensitive Role
+* Kubernetes Multi-Resource Discovery
+* Kubernetes Pod Exec Cloud Instance Metadata Access
+* Kubernetes Pod Exec Potential Reverse Shell
+* Kubernetes Pod Exec Sensitive File or Credential Path Access
+* Kubernetes Pod Exec with Curl or Wget to HTTPS
 * Kubernetes Potential Endpoint Permission Enumeration Attempt Detected
 * Kubernetes Potential Endpoint Permission Enumeration Attempt by Anonymous User Detected
+* Kubernetes RBAC Wildcard Elevation on Existing Role
+* Kubernetes Rapid Secret GET Activity Against Multiple Objects
 * Kubernetes Secret or ConfigMap Access via Azure Arc Proxy
 * LLM-Based Attack Chain Triage by Host
 * LLM-Based Compromised User Triage by User
@@ -381,15 +451,19 @@ Rules version: 9.4.2
 * Lateral Movement Alerts from a Newly Observed User
 * Long Base64 Encoded Command via Scripting Interpreter
 * M365 Azure Monitor Alert Email with Financial or Billing Theme
+* M365 Exchange Inbox Rule with Obfuscated Name
 * M365 Identity OAuth Flow by First-Party Microsoft App from Multiple IPs
 * M365 Identity User Account Lockouts
 * M365 Identity User Brute Force Attempted
 * M365 OneDrive/SharePoint Excessive File Downloads
 * M365 or Entra ID Identity Sign-in from a Suspicious Source
+* Microsoft Graph Multi-Category Reconnaissance Burst
+* Multi-Cloud CLI Token and Credential Access Commands
 * Multiple Alerts Involving a User
 * Multiple Alerts in Same ATT&CK Tactic by Host
 * Multiple Alerts on a Host Exhibiting CPU Spike
 * Multiple Cloud Secrets Accessed by Source Address
+* Multiple DHCP Servers Responding to the Same Transaction
 * Multiple Device Token Hashes for Single Okta Session
 * Multiple Elastic Defend Alerts by Agent
 * Multiple Elastic Defend Alerts from a Single Process Tree
@@ -415,6 +489,8 @@ Rules version: 9.4.2
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
 * Potential Credential Discovery via Recursive Grep
+* Potential DHCP Starvation via High Client MAC Cardinality
+* Potential DNS Exfiltration via Excessive Chunked Queries
 * Potential Denial of Azure OpenAI ML Service
 * Potential Dynamic IEX Reconstruction via Environment Variables
 * Potential Linux Local Account Brute Force Detected
@@ -440,6 +516,7 @@ Rules version: 9.4.2
 * Potential PowerShell Obfuscation via String Concatenation
 * Potential PowerShell Obfuscation via String Reordering
 * Potential Ransomware Behavior - Note Files by System
+* Potential SQL Injection Against Microsoft SQL Server
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
 * Potential Widespread Malware Infection Across Multiple Hosts
@@ -448,18 +525,17 @@ Rules version: 9.4.2
 * Rare Connection to WebDAV Target
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
+* Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
 * Suspected Lateral Movement from Compromised Host
 * Suspicious AWS S3 Connection via Script Interpreter
 * Suspicious Python Shell Command Execution
 * Suspicious TCC Access Granted for User Folders
 * Unusual Base64 Encoding/Decoding Activity
-* Unusual Command Execution from Web Server Parent
 * Unusual File Creation by Web Server
 * Unusual High Confidence Content Filter Blocks Detected
 * Unusual High Denied Sensitive Information Policy Blocks Detected
 * Unusual High Denied Topic Blocks Detected
 * Unusual High Word Policy Blocks Detected
-* Unusual Process Spawned from Web Server Parent
 * Web Server Discovery or Fuzzing Activity
 * Web Server Local File Inclusion Activity
 * Web Server Potential Command Injection Request
@@ -467,9 +543,9 @@ Rules version: 9.4.2
 * Web Server Potential Spike in Error Response Codes
 * Web Server Suspicious User Agent Requests
 
-### 'types.SimpleNamespace' object has no attribute 'type' (111)
+### 'types.SimpleNamespace' object has no attribute 'type' (117)
 
-111 rules:
+117 rules:
 
 * AWS RDS Snapshot Export
 * Attempt to Disable IPTables or Firewall
@@ -495,8 +571,10 @@ Rules version: 9.4.2
 * Deprecated - Azure Virtual Network Device Modified or Deleted
 * Deprecated - CAP_SYS_ADMIN Assigned to Binary
 * Deprecated - Creation of Kernel Module
+* Deprecated - EggShell Backdoor Execution
 * Deprecated - Execution of File Written or Modified by PDF Reader
 * Deprecated - LaunchDaemon Creation or Modification and Immediate Loading
+* Deprecated - Linux Restricted Shell Breakout via Linux Binary(s)
 * Deprecated - Modification of Standard Authentication Module or Configuration
 * Deprecated - Network Connection via Sudo Binary
 * Deprecated - Potential DNS Tunneling via Iodine
@@ -516,11 +594,15 @@ Rules version: 9.4.2
 * Deprecated - SSH Connection Established Inside A Running Container
 * Deprecated - SSH Process Launched From Inside A Container
 * Deprecated - SSH Process Launched From Inside A Container via Elastic Defend
+* Deprecated - Sudo Heap-Based Buffer Overflow Attempt
 * Deprecated - Suspicious File Creation in /etc for Persistence
 * Deprecated - Suspicious JAVA Child Process
 * Deprecated - Suspicious Renaming of ESXI index.html File
 * Deprecated - Threat Intel Filebeat Module (v8.x) Indicator Match
 * Deprecated - Threat Intel Indicator Match
+* Deprecated - Uncommon Destination Port Connection by Web Server
+* Deprecated - Unusual Command Execution from Web Server Parent
+* Deprecated - Unusual Process Spawned from Web Server Parent
 * Execution via Regsvcs/Regasm
 * FTP (File Transfer Protocol) Activity to the Internet
 * File and Directory Discovery
@@ -694,9 +776,9 @@ Rules version: 9.4.2
 * Unusual Windows Username
 * User Detected with Suspicious Windows Process(es)
 
-### Unsupported rule type: threshold (29)
+### Unsupported rule type: threshold (28)
 
-29 rules:
+28 rules:
 
 * AWS IAM Principal Enumeration via UpdateAssumeRolePolicy
 * AWS Management Console Brute Force of Root User Identity
@@ -706,7 +788,6 @@ Rules version: 9.4.2
 * Azure Compute Restore Point Collections Deleted
 * Azure Compute Snapshot Deletions by User
 * Azure Storage Account Deletions by User
-* Deprecated - Sudo Heap-Based Buffer Overflow Attempt
 * Entra ID Excessive Account Lockouts Detected
 * Excessive AWS S3 Object Encryption with SSE-C
 * GitHub UEBA - Multiple Alerts from a GitHub Account
@@ -739,20 +820,54 @@ Rules version: 9.4.2
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Unsupported query language: lucene (4)
+### Unsupported query language: lucene (5)
 
-4 rules:
+5 rules:
 
 * Cobalt Strike Command and Control Beacon
 * Halfbaked Command and Control Beacon
 * Inbound Connection to an Unsecure Elasticsearch Node
 * Possible FIN7 DGA Command and Control Behavior
+* Potential cPanel WHM CRLF Authentication Bypass (CVE-2026-41940)
+
+### Error at line:37,column:3
+Invalid syntax
+  *confluence/conf/server.xml
+  */.config/gcloud/application_default_credentials.json or
+  ^ (1)
+
+1 rules:
+
+* Kubernetes and Cloud Credential Path Access via Process Arguments
+
+### Error at line:7,column:19
+Invalid syntax
+  process.name:(curl or wget) or
+  process.args:(* curl* or */bin/curl* or *wget*)
+                  ^ (1)
+
+1 rules:
+
+* Curl or Wget Execution from Container Context
 
 ## Generation errors
 
-### Field type solver: constant_keyword (278)
+### Field type solver: constant_keyword (345)
 
-278 rules:
+345 rules:
+* AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
+* AWS Backup Recovery Point Deleted
+* AWS Backup Vault Deleted or Vault Lock Removed
+* AWS Bedrock Agent Created by IAM User or Root
+* AWS Bedrock Automated Reasoning Safety Policy Tampering
+* AWS Bedrock Foundation Model Access Enabled or Entitlement Granted
+* AWS Bedrock Foundation Model Enumeration Followed by Invocation via Long-Term Key
+* AWS Bedrock Guardrail Deleted or Weakened
+* AWS Bedrock Model Invocation Logging Disabled or Modified
+* AWS Bedrock Provisioned Model Throughput Tampering
+* AWS Bedrock Unauthorized Foundation Model Access Attempt
+* AWS Bedrock Unauthorized Resource-Based Policy Modification Attempt
+* AWS Bedrock Untrusted Model Imported or Marketplace Endpoint Registered
 * AWS CloudShell Environment Created
 * AWS CloudTrail Log Created
 * AWS CloudTrail Log Deleted
@@ -775,18 +890,29 @@ Rules version: 9.4.2
 * AWS EC2 Security Group Configuration Change
 * AWS EC2 Serial Console Access Enabled
 * AWS EFS File System Deleted
+* AWS EKS Access Entry Granted Cluster Admin Policy
+* AWS EKS Access Entry Modified
+* AWS EKS Control Plane Logging Disabled
 * AWS EventBridge Rule Disabled or Deleted
 * AWS GuardDuty Detector Deletion
 * AWS GuardDuty Member Account Manipulation
+* AWS IAM Account Password Policy Deleted
 * AWS IAM Deactivation of MFA Device
 * AWS IAM Group Creation
 * AWS IAM Group Deletion
+* AWS IAM Inline Policy Added to a Group
+* AWS IAM Login Profile Created or Modified for an IAM User
+* AWS IAM Permissions Boundary Modified or Removed
 * AWS IAM Roles Anywhere Profile Creation
 * AWS IAM SAML Provider Created
 * AWS IAM SAML Provider Updated
 * AWS IAM User Addition to Group
 * AWS KMS Customer Managed Key Disabled or Scheduled for Deletion
+* AWS KMS Imported Key Material Deleted
+* AWS Lambda Event Source Mapping Creation
+* AWS Lambda Function Deletion
 * AWS Lambda Layer Added to Existing Function
+* AWS Lambda Layer Shared Externally
 * AWS Management Console Root Login
 * AWS RDS DB Instance Restored
 * AWS RDS DB Instance or Cluster Deleted
@@ -796,6 +922,7 @@ Rules version: 9.4.2
 * AWS Route 53 Private Hosted Zone Associated With a VPC
 * AWS Route 53 Resolver Query Log Configuration Deleted
 * AWS S3 Bucket Configuration Deletion
+* AWS S3 Credential File Retrieved from Bucket
 * AWS SQS Queue Purge
 * AWS Sensitive IAM Operations Performed via CloudShell
 * AWS Sign-In Console Login with Federated User
@@ -830,7 +957,6 @@ Rules version: 9.4.2
 * Azure Automation Webhook Created
 * Azure Blob Storage Container Access Level Modified
 * Azure Blob Storage Permissions Modified
-* Azure Compute VM Command Executed
 * Azure Diagnostic Settings Alert Suppression Rule Created or Modified
 * Azure Event Hub Authorization Rule Created or Updated
 * Azure Event Hub Deleted
@@ -841,10 +967,13 @@ Rules version: 9.4.2
 * Azure Resource Group Deleted
 * Azure Service Principal Sign-In Followed by Arc Cluster Credential Access
 * Azure Storage Account Key Regenerated
+* Azure VM Boot Diagnostics Retrieved
+* Azure VM Extension Deployment by User
 * Azure VNet Firewall Front Door WAF Policy Deleted
 * Azure VNet Firewall Policy Deleted
 * Azure VNet Full Network Packet Capture Enabled
 * Azure VNet Network Watcher Deleted
+* Azure Virtual Machine Configuration Modified
 * Command and Scripting Interpreter via Windows Scripts
 * CrowdStrike External Alerts
 * CyberArk Privileged Access Security Error
@@ -857,23 +986,35 @@ Rules version: 9.4.2
 * Deprecated - M365 Security Compliance User Restricted from Sending Email
 * Deprecated - M365 Teams External Access Enabled
 * Deprecated - M365 Teams Guest Access Enabled
+* Deprecated - MFA Disabled for Google Workspace Organization
 * Direct Interactive Kubernetes API Request by Common Utilities
 * Direct Interactive Kubernetes API Request by Unusual Utilities
 * Domain Added to Google Workspace Trusted Domains
+* EKS Authentication Configuration Modified
 * Elastic Security External Alerts
 * Entra ID ADRS Token Request by Microsoft Authentication Broker
 * Entra ID Application Credential Modified
 * Entra ID Custom Domain Added or Verified
+* Entra ID Device Registration with ROADtools Default OS Build
 * Entra ID Domain Federation Configuration Change
 * Entra ID External Guest User Invited
 * Entra ID Global Administrator Role Assigned
 * Entra ID Global Administrator Role Assigned (PIM User)
+* Entra ID Guest Account Promoted to Member
 * Entra ID High Risk Sign-in
 * Entra ID High Risk User Sign-in Heuristic
+* Entra ID Kali365 Default User-Agent Detected
 * Entra ID MFA Disabled for User
+* Entra ID Microsoft Authentication Broker DRS Sign-In from Suspicious ASN
+* Entra ID Microsoft Authentication Broker Sign-In to Unusual Resource
+* Entra ID Microsoft Authentication Broker Sign-In with Non-Standard User Agent
+* Entra ID OAuth Application Redirect URI Modified
 * Entra ID OAuth Device Code Grant by Microsoft Authentication Broker
+* Entra ID OAuth Device Code Phishing via AiTM
+* Entra ID OAuth Device Code Sign-in to Azure AD Graph Enumeration
 * Entra ID OAuth PRT Issuance to Non-Managed Device Detected
 * Entra ID OAuth Phishing via First-Party Microsoft Application
+* Entra ID Potential AiTM Sign-In via OfficeHome (Tycoon2FA)
 * Entra ID PowerShell Sign-in
 * Entra ID Privileged Identity Management (PIM) Role Modified
 * Entra ID Protection - Risk Detection - Sign-in Risk
@@ -881,8 +1022,10 @@ Rules version: 9.4.2
 * Entra ID Protection Admin Confirmed Compromise
 * Entra ID Protection Alerts for User Detected
 * Entra ID Protection User Alert and Device Registration
+* Entra ID Register Device with Unusual User Agent (Azure AD Join)
 * Entra ID Service Principal Created
 * Entra ID Sign-in TeamFiltration User-Agent Detected
+* Entra ID Temporary Access Pass Created for User
 * Entra ID Unusual Cloud Device Registration
 * Entra ID User Added as Registered Application Owner
 * Entra ID User Added as Service Principal Owner
@@ -920,36 +1063,54 @@ Rules version: 9.4.2
 * GCP Virtual Private Cloud Network Deletion
 * GCP Virtual Private Cloud Route Creation
 * GCP Virtual Private Cloud Route Deletion
+* GKE Admission Webhook Created or Modified
+* GKE Cluster-Admin Role Binding Created or Modified
+* GKE Container Created with Excessive Linux Capabilities
+* GKE Pod Created With HostIPC
+* GKE Pod Created With HostNetwork
+* GKE Pod Created With HostPID
+* GKE Pod Created with a Sensitive hostPath Volume
+* GKE Privileged Pod Created
+* GKE Secret get or list with Suspicious User Agent
+* GKE Suspicious Self-Subject Review via Service Account
 * GitHub App Deleted
 * GitHub Owner Role Granted To User
 * GitHub Private Repository Turned Public
 * GitHub Protected Branch Settings Changed
 * GitHub Repository Deleted
 * GitHub Secret Scanning Disabled
-* Google Drive Ownership Transferred via Google Workspace
 * Google SecOps External Alerts
-* Google Workspace 2SV Policy Disabled
+* Google Workspace 2SV Policy Disabled By User
 * Google Workspace API Access Granted via Domain-Wide Delegation
-* Google Workspace Admin Role Assigned to a User
+* Google Workspace Admin Role Assigned to a User or Group
 * Google Workspace Admin Role Deletion
 * Google Workspace Bitlocker Setting Disabled
 * Google Workspace Custom Admin Role Created
-* Google Workspace Custom Gmail Route Created or Modified
+* Google Workspace Device Registration After OAuth from Suspicious ASN
+* Google Workspace Drive Data Transfer or Takeout Export Initiated
 * Google Workspace Drive Encryption Key(s) Accessed from Anonymous User
-* Google Workspace MFA Enforcement Disabled
-* Google Workspace Object Copied to External Drive with App Consent
+* Google Workspace Gmail Routing or Forwarding Rule Created or Modified
+* Google Workspace Login Flagged Suspicious
+* Google Workspace MFA Enforcement Disabled For Organization
+* Google Workspace Object Copied from External Drive with App Consent
 * Google Workspace Password Policy Modified
 * Google Workspace Restrictions for Marketplace Modified to Allow Any App
 * Google Workspace Role Modified
 * Google Workspace Suspended User Account Renewed
 * Google Workspace User Organizational Unit Changed
 * IBM QRadar External Alerts
+* ICMP Redirect Message from Internal Host
+* ICMP Timestamp or Information Request from the Internet
 * IPSEC NAT Traversal Port Activity
 * Initial Access via File Upload Followed by GET Request
 * Insecure AWS EC2 VPC Security Group Ingress Rule Added
+* Kubernetes API Request Impersonating Privileged Identity
 * Kubernetes Anonymous User Create/Update/Patch Pods Request
+* Kubernetes Client Certificate Signing Request Created or Approved
 * Kubernetes Cluster-Admin Role Binding Created
+* Kubernetes CoreDNS or Kube-DNS Configuration Modified
 * Kubernetes Creation of a RoleBinding Referencing a ServiceAccount
+* Kubernetes Ephemeral Container Added to Pod
 * Kubernetes Events Deleted
 * Kubernetes Exposed Service Created With Type NodePort
 * Kubernetes Forbidden Creation Request
@@ -958,8 +1119,11 @@ Rules version: 9.4.2
 * Kubernetes Pod Created With HostPID
 * Kubernetes Pod Created with a Sensitive hostPath Volume
 * Kubernetes Privileged Pod Created
+* Kubernetes Secret get or list from Node or Pod Service Account
+* Kubernetes Secret get or list with Suspicious User Agent
 * Kubernetes Sensitive RBAC Change Followed by Workload Modification
 * Kubernetes Service Account Modified RBAC Objects
+* Kubernetes Service Account Token Created via TokenRequest API
 * Kubernetes Suspicious Assignment of Controller Service Account
 * Kubernetes User Exec into Pod
 * M365 Exchange Anti-Phish Policy Deleted
@@ -980,12 +1144,13 @@ Rules version: 9.4.2
 * M365 Identity OAuth Flow by User Sign-in to Device Registration
 * M365 Identity OAuth Phishing via First-Party Microsoft Application
 * M365 OneDrive Malware File Upload
+* M365 Potential AiTM UserLoggedIn via Office App (Tycoon2FA)
 * M365 SharePoint Malware File Detected
 * M365 SharePoint Search for Sensitive Content
 * M365 SharePoint Site Administrator Added
 * M365 SharePoint Site Sharing Policy Weakened
 * M365 Teams Custom Application Interaction Enabled
-* MFA Disabled for Google Workspace Organization
+* M365 Teams Rogue Help Desk Chat Created
 * Microsoft Sentinel External Alerts
 * Modification or Removal of an Okta Application Sign-On Policy
 * New GitHub App Installed
@@ -997,10 +1162,12 @@ Rules version: 9.4.2
 * Okta User Assigned Administrator Role
 * Okta User Session Impersonation
 * Possible Okta DoS Attack
-* Potential Credential Access via Renamed COM+ Services DLL
 * Potential DLL Side-Loading via Trusted Microsoft Programs
 * Potential File Transfer via Curl for Windows
 * Potential Persistence via File Modification
+* Potential Redis CONFIG SET Cron Directory Persistence (RedisRaider)
+* Potential Redis CONFIG SET SSH Authorized Key Injection
+* Potential Redis Lua Use-After-Free RCE Attempt (CVE-2025-49844 / RediShell)
 * Potential Toolshell Initial Exploit (CVE-2025-53770 & CVE-2025-53771)
 * Potential VIEWSTATE RCE Attempt on SharePoint/IIS
 * Potential Webshell Deployed via Apache Struts CVE-2023-50164 Exploitation
@@ -1011,10 +1178,12 @@ Rules version: 9.4.2
 * RPC (Remote Procedure Call) to the Internet
 * React2Shell Network Security Alert
 * Roshal Archive (RAR) or PowerShell File Downloaded from the Internet
-* SMTP on Port 26/TCP
+* SMTP to the Internet on Port 26/TCP
+* Sensitive Identity File Open by Suspicious Process via Auditd
 * SentinelOne Alert External Alerts
 * SentinelOne Threat External Alerts
 * Service Account Token or Certificate Access Followed by Kubernetes API Request
+* Splunk Enterprise PostgreSQL Recovery Endpoint Injection Artifacts
 * Splunk External Alerts
 * Stolen Credentials Used to Login to Okta Account After MFA Reset
 * Suricata and Elastic Defend Network Correlation
@@ -1041,7 +1210,6 @@ Rules version: 9.4.2
 * Entra ID Sign-in BloodHound Suite User-Agent Detected
 * Executable File Creation with Multiple Extensions
 * File Deletion via Shred
-* File Download Detected via Defend for Containers
 * GenAI Process Connection to Suspicious Top Level Domain
 * Masquerading Space After Filename
 * Network Activity to a Suspicious Top Level Domain
@@ -1053,6 +1221,7 @@ Rules version: 9.4.2
 * Potential Exploitation of an Unquoted Service Path Vulnerability
 * Potential Linux Tunneling and/or Port Forwarding
 * Potential Linux Tunneling and/or Port Forwarding via Command Line
+* Potential SSH Reverse Port Forwarding
 * Potential Windows Error Manager Masquerading
 * Process Created with a Duplicated Token
 * Process Started from Process ID (PID) File
@@ -1071,9 +1240,9 @@ Rules version: 9.4.2
 * Unusual Process Execution Path - Alternate Data Stream
 * Web Server Exploitation Detected via Defend for Containers
 
-### Unsupported function: stringContains (23)
+### Unsupported function: stringContains (25)
 
-23 rules:
+25 rules:
 * AWS EC2 EBS Snapshot Access Removed
 * AWS EC2 EBS Snapshot Shared or Made Public
 * AWS EC2 Instance Console Login via Assumed Role
@@ -1084,7 +1253,9 @@ Rules version: 9.4.2
 * AWS IAM CompromisedKeyQuarantine Policy Attached to User
 * AWS IAM Login Profile Added for Root
 * AWS IAM Roles Anywhere Trust Anchor Created with External CA
+* AWS Lambda Function Policy Updated to Allow Cross-Account Invocation
 * AWS Lambda Function Policy Updated to Allow Public Invocation
+* AWS Lambda Function URL Created with Public Access
 * AWS RDS DB Instance Made Public
 * AWS RDS DB Instance or Cluster Deletion Protection Disabled
 * AWS RDS DB Instance or Cluster Password Modified
@@ -1098,19 +1269,19 @@ Rules version: 9.4.2
 * AWS S3 Object Versioning Suspended
 * AWS Suspicious User Agent Fingerprint
 
-### Root with too many branches (limit: 10000) (22)
+### Root with too many branches (limit: 10000) (24)
 
-22 rules:
+24 rules:
 * Connection to Common Large Language Model Endpoints
 * Connection to Commonly Abused Web Services
 * Decoded Payload Piped to Interpreter Detected via Defend for Containers
 * Execution from Unusual Directory - Command Line
 * Execution of a Downloaded Windows Script
 * External IP Lookup from Non-Browser Process
-* GenAI Process Accessing Sensitive Files
 * GenAI or MCP Server Child Process Execution
 * Ingress Tool Transfer Followed by Execution and Deletion Detected via Defend for Containers
 * Kubelet Pod Discovery Detected via Defend for Containers
+* Potential Copy Fail (CVE-2026-31431) Exploitation via AF_ALG Socket
 * Potential DNS Tunneling via NsLookup
 * Potential Evasion via Windows Filtering Platform
 * Potential External Linux SSH Brute Force Detected
@@ -1121,8 +1292,25 @@ Rules version: 9.4.2
 * Potential Reverse Shell via Suspicious Binary
 * Potential Reverse Shell via Suspicious Child Process
 * Potential Successful SSH Brute Force Attack
+* Suspicious Child Execution via Web Server
+* Suspicious Command Execution via Web Server
 * Suspicious React Server Child Process
 * Unusual User Privilege Enumeration via id
+
+### Root without branches (11)
+
+11 rules:
+* Initramfs Extraction via CPIO
+* Interactive Shell Spawn Detected via Defend for Containers
+* Interactive Terminal Spawned via Perl
+* Kubectl Configuration Discovery
+* Kubectl Secrets Enumeration Across All Namespaces
+* Linux User or Group Deletion
+* Linux init (PID 1) Secret Dump via GDB
+* Passwordless Sudo Probing
+* Potential Docker Escape via Nsenter
+* Potential Linux Backdoor User Account Creation
+* Suspicious Data Encryption via OpenSSL Utility
 
 ### Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)
 
@@ -1139,39 +1327,28 @@ Rules version: 9.4.2
 * Suspicious Process Access via Direct System Call
 * Uncommon Registry Persistence Change
 
-### Root without branches (10)
+### Unsupported argument type(s): <class 'eql.ast.Field'> (10)
 
 10 rules:
-* Initramfs Extraction via CPIO
-* Interactive Shell Spawn Detected via Defend for Containers
-* Interactive Terminal Spawned via Perl
-* Kubectl Configuration Discovery
-* Kubectl Secrets Enumeration Across All Namespaces
-* Linux User or Group Deletion
-* Linux init (PID 1) Secret Dump via GDB
-* Potential Docker Escape via Nsenter
-* Potential Linux Backdoor User Account Creation
-* Suspicious Data Encryption via OpenSSL Utility
-
-### Unsupported argument type(s): <class 'eql.ast.Field'> (8)
-
-8 rules:
 * External User Added to Google Workspace Group
 * Image Loaded with Invalid Signature
 * Interactive Logon by an Unusual Process
 * M365 Exchange Inbox Forwarding Rule Created
+* Payload Downloaded by Interpreter and Piped to Interpreter
+* Potential Privilege Escalation via SUID/SGID
 * Potential Ransomware Note File Dropped via SMB
 * Suspicious File Renamed via SMB
 * Unusual Network Activity from a Windows System Binary
 * Windows Service Installed via an Unusual Client
 
-### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (6)
+### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)
 
-6 rules:
+7 rules:
 * Execution via MS VisualStudio Pre/Post Build Events
 * Suspicious Execution from VS Code Extension
 * Suspicious Execution from a WebDav Share
 * Suspicious JetBrains TeamCity Child Process
+* Suspicious Microsoft HTML Application Child Process
 * Suspicious Shell Execution via Velociraptor
 * Suspicious Windows Command Shell Arguments
 
@@ -1190,12 +1367,26 @@ Rules version: 9.4.2
 * Potential Meterpreter Reverse Shell
 * Potential Reverse Shell via UDP
 
+### Field type solver: match_only_text (3)
+
+3 rules:
+* Segfault Detected
+* Segfault from Sensitive Process Detected
+* Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)
+
 ### Unsolvable constraints: event.category & event.type (empty intersection) (3)
 
 3 rules:
 * File Execution Permission Modification Detected via Defend for Containers
 * File with Right-to-Left Override Character (RTLO) Created/Executed
 * Unsigned DLL loaded by DNS Service
+
+### Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)
+
+3 rules:
+* AWS SSM Session Manager Child Process Execution
+* Delayed Execution via Ping
+* Veeam Backup Library Loaded by Unusual Process
 
 ### Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)
 
@@ -1218,12 +1409,6 @@ Rules version: 9.4.2
 * Potential Machine Account Relay Attack via SMB
 * Unusual Execution via Microsoft Common Console File
 
-### Field type solver: match_only_text (2)
-
-2 rules:
-* Segfault Detected
-* Windows CryptoAPI Spoofing Vulnerability (CVE-2020-0601 - CurveBall)
-
 ### Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)
 
 2 rules:
@@ -1236,6 +1421,12 @@ Rules version: 9.4.2
 * Suspicious Network Tool Launch Detected via Defend for Containers
 * Suspicious Network Tool Launched Inside A Container
 
+### Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)
+
+2 rules:
+* Base64 Decoded Payload Piped to Interpreter
+* Shared Object Load via LoLBin
+
 ### Unsolvable constraints: process.name (excluded by Strings({'rundll32.exe'}): ('rundll32.exe')) (2)
 
 2 rules:
@@ -1247,6 +1438,12 @@ Rules version: 9.4.2
 2 rules:
 * Downloaded Shortcut Files
 * File with Suspicious Extension Downloaded
+
+### Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)
+
+2 rules:
+* Java Dropped and Executed With DNS Lookup
+* Suspicious Inter-Process Communication via Outlook
 
 ### Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)
 
@@ -1270,11 +1467,6 @@ Rules version: 9.4.2
 1 rules:
 * Potential Okta MFA Bombing via Push Notifications
 
-### Cannot choose from an empty set (1)
-
-1 rules:
-* DNS Request for IP Lookup Service via Unsigned Binary
-
 ### Unsolvable constraints: file.Ext.header_bytes (excluded by Strings({'504B0304*'}): ('504B0304*')) (1)
 
 1 rules:
@@ -1284,6 +1476,11 @@ Rules version: 9.4.2
 
 1 rules:
 * Pluggable Authentication Module or Configuration Creation
+
+### Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)
+
+1 rules:
+* GenAI Process Accessing Sensitive Files
 
 ### Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)
 
@@ -1364,6 +1561,11 @@ Rules version: 9.4.2
 
 1 rules:
 * Potential PowerShell Pass-the-Hash/Relay Script
+
+### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'NdrClientCall'}): ('GetProcAddress')) (1)
+
+1 rules:
+* Potential AMSI Bypass via RPC Runtime Hooking
 
 ### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'New-MailboxExportRequest'}): ('-FilePath')) (1)
 
@@ -1500,6 +1702,11 @@ Rules version: 9.4.2
 1 rules:
 * Remote System Discovery Commands
 
+### Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (1)
+
+1 rules:
+* Suspicious macOS MS Office Child Process
+
 ### Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)
 
 1 rules:
@@ -1530,35 +1737,15 @@ Rules version: 9.4.2
 1 rules:
 * Curl or Wget Egress Network Connection via LoLBin
 
-### Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (1)
-
-1 rules:
-* Delayed Execution via Ping
-
-### Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (1)
-
-1 rules:
-* Base64 Decoded Payload Piped to Interpreter
-
 ### Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)
 
 1 rules:
 * Enumeration Command Spawned via WMIPrvSE
 
-### Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)
+### Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)
 
 1 rules:
-* Suspicious macOS MS Office Child Process
-
-### Unsolvable constraints: process.name (not in Strings({'java'}): ('.*')) (1)
-
-1 rules:
-* Suspicious Child Execution via Web Server
-
-### Unsolvable constraints: process.name (not in Strings({'pluginkit'}): ('python*')) (1)
-
-1 rules:
-* Finder Sync Plugin Registered and Enabled
+* Unusual Executable File Creation by a System Critical Process
 
 ### Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)
 
@@ -1625,6 +1812,11 @@ Rules version: 9.4.2
 1 rules:
 * Scheduled Task Execution at Scale via GPO
 
+### Unsolvable constraints: winlog.event_data.param1 (not in Strings({'*FullControl*'}): ('*setsharingmode*')) (1)
+
+1 rules:
+* Quick Assist Full Control Sharing Mode Enabled
+
 ### Unsupported &keyword 'dll.Ext.relative_file_creation_time' constraint: < (1)
 
 1 rules:
@@ -1664,8 +1856,3 @@ Rules version: 9.4.2
 
 1 rules:
 * Machine Learning Detected a Suspicious Windows Event with a High Malicious Probability Score
-
-### Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (1)
-
-1 rules:
-* Suspicious Inter-Process Communication via Outlook


### PR DESCRIPTION
Applies pending Renovate PRs for `security_detection_engine` package updates.

## Version bumps

| Deployment | Series | Old | New | Renovate PR |
|---|---|---|---|---|
| ECH | 8.19 | 8.19.22 | 8.19.27 | #772 |
| ECH | 9.2 | 9.2.14 | 9.2.19 | #766 |
| ECH | 9.3 | 9.3.10 | 9.3.15 | #767 |
| ECH | 9.4 | 9.4.2 | 9.4.7 | #769 |
| Serverless | serverless | 9.4.2 | 9.4.7 | #768 |

## Reports updated

- `alerts_from_rules-{8.19,9.2,9.3,9.4,serverless}.md`
- `documents_from_rules-{8.19,9.2,9.3,9.4,serverless}.md`

## stack_signals changes

| Series | ack_failed | ack_unsuccessful_with_signals | ack_too_few_signals |
|---|---|---|---|
| 8.19 | 14 → 18 | 14 → 18 | 17 → 22 |
| 9.2 | 13 → 17 | 13 → 17 | 16 → 21 |
| 9.3 | 20 → 24 | 20 → 24 | 23 → 28 |
| 9.4 | 20 → 24 | 20 → 24 | 23 → 28 |
| serverless | 20 → 24 | 20 → 24 | 23 → 28 |