### PR TITLE
Update rules to 9.3.17, 8.19.29, 9.4.9, and serverless 9.5.2

### DIFF
--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -35,7 +35,7 @@ emitter_rules:
     # renovate: datasource=epr package=security_detection_engine-8.18
     "8.18": "8.18.15"
     # renovate: datasource=epr package=security_detection_engine-8.19
-    "8.19": "8.19.28"
+    "8.19": "8.19.29"
     # renovate: datasource=epr package=security_detection_engine-9.0
     "9.0": "9.0.19"
     # renovate: datasource=epr package=security_detection_engine-9.1
@@ -43,11 +43,11 @@ emitter_rules:
     # renovate: datasource=epr package=security_detection_engine-9.2
     "9.2": "9.2.19"
     # renovate: datasource=epr package=security_detection_engine-9.3
-    "9.3": "9.3.16"
+    "9.3": "9.3.17"
     # renovate: datasource=epr package=security_detection_engine-9.4
-    "9.4": "9.4.8"
+    "9.4": "9.4.9"
     # renovate: datasource=epr package=security_detection_engine
-    "serverless": "9.4.8"
+    "serverless": "9.5.2"
 
   stack_signals:
     "8.2":
@@ -124,10 +124,10 @@ emitter_rules:
       ack_no_signals: 7
       ack_too_few_signals: 15
     "8.19":
-      ack_failed: 17
-      ack_unsuccessful_with_signals: 17
+      ack_failed: 18
+      ack_unsuccessful_with_signals: 18
       ack_no_signals: 5
-      ack_too_few_signals: 21
+      ack_too_few_signals: 22
     "9.0":
       ack_failed: 17
       ack_unsuccessful_with_signals: 16
@@ -144,17 +144,17 @@ emitter_rules:
       ack_no_signals: 5
       ack_too_few_signals: 21
     "9.3":
-      ack_failed: 23
-      ack_unsuccessful_with_signals: 23
+      ack_failed: 24
+      ack_unsuccessful_with_signals: 24
       ack_no_signals: 5
-      ack_too_few_signals: 27
+      ack_too_few_signals: 28
     "9.4":
-      ack_failed: 23
-      ack_unsuccessful_with_signals: 23
+      ack_failed: 24
+      ack_unsuccessful_with_signals: 24
       ack_no_signals: 5
-      ack_too_few_signals: 27
+      ack_too_few_signals: 28
     "serverless":
-      ack_failed: 23
-      ack_unsuccessful_with_signals: 23
+      ack_failed: 24
+      ack_unsuccessful_with_signals: 24
       ack_no_signals: 5
-      ack_too_few_signals: 27
+      ack_too_few_signals: 28

--- a/tests/reports/alerts_from_rules-8.19.md
+++ b/tests/reports/alerts_from_rules-8.19.md
@@ -5,22 +5,137 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.28
+Rules version: 8.19.29
 
 ## Table of contents
-   1. [Failed rules (17)](#failed-rules-17)
-   1. [Unsuccessful rules with signals (17)](#unsuccessful-rules-with-signals-17)
+   1. [Failed rules (18)](#failed-rules-18)
+   1. [Unsuccessful rules with signals (18)](#unsuccessful-rules-with-signals-18)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
-   1. [Rules with too few signals (21)](#rules-with-too-few-signals-21)
+   1. [Rules with too few signals (22)](#rules-with-too-few-signals-22)
    1. [Rules with the correct signals (770)](#rules-with-the-correct-signals-770)
 
-## Failed rules (17)
+## Failed rules (18)
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0366  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
+```
+
+
 
 ### Execution of a Downloaded Windows Script
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0549  
+Index: geneve-ut-0564  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -46,7 +161,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0552  
+Index: geneve-ut-0567  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -115,7 +230,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0574  
+Index: geneve-ut-0589  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -144,7 +259,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0693  
+Index: geneve-ut-0717  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -175,7 +290,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0871  
+Index: geneve-ut-0895  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -228,7 +343,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0997  
+Index: geneve-ut-1022  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -261,7 +376,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1115  
+Index: geneve-ut-1141  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -287,7 +402,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1132  
+Index: geneve-ut-1159  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -325,7 +440,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1190  
+Index: geneve-ut-1218  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -347,7 +462,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1205  
+Index: geneve-ut-1233  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -386,7 +501,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1287  
+Index: geneve-ut-1315  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -449,7 +564,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1583  
+Index: geneve-ut-1613  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -497,7 +612,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1598  
+Index: geneve-ut-1628  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -532,7 +647,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1619  
+Index: geneve-ut-1649  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -595,7 +710,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1624  
+Index: geneve-ut-1654  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -623,7 +738,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1633  
+Index: geneve-ut-1663  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -655,7 +770,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1723  
+Index: geneve-ut-1754  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -720,19 +835,131 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
 
 
-## Unsuccessful rules with signals (17)
+## Unsuccessful rules with signals (18)
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0366
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
+```
+
+
 
 ### Execution of a Downloaded Windows Script
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0549
+Index: geneve-ut-0564
 
 ```python
 sequence by host.id, user.id with maxspan=3m
@@ -755,7 +982,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0552
+Index: geneve-ut-0567
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -821,7 +1048,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0574
+Index: geneve-ut-0589
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -847,7 +1074,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0693
+Index: geneve-ut-0717
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -875,7 +1102,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0871
+Index: geneve-ut-0895
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -925,7 +1152,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0997
+Index: geneve-ut-1022
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -955,7 +1182,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1115
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -978,7 +1205,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1132
+Index: geneve-ut-1159
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1013,7 +1240,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1190
+Index: geneve-ut-1218
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1032,7 +1259,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1205
+Index: geneve-ut-1233
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1068,7 +1295,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1287
+Index: geneve-ut-1315
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1128,7 +1355,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1583
+Index: geneve-ut-1613
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1173,7 +1400,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1598
+Index: geneve-ut-1628
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1205,7 +1432,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1619
+Index: geneve-ut-1649
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1265,7 +1492,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1624
+Index: geneve-ut-1654
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1290,7 +1517,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1633
+Index: geneve-ut-1663
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -1319,7 +1546,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1723
+Index: geneve-ut-1754
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -1381,7 +1608,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -1393,7 +1620,7 @@ not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0228
+Index: geneve-ut-0235
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1634,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0872
+Index: geneve-ut-0896
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1419,7 +1646,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0878
+Index: geneve-ut-0902
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1431,7 +1658,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1238
+Index: geneve-ut-1266
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1449,7 +1676,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1423
+Index: geneve-ut-1452
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -1460,13 +1687,127 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 
 
-## Rules with too few signals (21)
+## Rules with too few signals (22)
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0366  
+Failure message(s):  
+  got 1000 signals, expected 1680  
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
+```
+
+
 
 ### Execution of a Downloaded Windows Script
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0549  
+Index: geneve-ut-0564  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -1491,7 +1832,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0552  
+Index: geneve-ut-0567  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -1559,7 +1900,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0574  
+Index: geneve-ut-0589  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -1587,7 +1928,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0693  
+Index: geneve-ut-0717  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -1617,7 +1958,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0850  
+Index: geneve-ut-0874  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -1636,7 +1977,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0871  
+Index: geneve-ut-0895  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -1688,7 +2029,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0978  
+Index: geneve-ut-1003  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -1708,7 +2049,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-0997  
+Index: geneve-ut-1022  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -1740,7 +2081,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1115  
+Index: geneve-ut-1141  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -1765,7 +2106,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1132  
+Index: geneve-ut-1159  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -1802,7 +2143,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1190  
+Index: geneve-ut-1218  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -1823,7 +2164,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1205  
+Index: geneve-ut-1233  
 Failure message(s):  
   got 1000 signals, expected 1085  
 
@@ -1861,7 +2202,7 @@ process.command_line like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1279  
+Index: geneve-ut-1307  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -1878,7 +2219,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1287  
+Index: geneve-ut-1315  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -1940,7 +2281,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1392  
+Index: geneve-ut-1421  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -1965,7 +2306,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1583  
+Index: geneve-ut-1613  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -2012,7 +2353,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1598  
+Index: geneve-ut-1628  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -2046,7 +2387,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1619  
+Index: geneve-ut-1649  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -2108,7 +2449,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1624  
+Index: geneve-ut-1654  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -2135,7 +2476,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1633  
+Index: geneve-ut-1663  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -2166,7 +2507,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1723  
+Index: geneve-ut-1754  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -2230,7 +2571,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -2329,7 +2670,7 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0049
+Index: geneve-ut-0051
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -2347,7 +2688,7 @@ process.command_line like~ (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0066
+Index: geneve-ut-0068
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2364,7 +2705,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0098
+Index: geneve-ut-0101
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2383,7 +2724,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0105
+Index: geneve-ut-0108
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
@@ -2396,7 +2737,7 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0115
+Index: geneve-ut-0119
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2428,7 +2769,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0123
+Index: geneve-ut-0128
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2444,7 +2785,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0125
+Index: geneve-ut-0130
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2459,7 +2800,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0145
+Index: geneve-ut-0150
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
@@ -2472,7 +2813,7 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0179
+Index: geneve-ut-0185
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2488,7 +2829,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0180
+Index: geneve-ut-0186
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -2503,7 +2844,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0190
+Index: geneve-ut-0197
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -2518,7 +2859,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0199
+Index: geneve-ut-0206
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2542,7 +2883,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0200
+Index: geneve-ut-0207
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -2577,7 +2918,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0201
+Index: geneve-ut-0208
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -2594,7 +2935,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0202
+Index: geneve-ut-0209
 
 ```python
 any where host.os.type == "windows" and
@@ -2619,7 +2960,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0204
+Index: geneve-ut-0211
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -2647,7 +2988,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0206
+Index: geneve-ut-0213
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2660,7 +3001,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0208
+Index: geneve-ut-0215
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -2676,7 +3017,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0209
+Index: geneve-ut-0216
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2696,7 +3037,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0210
+Index: geneve-ut-0217
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2717,7 +3058,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0211
+Index: geneve-ut-0218
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -2729,7 +3070,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0214
+Index: geneve-ut-0221
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -2741,7 +3082,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0226
+Index: geneve-ut-0233
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -2758,7 +3099,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0227
+Index: geneve-ut-0234
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -2770,7 +3111,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0229
+Index: geneve-ut-0236
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -2790,7 +3131,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0230
+Index: geneve-ut-0237
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -2804,7 +3145,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0234
+Index: geneve-ut-0241
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -2835,7 +3176,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0235
+Index: geneve-ut-0242
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -2847,7 +3188,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0236
+Index: geneve-ut-0243
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2861,7 +3202,7 @@ process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clea
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0237
+Index: geneve-ut-0244
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2876,7 +3217,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0247
+Index: geneve-ut-0254
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -2895,7 +3236,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0248
+Index: geneve-ut-0255
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -2909,7 +3250,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0249
+Index: geneve-ut-0256
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -2940,7 +3281,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0250
+Index: geneve-ut-0257
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2963,7 +3304,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0251
+Index: geneve-ut-0258
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -2977,7 +3318,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0252
+Index: geneve-ut-0259
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -2996,7 +3337,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0253
+Index: geneve-ut-0260
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3010,7 +3351,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0254
+Index: geneve-ut-0261
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3035,7 +3376,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0259
+Index: geneve-ut-0266
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3054,7 +3395,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0262
+Index: geneve-ut-0269
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3067,7 +3408,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0264
+Index: geneve-ut-0271
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3109,7 +3450,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0267
+Index: geneve-ut-0274
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -3124,7 +3465,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0300
+Index: geneve-ut-0314
 
 ```python
 event.dataset:azure.activitylogs and
@@ -3138,7 +3479,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0303
+Index: geneve-ut-0317
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -3156,7 +3497,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0321
+Index: geneve-ut-0335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3174,7 +3515,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0322
+Index: geneve-ut-0336
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3192,7 +3533,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0323
+Index: geneve-ut-0337
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3207,7 +3548,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0324
+Index: geneve-ut-0338
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3221,7 +3562,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0325
+Index: geneve-ut-0339
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3236,7 +3577,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0327
+Index: geneve-ut-0341
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -3253,7 +3594,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0328
+Index: geneve-ut-0342
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -3265,7 +3606,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0329
+Index: geneve-ut-0343
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -3277,7 +3618,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0330
+Index: geneve-ut-0344
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3292,7 +3633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0331
+Index: geneve-ut-0345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -3312,7 +3653,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0332
+Index: geneve-ut-0346
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3334,7 +3675,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0334
+Index: geneve-ut-0348
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -3380,7 +3721,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0335
+Index: geneve-ut-0349
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3414,7 +3755,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0336
+Index: geneve-ut-0350
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3437,7 +3778,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0337
+Index: geneve-ut-0352
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -3459,7 +3800,7 @@ process.executable != null and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0338
+Index: geneve-ut-0353
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -3475,7 +3816,7 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0340
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3500,7 +3841,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0341
+Index: geneve-ut-0356
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -3530,7 +3871,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0343
+Index: geneve-ut-0358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3544,7 +3885,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0344
+Index: geneve-ut-0359
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3566,7 +3907,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0345
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -3580,7 +3921,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0346
+Index: geneve-ut-0361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -3600,7 +3941,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0349
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3613,95 +3954,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Component Object Model Hijacking
-
-Branch count: 60  
-Document count: 60  
-Index: geneve-ut-0351
-
-```python
-registry where host.os.type == "windows" and event.type == "change" and
-  /* not necessary but good for filtering privileged installations */
-  user.domain != "NT AUTHORITY" and process.executable != null and 
-  (
-    (
-      registry.path : "HK*\\InprocServer32\\" and
-      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
-      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
-    ) or
-
-    (
-      registry.path : "HKLM\\*\\InProcServer32\\*" and
-        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
-    ) or
-
-    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
-    (
-      registry.path : (
-        "HKEY_USERS\\*\\InprocServer32\\",
-        "HKEY_USERS\\*\\LocalServer32\\",
-        "HKEY_USERS\\*\\DelegateExecute",
-        "HKEY_USERS\\*\\TreatAs\\",
-        "HKEY_USERS\\*\\ScriptletURL*", 
-        "HKEY_USERS\\*\\TypeLib*\\Win*"
-      ) and
-      not registry.data.strings : (
-            /* COM related to Windows Spotlight feature */
-            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
-
-            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
-            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
-            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
-            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
-      )
-    )
-  ) and 
-
-  not (
-    process.code_signature.trusted == true and
-    process.code_signature.subject_name in (
-        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
-        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
-        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
-        "Vivaldi Technologies AS"
-    )
-  ) and 
-
-  /* excludes Microsoft signed noisy processes */
-  not
-  (
-    process.name : (
-      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
-      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
-    ) and
-    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
-  ) and
-
-  not process.executable : (
-        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
-        "?:\\Program Files (x86)\\*.exe",
-        "?:\\Program Files\\*.exe",
-        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
-        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
-        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
-        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
-        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
-        "?:\\Windows\\System32\\FMToastNotification.exe",
-        "?:\\Windows\\System32\\msiexec.exe",
-        "?:\\Windows\\System32\\svchost.exe",
-        "?:\\Windows\\SysWOW64\\regsvr32.exe",
-        "?:\\Windows\\System32\\regsvr32.exe",
-        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
-  )
-```
-
-
-
 ### Compression DLL Loaded by Unusual Process
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0352
+Index: geneve-ut-0367
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -3731,7 +3988,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0355
+Index: geneve-ut-0370
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -3756,7 +4013,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0357
+Index: geneve-ut-0372
 
 ```python
 sequence by process.entity_id
@@ -3777,7 +4034,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0358
+Index: geneve-ut-0373
 
 ```python
 sequence by process.entity_id
@@ -3798,7 +4055,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0360
+Index: geneve-ut-0375
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -3829,7 +4086,7 @@ not process.parent.executable in (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0361
+Index: geneve-ut-0376
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3852,7 +4109,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0364
+Index: geneve-ut-0379
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -3865,7 +4122,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0365
+Index: geneve-ut-0380
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3878,7 +4135,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0367
+Index: geneve-ut-0382
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -3895,7 +4152,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0368
+Index: geneve-ut-0383
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -3908,7 +4165,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0369
+Index: geneve-ut-0384
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -3925,7 +4182,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0370
+Index: geneve-ut-0385
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -3937,7 +4194,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0371
+Index: geneve-ut-0386
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -4005,7 +4262,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0372
+Index: geneve-ut-0387
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -4023,7 +4280,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0373
+Index: geneve-ut-0388
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -4036,7 +4293,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0374
+Index: geneve-ut-0389
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4054,7 +4311,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0375
+Index: geneve-ut-0390
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4066,7 +4323,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0376
+Index: geneve-ut-0391
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4078,7 +4335,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0377
+Index: geneve-ut-0392
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4090,7 +4347,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0378
+Index: geneve-ut-0393
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4102,7 +4359,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0379
+Index: geneve-ut-0394
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -4147,7 +4404,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0381
+Index: geneve-ut-0396
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4167,7 +4424,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0382
+Index: geneve-ut-0397
 
 ```python
 sequence with maxspan=10s
@@ -4187,7 +4444,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0383
+Index: geneve-ut-0398
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4214,7 +4471,7 @@ process.name == "curl" and (
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0386
+Index: geneve-ut-0401
 
 ```python
 process where event.type == "start" and
@@ -4239,7 +4496,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0389
+Index: geneve-ut-0404
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4283,7 +4540,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0390
+Index: geneve-ut-0405
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -4317,7 +4574,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0391
+Index: geneve-ut-0406
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -4333,7 +4590,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0392
+Index: geneve-ut-0407
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -4358,7 +4615,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0394
+Index: geneve-ut-0409
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4376,7 +4633,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0396
+Index: geneve-ut-0411
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -4389,7 +4646,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0401
+Index: geneve-ut-0416
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4403,7 +4660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0402
+Index: geneve-ut-0417
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4424,7 +4681,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0403
+Index: geneve-ut-0418
 
 ```python
 registry where host.os.type == "windows" and
@@ -4438,7 +4695,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0412
+Index: geneve-ut-0427
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -4458,52 +4715,11 @@ event.category: "process" and host.os.type:windows and
 
 
 
-### Deprecated - Potential CVE-2025-41244 vmtoolsd LPE Exploitation Attempt
-
-Branch count: 54  
-Document count: 54  
-Index: geneve-ut-0413
-
-```python
-process where host.os.type == "linux" and event.type == "start" and
-event.action in ("exec", "exec_event", "start", "executed", "process_started", "ProcessRollup2") and
-(
-  (
-    process.parent.name == "vmtoolsd"
-  ) or
-  (
-    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
-    ?process.parent.args like ("/*/open-vm-tools/serviceDiscovery/scripts/get-versions.sh")
-  )
-) and not (
-  process.executable == null or
-  ?process.parent.args == "--version" or
-  process.args like (
-    "/etc/vmware-tools/resume-vm-default",
-    "/etc/vmware-tools/suspend-vm-default",
-    "/sbin/shutdown",
-    "/sbin/shutdown*",
-    "/etc/vmware-tools/poweroff-vm-default",
-    "/etc/vmware-tools/poweroff-vm-default",
-    "/bin/touch",
-    "/tmp/vmware-administrator_*",
-    "/tmp/vmware-root_*",
-    "/etc/vmware-tools/scripts/vmware/network",
-    "/etc/vmware-tools/poweron-vm-default"
-  ) or
-  process.executable == "/usr/sbin/unix_chkpwd" or
-  ?process.working_directory like ("/var/opt/ds_agent", "/tmp/vmware-root_*/tmpvmware*") or
-  process.command_line like ("*/usr/bin/lsb_release*", "*/bin/touch*", "*/tmp/vmware-root_*")
-)
-```
-
-
-
 ### Directory Creation in /bin directory
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0422
+Index: geneve-ut-0437
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4519,7 +4735,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0423
+Index: geneve-ut-0438
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4547,7 +4763,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0424
+Index: geneve-ut-0439
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4564,7 +4780,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0425
+Index: geneve-ut-0440
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4581,7 +4797,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0426
+Index: geneve-ut-0441
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4602,7 +4818,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0428
+Index: geneve-ut-0443
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4622,7 +4838,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0429
+Index: geneve-ut-0444
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -4637,7 +4853,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0431
+Index: geneve-ut-0446
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -4650,7 +4866,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0432
+Index: geneve-ut-0447
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4670,7 +4886,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0435
+Index: geneve-ut-0450
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -4683,7 +4899,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0436
+Index: geneve-ut-0451
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4721,7 +4937,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0437
+Index: geneve-ut-0452
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -4741,7 +4957,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0438
+Index: geneve-ut-0453
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -4754,7 +4970,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0439
+Index: geneve-ut-0454
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4777,7 +4993,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0441
+Index: geneve-ut-0456
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4808,7 +5024,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0442
+Index: geneve-ut-0457
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -4827,7 +5043,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0443
+Index: geneve-ut-0458
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -4870,7 +5086,7 @@ not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0445
+Index: geneve-ut-0460
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4885,7 +5101,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0446
+Index: geneve-ut-0461
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4901,7 +5117,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0447
+Index: geneve-ut-0462
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4915,7 +5131,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0448
+Index: geneve-ut-0463
 
 ```python
 sequence by host.id with maxspan=3s
@@ -4941,7 +5157,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0449
+Index: geneve-ut-0464
 
 ```python
 process where event.type == "start" and
@@ -4979,11 +5195,11 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0454
+Index: geneve-ut-0469
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
- file.path like ("/private/etc/emond.d/rules/*.plist", "/etc/emon.d/rules/*.plist", "/private/var/db/emondClients/*")
+ file.path like ("/private/etc/emond.d/rules/*.plist", "/etc/emond.d/rules/*.plist", "/private/var/db/emondClients/*")
 ```
 
 
@@ -4992,7 +5208,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0455
+Index: geneve-ut-0470
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5006,7 +5222,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0456
+Index: geneve-ut-0471
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5041,7 +5257,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0457
+Index: geneve-ut-0472
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -5053,7 +5269,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0504
+Index: geneve-ut-0519
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -5065,7 +5281,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0530
+Index: geneve-ut-0545
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5079,7 +5295,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0533
+Index: geneve-ut-0548
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5106,7 +5322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0536
+Index: geneve-ut-0551
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5127,7 +5343,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0539
+Index: geneve-ut-0554
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -5160,7 +5376,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0541
+Index: geneve-ut-0556
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -5177,7 +5393,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0542
+Index: geneve-ut-0557
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -5205,7 +5421,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0543
+Index: geneve-ut-0558
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -5218,7 +5434,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0545
+Index: geneve-ut-0560
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -5238,7 +5454,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0546
+Index: geneve-ut-0561
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5264,7 +5480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0547
+Index: geneve-ut-0562
 
 ```python
 sequence with maxspan=2h
@@ -5286,7 +5502,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0548
+Index: geneve-ut-0563
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -5315,7 +5531,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0551
+Index: geneve-ut-0566
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5328,7 +5544,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0555
+Index: geneve-ut-0570
 
 ```python
 sequence by user.id with maxspan=5s
@@ -5343,7 +5559,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0556
+Index: geneve-ut-0571
 
 ```python
 process where event.type == "start" and
@@ -5365,7 +5581,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0557
+Index: geneve-ut-0572
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -5377,7 +5593,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0558
+Index: geneve-ut-0573
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5399,7 +5615,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0560
+Index: geneve-ut-0575
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -5416,7 +5632,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0561
+Index: geneve-ut-0576
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5430,7 +5646,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0562
+Index: geneve-ut-0577
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -5443,7 +5659,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0563
+Index: geneve-ut-0578
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5455,7 +5671,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0564
+Index: geneve-ut-0579
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5467,7 +5683,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0565
+Index: geneve-ut-0580
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5481,7 +5697,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0566
+Index: geneve-ut-0581
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -5491,15 +5707,15 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 ### External IP Address Discovery via Curl
 
-Branch count: 304  
-Document count: 304  
-Index: geneve-ut-0567
+Branch count: 342  
+Document count: 342  
+Index: geneve-ut-0582
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
   ((process.parent.executable like ("/Applications/*", "/Volumes/*", "/private/var/folders/*")) or
    (process.parent.name in ("bash", "sh", "zsh") and process.parent.command_line like "*http*") or
-   (process.parent.code_signature.trusted == false or process.code_signature.exists == false)) and
+   (process.parent.code_signature.trusted == false or process.parent.code_signature.exists == false or process.code_signature.exists == false)) and
   process.name in ("curl", "nscurl") and
   process.args_count <= 5 and
   process.command_line like ("*ip-api.com*", "*ipwho.is*", "*checkip.dyndns.org*", "*api.ipify.org*",
@@ -5515,7 +5731,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0570
+Index: geneve-ut-0585
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -5564,7 +5780,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0571
+Index: geneve-ut-0586
 
 ```python
 sequence by host.id with maxspan=10s
@@ -5584,7 +5800,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0577
+Index: geneve-ut-0592
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5599,7 +5815,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0578
+Index: geneve-ut-0593
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5613,7 +5829,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0580
+Index: geneve-ut-0595
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5635,7 +5851,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0581
+Index: geneve-ut-0596
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -5656,7 +5872,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0582
+Index: geneve-ut-0597
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5682,7 +5898,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0583
+Index: geneve-ut-0598
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -5710,7 +5926,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0586
+Index: geneve-ut-0601
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -5724,7 +5940,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0620
+Index: geneve-ut-0638
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -5741,7 +5957,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0621
+Index: geneve-ut-0639
 
 ```python
 registry where host.os.type == "windows" and
@@ -5759,7 +5975,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0683
+Index: geneve-ut-0707
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -5798,7 +6014,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0684
+Index: geneve-ut-0708
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5825,7 +6041,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0685
+Index: geneve-ut-0709
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -5840,7 +6056,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0686
+Index: geneve-ut-0710
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -5927,7 +6143,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0694
+Index: geneve-ut-0718
 
 ```python
 sequence by host.id with maxspan=3s
@@ -5945,7 +6161,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0695
+Index: geneve-ut-0719
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -5976,7 +6192,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0696
+Index: geneve-ut-0720
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6003,7 +6219,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0697
+Index: geneve-ut-0721
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -6023,7 +6239,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0701
+Index: geneve-ut-0725
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -6036,7 +6252,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0704
+Index: geneve-ut-0728
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -6048,7 +6264,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0707
+Index: geneve-ut-0731
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -6060,7 +6276,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0711
+Index: geneve-ut-0735
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -6072,7 +6288,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0713
+Index: geneve-ut-0737
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -6089,7 +6305,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0737
+Index: geneve-ut-0761
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6102,7 +6318,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0739
+Index: geneve-ut-0763
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -6126,7 +6342,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0740
+Index: geneve-ut-0764
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -6138,7 +6354,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0753
+Index: geneve-ut-0777
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6156,7 +6372,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0754
+Index: geneve-ut-0778
 
 ```python
 any where process.executable != null and
@@ -6205,7 +6421,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0755
+Index: geneve-ut-0779
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6219,7 +6435,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0759
+Index: geneve-ut-0783
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6234,7 +6450,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0764
+Index: geneve-ut-0788
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6251,7 +6467,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0766
+Index: geneve-ut-0790
 
 ```python
 sequence with maxspan=1m
@@ -6270,7 +6486,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0767
+Index: geneve-ut-0791
 
 ```python
 sequence by host.id with maxspan=1m
@@ -6288,7 +6504,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0768
+Index: geneve-ut-0792
 
 ```python
 sequence by host.id with maxspan=5s
@@ -6307,7 +6523,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0769
+Index: geneve-ut-0793
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -6323,7 +6539,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0770
+Index: geneve-ut-0794
 
 ```python
 sequence by host.id with maxspan=30s
@@ -6339,7 +6555,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0771
+Index: geneve-ut-0795
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6352,7 +6568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0775
+Index: geneve-ut-0799
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6369,7 +6585,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0777
+Index: geneve-ut-0801
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6382,7 +6598,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0778
+Index: geneve-ut-0802
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -6398,7 +6614,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0779
+Index: geneve-ut-0803
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6425,7 +6641,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0780
+Index: geneve-ut-0804
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6449,7 +6665,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0784
+Index: geneve-ut-0808
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6473,7 +6689,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0786
+Index: geneve-ut-0810
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6509,7 +6725,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0787
+Index: geneve-ut-0811
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -6521,7 +6737,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0788
+Index: geneve-ut-0812
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6535,7 +6751,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0789
+Index: geneve-ut-0813
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -6548,7 +6764,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0790
+Index: geneve-ut-0814
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -6607,7 +6823,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0791
+Index: geneve-ut-0815
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6620,7 +6836,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0792
+Index: geneve-ut-0816
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6633,7 +6849,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0793
+Index: geneve-ut-0817
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6654,7 +6870,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0794
+Index: geneve-ut-0818
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6672,7 +6888,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0795
+Index: geneve-ut-0819
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6706,7 +6922,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0796
+Index: geneve-ut-0820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6742,7 +6958,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0797
+Index: geneve-ut-0821
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6764,7 +6980,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0799
+Index: geneve-ut-0823
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6791,7 +7007,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0800
+Index: geneve-ut-0824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6817,7 +7033,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0801
+Index: geneve-ut-0825
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -6833,7 +7049,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0802
+Index: geneve-ut-0826
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -6849,7 +7065,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0804
+Index: geneve-ut-0828
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -6861,7 +7077,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0805
+Index: geneve-ut-0829
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -6889,7 +7105,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0807
+Index: geneve-ut-0831
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6905,7 +7121,7 @@ not process.command_line like ("*download.elastic.co*", "*github.com/kubernetes-
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0809
+Index: geneve-ut-0833
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6928,7 +7144,7 @@ process.name == "kubectl" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0810
+Index: geneve-ut-0834
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6942,7 +7158,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0811
+Index: geneve-ut-0835
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6965,7 +7181,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0812
+Index: geneve-ut-0836
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -6998,7 +7214,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0814
+Index: geneve-ut-0838
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -7019,7 +7235,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0815
+Index: geneve-ut-0839
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -7046,7 +7262,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-0825
+Index: geneve-ut-0849
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7068,7 +7284,7 @@ process.name in ("curl", "wget") and process.args like~ (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0851
+Index: geneve-ut-0875
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7087,7 +7303,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0854
+Index: geneve-ut-0878
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7131,7 +7347,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0856
+Index: geneve-ut-0880
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -7156,7 +7372,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0862
+Index: geneve-ut-0886
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -7194,7 +7410,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0867
+Index: geneve-ut-0891
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -7212,7 +7428,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0868
+Index: geneve-ut-0892
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7226,7 +7442,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0873
+Index: geneve-ut-0897
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -7241,7 +7457,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0874
+Index: geneve-ut-0898
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -7255,7 +7471,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0877
+Index: geneve-ut-0901
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7269,7 +7485,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0879
+Index: geneve-ut-0903
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7290,7 +7506,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-0880
+Index: geneve-ut-0904
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7320,7 +7536,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0884
+Index: geneve-ut-0908
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -7367,7 +7583,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0885
+Index: geneve-ut-0909
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7394,36 +7610,11 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 
 
-### Local Scheduled Task Creation
-
-Branch count: 600  
-Document count: 1200  
-Index: geneve-ut-0886
-
-```python
-sequence with maxspan=1m
-  [process where host.os.type == "windows" and event.type == "start" and
-    ((process.name : ("cmd.exe", "wscript.exe", "rundll32.exe", "regsvr32.exe", "wmic.exe", "mshta.exe",
-                      "powershell.exe", "pwsh.exe", "powershell_ise.exe", "WmiPrvSe.exe", "wsmprovhost.exe", "winrshost.exe") or
-    process.pe.original_file_name : ("cmd.exe", "wscript.exe", "rundll32.exe", "regsvr32.exe", "wmic.exe", "mshta.exe",
-                                     "powershell.exe", "pwsh.dll", "powershell_ise.exe", "WmiPrvSe.exe", "wsmprovhost.exe",
-                                     "winrshost.exe")) or
-    ?process.code_signature.trusted == false)] by process.entity_id
-  [process where host.os.type == "windows" and event.type == "start" and
-    (process.name : "schtasks.exe" or process.pe.original_file_name == "schtasks.exe") and
-    process.args : ("/create", "-create") and process.args : ("/RU", "/SC", "/TN", "/TR", "/F", "/XML") and
-    /* exclude SYSTEM Integrity Level - look for task creations by non-SYSTEM user */
-    not (?process.Ext.token.integrity_level_name : "System" or ?winlog.event_data.IntegrityLevel : "System")
-  ] by process.parent.entity_id
-```
-
-
-
 ### M365 AIR Investigation Signal
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0888
+Index: geneve-ut-0912
 
 ```python
 event.dataset:o365.audit and
@@ -7436,7 +7627,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0890
+Index: geneve-ut-0914
 
 ```python
 event.dataset:o365.audit and
@@ -7449,7 +7640,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0891
+Index: geneve-ut-0915
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -7461,7 +7652,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0927
+Index: geneve-ut-0951
 
 ```python
 event.dataset:o365.audit and
@@ -7474,7 +7665,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0928
+Index: geneve-ut-0952
 
 ```python
 event.dataset:o365.audit and
@@ -7487,7 +7678,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0929
+Index: geneve-ut-0953
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -7499,7 +7690,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0930
+Index: geneve-ut-0954
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -7511,7 +7702,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0931
+Index: geneve-ut-0955
 
 ```python
 event.dataset:o365.audit and
@@ -7524,7 +7715,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0939
+Index: geneve-ut-0963
 
 ```python
 event.dataset: "o365.audit" and
@@ -7537,7 +7728,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0942
+Index: geneve-ut-0966
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7557,7 +7748,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0943
+Index: geneve-ut-0967
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -7569,7 +7760,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0944
+Index: geneve-ut-0968
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -7581,7 +7772,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0948
+Index: geneve-ut-0972
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7593,7 +7784,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0949
+Index: geneve-ut-0973
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -7605,7 +7796,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0950
+Index: geneve-ut-0974
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7617,7 +7808,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0951
+Index: geneve-ut-0975
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7629,7 +7820,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0952
+Index: geneve-ut-0976
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7654,7 +7845,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0953
+Index: geneve-ut-0977
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -7674,7 +7865,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0954
+Index: geneve-ut-0978
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -7687,7 +7878,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-0955
+Index: geneve-ut-0979
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7698,11 +7889,36 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 
 
+### Mark-of-the-Web Removal by an Unusual Process
+
+Branch count: 12  
+Document count: 12  
+Index: geneve-ut-0980
+
+```python
+file where host.os.type == "windows" and event.type == "deletion" and
+  file.path : (
+    "*.exe:Zone.Identifier",
+    "*.exe:Zone.Identifier:$DATA",
+    "*.msi:Zone.Identifier",
+    "*.msi:Zone.Identifier:$DATA"
+  ) and
+
+  /* Explorer may remove MOTW after SmartScreen */
+  not (
+    process.executable : "?:\\Windows\\explorer.exe" and
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name : "Microsoft Windows"
+  )
+```
+
+
+
 ### Member Removed From GitHub Organization
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0957
+Index: geneve-ut-0982
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -7714,7 +7930,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0960
+Index: geneve-ut-0985
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7726,7 +7942,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0961
+Index: geneve-ut-0986
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -7738,7 +7954,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0962
+Index: geneve-ut-0987
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -7772,7 +7988,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0965
+Index: geneve-ut-0990
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7786,7 +8002,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0966
+Index: geneve-ut-0991
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7807,7 +8023,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0967
+Index: geneve-ut-0992
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7821,7 +8037,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0971
+Index: geneve-ut-0996
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7856,7 +8072,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0972
+Index: geneve-ut-0997
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7881,7 +8097,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0973
+Index: geneve-ut-0998
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7898,7 +8114,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0977
+Index: geneve-ut-1002
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7912,7 +8128,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0979
+Index: geneve-ut-1004
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7943,7 +8159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0981
+Index: geneve-ut-1006
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -7997,7 +8213,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0982
+Index: geneve-ut-1007
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -8009,7 +8225,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0983
+Index: geneve-ut-1008
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8027,7 +8243,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0984
+Index: geneve-ut-1009
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8044,7 +8260,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0986
+Index: geneve-ut-1011
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8059,7 +8275,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0988
+Index: geneve-ut-1013
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8075,7 +8291,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0989
+Index: geneve-ut-1014
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -8087,22 +8303,28 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 ### Mofcomp Activity
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-0991
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1016
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.name : "mofcomp.exe" and process.args : "*.mof" and
   not user.id : "S-1-5-18" and
-  not
-  (
-    process.parent.name : "ScenarioEngine.exe" and
-    process.args : (
-      "*\\MSSQL\\Binn\\*.mof",
-      "*\\Microsoft SQL Server\\???\\Shared\\*.mof",
-      "*\\OLAP\\bin\\*.mof"
-    )
+  not process.args : (
+    "?:\\Program Files (x86)\\Microsoft Power BI Report Server\\*.mof",
+    "?:\\Program Files (x86)\\Microsoft SQL Server Reporting Services\\*.mof",
+    "?:\\Program Files (x86)\\Microsoft SQL Server\\*.mof",
+    "?:\\Program Files\\Microsoft Policy Platform\\*.mof",
+    "?:\\Program Files\\Microsoft Power BI Report Server\\*.mof",
+    "?:\\Program Files\\Microsoft SQL Server Reporting Services\\*.mof",
+    "?:\\Program Files\\Microsoft SQL Server\\*.mof",
+    "?:\\Windows\\System32\\wbem\\com.hp.provider.*.mof",
+    "?:\\Windows\\System32\\wbem\\CxAudioSvc_*.mof",
+    "?:\\Windows\\System32\\wbem\\Framework\\root\\*.mof",
+    "?:\\Windows\\System32\\wbem\\Veeam.Backup.*.mof",
+    "?:\\Windows\\System32\\wbem\\ZTITatoo.mof",
+    "?:\\Windows\\SysWOW64\\wbem\\Framework\\root\\*.mof"
   )
 ```
 
@@ -8112,7 +8334,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0992
+Index: geneve-ut-1017
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8134,7 +8356,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0993
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8153,7 +8375,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0994
+Index: geneve-ut-1019
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -8186,7 +8408,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0995
+Index: geneve-ut-1020
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -8204,7 +8426,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-0996
+Index: geneve-ut-1021
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8245,7 +8467,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1009
+Index: geneve-ut-1033
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -8271,7 +8493,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1016
+Index: geneve-ut-1041
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -8295,7 +8517,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1019
+Index: geneve-ut-1045
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8309,7 +8531,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1020
+Index: geneve-ut-1046
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8328,7 +8550,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1021
+Index: geneve-ut-1047
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -8348,7 +8570,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1022
+Index: geneve-ut-1048
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8369,7 +8591,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1023
+Index: geneve-ut-1049
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8384,7 +8606,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1024
+Index: geneve-ut-1050
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8401,7 +8623,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1026
+Index: geneve-ut-1052
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -8425,7 +8647,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1028
+Index: geneve-ut-1054
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -8471,7 +8693,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1029
+Index: geneve-ut-1055
 
 ```python
 sequence by host.id with maxspan=1s
@@ -8513,7 +8735,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1030
+Index: geneve-ut-1056
 
 ```python
 sequence by host.id with maxspan=10s
@@ -8530,7 +8752,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1032
+Index: geneve-ut-1058
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8545,7 +8767,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1033
+Index: geneve-ut-1059
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -8564,7 +8786,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1034
+Index: geneve-ut-1060
 
 ```python
 sequence by process.entity_id
@@ -8584,7 +8806,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1035
+Index: geneve-ut-1061
 
 ```python
 sequence by process.entity_id
@@ -8603,7 +8825,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1036
+Index: geneve-ut-1062
 
 ```python
 sequence by host.id with maxspan=1m
@@ -8632,7 +8854,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1037
+Index: geneve-ut-1063
 
 ```python
 sequence by process.entity_id
@@ -8657,7 +8879,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1038
+Index: geneve-ut-1064
 
 ```python
 sequence by process.entity_id
@@ -8679,7 +8901,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1039
+Index: geneve-ut-1065
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -8712,7 +8934,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1040
+Index: geneve-ut-1066
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8742,7 +8964,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1043
+Index: geneve-ut-1069
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -8759,7 +8981,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1044
+Index: geneve-ut-1070
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -8796,7 +9018,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1045
+Index: geneve-ut-1071
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8809,7 +9031,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1050
+Index: geneve-ut-1076
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -8821,7 +9043,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1052
+Index: geneve-ut-1078
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -8833,7 +9055,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1060
+Index: geneve-ut-1086
 
 ```python
 sequence by host.id with maxspan=10s
@@ -8847,7 +9069,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1061
+Index: geneve-ut-1087
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8861,7 +9083,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1062
+Index: geneve-ut-1088
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -8881,7 +9103,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1064
+Index: geneve-ut-1090
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -8894,7 +9116,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1065
+Index: geneve-ut-1091
 
 ```python
 event.dataset: "okta.system"
@@ -8909,7 +9131,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1067
+Index: geneve-ut-1093
 
 ```python
 sequence by user.name with maxspan=30m
@@ -8931,7 +9153,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1076
+Index: geneve-ut-1102
 
 ```python
 network where event.action == "connection_accepted" and
@@ -8958,7 +9180,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1077
+Index: geneve-ut-1103
 
 ```python
 network where event.action == "lookup_requested" and
@@ -8978,7 +9200,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1078
+Index: geneve-ut-1104
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8993,7 +9215,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1079
+Index: geneve-ut-1105
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -9020,7 +9242,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1080
+Index: geneve-ut-1106
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -9035,7 +9257,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1081
+Index: geneve-ut-1107
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -9051,7 +9273,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1082
+Index: geneve-ut-1108
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -9065,7 +9287,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1083
+Index: geneve-ut-1109
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -9075,7 +9297,7 @@ file where host.os.type == "linux" and event.type in ("creation", "change") and 
   ) or
   process.name like ("php-fpm*", "lsphp*", "*.cgi", "*.fcgi")
 ) and
-file.path like~ "*/wp-content/plugins/*.php*"
+file.path like~ "*/wp-content/plugins/*"
 ```
 
 
@@ -9084,7 +9306,7 @@ file.path like~ "*/wp-content/plugins/*.php*"
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1088
+Index: geneve-ut-1114
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -9099,7 +9321,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1089
+Index: geneve-ut-1115
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9113,7 +9335,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1090
+Index: geneve-ut-1116
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9132,7 +9354,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1091
+Index: geneve-ut-1117
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9144,7 +9366,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1092
+Index: geneve-ut-1118
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9156,7 +9378,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1093
+Index: geneve-ut-1119
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9174,7 +9396,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1094
+Index: geneve-ut-1120
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9187,7 +9409,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1095
+Index: geneve-ut-1121
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9202,7 +9424,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1096
+Index: geneve-ut-1122
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -9217,7 +9439,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1098
+Index: geneve-ut-1124
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -9237,7 +9459,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1099
+Index: geneve-ut-1125
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9261,7 +9483,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1100
+Index: geneve-ut-1126
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9275,7 +9497,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1101
+Index: geneve-ut-1127
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9292,9 +9514,9 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 ### Persistence via Scheduled Job Creation
 
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-1102
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1128
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9304,12 +9526,14 @@ file where host.os.type == "windows" and event.type != "deletion" and
       process.executable : "?:\\Program Files\\CCleaner\\CCleaner64.exe" and
       file.path : "?:\\Windows\\Tasks\\CCleanerCrashReporting.job"
     ) or
-    (
-      process.executable : (
-        "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\bin\\dcagentregister.exe",
-        "?:\\Program Files (x86)\\DesktopCentral_Agent\\bin\\dcagentregister.exe"
-      ) and
-      file.path : "?:\\Windows\\Tasks\\DCAgentUpdater.job"
+    process.executable : (
+      "?:\\Program Files (x86)\\DesktopCentral_Agent\\bin\\dcagentregister.exe",
+      "?:\\Program Files (x86)\\epson\\Epson Scan 2\\Update\\e_dtsksd.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\bin\\dcagentregister.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\dcconfig.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\Updates\\UemsComponentUpgrader.exe",
+      "?:\\Program Files (x86)\\Skillbrains\\Updater\\*\\Updater.exe",
+      "?:\\Windows\\System32\\drivers\\RivetNetworks\\Killer\\CustomizeInstallFirstRun.exe"
     )
   )
 ```
@@ -9320,7 +9544,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1103
+Index: geneve-ut-1129
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -9349,7 +9573,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1104
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9368,7 +9592,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1105
+Index: geneve-ut-1131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9396,7 +9620,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1106
+Index: geneve-ut-1132
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9411,7 +9635,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1107
+Index: geneve-ut-1133
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9474,7 +9698,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1108
+Index: geneve-ut-1134
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -9495,7 +9719,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1109
+Index: geneve-ut-1135
 
 ```python
 any where host.os.type == "windows" and
@@ -9557,7 +9781,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1111
+Index: geneve-ut-1137
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -9586,7 +9810,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1112
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -9600,7 +9824,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1113
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9633,7 +9857,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1116
+Index: geneve-ut-1142
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -9680,7 +9904,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1117
+Index: geneve-ut-1143
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9707,7 +9931,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1118
+Index: geneve-ut-1144
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -9720,7 +9944,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1128
+Index: geneve-ut-1155
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9737,7 +9961,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1130
+Index: geneve-ut-1157
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -9762,7 +9986,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1135
+Index: geneve-ut-1162
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9778,7 +10002,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1136
+Index: geneve-ut-1163
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9799,7 +10023,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1137
+Index: geneve-ut-1164
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -9816,7 +10040,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1138
+Index: geneve-ut-1165
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9840,7 +10064,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1140
+Index: geneve-ut-1167
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -9869,7 +10093,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1142
+Index: geneve-ut-1169
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -9893,7 +10117,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1145
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -9911,7 +10135,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1146
+Index: geneve-ut-1173
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -9934,7 +10158,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1147
+Index: geneve-ut-1174
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9991,7 +10215,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1148
+Index: geneve-ut-1175
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10008,7 +10232,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1149
+Index: geneve-ut-1176
 
 ```python
 sequence by process.entity_id
@@ -10022,7 +10246,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1163
+Index: geneve-ut-1190
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10037,7 +10261,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1164
+Index: geneve-ut-1191
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10068,7 +10292,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1165
+Index: geneve-ut-1192
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10082,7 +10306,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1166
+Index: geneve-ut-1193
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10095,7 +10319,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1167
+Index: geneve-ut-1194
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -10107,7 +10331,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1168
+Index: geneve-ut-1195
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10120,7 +10344,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1170
+Index: geneve-ut-1197
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -10139,7 +10363,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1171
+Index: geneve-ut-1198
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10160,7 +10384,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1172
+Index: geneve-ut-1199
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10170,11 +10394,31 @@ process.name == "setenforce" and process.args == "0"
 
 
 
+### Potential EDR-Freeze via WerFaultSecure Abuse
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1202
+
+```python
+process where host.os.type == "windows" and event.type == "start" and
+  process.executable : "?:\\Windows\\System32\\WerFaultSecure.exe" and
+
+  /* WerFaultSecure secure dumps are normally initiated by the WER service hosted in svchost.exe */
+  process.parent.executable != null and
+  not process.parent.executable : ("?:\\Windows\\System32\\svchost.exe", "?:\\Windows\\System32\\wermgr.exe", "?:\\Windows\\System32\\WerFault.exe", "?:\\Windows\\System32\\WerFaultSecure.exe") and
+
+  /* arguments used to take a secure memory dump of a target process (e.g. /pid <target> /encfile <handle> /type 268310) */
+  process.args : "/pid" and process.args : "/encfile"
+```
+
+
+
 ### Potential Enumeration via Active Directory Web Service
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1175
+Index: geneve-ut-1203
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -10198,7 +10442,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1176
+Index: geneve-ut-1204
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -10214,7 +10458,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1177
+Index: geneve-ut-1205
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -10231,7 +10475,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1178
+Index: geneve-ut-1206
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10252,7 +10496,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1180
+Index: geneve-ut-1208
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -10265,7 +10509,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1182
+Index: geneve-ut-1210
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10293,7 +10537,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1185
+Index: geneve-ut-1213
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10309,7 +10553,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1186
+Index: geneve-ut-1214
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10332,7 +10576,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1187
+Index: geneve-ut-1215
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10345,7 +10589,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1189
+Index: geneve-ut-1217
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10358,7 +10602,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1194
+Index: geneve-ut-1222
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10372,7 +10616,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1195
+Index: geneve-ut-1223
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10387,7 +10631,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 375  
 Document count: 375  
-Index: geneve-ut-1197
+Index: geneve-ut-1225
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10408,7 +10652,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1200
+Index: geneve-ut-1228
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10451,7 +10695,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1201
+Index: geneve-ut-1229
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10469,7 +10713,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1202
+Index: geneve-ut-1230
 
 ```python
 host.os.type:"windows" and
@@ -10485,7 +10729,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1204
+Index: geneve-ut-1232
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -10497,7 +10741,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1206
+Index: geneve-ut-1234
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -10513,7 +10757,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1207
+Index: geneve-ut-1235
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10531,7 +10775,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1208
+Index: geneve-ut-1236
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -10545,7 +10789,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1210
+Index: geneve-ut-1238
 
 ```python
 sequence by host.id with maxspan=30s
@@ -10555,7 +10799,11 @@ sequence by host.id with maxspan=30s
   ] by process.entity_id
   /* add more executable / script extensions here if they are not noisy in your environment */
   [file where host.os.type == "windows" and event.type in ("creation", "change") and process.pid == 4 and user.id like ("S-1-5-21*", "S-1-12-*") and 
-   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl"))] by process.entity_id
+   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl")) and
+   not file.path : (
+     "?:\\Windows\\VeeamVssSupport\\*",
+     "?:\\Windows\\VeeamLogShipper\\*"
+   )] by process.entity_id
 ```
 
 
@@ -10564,7 +10812,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1212
+Index: geneve-ut-1240
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -10580,7 +10828,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1213
+Index: geneve-ut-1241
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10593,7 +10841,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1214
+Index: geneve-ut-1242
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10623,7 +10871,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1219
+Index: geneve-ut-1247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10646,7 +10894,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1220
+Index: geneve-ut-1248
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10665,7 +10913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1225
+Index: geneve-ut-1253
 
 ```python
 process where host.os.type == "windows" and 
@@ -10807,7 +11055,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1226
+Index: geneve-ut-1254
 
 ```python
 process where host.os.type == "windows" and
@@ -10884,7 +11132,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1229
+Index: geneve-ut-1257
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -10901,7 +11149,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1230
+Index: geneve-ut-1258
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -10935,7 +11183,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1232
+Index: geneve-ut-1260
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -10947,7 +11195,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1233
+Index: geneve-ut-1261
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10986,7 +11234,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1235
+Index: geneve-ut-1263
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10999,7 +11247,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1240
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11013,7 +11261,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1247
+Index: geneve-ut-1275
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -11051,7 +11299,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1248
+Index: geneve-ut-1276
 
 ```python
 network where host.os.type == "windows" and
@@ -11077,7 +11325,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1251
+Index: geneve-ut-1279
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11092,7 +11340,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1253
+Index: geneve-ut-1281
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -11106,7 +11354,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1254
+Index: geneve-ut-1282
 
 ```python
 file where host.os.type == "windows" and
@@ -11120,7 +11368,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1255
+Index: geneve-ut-1283
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11133,7 +11381,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1256
+Index: geneve-ut-1284
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11153,7 +11401,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1257
+Index: geneve-ut-1285
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11173,7 +11421,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1259
+Index: geneve-ut-1287
 
 ```python
 host.os.type:windows and event.category:process and
@@ -11212,7 +11460,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1260
+Index: geneve-ut-1288
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11407,7 +11655,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1273
+Index: geneve-ut-1301
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11423,7 +11671,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1274
+Index: geneve-ut-1302
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -11437,7 +11685,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1275
+Index: geneve-ut-1303
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -11451,7 +11699,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1276
+Index: geneve-ut-1304
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -11468,7 +11716,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1277
+Index: geneve-ut-1305
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -11482,7 +11730,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1278
+Index: geneve-ut-1306
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11498,7 +11746,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1282
+Index: geneve-ut-1310
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -11510,7 +11758,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1283
+Index: geneve-ut-1311
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -11526,7 +11774,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1284
+Index: geneve-ut-1312
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11546,7 +11794,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1286
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11586,7 +11834,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1288
+Index: geneve-ut-1316
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -11598,7 +11846,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1289
+Index: geneve-ut-1317
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -11619,7 +11867,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1290
+Index: geneve-ut-1318
 
 ```python
 sequence by host.id with maxspan=15s
@@ -11640,7 +11888,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1291
+Index: geneve-ut-1319
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -11661,7 +11909,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1292
+Index: geneve-ut-1320
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -11687,7 +11935,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1293
+Index: geneve-ut-1321
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -11703,7 +11951,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1294
+Index: geneve-ut-1322
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -11717,7 +11965,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1295
+Index: geneve-ut-1323
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -11740,7 +11988,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1297
+Index: geneve-ut-1325
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -11757,7 +12005,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1298
+Index: geneve-ut-1326
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -11780,7 +12028,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1299
+Index: geneve-ut-1327
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11793,7 +12041,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1300
+Index: geneve-ut-1328
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11807,7 +12055,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1301
+Index: geneve-ut-1329
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11824,7 +12072,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1302
+Index: geneve-ut-1330
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11878,7 +12126,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1303
+Index: geneve-ut-1331
 
 ```python
 any where host.os.type == "windows" and
@@ -11905,7 +12153,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1309
+Index: geneve-ut-1337
 
 ```python
 file where host.os.type == "windows" and
@@ -11920,7 +12168,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1310
+Index: geneve-ut-1338
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -11951,7 +12199,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1311
+Index: geneve-ut-1339
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11965,7 +12213,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1312
+Index: geneve-ut-1340
 
 ```python
 sequence with maxspan=1m
@@ -12007,7 +12255,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1313
+Index: geneve-ut-1341
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12032,7 +12280,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1314
+Index: geneve-ut-1342
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12086,7 +12334,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1315
+Index: geneve-ut-1343
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12106,7 +12354,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1316
+Index: geneve-ut-1344
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -12127,7 +12375,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1317
+Index: geneve-ut-1345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12142,7 +12390,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1318
+Index: geneve-ut-1346
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -12162,7 +12410,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1319
+Index: geneve-ut-1347
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12204,7 +12452,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1323
+Index: geneve-ut-1351
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -12219,7 +12467,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1324
+Index: geneve-ut-1352
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -12254,7 +12502,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1325
+Index: geneve-ut-1353
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -12271,7 +12519,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1327
+Index: geneve-ut-1355
 
 ```python
 sequence by host.id with maxspan=3s
@@ -12285,7 +12533,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1330
+Index: geneve-ut-1358
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -12298,7 +12546,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1331
+Index: geneve-ut-1359
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -12310,7 +12558,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1332
+Index: geneve-ut-1360
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -12325,7 +12573,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1334
+Index: geneve-ut-1362
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -12353,7 +12601,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1335
+Index: geneve-ut-1363
 
 ```python
 sequence by host.id with maxspan=1s
@@ -12378,7 +12626,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1339
+Index: geneve-ut-1367
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -12415,7 +12663,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1340
+Index: geneve-ut-1368
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12429,7 +12677,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1341
+Index: geneve-ut-1369
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -12445,7 +12693,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1342
+Index: geneve-ut-1370
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -12459,7 +12707,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1343
+Index: geneve-ut-1371
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -12489,7 +12737,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1344
+Index: geneve-ut-1372
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -12518,7 +12766,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1345
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12534,7 +12782,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1346
+Index: geneve-ut-1374
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12548,7 +12796,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1347
+Index: geneve-ut-1375
 
 ```python
 file where host.os.type == "windows" and
@@ -12580,11 +12828,25 @@ file where host.os.type == "windows" and
 
 
 
+### Potential Tunneling via Tailscaled
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1378
+
+```python
+process where event.type == "start" and
+process.name like~ ("tailscaled", "tailscaled.exe") and
+process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
+```
+
+
+
 ### Potential Unauthorized Access via Wildcard Injection Detected
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1350
+Index: geneve-ut-1379
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12598,7 +12860,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1351
+Index: geneve-ut-1380
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12618,7 +12880,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1353
+Index: geneve-ut-1382
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12635,7 +12897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1354
+Index: geneve-ut-1383
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -12647,7 +12909,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1355
+Index: geneve-ut-1384
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -12664,7 +12926,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1356
+Index: geneve-ut-1385
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12682,7 +12944,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1363
+Index: geneve-ut-1392
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12709,7 +12971,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1364
+Index: geneve-ut-1393
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -12723,7 +12985,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1366
+Index: geneve-ut-1395
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12740,7 +13002,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1367
+Index: geneve-ut-1396
 
 ```python
 event.category:process and host.os.type:windows and
@@ -12763,7 +13025,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1369
+Index: geneve-ut-1398
 
 ```python
 event.category:process and host.os.type:windows and
@@ -12780,7 +13042,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1372
+Index: geneve-ut-1401
 
 ```python
 event.category:process and host.os.type:windows and
@@ -12793,7 +13055,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1374
+Index: geneve-ut-1403
 
 ```python
 event.category:process and host.os.type:windows and
@@ -12817,7 +13079,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1375
+Index: geneve-ut-1404
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12845,7 +13107,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1390
+Index: geneve-ut-1419
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12866,7 +13128,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1393
+Index: geneve-ut-1422
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -12906,7 +13168,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1394
+Index: geneve-ut-1423
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -12923,7 +13185,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1395
+Index: geneve-ut-1424
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12937,7 +13199,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1396
+Index: geneve-ut-1425
 
 ```python
 file where host.os.type == "windows" and
@@ -12956,7 +13218,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1397
+Index: geneve-ut-1426
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12970,7 +13232,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1399
+Index: geneve-ut-1428
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12988,7 +13250,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1401
+Index: geneve-ut-1430
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -13006,7 +13268,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1404
+Index: geneve-ut-1433
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13020,7 +13282,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1406
+Index: geneve-ut-1435
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13035,7 +13297,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1407
+Index: geneve-ut-1436
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -13058,7 +13320,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1409
+Index: geneve-ut-1438
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13140,7 +13402,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1410
+Index: geneve-ut-1439
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -13161,7 +13423,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1411
+Index: geneve-ut-1440
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and
@@ -13180,7 +13442,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1413
+Index: geneve-ut-1442
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13233,7 +13495,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1414
+Index: geneve-ut-1443
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13245,7 +13507,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1415
+Index: geneve-ut-1444
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13257,7 +13519,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1416
+Index: geneve-ut-1445
 
 ```python
 process where host.os.type == "windows" and
@@ -13272,7 +13534,7 @@ process where host.os.type == "windows" and
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1417
+Index: geneve-ut-1446
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -13332,7 +13594,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1420
+Index: geneve-ut-1449
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -13345,7 +13607,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1421
+Index: geneve-ut-1450
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13377,7 +13639,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1422
+Index: geneve-ut-1451
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -13401,7 +13663,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1424
+Index: geneve-ut-1453
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13434,7 +13696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1425
+Index: geneve-ut-1454
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -13451,7 +13713,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1426
+Index: geneve-ut-1455
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -13480,7 +13742,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1427
+Index: geneve-ut-1456
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13494,7 +13756,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1428
+Index: geneve-ut-1457
 
 ```python
 sequence by process.entity_id
@@ -13519,7 +13781,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1429
+Index: geneve-ut-1458
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -13553,7 +13815,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1430
+Index: geneve-ut-1459
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -13581,7 +13843,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1431
+Index: geneve-ut-1460
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -13600,7 +13862,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1435
+Index: geneve-ut-1464
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13628,7 +13890,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1436
+Index: geneve-ut-1465
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -13647,7 +13909,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1440
+Index: geneve-ut-1469
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -13659,7 +13921,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1441
+Index: geneve-ut-1470
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13671,7 +13933,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1442
+Index: geneve-ut-1471
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -13683,7 +13945,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1443
+Index: geneve-ut-1472
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13695,7 +13957,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1451
+Index: geneve-ut-1480
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13708,7 +13970,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1452
+Index: geneve-ut-1481
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13746,7 +14008,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1454
+Index: geneve-ut-1483
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13761,7 +14023,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1455
+Index: geneve-ut-1484
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13780,7 +14042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1456
+Index: geneve-ut-1485
 
 ```python
 sequence with maxspan=1m
@@ -13828,7 +14090,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1458
+Index: geneve-ut-1487
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -13851,7 +14113,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1460
+Index: geneve-ut-1489
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13865,7 +14127,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1461
+Index: geneve-ut-1490
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13879,7 +14141,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1463
+Index: geneve-ut-1492
 
 ```python
 sequence by host.id, process.entity_id
@@ -13896,7 +14158,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1464
+Index: geneve-ut-1493
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -13910,7 +14172,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1465
+Index: geneve-ut-1494
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13930,7 +14192,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1466
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13959,7 +14221,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1467
+Index: geneve-ut-1496
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -13979,7 +14241,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1468
+Index: geneve-ut-1497
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -13992,7 +14254,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1470
+Index: geneve-ut-1499
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -14034,7 +14296,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1471
+Index: geneve-ut-1500
 
 ```python
 sequence with maxspan=1m
@@ -14057,7 +14319,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1472
+Index: geneve-ut-1501
 
 ```python
 sequence with maxspan=1s
@@ -14105,7 +14367,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1473
+Index: geneve-ut-1502
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14122,7 +14384,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1475
+Index: geneve-ut-1504
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -14151,7 +14413,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1476
+Index: geneve-ut-1505
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14179,7 +14441,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1477
+Index: geneve-ut-1506
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -14196,7 +14458,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1479
+Index: geneve-ut-1508
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -14215,7 +14477,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1480
+Index: geneve-ut-1509
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -14236,7 +14498,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1486
+Index: geneve-ut-1515
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -14255,7 +14517,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1487
+Index: geneve-ut-1516
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -14269,7 +14531,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1488
+Index: geneve-ut-1517
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -14289,7 +14551,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1490
+Index: geneve-ut-1519
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14307,7 +14569,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1491
+Index: geneve-ut-1520
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -14328,7 +14590,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1493
+Index: geneve-ut-1522
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14342,7 +14604,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1494
+Index: geneve-ut-1523
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14357,7 +14619,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1495
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14398,7 +14660,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1497
+Index: geneve-ut-1526
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -14423,7 +14685,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1498
+Index: geneve-ut-1527
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -14462,7 +14724,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1499
+Index: geneve-ut-1528
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14476,7 +14738,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1500
+Index: geneve-ut-1529
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14515,7 +14777,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1501
+Index: geneve-ut-1530
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14529,7 +14791,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1502
+Index: geneve-ut-1531
 
 ```python
 process where event.type == "start" and
@@ -14601,7 +14863,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1505
+Index: geneve-ut-1534
 
 ```python
 event.code : "4719" and host.os.type : "windows" and
@@ -14622,7 +14884,7 @@ event.code : "4719" and host.os.type : "windows" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1506
+Index: geneve-ut-1535
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -14643,7 +14905,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1508
+Index: geneve-ut-1537
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14660,7 +14922,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1510
+Index: geneve-ut-1539
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14678,7 +14940,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1511
+Index: geneve-ut-1540
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -14690,7 +14952,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1512
+Index: geneve-ut-1541
 
 ```python
 file where host.os.type == "windows" and
@@ -14723,7 +14985,7 @@ file where host.os.type == "windows" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1515
+Index: geneve-ut-1544
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -14740,7 +15002,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1516
+Index: geneve-ut-1545
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -14760,7 +15022,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1518
+Index: geneve-ut-1547
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14775,7 +15037,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1519
+Index: geneve-ut-1548
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14796,7 +15058,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1520
+Index: geneve-ut-1549
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14819,7 +15081,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1521
+Index: geneve-ut-1550
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -14832,7 +15094,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1522
+Index: geneve-ut-1551
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14849,7 +15111,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1524
+Index: geneve-ut-1553
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -14874,7 +15136,7 @@ not (
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1527
+Index: geneve-ut-1556
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -14923,7 +15185,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1528
+Index: geneve-ut-1557
 
 ```python
 sequence by host.id with maxspan=10s
@@ -14937,7 +15199,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1529
+Index: geneve-ut-1558
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -14952,7 +15214,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1530
+Index: geneve-ut-1559
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14967,7 +15229,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1531
+Index: geneve-ut-1560
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -14989,7 +15251,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1532
+Index: geneve-ut-1561
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15010,7 +15272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1535
+Index: geneve-ut-1564
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15024,7 +15286,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1536
+Index: geneve-ut-1565
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -15047,7 +15309,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1564
+Index: geneve-ut-1593
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -15072,7 +15334,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1565
+Index: geneve-ut-1594
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -15105,7 +15367,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1566
+Index: geneve-ut-1595
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -15164,7 +15426,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1568
+Index: geneve-ut-1597
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -15182,7 +15444,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1569
+Index: geneve-ut-1598
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -15194,7 +15456,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1571
+Index: geneve-ut-1600
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -15219,7 +15481,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1576
+Index: geneve-ut-1606
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15234,7 +15496,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1577
+Index: geneve-ut-1607
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -15257,7 +15519,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1580
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15271,7 +15533,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1582
+Index: geneve-ut-1612
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15293,7 +15555,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1584
+Index: geneve-ut-1614
 
 ```python
 sequence by host.id with maxspan=5s
@@ -15320,7 +15582,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1588
+Index: geneve-ut-1618
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -15359,7 +15621,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1589
+Index: geneve-ut-1619
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -15382,7 +15644,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1590
+Index: geneve-ut-1620
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -15396,7 +15658,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1591
+Index: geneve-ut-1621
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15412,7 +15674,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1592
+Index: geneve-ut-1622
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -15428,7 +15690,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1593
+Index: geneve-ut-1623
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15442,7 +15704,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1595
+Index: geneve-ut-1625
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15465,7 +15727,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1596
+Index: geneve-ut-1626
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15493,7 +15755,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1597
+Index: geneve-ut-1627
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15508,7 +15770,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1600
+Index: geneve-ut-1630
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15535,7 +15797,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1602
+Index: geneve-ut-1632
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -15551,7 +15813,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1603
+Index: geneve-ut-1633
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -15564,7 +15826,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1605
+Index: geneve-ut-1635
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15580,7 +15842,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1606
+Index: geneve-ut-1636
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -15596,7 +15858,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1607
+Index: geneve-ut-1637
 
 ```python
 any where host.os.type == "windows" and 
@@ -15663,7 +15925,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1609
+Index: geneve-ut-1639
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -15679,7 +15941,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1610
+Index: geneve-ut-1640
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15715,7 +15977,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1611
+Index: geneve-ut-1641
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15753,7 +16015,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1612
+Index: geneve-ut-1642
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -15788,7 +16050,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1613
+Index: geneve-ut-1643
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15822,7 +16084,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1615
+Index: geneve-ut-1645
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -15841,9 +16103,9 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 ### Suspicious Execution via Windows Subsystem for Linux
 
-Branch count: 14  
-Document count: 14  
-Index: geneve-ut-1620
+Branch count: 201  
+Document count: 201  
+Index: geneve-ut-1650
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -15857,9 +16119,58 @@ process where host.os.type == "windows" and event.type : "start" and
       process.parent.name : "wsl.exe" and process.parent.command_line : "bash*" and not process.name : "wslhost.exe"
     ) or
     (
-      process.name : "wsl.exe" and process.args : (
-        "curl", "/etc/shadow", "/etc/passwd", "cat", "--system", "root", "-e", "--exec", "bash", "/mnt/c/*"
-      ) and not process.args : ("wsl-bootstrap", "docker-desktop-data", "*.vscode-server*")
+      process.name : "wsl.exe" and
+      (
+        process.args : "--system" or
+        (
+          process.args : "--manage" and process.args : "--set-default-user" and process.args : "root"
+        ) or
+        (
+          (process.args : ("curl", "wget") and process.args : ("http://*", "https://*")) or
+          process.args : ("*curl*http://*", "*curl*https://*", "*wget*http://*", "*wget*https://*")
+        ) or
+        (
+          (
+            process.args like~ ("*/dev/tcp/*", "*/dev/udp/*", "*zsh/net/tcp*") and
+            process.args like ("*&>*", "*<>*", "*>&*", "*<&*")
+          ) or
+          (
+            process.args : ("nc", "netcat", "nc.traditional", "ncat", "*/nc", "*/netcat", "*/nc.traditional", "*/ncat") and
+            process.args : ("sh", "/bin/sh", "bash", "/bin/bash") and
+            process.args : ("-e", "--exec", "-c", "--sh-exec")
+          ) or
+          (
+            process.args like~ "*socat*" and
+            process.args like~ ("*exec:*", "*system:*", "*shell:*") and
+            process.args like~ ("*tcp*", "*udp*", "*openssl*")
+          )
+        ) or
+        (
+          process.args : ("-e", "--exec") and
+          process.args : (
+            "/mnt/c/*.exe", "/mnt/c/*.ps1", "/mnt/c/*.bat", "/mnt/c/*.cmd", "/mnt/c/*.vbs", "/mnt/c/*.js",
+            "/mnt/c/*.hta"
+          ) and
+          not process.args : "*wslpath*"
+        ) or
+        process.args : (
+          "*/etc/passwd*", "*/etc/shadow*", "*/etc/sudoers*", "*/etc/sudoers.d/*", "*/root/.ssh/*", "*/home/*/.ssh/*",
+          "*/root/.aws/credentials*", "*/home/*/.aws/credentials*", "*/root/.kube/config*", "*/home/*/.kube/config*",
+          "*/mnt/c/Windows/System32/config/SAM*",
+          "*/mnt/c/Windows/System32/config/SECURITY*",
+          "*/mnt/c/Windows/System32/config/SYSTEM", "*/mnt/c/Windows/System32/config/SYSTEM.*",
+          "*/mnt/c/Windows/NTDS/ntds.dit*",
+          "*/mnt/c/Users/*/AppData/Roaming/Microsoft/Credentials/*",
+          "*/mnt/c/Users/*/AppData/Local/Microsoft/Credentials/*",
+          "*/mnt/c/Users/*/AppData/Roaming/Microsoft/Protect/*",
+          "*/mnt/c/Users/*/.ssh/*",
+          "*/mnt/c/Users/*/.aws/credentials",
+          "*/mnt/c/Users/*/.azure/*",
+          "*/mnt/c/Users/*/.config/gcloud/*",
+          "*/mnt/c/Users/*/AppData/Local/Google/Chrome/User Data/*/Login Data*",
+          "*/mnt/c/Users/*/AppData/Local/Microsoft/Edge/User Data/*/Login Data*"
+        )
+      )
     )
   ) and
     not process.parent.executable : ("?:\\Program Files\\Docker\\*.exe", "?:\\Program Files (x86)\\Docker\\*.exe")
@@ -15869,21 +16180,21 @@ process where host.os.type == "windows" and event.type : "start" and
 
 ### Suspicious Execution with NodeJS
 
-Branch count: 18  
-Document count: 18  
-Index: geneve-ut-1621
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1651
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
 
-(process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or ?process.code_signature.subject_name : "OpenJS Foundation") and
+(process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or
+ ?process.code_signature.subject_name : ("OpenJS Foundation", "Node.js Foundation")) and
 
 (
-  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
+  (process.args : ("-r", "--require", "--require=*") and
+   process.parent.name : ("powershell.exe", "pwsh.exe")) or
 
-  (process.args : "-r" and process.parent.name : "powershell.exe") or
-
-   process.command_line : ("*eval(*", "*atob(*", "*require*child_process*")
+  process.command_line : ("*eval(*", "*atob(*", "*require*child_process*")
 )
 ```
 
@@ -15893,7 +16204,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1622
+Index: geneve-ut-1652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15917,7 +16228,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1623
+Index: geneve-ut-1653
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -15938,7 +16249,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1626
+Index: geneve-ut-1656
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15953,7 +16264,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1629
+Index: geneve-ut-1659
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15966,7 +16277,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1630
+Index: geneve-ut-1660
 
 ```python
 any where host.os.type == "windows" and
@@ -15981,7 +16292,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1631
+Index: geneve-ut-1661
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15997,7 +16308,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1632
+Index: geneve-ut-1662
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -16011,7 +16322,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1636
+Index: geneve-ut-1666
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16025,7 +16336,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1638
+Index: geneve-ut-1668
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -16057,7 +16368,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1640
+Index: geneve-ut-1670
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -16070,7 +16381,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1641
+Index: geneve-ut-1671
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16089,7 +16400,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1642
+Index: geneve-ut-1672
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16135,7 +16446,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1644
+Index: geneve-ut-1674
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16156,7 +16467,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1645
+Index: geneve-ut-1675
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16176,7 +16487,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1646
+Index: geneve-ut-1676
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16190,7 +16501,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1647
+Index: geneve-ut-1677
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16222,7 +16533,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1650
+Index: geneve-ut-1680
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -16243,7 +16554,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1652
+Index: geneve-ut-1682
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -16344,7 +16655,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1655
+Index: geneve-ut-1685
 
 ```python
 sequence by host.id with maxspan=5s
@@ -16392,7 +16703,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1657
+Index: geneve-ut-1687
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16418,7 +16729,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1658
+Index: geneve-ut-1688
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16463,7 +16774,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1659
+Index: geneve-ut-1689
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16487,7 +16798,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1660
+Index: geneve-ut-1690
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -16503,7 +16814,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1662
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -16528,7 +16839,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1663
+Index: geneve-ut-1693
 
 ```python
 event.category:process and host.os.type:windows and
@@ -16543,7 +16854,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1666
+Index: geneve-ut-1696
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -16557,7 +16868,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1667
+Index: geneve-ut-1697
 
 ```python
 sequence by host.id with maxspan=30s
@@ -16577,7 +16888,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1668
+Index: geneve-ut-1698
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16612,7 +16923,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1672
+Index: geneve-ut-1702
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16625,7 +16936,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1674
+Index: geneve-ut-1704
 
 ```python
 any where host.os.type == "windows" and
@@ -16658,7 +16969,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1676
+Index: geneve-ut-1706
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -16676,7 +16987,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1677
+Index: geneve-ut-1707
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -16698,7 +17009,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1680
+Index: geneve-ut-1710
 
 ```python
 sequence by host.id with maxspan=30s
@@ -16737,7 +17048,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1681
+Index: geneve-ut-1711
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16767,7 +17078,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1682
+Index: geneve-ut-1712
 
 ```python
 any where host.os.type == "windows" and
@@ -16801,7 +17112,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1683
+Index: geneve-ut-1713
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -16815,7 +17126,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1686
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16846,7 +17157,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1687
+Index: geneve-ut-1717
 
 ```python
 any where host.os.type == "windows" and
@@ -16866,7 +17177,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1688
+Index: geneve-ut-1718
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16907,7 +17218,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1689
+Index: geneve-ut-1719
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -16923,7 +17234,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1690
+Index: geneve-ut-1720
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16953,7 +17264,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1694
+Index: geneve-ut-1724
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -16966,7 +17277,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1695
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -16990,7 +17301,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1697
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17008,7 +17319,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1699
+Index: geneve-ut-1730
 
 ```python
 any where host.os.type == "windows" and
@@ -17023,7 +17334,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1700
+Index: geneve-ut-1731
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -17041,7 +17352,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1701
+Index: geneve-ut-1732
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -17062,7 +17373,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1702
+Index: geneve-ut-1733
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17081,7 +17392,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1705
+Index: geneve-ut-1736
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17106,7 +17417,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1706
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17119,7 +17430,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1708
+Index: geneve-ut-1739
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -17132,7 +17443,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1710
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17155,7 +17466,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1712
+Index: geneve-ut-1743
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17174,7 +17485,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1713
+Index: geneve-ut-1744
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -17196,7 +17507,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1714
+Index: geneve-ut-1745
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -17229,7 +17540,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1716
+Index: geneve-ut-1747
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17247,7 +17558,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1717
+Index: geneve-ut-1748
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -17261,7 +17572,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1718
+Index: geneve-ut-1749
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17285,7 +17596,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1719
+Index: geneve-ut-1750
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -17308,7 +17619,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1720
+Index: geneve-ut-1751
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -17327,7 +17638,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1724
+Index: geneve-ut-1755
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -17362,7 +17673,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1725
+Index: geneve-ut-1756
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17379,7 +17690,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1726
+Index: geneve-ut-1757
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17399,7 +17710,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1727
+Index: geneve-ut-1758
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -17439,7 +17750,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1728
+Index: geneve-ut-1759
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -17455,7 +17766,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1729
+Index: geneve-ut-1760
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17469,7 +17780,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1730
+Index: geneve-ut-1761
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17507,7 +17818,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1731
+Index: geneve-ut-1762
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17561,7 +17872,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1732
+Index: geneve-ut-1763
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -17589,7 +17900,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1734
+Index: geneve-ut-1765
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -17603,7 +17914,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1735
+Index: geneve-ut-1766
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17649,7 +17960,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1736
+Index: geneve-ut-1767
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -17688,7 +17999,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1737
+Index: geneve-ut-1768
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -17701,7 +18012,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1740
+Index: geneve-ut-1771
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -17734,7 +18045,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1741
+Index: geneve-ut-1772
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -17748,7 +18059,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1742
+Index: geneve-ut-1773
 
 ```python
 sequence by host.id with maxspan=1s
@@ -17762,7 +18073,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1743
+Index: geneve-ut-1774
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -17776,7 +18087,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1744
+Index: geneve-ut-1775
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -17815,7 +18126,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1750
+Index: geneve-ut-1782
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -17857,7 +18168,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1751
+Index: geneve-ut-1783
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -17870,7 +18181,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1752
+Index: geneve-ut-1784
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17887,7 +18198,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1753
+Index: geneve-ut-1785
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -17903,7 +18214,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1754
+Index: geneve-ut-1786
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17916,7 +18227,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1755
+Index: geneve-ut-1787
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -17931,7 +18242,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1756
+Index: geneve-ut-1788
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17954,7 +18265,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1757
+Index: geneve-ut-1789
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17970,7 +18281,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1758
+Index: geneve-ut-1790
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17986,7 +18297,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1763
+Index: geneve-ut-1795
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -17998,7 +18309,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1764
+Index: geneve-ut-1796
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18027,7 +18338,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1766
+Index: geneve-ut-1798
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -18041,7 +18352,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1771
+Index: geneve-ut-1803
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -18061,7 +18372,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1772
+Index: geneve-ut-1804
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -18086,7 +18397,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1778
+Index: geneve-ut-1810
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18100,7 +18411,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1779
+Index: geneve-ut-1811
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18123,7 +18434,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1784
+Index: geneve-ut-1816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -18157,7 +18468,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1786
+Index: geneve-ut-1818
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18176,7 +18487,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-1793
+Index: geneve-ut-1825
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -18195,7 +18506,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1806
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -18212,7 +18523,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1809
+Index: geneve-ut-1842
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -18229,7 +18540,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1825
+Index: geneve-ut-1858
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -18248,7 +18559,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1829
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18290,7 +18601,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1830
+Index: geneve-ut-1863
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18335,7 +18646,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1833
+Index: geneve-ut-1866
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18377,7 +18688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1835
+Index: geneve-ut-1868
 
 ```python
 host.os.type:"linux" and 
@@ -18405,7 +18716,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1838
+Index: geneve-ut-1871
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18429,7 +18740,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1839
+Index: geneve-ut-1872
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18469,7 +18780,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1840
+Index: geneve-ut-1873
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -18516,7 +18827,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1844
+Index: geneve-ut-1877
 
 ```python
 sequence by process.entity_id
@@ -18553,7 +18864,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1876
+Index: geneve-ut-1909
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18567,7 +18878,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1877
+Index: geneve-ut-1910
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -18610,7 +18921,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1878
+Index: geneve-ut-1911
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -18623,7 +18934,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1880
+Index: geneve-ut-1913
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -18637,7 +18948,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1881
+Index: geneve-ut-1914
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -18650,7 +18961,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1885
+Index: geneve-ut-1918
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -18675,7 +18986,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1886
+Index: geneve-ut-1919
 
 ```python
 process where event.type == "start" and
@@ -18690,7 +19001,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1887
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -18707,7 +19018,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1888
+Index: geneve-ut-1921
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18721,7 +19032,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1889
+Index: geneve-ut-1922
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18737,7 +19048,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1890
+Index: geneve-ut-1923
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18751,7 +19062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1891
+Index: geneve-ut-1924
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -18778,7 +19089,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1893
+Index: geneve-ut-1926
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -18790,7 +19101,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1894
+Index: geneve-ut-1927
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18806,7 +19117,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1895
+Index: geneve-ut-1928
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -18829,7 +19140,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1896
+Index: geneve-ut-1929
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -18842,7 +19153,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1897
+Index: geneve-ut-1930
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -18854,7 +19165,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1898
+Index: geneve-ut-1931
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -18866,7 +19177,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1899
+Index: geneve-ut-1932
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -18878,7 +19189,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1900
+Index: geneve-ut-1933
 
 ```python
 web where (
@@ -18906,7 +19217,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-1903
+Index: geneve-ut-1936
 
 ```python
 any where (
@@ -18978,7 +19289,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1905
+Index: geneve-ut-1938
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18999,7 +19310,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1908
+Index: geneve-ut-1941
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -19013,7 +19324,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1909
+Index: geneve-ut-1942
 
 ```python
 file where event.type == "deletion" and
@@ -19030,7 +19341,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1910
+Index: geneve-ut-1943
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19048,7 +19359,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1912
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19086,7 +19397,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1914
+Index: geneve-ut-1947
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19123,7 +19434,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1915
+Index: geneve-ut-1948
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19138,7 +19449,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1916
+Index: geneve-ut-1949
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -19151,7 +19462,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1917
+Index: geneve-ut-1950
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19170,10 +19481,10 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-1918
+Index: geneve-ut-1951
 
 ```python
-sequence with maxspan=1m
+sequence by host.id with maxspan=1m
   [registry where host.os.type == "windows" and event.type == "change" and process.name : "msiexec.exe" and
    (
     (registry.value : "InstallSource" and
@@ -19195,7 +19506,7 @@ sequence with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1919
+Index: geneve-ut-1952
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19221,7 +19532,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1920
+Index: geneve-ut-1953
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -19243,7 +19554,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1921
+Index: geneve-ut-1954
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19260,7 +19571,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-1923
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -19279,7 +19590,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-1924
+Index: geneve-ut-1957
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -19319,7 +19630,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1925
+Index: geneve-ut-1958
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19336,7 +19647,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1927
+Index: geneve-ut-1960
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -19349,7 +19660,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1928
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -19363,7 +19674,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1929
+Index: geneve-ut-1962
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19391,7 +19702,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1930
+Index: geneve-ut-1963
 
 ```python
 process where event.type == "start" and
@@ -19416,7 +19727,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1931
+Index: geneve-ut-1964
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19430,7 +19741,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1932
+Index: geneve-ut-1965
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19446,7 +19757,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1933
+Index: geneve-ut-1966
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19481,7 +19792,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1934
+Index: geneve-ut-1967
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19499,7 +19810,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1937
+Index: geneve-ut-1970
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.3.md
+++ b/tests/reports/alerts_from_rules-9.3.md
@@ -5,22 +5,22 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.16
+Rules version: 9.3.17
 
 ## Table of contents
-   1. [Failed rules (23)](#failed-rules-23)
-   1. [Unsuccessful rules with signals (23)](#unsuccessful-rules-with-signals-23)
+   1. [Failed rules (24)](#failed-rules-24)
+   1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
-   1. [Rules with too few signals (27)](#rules-with-too-few-signals-27)
+   1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
    1. [Rules with the correct signals (804)](#rules-with-the-correct-signals-804)
 
-## Failed rules (23)
+## Failed rules (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0345  
+Index: geneve-ut-0360  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -66,7 +66,122 @@ process.args like~ (
   "*/.config/gcloud/*", "*application_default_credentials.json*",
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*",
   "*/var/run/secrets/google/*", "*GOOGLE_APPLICATION_CREDENTIALS*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
+```
+
+
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0371  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
 ```
 
 
@@ -75,7 +190,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0574  
+Index: geneve-ut-0590  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -144,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0597  
+Index: geneve-ut-0613  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -173,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0719  
+Index: geneve-ut-0744  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -204,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0910  
+Index: geneve-ut-0933  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -257,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1037  
+Index: geneve-ut-1061  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -290,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1065  
+Index: geneve-ut-1090  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -324,7 +439,7 @@ process.args like~ (
   "-*e*",
   /* file transfer via stdout/pipe */
   ">","<", "|"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -333,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1133  
+Index: geneve-ut-1158  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -374,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1161  
+Index: geneve-ut-1186  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -400,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1178  
+Index: geneve-ut-1204  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -438,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1239  
+Index: geneve-ut-1266  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -460,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1254  
+Index: geneve-ut-1281  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -501,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1338  
+Index: geneve-ut-1365  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -564,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1564  
+Index: geneve-ut-1593  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -601,7 +716,7 @@ process.args like~ (
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*", "*/var/run/secrets/google/*",
   "*GOOGLE_APPLICATION_CREDENTIALS*", "*AZURE_CLIENT_ID*", "*AZURE_TENANT_ID*", "*AZURE_CLIENT_SECRET*",
   "*AZURE_FEDERATED_TOKEN_FILE*", "*IDENTITY_ENDPOINT*", "*IDENTITY_HEADER*", "*MSI_ENDPOINT*", "*MSI_SECRET*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -610,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1568  
+Index: geneve-ut-1597  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -644,7 +759,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 process.args like~ (
   "*BEGIN PRIVATE*", "*BEGIN OPENSSH PRIVATE*", "*BEGIN RSA PRIVATE*", "*BEGIN DSA PRIVATE*", "*BEGIN EC PRIVATE*",
   "*password*", "*ssh*", "*id_rsa*", "*id_dsa*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -653,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1648  
+Index: geneve-ut-1678  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -701,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1663  
+Index: geneve-ut-1693  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -736,13 +851,13 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1676  
+Index: geneve-ut-1706  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
 process.args in ("-lc", "-c", "-cl") and process.args like ("*echo *", "*printf *") and
 process.args like (
@@ -761,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1686  
+Index: geneve-ut-1716  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -824,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1691  
+Index: geneve-ut-1721  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -852,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1700  
+Index: geneve-ut-1730  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -884,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1794  
+Index: geneve-ut-1825  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -949,7 +1064,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -959,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1822  
+Index: geneve-ut-1854  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -997,18 +1112,18 @@ process.args in (
   "nmap", "zenmap", "nuclei", "netdiscover", "legion", "masscan", "zmap", "zgrab", "ngrep", "telnet", "mitmproxy", "zmap",
   "masscan", "zgrab"
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
 
-## Unsuccessful rules with signals (23)
+## Unsuccessful rules with signals (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0345
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1051,7 +1166,119 @@ process.args like~ (
   "*/.config/gcloud/*", "*application_default_credentials.json*",
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*",
   "*/var/run/secrets/google/*", "*GOOGLE_APPLICATION_CREDENTIALS*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
+```
+
+
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0371
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
 ```
 
 
@@ -1060,7 +1287,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0574
+Index: geneve-ut-0590
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1126,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0597
+Index: geneve-ut-0613
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1152,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0719
+Index: geneve-ut-0744
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1180,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0910
+Index: geneve-ut-0933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1230,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1037
+Index: geneve-ut-1061
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1260,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1065
+Index: geneve-ut-1090
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1291,7 +1518,7 @@ process.args like~ (
   "-*e*",
   /* file transfer via stdout/pipe */
   ">","<", "|"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -1300,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1133
+Index: geneve-ut-1158
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1338,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1161
+Index: geneve-ut-1186
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1361,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1178
+Index: geneve-ut-1204
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1396,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1239
+Index: geneve-ut-1266
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1415,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1254
+Index: geneve-ut-1281
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1453,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1338
+Index: geneve-ut-1365
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1513,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1564
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1547,7 +1774,7 @@ process.args like~ (
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*", "*/var/run/secrets/google/*",
   "*GOOGLE_APPLICATION_CREDENTIALS*", "*AZURE_CLIENT_ID*", "*AZURE_TENANT_ID*", "*AZURE_CLIENT_SECRET*",
   "*AZURE_FEDERATED_TOKEN_FILE*", "*IDENTITY_ENDPOINT*", "*IDENTITY_HEADER*", "*MSI_ENDPOINT*", "*MSI_SECRET*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -1556,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1568
+Index: geneve-ut-1597
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1587,7 +1814,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 process.args like~ (
   "*BEGIN PRIVATE*", "*BEGIN OPENSSH PRIVATE*", "*BEGIN RSA PRIVATE*", "*BEGIN DSA PRIVATE*", "*BEGIN EC PRIVATE*",
   "*password*", "*ssh*", "*id_rsa*", "*id_dsa*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -1596,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1648
+Index: geneve-ut-1678
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1641,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1663
+Index: geneve-ut-1693
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1673,10 +1900,10 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1676
+Index: geneve-ut-1706
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
 process.args in ("-lc", "-c", "-cl") and process.args like ("*echo *", "*printf *") and
 process.args like (
@@ -1695,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1686
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1755,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1691
+Index: geneve-ut-1721
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1780,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1700
+Index: geneve-ut-1730
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -1809,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1794
+Index: geneve-ut-1825
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -1871,7 +2098,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -1881,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1822
+Index: geneve-ut-1854
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1916,7 +2143,7 @@ process.args in (
   "nmap", "zenmap", "nuclei", "netdiscover", "legion", "masscan", "zmap", "zgrab", "ngrep", "telnet", "mitmproxy", "zmap",
   "masscan", "zgrab"
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -1927,7 +2154,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0231
+Index: geneve-ut-0238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1941,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0911
+Index: geneve-ut-0934
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1953,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0917
+Index: geneve-ut-0940
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1965,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1289
+Index: geneve-ut-1316
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1983,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1477
+Index: geneve-ut-1506
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -1994,13 +2221,13 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 
 
-## Rules with too few signals (27)
+## Rules with too few signals (28)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0345  
+Index: geneve-ut-0360  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2045,7 +2272,121 @@ process.args like~ (
   "*/.config/gcloud/*", "*application_default_credentials.json*",
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*",
   "*/var/run/secrets/google/*", "*GOOGLE_APPLICATION_CREDENTIALS*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
+```
+
+
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0371  
+Failure message(s):  
+  got 1000 signals, expected 1680  
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
 ```
 
 
@@ -2054,7 +2395,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0574  
+Index: geneve-ut-0590  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2122,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0597  
+Index: geneve-ut-0613  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2150,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0719  
+Index: geneve-ut-0744  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2180,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0883  
+Index: geneve-ut-0906  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2199,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0910  
+Index: geneve-ut-0933  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2251,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1016  
+Index: geneve-ut-1040  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2271,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1037  
+Index: geneve-ut-1061  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2303,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1065  
+Index: geneve-ut-1090  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2336,7 +2677,7 @@ process.args like~ (
   "-*e*",
   /* file transfer via stdout/pipe */
   ">","<", "|"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -2345,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1133  
+Index: geneve-ut-1158  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2385,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1161  
+Index: geneve-ut-1186  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2410,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1178  
+Index: geneve-ut-1204  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2447,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1239  
+Index: geneve-ut-1266  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2468,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1254  
+Index: geneve-ut-1281  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2508,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1330  
+Index: geneve-ut-1357  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2525,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1338  
+Index: geneve-ut-1365  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2587,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1445  
+Index: geneve-ut-1474  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2612,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1564  
+Index: geneve-ut-1593  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2648,7 +2989,7 @@ process.args like~ (
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*", "*/var/run/secrets/google/*",
   "*GOOGLE_APPLICATION_CREDENTIALS*", "*AZURE_CLIENT_ID*", "*AZURE_TENANT_ID*", "*AZURE_CLIENT_SECRET*",
   "*AZURE_FEDERATED_TOKEN_FILE*", "*IDENTITY_ENDPOINT*", "*IDENTITY_HEADER*", "*MSI_ENDPOINT*", "*MSI_SECRET*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -2657,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1568  
+Index: geneve-ut-1597  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -2690,7 +3031,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 process.args like~ (
   "*BEGIN PRIVATE*", "*BEGIN OPENSSH PRIVATE*", "*BEGIN RSA PRIVATE*", "*BEGIN DSA PRIVATE*", "*BEGIN EC PRIVATE*",
   "*password*", "*ssh*", "*id_rsa*", "*id_dsa*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -2699,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1648  
+Index: geneve-ut-1678  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -2746,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1663  
+Index: geneve-ut-1693  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -2780,12 +3121,12 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1676  
+Index: geneve-ut-1706  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
 process.args in ("-lc", "-c", "-cl") and process.args like ("*echo *", "*printf *") and
 process.args like (
@@ -2804,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1686  
+Index: geneve-ut-1716  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -2866,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1691  
+Index: geneve-ut-1721  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -2893,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1700  
+Index: geneve-ut-1730  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -2924,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1794  
+Index: geneve-ut-1825  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -2988,7 +3329,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -2998,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1822  
+Index: geneve-ut-1854  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3035,7 +3376,7 @@ process.args in (
   "nmap", "zenmap", "nuclei", "netdiscover", "legion", "masscan", "zmap", "zgrab", "ngrep", "telnet", "mitmproxy", "zmap",
   "masscan", "zgrab"
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -3133,7 +3474,7 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0050
+Index: geneve-ut-0052
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -3151,7 +3492,7 @@ process.command_line like~ (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0067
+Index: geneve-ut-0069
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3168,7 +3509,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0099
+Index: geneve-ut-0102
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3187,7 +3528,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0106
+Index: geneve-ut-0109
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
@@ -3200,7 +3541,7 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0117
+Index: geneve-ut-0121
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3232,7 +3573,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0125
+Index: geneve-ut-0130
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3248,7 +3589,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0127
+Index: geneve-ut-0132
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3263,7 +3604,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0147
+Index: geneve-ut-0152
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
@@ -3276,7 +3617,7 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0182
+Index: geneve-ut-0188
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3292,7 +3633,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0183
+Index: geneve-ut-0189
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -3307,7 +3648,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0193
+Index: geneve-ut-0200
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -3322,7 +3663,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0202
+Index: geneve-ut-0209
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3346,7 +3687,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0203
+Index: geneve-ut-0210
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -3381,7 +3722,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0204
+Index: geneve-ut-0211
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -3398,7 +3739,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0205
+Index: geneve-ut-0212
 
 ```python
 any where host.os.type == "windows" and
@@ -3423,7 +3764,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0207
+Index: geneve-ut-0214
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -3451,7 +3792,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0209
+Index: geneve-ut-0216
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3464,7 +3805,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0211
+Index: geneve-ut-0218
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -3480,7 +3821,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0212
+Index: geneve-ut-0219
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3500,7 +3841,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0213
+Index: geneve-ut-0220
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3521,7 +3862,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0214
+Index: geneve-ut-0221
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3533,7 +3874,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0217
+Index: geneve-ut-0224
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3545,7 +3886,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0229
+Index: geneve-ut-0236
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3562,7 +3903,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0230
+Index: geneve-ut-0237
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3574,7 +3915,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0232
+Index: geneve-ut-0239
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3594,7 +3935,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0233
+Index: geneve-ut-0240
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3608,7 +3949,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0237
+Index: geneve-ut-0244
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3639,7 +3980,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0238
+Index: geneve-ut-0245
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3651,7 +3992,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0239
+Index: geneve-ut-0246
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3665,7 +4006,7 @@ process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clea
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0240
+Index: geneve-ut-0247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3680,7 +4021,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0250
+Index: geneve-ut-0257
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -3699,7 +4040,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0251
+Index: geneve-ut-0258
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3713,7 +4054,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0252
+Index: geneve-ut-0259
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -3744,7 +4085,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0253
+Index: geneve-ut-0260
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3767,7 +4108,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0254
+Index: geneve-ut-0261
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3781,7 +4122,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0255
+Index: geneve-ut-0262
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3800,7 +4141,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0256
+Index: geneve-ut-0263
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3814,7 +4155,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0257
+Index: geneve-ut-0264
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3839,7 +4180,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0262
+Index: geneve-ut-0269
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3858,7 +4199,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0265
+Index: geneve-ut-0272
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3871,7 +4212,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0267
+Index: geneve-ut-0274
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3913,7 +4254,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0270
+Index: geneve-ut-0277
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -3928,7 +4269,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0303
+Index: geneve-ut-0317
 
 ```python
 event.dataset:azure.activitylogs and
@@ -3942,7 +4283,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0306
+Index: geneve-ut-0320
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -3960,7 +4301,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0324
+Index: geneve-ut-0338
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3978,7 +4319,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0325
+Index: geneve-ut-0339
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3996,7 +4337,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0326
+Index: geneve-ut-0340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4011,7 +4352,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0327
+Index: geneve-ut-0341
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4025,7 +4366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0328
+Index: geneve-ut-0342
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4040,7 +4381,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0330
+Index: geneve-ut-0344
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4057,7 +4398,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0331
+Index: geneve-ut-0345
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4069,7 +4410,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0332
+Index: geneve-ut-0346
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4081,7 +4422,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0333
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4096,7 +4437,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0334
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4116,7 +4457,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0335
+Index: geneve-ut-0349
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4138,7 +4479,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0337
+Index: geneve-ut-0351
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4184,7 +4525,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0338
+Index: geneve-ut-0352
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4218,7 +4559,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0339
+Index: geneve-ut-0353
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4241,7 +4582,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0340
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4263,7 +4604,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0341
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4291,7 +4632,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0342
+Index: geneve-ut-0357
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4307,7 +4648,7 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0344
+Index: geneve-ut-0359
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4332,7 +4673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0346
+Index: geneve-ut-0361
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4362,7 +4703,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0348
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4376,7 +4717,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0349
+Index: geneve-ut-0364
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4398,7 +4739,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0350
+Index: geneve-ut-0365
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4412,7 +4753,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0351
+Index: geneve-ut-0366
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4432,7 +4773,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0354
+Index: geneve-ut-0369
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4445,95 +4786,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Component Object Model Hijacking
-
-Branch count: 60  
-Document count: 60  
-Index: geneve-ut-0356
-
-```python
-registry where host.os.type == "windows" and event.type == "change" and
-  /* not necessary but good for filtering privileged installations */
-  user.domain != "NT AUTHORITY" and process.executable != null and 
-  (
-    (
-      registry.path : "HK*\\InprocServer32\\" and
-      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
-      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
-    ) or
-
-    (
-      registry.path : "HKLM\\*\\InProcServer32\\*" and
-        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
-    ) or
-
-    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
-    (
-      registry.path : (
-        "HKEY_USERS\\*\\InprocServer32\\",
-        "HKEY_USERS\\*\\LocalServer32\\",
-        "HKEY_USERS\\*\\DelegateExecute",
-        "HKEY_USERS\\*\\TreatAs\\",
-        "HKEY_USERS\\*\\ScriptletURL*", 
-        "HKEY_USERS\\*\\TypeLib*\\Win*"
-      ) and
-      not registry.data.strings : (
-            /* COM related to Windows Spotlight feature */
-            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
-
-            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
-            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
-            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
-            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
-      )
-    )
-  ) and 
-
-  not (
-    process.code_signature.trusted == true and
-    process.code_signature.subject_name in (
-        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
-        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
-        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
-        "Vivaldi Technologies AS"
-    )
-  ) and 
-
-  /* excludes Microsoft signed noisy processes */
-  not
-  (
-    process.name : (
-      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
-      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
-    ) and
-    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
-  ) and
-
-  not process.executable : (
-        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
-        "?:\\Program Files (x86)\\*.exe",
-        "?:\\Program Files\\*.exe",
-        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
-        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
-        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
-        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
-        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
-        "?:\\Windows\\System32\\FMToastNotification.exe",
-        "?:\\Windows\\System32\\msiexec.exe",
-        "?:\\Windows\\System32\\svchost.exe",
-        "?:\\Windows\\SysWOW64\\regsvr32.exe",
-        "?:\\Windows\\System32\\regsvr32.exe",
-        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
-  )
-```
-
-
-
 ### Compression DLL Loaded by Unusual Process
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0357
+Index: geneve-ut-0372
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4563,7 +4820,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0360
+Index: geneve-ut-0375
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4588,7 +4845,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0362
+Index: geneve-ut-0377
 
 ```python
 sequence by process.entity_id
@@ -4609,7 +4866,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0363
+Index: geneve-ut-0378
 
 ```python
 sequence by process.entity_id
@@ -4630,7 +4887,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0366
+Index: geneve-ut-0381
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4661,7 +4918,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0367
+Index: geneve-ut-0382
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4673,7 +4930,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0368
+Index: geneve-ut-0383
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4696,7 +4953,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0371
+Index: geneve-ut-0386
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4709,7 +4966,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0372
+Index: geneve-ut-0387
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4722,7 +4979,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0374
+Index: geneve-ut-0389
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4739,7 +4996,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0375
+Index: geneve-ut-0390
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -4752,7 +5009,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0376
+Index: geneve-ut-0391
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -4769,7 +5026,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0377
+Index: geneve-ut-0392
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -4781,7 +5038,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0378
+Index: geneve-ut-0393
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -4849,7 +5106,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0379
+Index: geneve-ut-0394
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -4867,7 +5124,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0380
+Index: geneve-ut-0395
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -4880,7 +5137,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0381
+Index: geneve-ut-0396
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4898,7 +5155,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0382
+Index: geneve-ut-0397
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4910,7 +5167,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0383
+Index: geneve-ut-0398
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4922,7 +5179,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0384
+Index: geneve-ut-0399
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4934,7 +5191,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0385
+Index: geneve-ut-0400
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4946,7 +5203,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0386
+Index: geneve-ut-0401
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -4991,7 +5248,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0388
+Index: geneve-ut-0403
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5011,7 +5268,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0389
+Index: geneve-ut-0404
 
 ```python
 sequence with maxspan=10s
@@ -5031,7 +5288,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0390
+Index: geneve-ut-0405
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5058,12 +5315,12 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0391
+Index: geneve-ut-0406
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
 process.name == "curl" and process.args like ("--socks5-hostname", "--proxy", "--preproxy", "socks5*", "-x") and
-process.interactive == true and container.id like "?*"
+container.id like "?*"
 ```
 
 
@@ -5072,7 +5329,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0394
+Index: geneve-ut-0409
 
 ```python
 process where event.type == "start" and
@@ -5097,7 +5354,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0397
+Index: geneve-ut-0412
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5141,7 +5398,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0398
+Index: geneve-ut-0413
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5175,11 +5432,11 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0399
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.interactive == true and container.id like "*" and 
+container.id like "*" and 
 (
   /* getent hosts is often used without a target arg */
   (process.name == "getent" and process.args == "hosts") or
@@ -5220,7 +5477,7 @@ process.interactive == true and container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0400
+Index: geneve-ut-0415
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5236,7 +5493,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0401
+Index: geneve-ut-0416
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5261,7 +5518,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0402
+Index: geneve-ut-0417
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5280,7 +5537,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0404
+Index: geneve-ut-0419
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5407,7 +5664,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0405
+Index: geneve-ut-0420
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5425,7 +5682,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0407
+Index: geneve-ut-0422
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5438,7 +5695,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0408
+Index: geneve-ut-0423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5459,7 +5716,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
   )
 ) and
 process.args like "/dev/sd*" and not process.args == "-R" and
-container.security_context.privileged == true and process.interactive == true and container.id like "*"
+container.security_context.privileged == true and container.id like "*"
 ```
 
 
@@ -5468,7 +5725,7 @@ container.security_context.privileged == true and process.interactive == true an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0414
+Index: geneve-ut-0429
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5482,7 +5739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0415
+Index: geneve-ut-0430
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5503,7 +5760,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0416
+Index: geneve-ut-0431
 
 ```python
 registry where host.os.type == "windows" and
@@ -5517,7 +5774,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0425
+Index: geneve-ut-0440
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5537,52 +5794,11 @@ event.category: "process" and host.os.type:windows and
 
 
 
-### Deprecated - Potential CVE-2025-41244 vmtoolsd LPE Exploitation Attempt
-
-Branch count: 54  
-Document count: 54  
-Index: geneve-ut-0426
-
-```python
-process where host.os.type == "linux" and event.type == "start" and
-event.action in ("exec", "exec_event", "start", "executed", "process_started", "ProcessRollup2") and
-(
-  (
-    process.parent.name == "vmtoolsd"
-  ) or
-  (
-    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
-    ?process.parent.args like ("/*/open-vm-tools/serviceDiscovery/scripts/get-versions.sh")
-  )
-) and not (
-  process.executable == null or
-  ?process.parent.args == "--version" or
-  process.args like (
-    "/etc/vmware-tools/resume-vm-default",
-    "/etc/vmware-tools/suspend-vm-default",
-    "/sbin/shutdown",
-    "/sbin/shutdown*",
-    "/etc/vmware-tools/poweroff-vm-default",
-    "/etc/vmware-tools/poweroff-vm-default",
-    "/bin/touch",
-    "/tmp/vmware-administrator_*",
-    "/tmp/vmware-root_*",
-    "/etc/vmware-tools/scripts/vmware/network",
-    "/etc/vmware-tools/poweron-vm-default"
-  ) or
-  process.executable == "/usr/sbin/unix_chkpwd" or
-  ?process.working_directory like ("/var/opt/ds_agent", "/tmp/vmware-root_*/tmpvmware*") or
-  process.command_line like ("*/usr/bin/lsb_release*", "*/bin/touch*", "*/tmp/vmware-root_*")
-)
-```
-
-
-
-### Direct Interactive Kubernetes API Request Detected via Defend for Containers
+### Direct Kubernetes API Request Detected via Defend for Containers
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0435
+Index: geneve-ut-0451
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5627,7 +5843,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
   (process.name == "ncat" and process.args like "--ssl*") or
   (process.name == "kubectl" and process.args in ("get", "list", "watch", "create", "patch", "update"))
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -5636,7 +5852,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0438
+Index: geneve-ut-0453
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5652,7 +5868,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0439
+Index: geneve-ut-0454
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5680,7 +5896,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0440
+Index: geneve-ut-0455
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5697,7 +5913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0441
+Index: geneve-ut-0456
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5714,7 +5930,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0442
+Index: geneve-ut-0457
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5735,7 +5951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0444
+Index: geneve-ut-0459
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5755,7 +5971,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0445
+Index: geneve-ut-0460
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5770,7 +5986,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0447
+Index: geneve-ut-0462
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5783,7 +5999,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0448
+Index: geneve-ut-0463
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5803,7 +6019,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0451
+Index: geneve-ut-0466
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -5816,7 +6032,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0452
+Index: geneve-ut-0467
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5854,7 +6070,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0453
+Index: geneve-ut-0468
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -5874,7 +6090,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0454
+Index: geneve-ut-0469
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5887,7 +6103,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0455
+Index: geneve-ut-0470
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5910,7 +6126,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0457
+Index: geneve-ut-0472
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5941,7 +6157,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0458
+Index: geneve-ut-0473
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -5960,7 +6176,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0459
+Index: geneve-ut-0474
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6003,12 +6219,12 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0460
+Index: geneve-ut-0475
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
 file.path like ("/etc/ld.so.preload", "/etc/ld.so.conf.d/*", "/etc/ld.so.conf") and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -6017,7 +6233,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0462
+Index: geneve-ut-0477
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6032,7 +6248,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0463
+Index: geneve-ut-0478
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6048,7 +6264,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0464
+Index: geneve-ut-0479
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6062,7 +6278,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0465
+Index: geneve-ut-0480
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6088,7 +6304,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0466
+Index: geneve-ut-0481
 
 ```python
 process where event.type == "start" and
@@ -6126,11 +6342,11 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0473
+Index: geneve-ut-0488
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
- file.path like ("/private/etc/emond.d/rules/*.plist", "/etc/emon.d/rules/*.plist", "/private/var/db/emondClients/*")
+ file.path like ("/private/etc/emond.d/rules/*.plist", "/etc/emond.d/rules/*.plist", "/private/var/db/emondClients/*")
 ```
 
 
@@ -6139,7 +6355,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0474
+Index: geneve-ut-0489
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6153,10 +6369,10 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0475
+Index: geneve-ut-0490
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (process.name in ("base64", "base64plain", "base64url", "base64mime", "base64pem", "base32", "base16") and process.args like~ "*-*d*") or
   (process.name == "xxd" and process.args like~ ("-*r*", "-*p*")) or
   (process.name == "openssl" and process.args == "enc" and process.args in ("-d", "-base64", "-a")) or
@@ -6175,7 +6391,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0476
+Index: geneve-ut-0491
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6210,7 +6426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0477
+Index: geneve-ut-0492
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6222,7 +6438,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0525
+Index: geneve-ut-0540
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6234,7 +6450,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0551
+Index: geneve-ut-0566
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6248,7 +6464,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0554
+Index: geneve-ut-0569
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6275,7 +6491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0557
+Index: geneve-ut-0572
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6296,7 +6512,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0558
+Index: geneve-ut-0573
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6317,7 +6533,25 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     )
   )
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
+```
+
+
+
+### Exec Into Container Detected via Defend for Containers
+
+Branch count: 9  
+Document count: 9  
+Index: geneve-ut-0576
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "busybox") and
+process.entry_leader.entry_meta.type == "container" and
+
+/* process is the initial process run in a container */
+process.entry_leader.same_as_process == true and
+container.id like "*"
 ```
 
 
@@ -6326,7 +6560,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0561
+Index: geneve-ut-0577
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6359,7 +6593,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0563
+Index: geneve-ut-0579
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6376,7 +6610,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0564
+Index: geneve-ut-0580
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6404,7 +6638,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0565
+Index: geneve-ut-0581
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6417,7 +6651,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0567
+Index: geneve-ut-0583
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6437,7 +6671,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0568
+Index: geneve-ut-0584
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6463,7 +6697,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0569
+Index: geneve-ut-0585
 
 ```python
 sequence with maxspan=2h
@@ -6485,7 +6719,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0570
+Index: geneve-ut-0586
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6514,7 +6748,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0573
+Index: geneve-ut-0589
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6527,7 +6761,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0577
+Index: geneve-ut-0593
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6542,7 +6776,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0578
+Index: geneve-ut-0594
 
 ```python
 process where event.type == "start" and
@@ -6564,7 +6798,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0579
+Index: geneve-ut-0595
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6576,7 +6810,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0580
+Index: geneve-ut-0596
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6598,7 +6832,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0582
+Index: geneve-ut-0598
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6615,7 +6849,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0583
+Index: geneve-ut-0599
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6629,7 +6863,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0584
+Index: geneve-ut-0600
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6642,7 +6876,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0585
+Index: geneve-ut-0601
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6654,7 +6888,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0586
+Index: geneve-ut-0602
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6666,7 +6900,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0587
+Index: geneve-ut-0603
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6680,7 +6914,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0588
+Index: geneve-ut-0604
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6690,15 +6924,15 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 ### External IP Address Discovery via Curl
 
-Branch count: 304  
-Document count: 304  
-Index: geneve-ut-0589
+Branch count: 342  
+Document count: 342  
+Index: geneve-ut-0605
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
   ((process.parent.executable like ("/Applications/*", "/Volumes/*", "/private/var/folders/*")) or
    (process.parent.name in ("bash", "sh", "zsh") and process.parent.command_line like "*http*") or
-   (process.parent.code_signature.trusted == false or process.code_signature.exists == false)) and
+   (process.parent.code_signature.trusted == false or process.parent.code_signature.exists == false or process.code_signature.exists == false)) and
   process.name in ("curl", "nscurl") and
   process.args_count <= 5 and
   process.command_line like ("*ip-api.com*", "*ipwho.is*", "*checkip.dyndns.org*", "*api.ipify.org*",
@@ -6714,7 +6948,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0592
+Index: geneve-ut-0608
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6763,15 +6997,15 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0593
+Index: geneve-ut-0609
 
 ```python
 sequence by container.id, user.id with maxspan=3s
-  [file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and container.id like "?*" and
+  [file where host.os.type == "linux" and event.type == "creation" and container.id like "?*" and
    file.path like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/root/*", "/home/*") and
    not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf", "apk", "pacman", "rpm", "dpkg")] by file.path
   [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-   process.interactive == true and container.id like "?*"] by process.executable
+   container.id like "?*"] by process.executable
 ```
 
 
@@ -6780,7 +7014,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0594
+Index: geneve-ut-0610
 
 ```python
 sequence by host.id with maxspan=10s
@@ -6800,10 +7034,10 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0599
+Index: geneve-ut-0615
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (
     (process.name == "curl" or process.args in ("curl", "/bin/curl", "/usr/bin/curl", "/usr/local/bin/curl")) and
     process.args in ("-o", "-O", "--output", "--remote-name", "--remote-name-all", "--output-dir")
@@ -6822,7 +7056,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0602
+Index: geneve-ut-0618
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -6837,7 +7071,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0603
+Index: geneve-ut-0619
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6851,7 +7085,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0605
+Index: geneve-ut-0621
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6873,7 +7107,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0606
+Index: geneve-ut-0622
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -6894,7 +7128,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0607
+Index: geneve-ut-0623
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6920,7 +7154,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0608
+Index: geneve-ut-0624
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -6948,7 +7182,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0611
+Index: geneve-ut-0627
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -6962,7 +7196,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0646
+Index: geneve-ut-0665
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -6979,7 +7213,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0647
+Index: geneve-ut-0666
 
 ```python
 registry where host.os.type == "windows" and
@@ -6997,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0709
+Index: geneve-ut-0734
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7036,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0710
+Index: geneve-ut-0735
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7063,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0711
+Index: geneve-ut-0736
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7078,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0712
+Index: geneve-ut-0737
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7165,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0720
+Index: geneve-ut-0745
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7183,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0721
+Index: geneve-ut-0746
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7214,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0722
+Index: geneve-ut-0747
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7241,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0723
+Index: geneve-ut-0748
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7261,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0727
+Index: geneve-ut-0752
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7274,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0730
+Index: geneve-ut-0755
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7286,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0733
+Index: geneve-ut-0758
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7298,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0737
+Index: geneve-ut-0762
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7310,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0739
+Index: geneve-ut-0764
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7327,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0763
+Index: geneve-ut-0788
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7340,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0765
+Index: geneve-ut-0790
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7364,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0766
+Index: geneve-ut-0791
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7376,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0779
+Index: geneve-ut-0804
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7394,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0780
+Index: geneve-ut-0805
 
 ```python
 any where process.executable != null and
@@ -7443,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0781
+Index: geneve-ut-0806
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7457,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0785
+Index: geneve-ut-0810
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7472,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0790
+Index: geneve-ut-0815
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7489,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0792
+Index: geneve-ut-0817
 
 ```python
 sequence with maxspan=1m
@@ -7508,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0793
+Index: geneve-ut-0818
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7526,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0794
+Index: geneve-ut-0819
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7545,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0795
+Index: geneve-ut-0820
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7561,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0796
+Index: geneve-ut-0821
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7577,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0797
+Index: geneve-ut-0822
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7590,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0802
+Index: geneve-ut-0827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7607,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0804
+Index: geneve-ut-0829
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7620,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0805
+Index: geneve-ut-0830
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7636,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0806
+Index: geneve-ut-0831
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7663,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0807
+Index: geneve-ut-0832
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7683,59 +7917,11 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 
 
-### Interactive Exec Into Container Detected via Defend for Containers
-
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-0808
-
-```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "busybox") and
-process.entry_leader.entry_meta.type == "container" and
-
-/* process is the inital process run in a container */
-process.entry_leader.same_as_process == true and
-
-/* interactive process */
-process.interactive == true and container.id like "*"
-```
-
-
-
-### Interactive Privilege Boundary Enumeration Detected via Defend for Containers
-
-Branch count: 25  
-Document count: 25  
-Index: geneve-ut-0810
-
-```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
-  (process.name in ("id", "whoami", "capsh", "getcap", "lsns")) or
-  (process.args in (
-     "id", "/bin/id", "/usr/bin/id", "/usr/local/bin/id",
-     "whoami", "/bin/whoami", "/usr/bin/whoami", "/usr/local/bin/whoami",
-     "capsh", "/bin/capsh", "/usr/bin/capsh", "/usr/local/bin/capsh",
-     "getcap", "/bin/getcap", "/usr/bin/getcap", "/usr/local/bin/getcap",
-     "lsns", "/bin/lsns", "/usr/bin/lsns", "/usr/local/bin/lsns"
-   ) and
-    /* default exclusion list to not FP on default multi-process commands */
-    not process.args in (
-      "man", "/bin/man", "/usr/bin/man", "/usr/local/bin/man",
-      "chmod", "/bin/chmod", "/usr/bin/chmod", "/usr/local/bin/chmod",
-      "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
-    )
-  )
-) and container.id like "?*"
-```
-
-
-
 ### Interactive Terminal Spawned via Python
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0814
+Index: geneve-ut-0837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7759,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0816
+Index: geneve-ut-0839
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7795,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0817
+Index: geneve-ut-0840
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7807,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0818
+Index: geneve-ut-0841
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -7821,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0819
+Index: geneve-ut-0842
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -7834,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0820
+Index: geneve-ut-0843
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -7893,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0821
+Index: geneve-ut-0844
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -7906,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0822
+Index: geneve-ut-0845
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -7919,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0823
+Index: geneve-ut-0846
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7940,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0824
+Index: geneve-ut-0847
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7958,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0825
+Index: geneve-ut-0848
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7992,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0827
+Index: geneve-ut-0850
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8014,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0829
+Index: geneve-ut-0852
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8041,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0830
+Index: geneve-ut-0853
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8067,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0831
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8083,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0832
+Index: geneve-ut-0855
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8099,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0834
+Index: geneve-ut-0857
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8111,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0835
+Index: geneve-ut-0858
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8139,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0837
+Index: geneve-ut-0860
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8155,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0839
+Index: geneve-ut-0862
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8180,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0840
+Index: geneve-ut-0863
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8194,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0842
+Index: geneve-ut-0865
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8217,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0843
+Index: geneve-ut-0866
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8250,10 +8436,10 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0844
+Index: geneve-ut-0867
 
 ```python
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where host.os.type == "linux" and container.id like "*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and file.path like "/var/lib/kubelet/pki/*") or
   (event.category == "process" and event.type == "start" and event.action == "exec" and
   (
@@ -8277,7 +8463,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0847
+Index: geneve-ut-0870
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8298,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0848
+Index: geneve-ut-0871
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8325,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0858
+Index: geneve-ut-0881
 
 ```python
 process where event.type == "start" and
@@ -8347,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0884
+Index: geneve-ut-0907
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8366,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0887
+Index: geneve-ut-0910
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8410,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0889
+Index: geneve-ut-0912
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8435,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0901
+Index: geneve-ut-0924
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8473,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0906
+Index: geneve-ut-0929
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8491,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0907
+Index: geneve-ut-0930
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8505,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0912
+Index: geneve-ut-0935
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8520,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0913
+Index: geneve-ut-0936
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8534,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0916
+Index: geneve-ut-0939
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8548,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0918
+Index: geneve-ut-0941
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8569,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-0919
+Index: geneve-ut-0942
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8599,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0923
+Index: geneve-ut-0946
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8646,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0924
+Index: geneve-ut-0947
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8673,36 +8859,11 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 
 
-### Local Scheduled Task Creation
-
-Branch count: 600  
-Document count: 1200  
-Index: geneve-ut-0925
-
-```python
-sequence with maxspan=1m
-  [process where host.os.type == "windows" and event.type == "start" and
-    ((process.name : ("cmd.exe", "wscript.exe", "rundll32.exe", "regsvr32.exe", "wmic.exe", "mshta.exe",
-                      "powershell.exe", "pwsh.exe", "powershell_ise.exe", "WmiPrvSe.exe", "wsmprovhost.exe", "winrshost.exe") or
-    process.pe.original_file_name : ("cmd.exe", "wscript.exe", "rundll32.exe", "regsvr32.exe", "wmic.exe", "mshta.exe",
-                                     "powershell.exe", "pwsh.dll", "powershell_ise.exe", "WmiPrvSe.exe", "wsmprovhost.exe",
-                                     "winrshost.exe")) or
-    ?process.code_signature.trusted == false)] by process.entity_id
-  [process where host.os.type == "windows" and event.type == "start" and
-    (process.name : "schtasks.exe" or process.pe.original_file_name == "schtasks.exe") and
-    process.args : ("/create", "-create") and process.args : ("/RU", "/SC", "/TN", "/TR", "/F", "/XML") and
-    /* exclude SYSTEM Integrity Level - look for task creations by non-SYSTEM user */
-    not (?process.Ext.token.integrity_level_name : "System" or ?winlog.event_data.IntegrityLevel : "System")
-  ] by process.parent.entity_id
-```
-
-
-
 ### M365 AIR Investigation Signal
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0927
+Index: geneve-ut-0950
 
 ```python
 event.dataset:o365.audit and
@@ -8715,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0929
+Index: geneve-ut-0952
 
 ```python
 event.dataset:o365.audit and
@@ -8728,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0930
+Index: geneve-ut-0953
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8740,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0966
+Index: geneve-ut-0989
 
 ```python
 event.dataset:o365.audit and
@@ -8753,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0967
+Index: geneve-ut-0990
 
 ```python
 event.dataset:o365.audit and
@@ -8766,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0968
+Index: geneve-ut-0991
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8778,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0969
+Index: geneve-ut-0992
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8790,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0970
+Index: geneve-ut-0993
 
 ```python
 event.dataset:o365.audit and
@@ -8803,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0978
+Index: geneve-ut-1001
 
 ```python
 event.dataset: "o365.audit" and
@@ -8816,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0981
+Index: geneve-ut-1004
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8836,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0982
+Index: geneve-ut-1005
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -8848,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0983
+Index: geneve-ut-1006
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -8860,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0987
+Index: geneve-ut-1010
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -8872,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0988
+Index: geneve-ut-1011
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -8884,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0989
+Index: geneve-ut-1012
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -8896,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0990
+Index: geneve-ut-1013
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -8908,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0991
+Index: geneve-ut-1014
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8933,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0992
+Index: geneve-ut-1015
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8953,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0993
+Index: geneve-ut-1016
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -8966,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-0994
+Index: geneve-ut-1017
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8977,11 +9138,36 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 
 
+### Mark-of-the-Web Removal by an Unusual Process
+
+Branch count: 12  
+Document count: 12  
+Index: geneve-ut-1018
+
+```python
+file where host.os.type == "windows" and event.type == "deletion" and
+  file.path : (
+    "*.exe:Zone.Identifier",
+    "*.exe:Zone.Identifier:$DATA",
+    "*.msi:Zone.Identifier",
+    "*.msi:Zone.Identifier:$DATA"
+  ) and
+
+  /* Explorer may remove MOTW after SmartScreen */
+  not (
+    process.executable : "?:\\Windows\\explorer.exe" and
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name : "Microsoft Windows"
+  )
+```
+
+
+
 ### Member Removed From GitHub Organization
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0996
+Index: geneve-ut-1020
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -8993,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0999
+Index: geneve-ut-1023
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9005,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1000
+Index: geneve-ut-1024
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9017,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1001
+Index: geneve-ut-1025
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9051,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1004
+Index: geneve-ut-1028
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9065,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1005
+Index: geneve-ut-1029
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9086,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1006
+Index: geneve-ut-1030
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9100,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1009
+Index: geneve-ut-1033
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9135,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1010
+Index: geneve-ut-1034
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9160,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1011
+Index: geneve-ut-1035
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9177,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1015
+Index: geneve-ut-1039
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9191,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1017
+Index: geneve-ut-1041
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9222,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1019
+Index: geneve-ut-1043
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9276,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1020
+Index: geneve-ut-1044
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9288,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1021
+Index: geneve-ut-1045
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9306,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1022
+Index: geneve-ut-1046
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9323,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1024
+Index: geneve-ut-1048
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9338,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1025
+Index: geneve-ut-1049
 
 ```python
 file where event.type != "deletion" and
@@ -9388,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1027
+Index: geneve-ut-1051
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9404,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1028
+Index: geneve-ut-1052
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9416,22 +9602,28 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 ### Mofcomp Activity
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1030
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1054
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.name : "mofcomp.exe" and process.args : "*.mof" and
   not user.id : "S-1-5-18" and
-  not
-  (
-    process.parent.name : "ScenarioEngine.exe" and
-    process.args : (
-      "*\\MSSQL\\Binn\\*.mof",
-      "*\\Microsoft SQL Server\\???\\Shared\\*.mof",
-      "*\\OLAP\\bin\\*.mof"
-    )
+  not process.args : (
+    "?:\\Program Files (x86)\\Microsoft Power BI Report Server\\*.mof",
+    "?:\\Program Files (x86)\\Microsoft SQL Server Reporting Services\\*.mof",
+    "?:\\Program Files (x86)\\Microsoft SQL Server\\*.mof",
+    "?:\\Program Files\\Microsoft Policy Platform\\*.mof",
+    "?:\\Program Files\\Microsoft Power BI Report Server\\*.mof",
+    "?:\\Program Files\\Microsoft SQL Server Reporting Services\\*.mof",
+    "?:\\Program Files\\Microsoft SQL Server\\*.mof",
+    "?:\\Windows\\System32\\wbem\\com.hp.provider.*.mof",
+    "?:\\Windows\\System32\\wbem\\CxAudioSvc_*.mof",
+    "?:\\Windows\\System32\\wbem\\Framework\\root\\*.mof",
+    "?:\\Windows\\System32\\wbem\\Veeam.Backup.*.mof",
+    "?:\\Windows\\System32\\wbem\\ZTITatoo.mof",
+    "?:\\Windows\\SysWOW64\\wbem\\Framework\\root\\*.mof"
   )
 ```
 
@@ -9441,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1031
+Index: geneve-ut-1055
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9460,7 +9652,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
       "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
     )
   )
-) and container.security_context.privileged == true and process.interactive == true and container.id like "*"
+) and container.security_context.privileged == true and container.id like "*"
 ```
 
 
@@ -9469,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1032
+Index: geneve-ut-1056
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9491,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1033
+Index: geneve-ut-1057
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9510,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1034
+Index: geneve-ut-1058
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9543,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1035
+Index: geneve-ut-1059
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9561,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1036
+Index: geneve-ut-1060
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9602,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1049
+Index: geneve-ut-1072
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9628,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1057
+Index: geneve-ut-1081
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9652,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1060
+Index: geneve-ut-1085
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9666,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1061
+Index: geneve-ut-1086
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9685,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1062
+Index: geneve-ut-1087
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9705,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1063
+Index: geneve-ut-1088
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9728,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1064
+Index: geneve-ut-1089
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9749,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1066
+Index: geneve-ut-1091
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9764,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1067
+Index: geneve-ut-1092
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9781,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1069
+Index: geneve-ut-1094
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9805,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1071
+Index: geneve-ut-1096
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -9851,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1072
+Index: geneve-ut-1097
 
 ```python
 sequence by host.id with maxspan=1s
@@ -9893,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1073
+Index: geneve-ut-1098
 
 ```python
 sequence by host.id with maxspan=10s
@@ -9910,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1075
+Index: geneve-ut-1100
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9925,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1076
+Index: geneve-ut-1101
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -9944,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1077
+Index: geneve-ut-1102
 
 ```python
 sequence by process.entity_id
@@ -9964,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1078
+Index: geneve-ut-1103
 
 ```python
 sequence by process.entity_id
@@ -9983,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1079
+Index: geneve-ut-1104
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10012,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1080
+Index: geneve-ut-1105
 
 ```python
 sequence by process.entity_id
@@ -10037,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1081
+Index: geneve-ut-1106
 
 ```python
 sequence by process.entity_id
@@ -10059,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1082
+Index: geneve-ut-1107
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10092,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1083
+Index: geneve-ut-1108
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10122,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1086
+Index: geneve-ut-1111
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10139,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1087
+Index: geneve-ut-1112
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10176,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1088
+Index: geneve-ut-1113
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10189,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1093
+Index: geneve-ut-1118
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10201,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1096
+Index: geneve-ut-1121
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10213,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1104
+Index: geneve-ut-1129
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10227,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1105
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10241,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1106
+Index: geneve-ut-1131
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10255,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1107
+Index: geneve-ut-1132
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10275,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1109
+Index: geneve-ut-1134
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10288,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1110
+Index: geneve-ut-1135
 
 ```python
 event.dataset: "okta.system"
@@ -10303,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1112
+Index: geneve-ut-1137
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10325,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1121
+Index: geneve-ut-1146
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10352,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1122
+Index: geneve-ut-1147
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10372,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1123
+Index: geneve-ut-1148
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10387,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1124
+Index: geneve-ut-1149
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10414,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1125
+Index: geneve-ut-1150
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10429,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1126
+Index: geneve-ut-1151
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10445,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1127
+Index: geneve-ut-1152
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10459,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1128
+Index: geneve-ut-1153
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10469,7 +10661,7 @@ file where host.os.type == "linux" and event.type in ("creation", "change") and 
   ) or
   process.name like ("php-fpm*", "lsphp*", "*.cgi", "*.fcgi")
 ) and
-file.path like~ "*/wp-content/plugins/*.php*"
+file.path like~ "*/wp-content/plugins/*"
 ```
 
 
@@ -10478,7 +10670,7 @@ file.path like~ "*/wp-content/plugins/*.php*"
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1134
+Index: geneve-ut-1159
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10493,7 +10685,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1135
+Index: geneve-ut-1160
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10507,7 +10699,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1136
+Index: geneve-ut-1161
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10526,7 +10718,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1137
+Index: geneve-ut-1162
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10538,7 +10730,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1138
+Index: geneve-ut-1163
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10550,7 +10742,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1139
+Index: geneve-ut-1164
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10568,7 +10760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1140
+Index: geneve-ut-1165
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10581,7 +10773,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1141
+Index: geneve-ut-1166
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10596,7 +10788,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1142
+Index: geneve-ut-1167
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10611,7 +10803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1144
+Index: geneve-ut-1169
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10631,7 +10823,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1145
+Index: geneve-ut-1170
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10655,7 +10847,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1146
+Index: geneve-ut-1171
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10669,7 +10861,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1147
+Index: geneve-ut-1172
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10686,9 +10878,9 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 ### Persistence via Scheduled Job Creation
 
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-1148
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1173
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10698,12 +10890,14 @@ file where host.os.type == "windows" and event.type != "deletion" and
       process.executable : "?:\\Program Files\\CCleaner\\CCleaner64.exe" and
       file.path : "?:\\Windows\\Tasks\\CCleanerCrashReporting.job"
     ) or
-    (
-      process.executable : (
-        "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\bin\\dcagentregister.exe",
-        "?:\\Program Files (x86)\\DesktopCentral_Agent\\bin\\dcagentregister.exe"
-      ) and
-      file.path : "?:\\Windows\\Tasks\\DCAgentUpdater.job"
+    process.executable : (
+      "?:\\Program Files (x86)\\DesktopCentral_Agent\\bin\\dcagentregister.exe",
+      "?:\\Program Files (x86)\\epson\\Epson Scan 2\\Update\\e_dtsksd.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\bin\\dcagentregister.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\dcconfig.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\Updates\\UemsComponentUpgrader.exe",
+      "?:\\Program Files (x86)\\Skillbrains\\Updater\\*\\Updater.exe",
+      "?:\\Windows\\System32\\drivers\\RivetNetworks\\Killer\\CustomizeInstallFirstRun.exe"
     )
   )
 ```
@@ -10714,7 +10908,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1149
+Index: geneve-ut-1174
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10743,7 +10937,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1150
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10762,7 +10956,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1151
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10790,7 +10984,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1152
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10805,7 +10999,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1153
+Index: geneve-ut-1178
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10868,7 +11062,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1154
+Index: geneve-ut-1179
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -10889,7 +11083,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1155
+Index: geneve-ut-1180
 
 ```python
 any where host.os.type == "windows" and
@@ -10951,7 +11145,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1157
+Index: geneve-ut-1182
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -10980,7 +11174,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1158
+Index: geneve-ut-1183
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -10994,7 +11188,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1159
+Index: geneve-ut-1184
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11027,7 +11221,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1162
+Index: geneve-ut-1187
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11074,7 +11268,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1163
+Index: geneve-ut-1188
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11101,7 +11295,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1164
+Index: geneve-ut-1189
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11114,7 +11308,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1174
+Index: geneve-ut-1200
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11131,7 +11325,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1176
+Index: geneve-ut-1202
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11156,7 +11350,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1181
+Index: geneve-ut-1207
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11172,7 +11366,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1182
+Index: geneve-ut-1208
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11193,7 +11387,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1183
+Index: geneve-ut-1209
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11210,11 +11404,11 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1184
+Index: geneve-ut-1210
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
-process.interactive == true and container.id like "?*"
+container.id like "?*"
 ```
 
 
@@ -11223,7 +11417,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1185
+Index: geneve-ut-1211
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11247,7 +11441,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1187
+Index: geneve-ut-1213
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11276,7 +11470,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1189
+Index: geneve-ut-1215
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11303,7 +11497,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1190
+Index: geneve-ut-1216
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11327,7 +11521,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1193
+Index: geneve-ut-1219
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11345,7 +11539,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1194
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11368,7 +11562,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1195
+Index: geneve-ut-1221
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11425,7 +11619,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1196
+Index: geneve-ut-1222
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11442,7 +11636,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1197
+Index: geneve-ut-1223
 
 ```python
 sequence by process.entity_id
@@ -11456,7 +11650,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1211
+Index: geneve-ut-1237
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11471,7 +11665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1212
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11502,7 +11696,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1213
+Index: geneve-ut-1239
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11516,7 +11710,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1214
+Index: geneve-ut-1240
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11529,7 +11723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1215
+Index: geneve-ut-1241
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11541,7 +11735,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1216
+Index: geneve-ut-1242
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11554,7 +11748,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1218
+Index: geneve-ut-1244
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11573,7 +11767,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1219
+Index: geneve-ut-1245
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11586,7 +11780,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1220
+Index: geneve-ut-1246
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11607,7 +11801,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1221
+Index: geneve-ut-1247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11617,11 +11811,31 @@ process.name == "setenforce" and process.args == "0"
 
 
 
+### Potential EDR-Freeze via WerFaultSecure Abuse
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1250
+
+```python
+process where host.os.type == "windows" and event.type == "start" and
+  process.executable : "?:\\Windows\\System32\\WerFaultSecure.exe" and
+
+  /* WerFaultSecure secure dumps are normally initiated by the WER service hosted in svchost.exe */
+  process.parent.executable != null and
+  not process.parent.executable : ("?:\\Windows\\System32\\svchost.exe", "?:\\Windows\\System32\\wermgr.exe", "?:\\Windows\\System32\\WerFault.exe", "?:\\Windows\\System32\\WerFaultSecure.exe") and
+
+  /* arguments used to take a secure memory dump of a target process (e.g. /pid <target> /encfile <handle> /type 268310) */
+  process.args : "/pid" and process.args : "/encfile"
+```
+
+
+
 ### Potential Enumeration via Active Directory Web Service
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1224
+Index: geneve-ut-1251
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11645,7 +11859,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1225
+Index: geneve-ut-1252
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11661,7 +11875,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1226
+Index: geneve-ut-1253
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11678,7 +11892,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1227
+Index: geneve-ut-1254
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11699,7 +11913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1229
+Index: geneve-ut-1256
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11712,7 +11926,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1231
+Index: geneve-ut-1258
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11740,7 +11954,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1234
+Index: geneve-ut-1261
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11756,7 +11970,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1235
+Index: geneve-ut-1262
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11779,7 +11993,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1236
+Index: geneve-ut-1263
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11792,7 +12006,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1238
+Index: geneve-ut-1265
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11805,7 +12019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1243
+Index: geneve-ut-1270
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11819,7 +12033,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1244
+Index: geneve-ut-1271
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11834,7 +12048,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1246
+Index: geneve-ut-1273
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -11857,7 +12071,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1249
+Index: geneve-ut-1276
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11900,7 +12114,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1250
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11918,7 +12132,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1251
+Index: geneve-ut-1278
 
 ```python
 host.os.type:"windows" and
@@ -11934,7 +12148,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1253
+Index: geneve-ut-1280
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -11946,7 +12160,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1255
+Index: geneve-ut-1282
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -11962,14 +12176,14 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1256
+Index: geneve-ut-1283
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (process.name == "kubeletctl" or process.args like "*kubeletctl*") or
   (process.args in ("-s", "--server") and process.args in ("run", "portForward", "scan", "attach", "exec", "pods", "runningpods", "cri", "pid2pod"))
 ) and
-process.interactive == true and container.id like "?*"
+container.id like "?*"
 ```
 
 
@@ -11978,7 +12192,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1257
+Index: geneve-ut-1284
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11996,7 +12210,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1258
+Index: geneve-ut-1285
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12010,7 +12224,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1260
+Index: geneve-ut-1287
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12020,7 +12234,11 @@ sequence by host.id with maxspan=30s
   ] by process.entity_id
   /* add more executable / script extensions here if they are not noisy in your environment */
   [file where host.os.type == "windows" and event.type in ("creation", "change") and process.pid == 4 and user.id like ("S-1-5-21*", "S-1-12-*") and 
-   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl"))] by process.entity_id
+   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl")) and
+   not file.path : (
+     "?:\\Windows\\VeeamVssSupport\\*",
+     "?:\\Windows\\VeeamLogShipper\\*"
+   )] by process.entity_id
 ```
 
 
@@ -12029,7 +12247,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1262
+Index: geneve-ut-1289
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12045,7 +12263,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1263
+Index: geneve-ut-1290
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12058,7 +12276,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1264
+Index: geneve-ut-1291
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12088,7 +12306,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1269
+Index: geneve-ut-1296
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12111,7 +12329,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1270
+Index: geneve-ut-1297
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12130,7 +12348,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1275
+Index: geneve-ut-1302
 
 ```python
 process where host.os.type == "windows" and 
@@ -12272,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1276
+Index: geneve-ut-1303
 
 ```python
 process where host.os.type == "windows" and
@@ -12349,7 +12567,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1280
+Index: geneve-ut-1307
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12366,7 +12584,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1281
+Index: geneve-ut-1308
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12400,7 +12618,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1283
+Index: geneve-ut-1310
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12412,7 +12630,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1284
+Index: geneve-ut-1311
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12451,7 +12669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1286
+Index: geneve-ut-1313
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12464,7 +12682,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1291
+Index: geneve-ut-1318
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12478,7 +12696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1298
+Index: geneve-ut-1325
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12516,7 +12734,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1299
+Index: geneve-ut-1326
 
 ```python
 network where host.os.type == "windows" and
@@ -12542,7 +12760,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1302
+Index: geneve-ut-1329
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12557,7 +12775,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1304
+Index: geneve-ut-1331
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12571,7 +12789,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1305
+Index: geneve-ut-1332
 
 ```python
 file where host.os.type == "windows" and
@@ -12585,7 +12803,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1306
+Index: geneve-ut-1333
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12598,7 +12816,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1307
+Index: geneve-ut-1334
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12618,7 +12836,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1308
+Index: geneve-ut-1335
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12638,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1310
+Index: geneve-ut-1337
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12677,7 +12895,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1311
+Index: geneve-ut-1338
 
 ```python
 event.category:process and host.os.type:windows and
@@ -12872,7 +13090,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1324
+Index: geneve-ut-1351
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12888,7 +13106,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1325
+Index: geneve-ut-1352
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -12902,7 +13120,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1326
+Index: geneve-ut-1353
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -12916,7 +13134,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1327
+Index: geneve-ut-1354
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -12933,7 +13151,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1328
+Index: geneve-ut-1355
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -12947,7 +13165,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1329
+Index: geneve-ut-1356
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12963,7 +13181,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1333
+Index: geneve-ut-1360
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -12975,7 +13193,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1334
+Index: geneve-ut-1361
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -12991,7 +13209,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1335
+Index: geneve-ut-1362
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13011,7 +13229,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1337
+Index: geneve-ut-1364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13051,7 +13269,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1339
+Index: geneve-ut-1366
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13063,7 +13281,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1340
+Index: geneve-ut-1367
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13084,7 +13302,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1341
+Index: geneve-ut-1368
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13105,7 +13323,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1342
+Index: geneve-ut-1369
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13126,7 +13344,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1343
+Index: geneve-ut-1370
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13152,7 +13370,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1344
+Index: geneve-ut-1371
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13168,7 +13386,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1345
+Index: geneve-ut-1372
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13182,7 +13400,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1346
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13205,7 +13423,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1348
+Index: geneve-ut-1375
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13222,7 +13440,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1349
+Index: geneve-ut-1376
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13245,7 +13463,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1350
+Index: geneve-ut-1377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13258,7 +13476,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1351
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13272,7 +13490,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1352
+Index: geneve-ut-1379
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13289,7 +13507,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1353
+Index: geneve-ut-1380
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13343,7 +13561,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1354
+Index: geneve-ut-1381
 
 ```python
 any where host.os.type == "windows" and
@@ -13370,7 +13588,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1360
+Index: geneve-ut-1387
 
 ```python
 file where host.os.type == "windows" and
@@ -13385,7 +13603,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1361
+Index: geneve-ut-1388
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13416,7 +13634,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1362
+Index: geneve-ut-1389
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13430,7 +13648,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1363
+Index: geneve-ut-1390
 
 ```python
 sequence with maxspan=1m
@@ -13472,7 +13690,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1364
+Index: geneve-ut-1391
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13497,7 +13715,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1365
+Index: geneve-ut-1392
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13551,7 +13769,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1366
+Index: geneve-ut-1393
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13571,7 +13789,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1367
+Index: geneve-ut-1394
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13592,7 +13810,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1368
+Index: geneve-ut-1395
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13607,7 +13825,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1369
+Index: geneve-ut-1396
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13627,7 +13845,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1370
+Index: geneve-ut-1397
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13669,7 +13887,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1374
+Index: geneve-ut-1401
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13684,7 +13902,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1375
+Index: geneve-ut-1402
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13719,7 +13937,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1376
+Index: geneve-ut-1403
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13736,7 +13954,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1378
+Index: geneve-ut-1405
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13750,7 +13968,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1381
+Index: geneve-ut-1408
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13763,7 +13981,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1382
+Index: geneve-ut-1409
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13775,7 +13993,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1383
+Index: geneve-ut-1410
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -13790,7 +14008,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1385
+Index: geneve-ut-1412
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -13818,7 +14036,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1386
+Index: geneve-ut-1413
 
 ```python
 sequence by host.id with maxspan=1s
@@ -13843,7 +14061,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1390
+Index: geneve-ut-1417
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -13880,7 +14098,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1391
+Index: geneve-ut-1418
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13894,7 +14112,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1392
+Index: geneve-ut-1419
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -13910,7 +14128,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1393
+Index: geneve-ut-1420
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13924,7 +14142,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1394
+Index: geneve-ut-1421
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -13954,7 +14172,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1395
+Index: geneve-ut-1422
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -13983,7 +14201,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1396
+Index: geneve-ut-1423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13999,7 +14217,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1397
+Index: geneve-ut-1424
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14013,7 +14231,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1398
+Index: geneve-ut-1425
 
 ```python
 file where host.os.type == "windows" and
@@ -14045,11 +14263,25 @@ file where host.os.type == "windows" and
 
 
 
+### Potential Tunneling via Tailscaled
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1428
+
+```python
+process where event.type == "start" and
+process.name like~ ("tailscaled", "tailscaled.exe") and
+process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
+```
+
+
+
 ### Potential Unauthorized Access via Wildcard Injection Detected
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1401
+Index: geneve-ut-1429
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14063,7 +14295,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1402
+Index: geneve-ut-1430
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14083,7 +14315,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1404
+Index: geneve-ut-1432
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14100,7 +14332,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1405
+Index: geneve-ut-1433
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14112,7 +14344,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1406
+Index: geneve-ut-1434
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14129,7 +14361,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1407
+Index: geneve-ut-1435
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14147,11 +14379,11 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1414
+Index: geneve-ut-1442
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
-file.name == "notify_on_release" and process.interactive == true and container.id like "*"
+file.name == "notify_on_release" and container.id like "*"
 ```
 
 
@@ -14160,7 +14392,7 @@ file.name == "notify_on_release" and process.interactive == true and container.i
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1415
+Index: geneve-ut-1443
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14187,11 +14419,11 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1416
+Index: geneve-ut-1444
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
-file.name == "release_agent" and process.interactive == true and container.id like "*"
+file.name == "release_agent" and container.id like "*"
 ```
 
 
@@ -14200,7 +14432,7 @@ file.name == "release_agent" and process.interactive == true and container.id li
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1417
+Index: geneve-ut-1445
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14214,7 +14446,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1419
+Index: geneve-ut-1447
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14463,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1420
+Index: geneve-ut-1448
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14254,7 +14486,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1422
+Index: geneve-ut-1450
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14271,7 +14503,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1425
+Index: geneve-ut-1453
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14284,7 +14516,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1427
+Index: geneve-ut-1455
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14308,7 +14540,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1428
+Index: geneve-ut-1456
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14336,7 +14568,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1443
+Index: geneve-ut-1471
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14353,11 +14585,39 @@ process where host.os.type == "linux" and event.type == "start" and
 
 
 
+### Privilege Boundary Enumeration Detected via Defend for Containers
+
+Branch count: 25  
+Document count: 25  
+Index: geneve-ut-1473
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.name in ("id", "whoami", "capsh", "getcap", "lsns")) or
+  (process.args in (
+     "id", "/bin/id", "/usr/bin/id", "/usr/local/bin/id",
+     "whoami", "/bin/whoami", "/usr/bin/whoami", "/usr/local/bin/whoami",
+     "capsh", "/bin/capsh", "/usr/bin/capsh", "/usr/local/bin/capsh",
+     "getcap", "/bin/getcap", "/usr/bin/getcap", "/usr/local/bin/getcap",
+     "lsns", "/bin/lsns", "/usr/bin/lsns", "/usr/local/bin/lsns"
+   ) and
+    /* default exclusion list to not FP on default multi-process commands */
+    not process.args in (
+      "man", "/bin/man", "/usr/bin/man", "/usr/local/bin/man",
+      "chmod", "/bin/chmod", "/usr/bin/chmod", "/usr/local/bin/chmod",
+      "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
+    )
+  )
+) and container.id like "?*"
+```
+
+
+
 ### Privilege Escalation via CAP_SETUID/SETGID Capabilities
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1446
+Index: geneve-ut-1475
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14397,7 +14657,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1447
+Index: geneve-ut-1476
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14414,7 +14674,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1448
+Index: geneve-ut-1477
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14428,7 +14688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1449
+Index: geneve-ut-1478
 
 ```python
 file where host.os.type == "windows" and
@@ -14447,7 +14707,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1450
+Index: geneve-ut-1479
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14461,7 +14721,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1452
+Index: geneve-ut-1481
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14479,7 +14739,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1454
+Index: geneve-ut-1483
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14497,7 +14757,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1457
+Index: geneve-ut-1486
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14511,7 +14771,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1459
+Index: geneve-ut-1488
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14526,7 +14786,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1460
+Index: geneve-ut-1489
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14549,7 +14809,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1462
+Index: geneve-ut-1491
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14631,7 +14891,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1463
+Index: geneve-ut-1492
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14652,7 +14912,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1464
+Index: geneve-ut-1493
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14678,7 +14938,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1466
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14731,7 +14991,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1467
+Index: geneve-ut-1496
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -14743,7 +15003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1468
+Index: geneve-ut-1497
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -14755,7 +15015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1469
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "windows" and
@@ -14770,7 +15030,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1470
+Index: geneve-ut-1499
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -14800,7 +15060,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1471
+Index: geneve-ut-1500
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -14860,7 +15120,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1474
+Index: geneve-ut-1503
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -14873,7 +15133,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1475
+Index: geneve-ut-1504
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14905,7 +15165,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1476
+Index: geneve-ut-1505
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -14929,7 +15189,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1478
+Index: geneve-ut-1507
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14962,7 +15222,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1479
+Index: geneve-ut-1508
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -14979,7 +15239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1480
+Index: geneve-ut-1509
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15008,7 +15268,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1481
+Index: geneve-ut-1510
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15022,7 +15282,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1482
+Index: geneve-ut-1511
 
 ```python
 sequence by process.entity_id
@@ -15047,7 +15307,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1483
+Index: geneve-ut-1512
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15081,7 +15341,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1484
+Index: geneve-ut-1513
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15109,7 +15369,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1485
+Index: geneve-ut-1514
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15128,7 +15388,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1489
+Index: geneve-ut-1518
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15156,7 +15416,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1490
+Index: geneve-ut-1519
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15175,7 +15435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1494
+Index: geneve-ut-1523
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15187,7 +15447,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1495
+Index: geneve-ut-1524
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15199,7 +15459,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1496
+Index: geneve-ut-1525
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15211,7 +15471,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1497
+Index: geneve-ut-1526
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15223,7 +15483,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1507
+Index: geneve-ut-1536
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15236,7 +15496,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1508
+Index: geneve-ut-1537
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15274,7 +15534,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1510
+Index: geneve-ut-1539
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15289,7 +15549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1511
+Index: geneve-ut-1540
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15308,7 +15568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1512
+Index: geneve-ut-1541
 
 ```python
 sequence with maxspan=1m
@@ -15356,7 +15616,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1514
+Index: geneve-ut-1543
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15379,7 +15639,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1516
+Index: geneve-ut-1545
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15393,7 +15653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1517
+Index: geneve-ut-1546
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15407,7 +15667,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1519
+Index: geneve-ut-1548
 
 ```python
 sequence by host.id, process.entity_id
@@ -15424,7 +15684,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1520
+Index: geneve-ut-1549
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15438,7 +15698,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1521
+Index: geneve-ut-1550
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15458,7 +15718,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1522
+Index: geneve-ut-1551
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15487,7 +15747,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1523
+Index: geneve-ut-1552
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15507,7 +15767,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1524
+Index: geneve-ut-1553
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15520,7 +15780,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1526
+Index: geneve-ut-1555
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15562,7 +15822,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1527
+Index: geneve-ut-1556
 
 ```python
 sequence with maxspan=1m
@@ -15585,7 +15845,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1528
+Index: geneve-ut-1557
 
 ```python
 sequence with maxspan=1s
@@ -15633,7 +15893,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1529
+Index: geneve-ut-1558
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15650,7 +15910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1531
+Index: geneve-ut-1560
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15679,7 +15939,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1532
+Index: geneve-ut-1561
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15707,7 +15967,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1533
+Index: geneve-ut-1562
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15724,7 +15984,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1535
+Index: geneve-ut-1564
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -15743,7 +16003,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1536
+Index: geneve-ut-1565
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -15764,12 +16024,12 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1541
+Index: geneve-ut-1570
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
 file.name in ("authorized_keys", "authorized_keys2") and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -15778,7 +16038,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1543
+Index: geneve-ut-1572
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -15797,7 +16057,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1544
+Index: geneve-ut-1573
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -15811,7 +16071,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1545
+Index: geneve-ut-1574
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -15831,7 +16091,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1547
+Index: geneve-ut-1576
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15849,7 +16109,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1548
+Index: geneve-ut-1577
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -15870,7 +16130,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1550
+Index: geneve-ut-1579
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15884,7 +16144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1551
+Index: geneve-ut-1580
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15899,7 +16159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1552
+Index: geneve-ut-1581
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -15940,7 +16200,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1554
+Index: geneve-ut-1583
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15965,7 +16225,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1555
+Index: geneve-ut-1584
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16004,7 +16264,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1556
+Index: geneve-ut-1585
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16018,7 +16278,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1557
+Index: geneve-ut-1586
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16057,7 +16317,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1558
+Index: geneve-ut-1587
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16071,7 +16331,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1559
+Index: geneve-ut-1588
 
 ```python
 process where event.type == "start" and
@@ -16143,7 +16403,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1563
+Index: geneve-ut-1592
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16164,7 +16424,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1566
+Index: geneve-ut-1595
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16181,7 +16441,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1569
+Index: geneve-ut-1598
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16199,7 +16459,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1570
+Index: geneve-ut-1599
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16211,7 +16471,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1571
+Index: geneve-ut-1600
 
 ```python
 file where host.os.type == "windows" and
@@ -16244,10 +16504,10 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1574
+Index: geneve-ut-1603
 
 ```python
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where host.os.type == "linux" and container.id like "*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and
   file.path in (
     "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
@@ -16276,10 +16536,10 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1576
+Index: geneve-ut-1605
 
 ```python
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where host.os.type == "linux" and container.id like "*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and
   file.path in (
     "/var/run/secrets/kubernetes.io/serviceaccount/token",
@@ -16312,7 +16572,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1577
+Index: geneve-ut-1606
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16329,7 +16589,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1578
+Index: geneve-ut-1607
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16349,7 +16609,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1580
+Index: geneve-ut-1609
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16364,7 +16624,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1581
+Index: geneve-ut-1610
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16385,7 +16645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1582
+Index: geneve-ut-1611
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16408,7 +16668,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1583
+Index: geneve-ut-1612
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16421,7 +16681,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1584
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16438,7 +16698,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1586
+Index: geneve-ut-1615
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16463,10 +16723,10 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1589
+Index: geneve-ut-1618
 
 ```python
-any where host.os.type == "linux" and event.category in ("file", "process") and process.interactive == true and container.id like "?*" and (
+any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
   (event.category == "file" and event.type == "deletion" and file.name in (".bash_history", ".sh_history",  ".zsh_history")) or
   (event.category == "process" and event.type == "start" and event.action == "exec" and (
     (
@@ -16494,7 +16754,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1590
+Index: geneve-ut-1619
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16543,7 +16803,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1591
+Index: geneve-ut-1620
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16557,7 +16817,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1592
+Index: geneve-ut-1621
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16572,7 +16832,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1593
+Index: geneve-ut-1622
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16587,7 +16847,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1594
+Index: geneve-ut-1623
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16609,7 +16869,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1595
+Index: geneve-ut-1624
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16630,7 +16890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1598
+Index: geneve-ut-1627
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16644,7 +16904,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1599
+Index: geneve-ut-1628
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16667,7 +16927,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1629
+Index: geneve-ut-1658
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16692,7 +16952,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1630
+Index: geneve-ut-1659
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16725,7 +16985,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1631
+Index: geneve-ut-1660
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -16784,7 +17044,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1633
+Index: geneve-ut-1662
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -16802,7 +17062,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1634
+Index: geneve-ut-1663
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -16814,7 +17074,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1636
+Index: geneve-ut-1665
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -16839,7 +17099,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1641
+Index: geneve-ut-1671
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16854,7 +17114,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1642
+Index: geneve-ut-1672
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -16877,7 +17137,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1645
+Index: geneve-ut-1675
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16891,7 +17151,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1647
+Index: geneve-ut-1677
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16913,7 +17173,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1649
+Index: geneve-ut-1679
 
 ```python
 sequence by host.id with maxspan=5s
@@ -16940,7 +17200,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1653
+Index: geneve-ut-1683
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -16979,7 +17239,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1654
+Index: geneve-ut-1684
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17002,7 +17262,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1655
+Index: geneve-ut-1685
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17016,7 +17276,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1656
+Index: geneve-ut-1686
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17032,7 +17292,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1657
+Index: geneve-ut-1687
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17048,7 +17308,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1658
+Index: geneve-ut-1688
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17062,7 +17322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1660
+Index: geneve-ut-1690
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17085,7 +17345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1661
+Index: geneve-ut-1691
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17113,7 +17373,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1662
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17128,7 +17388,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1665
+Index: geneve-ut-1695
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17155,7 +17415,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1667
+Index: geneve-ut-1697
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17186,7 +17446,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1668
+Index: geneve-ut-1698
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17202,7 +17462,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1669
+Index: geneve-ut-1699
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17215,7 +17475,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1671
+Index: geneve-ut-1701
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17231,7 +17491,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1672
+Index: geneve-ut-1702
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17247,7 +17507,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1673
+Index: geneve-ut-1703
 
 ```python
 any where host.os.type == "windows" and 
@@ -17314,7 +17574,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1675
+Index: geneve-ut-1705
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17330,7 +17590,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1677
+Index: geneve-ut-1707
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17366,7 +17626,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1678
+Index: geneve-ut-1708
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17404,7 +17664,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1679
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17439,7 +17699,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1680
+Index: geneve-ut-1710
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17473,7 +17733,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1682
+Index: geneve-ut-1712
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17492,9 +17752,9 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 ### Suspicious Execution via Windows Subsystem for Linux
 
-Branch count: 14  
-Document count: 14  
-Index: geneve-ut-1687
+Branch count: 201  
+Document count: 201  
+Index: geneve-ut-1717
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17508,9 +17768,58 @@ process where host.os.type == "windows" and event.type : "start" and
       process.parent.name : "wsl.exe" and process.parent.command_line : "bash*" and not process.name : "wslhost.exe"
     ) or
     (
-      process.name : "wsl.exe" and process.args : (
-        "curl", "/etc/shadow", "/etc/passwd", "cat", "--system", "root", "-e", "--exec", "bash", "/mnt/c/*"
-      ) and not process.args : ("wsl-bootstrap", "docker-desktop-data", "*.vscode-server*")
+      process.name : "wsl.exe" and
+      (
+        process.args : "--system" or
+        (
+          process.args : "--manage" and process.args : "--set-default-user" and process.args : "root"
+        ) or
+        (
+          (process.args : ("curl", "wget") and process.args : ("http://*", "https://*")) or
+          process.args : ("*curl*http://*", "*curl*https://*", "*wget*http://*", "*wget*https://*")
+        ) or
+        (
+          (
+            process.args like~ ("*/dev/tcp/*", "*/dev/udp/*", "*zsh/net/tcp*") and
+            process.args like ("*&>*", "*<>*", "*>&*", "*<&*")
+          ) or
+          (
+            process.args : ("nc", "netcat", "nc.traditional", "ncat", "*/nc", "*/netcat", "*/nc.traditional", "*/ncat") and
+            process.args : ("sh", "/bin/sh", "bash", "/bin/bash") and
+            process.args : ("-e", "--exec", "-c", "--sh-exec")
+          ) or
+          (
+            process.args like~ "*socat*" and
+            process.args like~ ("*exec:*", "*system:*", "*shell:*") and
+            process.args like~ ("*tcp*", "*udp*", "*openssl*")
+          )
+        ) or
+        (
+          process.args : ("-e", "--exec") and
+          process.args : (
+            "/mnt/c/*.exe", "/mnt/c/*.ps1", "/mnt/c/*.bat", "/mnt/c/*.cmd", "/mnt/c/*.vbs", "/mnt/c/*.js",
+            "/mnt/c/*.hta"
+          ) and
+          not process.args : "*wslpath*"
+        ) or
+        process.args : (
+          "*/etc/passwd*", "*/etc/shadow*", "*/etc/sudoers*", "*/etc/sudoers.d/*", "*/root/.ssh/*", "*/home/*/.ssh/*",
+          "*/root/.aws/credentials*", "*/home/*/.aws/credentials*", "*/root/.kube/config*", "*/home/*/.kube/config*",
+          "*/mnt/c/Windows/System32/config/SAM*",
+          "*/mnt/c/Windows/System32/config/SECURITY*",
+          "*/mnt/c/Windows/System32/config/SYSTEM", "*/mnt/c/Windows/System32/config/SYSTEM.*",
+          "*/mnt/c/Windows/NTDS/ntds.dit*",
+          "*/mnt/c/Users/*/AppData/Roaming/Microsoft/Credentials/*",
+          "*/mnt/c/Users/*/AppData/Local/Microsoft/Credentials/*",
+          "*/mnt/c/Users/*/AppData/Roaming/Microsoft/Protect/*",
+          "*/mnt/c/Users/*/.ssh/*",
+          "*/mnt/c/Users/*/.aws/credentials",
+          "*/mnt/c/Users/*/.azure/*",
+          "*/mnt/c/Users/*/.config/gcloud/*",
+          "*/mnt/c/Users/*/AppData/Local/Google/Chrome/User Data/*/Login Data*",
+          "*/mnt/c/Users/*/AppData/Local/Microsoft/Edge/User Data/*/Login Data*"
+        )
+      )
     )
   ) and
     not process.parent.executable : ("?:\\Program Files\\Docker\\*.exe", "?:\\Program Files (x86)\\Docker\\*.exe")
@@ -17520,21 +17829,21 @@ process where host.os.type == "windows" and event.type : "start" and
 
 ### Suspicious Execution with NodeJS
 
-Branch count: 18  
-Document count: 18  
-Index: geneve-ut-1688
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1718
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
 
-(process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or ?process.code_signature.subject_name : "OpenJS Foundation") and
+(process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or
+ ?process.code_signature.subject_name : ("OpenJS Foundation", "Node.js Foundation")) and
 
 (
-  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
+  (process.args : ("-r", "--require", "--require=*") and
+   process.parent.name : ("powershell.exe", "pwsh.exe")) or
 
-  (process.args : "-r" and process.parent.name : "powershell.exe") or
-
-   process.command_line : ("*eval(*", "*atob(*", "*require*child_process*")
+  process.command_line : ("*eval(*", "*atob(*", "*require*child_process*")
 )
 ```
 
@@ -17544,7 +17853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1689
+Index: geneve-ut-1719
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17568,7 +17877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1690
+Index: geneve-ut-1720
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17589,7 +17898,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1693
+Index: geneve-ut-1723
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17604,7 +17913,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1696
+Index: geneve-ut-1726
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17617,7 +17926,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1697
+Index: geneve-ut-1727
 
 ```python
 any where host.os.type == "windows" and
@@ -17632,7 +17941,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1698
+Index: geneve-ut-1728
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17648,7 +17957,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1699
+Index: geneve-ut-1729
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17662,10 +17971,10 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1703
+Index: geneve-ut-1733
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
 process.parent.executable != null and (
   (
     process.executable like ("/bin/perl*", "/usr/bin/perl*", "/usr/local/bin/perl*") and
@@ -17719,7 +18028,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1704
+Index: geneve-ut-1734
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +18042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1706
+Index: geneve-ut-1736
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -17765,7 +18074,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1708
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -17778,7 +18087,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1709
+Index: geneve-ut-1739
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -17797,7 +18106,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1710
+Index: geneve-ut-1740
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -17843,7 +18152,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1712
+Index: geneve-ut-1742
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17864,7 +18173,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1713
+Index: geneve-ut-1743
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -17884,7 +18193,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1714
+Index: geneve-ut-1744
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17898,7 +18207,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1715
+Index: geneve-ut-1745
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17930,7 +18239,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1718
+Index: geneve-ut-1748
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -17951,7 +18260,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1720
+Index: geneve-ut-1750
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18052,7 +18361,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1723
+Index: geneve-ut-1753
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18100,7 +18409,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1726
+Index: geneve-ut-1756
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18126,7 +18435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1727
+Index: geneve-ut-1757
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18171,7 +18480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1728
+Index: geneve-ut-1758
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18195,7 +18504,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1729
+Index: geneve-ut-1759
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18211,7 +18520,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1731
+Index: geneve-ut-1761
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18236,7 +18545,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1732
+Index: geneve-ut-1762
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18251,7 +18560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1735
+Index: geneve-ut-1765
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18265,7 +18574,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1736
+Index: geneve-ut-1766
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18285,7 +18594,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1737
+Index: geneve-ut-1767
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18320,10 +18629,10 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1741
+Index: geneve-ut-1771
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where event.type == "start" and event.action == "exec" and (
   process.executable like (
     "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/*", "/var/run/*", "/mnt/*", "/media/*", "/boot/*"
   ) or
@@ -18338,7 +18647,7 @@ process where event.type == "start" and event.action == "exec" and process.inter
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1742
+Index: geneve-ut-1772
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18351,7 +18660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1744
+Index: geneve-ut-1774
 
 ```python
 any where host.os.type == "windows" and
@@ -18384,7 +18693,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1746
+Index: geneve-ut-1776
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18402,7 +18711,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1747
+Index: geneve-ut-1777
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18424,7 +18733,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1750
+Index: geneve-ut-1780
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18463,7 +18772,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1751
+Index: geneve-ut-1781
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18493,7 +18802,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1752
+Index: geneve-ut-1782
 
 ```python
 any where host.os.type == "windows" and
@@ -18527,7 +18836,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1753
+Index: geneve-ut-1783
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18541,7 +18850,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1756
+Index: geneve-ut-1786
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18572,7 +18881,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1757
+Index: geneve-ut-1787
 
 ```python
 any where host.os.type == "windows" and
@@ -18592,7 +18901,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1758
+Index: geneve-ut-1788
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18633,7 +18942,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1759
+Index: geneve-ut-1789
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18649,7 +18958,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1760
+Index: geneve-ut-1790
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18679,7 +18988,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1764
+Index: geneve-ut-1794
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -18692,7 +19001,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1765
+Index: geneve-ut-1795
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -18716,7 +19025,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1767
+Index: geneve-ut-1798
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18734,7 +19043,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1769
+Index: geneve-ut-1800
 
 ```python
 any where host.os.type == "windows" and
@@ -18749,7 +19058,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1770
+Index: geneve-ut-1801
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -18767,7 +19076,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1771
+Index: geneve-ut-1802
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -18788,7 +19097,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1772
+Index: geneve-ut-1803
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18807,7 +19116,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1775
+Index: geneve-ut-1806
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18832,7 +19141,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1776
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18845,7 +19154,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1778
+Index: geneve-ut-1809
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -18858,7 +19167,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1780
+Index: geneve-ut-1811
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18881,7 +19190,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1782
+Index: geneve-ut-1813
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18900,7 +19209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1783
+Index: geneve-ut-1814
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -18922,7 +19231,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1784
+Index: geneve-ut-1815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -18955,7 +19264,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1786
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18973,7 +19282,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1787
+Index: geneve-ut-1818
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -18987,7 +19296,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1788
+Index: geneve-ut-1819
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19011,7 +19320,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1789
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19034,7 +19343,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1790
+Index: geneve-ut-1821
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19053,10 +19362,10 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1793
+Index: geneve-ut-1824
 
 ```python
-file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and
+file where host.os.type == "linux" and event.type == "creation" and
 file.path like (
   "/etc/*", "/root/*", "/bin/*", "/usr/bin/*", "/usr/local/bin/*", "/entrypoint*"
 ) and (
@@ -19072,7 +19381,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1795
+Index: geneve-ut-1826
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19107,7 +19416,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1796
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19124,7 +19433,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1797
+Index: geneve-ut-1828
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19144,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1798
+Index: geneve-ut-1829
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19184,7 +19493,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1799
+Index: geneve-ut-1830
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19200,7 +19509,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1800
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19214,7 +19523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1801
+Index: geneve-ut-1832
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19252,7 +19561,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1802
+Index: geneve-ut-1833
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19306,7 +19615,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1803
+Index: geneve-ut-1834
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19334,7 +19643,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1805
+Index: geneve-ut-1836
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19348,7 +19657,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1806
+Index: geneve-ut-1837
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19394,7 +19703,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1807
+Index: geneve-ut-1838
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19433,7 +19742,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1808
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19446,7 +19755,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1811
+Index: geneve-ut-1842
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19479,7 +19788,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1812
+Index: geneve-ut-1843
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19493,7 +19802,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1813
+Index: geneve-ut-1844
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19507,7 +19816,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1814
+Index: geneve-ut-1845
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19521,7 +19830,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1815
+Index: geneve-ut-1846
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19560,7 +19869,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1821
+Index: geneve-ut-1853
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19602,10 +19911,10 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1823
+Index: geneve-ut-1855
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf") and process.args == "install") or
   (process.name == "apk" and process.args == "add") or
   (process.name == "pacman" and process.args like "-*S*") or
@@ -19624,7 +19933,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1824
+Index: geneve-ut-1856
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19637,7 +19946,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1826
+Index: geneve-ut-1858
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19654,7 +19963,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1827
+Index: geneve-ut-1859
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19670,7 +19979,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1828
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19683,7 +19992,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1829
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -19698,7 +20007,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1830
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19721,7 +20030,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1831
+Index: geneve-ut-1863
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19737,7 +20046,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1832
+Index: geneve-ut-1864
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19753,7 +20062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1838
+Index: geneve-ut-1870
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -19765,7 +20074,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1839
+Index: geneve-ut-1871
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19794,7 +20103,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1841
+Index: geneve-ut-1873
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -19808,7 +20117,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1846
+Index: geneve-ut-1878
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -19828,7 +20137,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1847
+Index: geneve-ut-1879
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -19853,7 +20162,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1854
+Index: geneve-ut-1886
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19867,7 +20176,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1855
+Index: geneve-ut-1887
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19890,7 +20199,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1864
+Index: geneve-ut-1896
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19924,7 +20233,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1866
+Index: geneve-ut-1898
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -19943,7 +20252,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-1873
+Index: geneve-ut-1905
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -19962,7 +20271,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1887
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -19979,7 +20288,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1890
+Index: geneve-ut-1923
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -19996,7 +20305,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1906
+Index: geneve-ut-1939
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20015,7 +20324,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1910
+Index: geneve-ut-1943
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20057,7 +20366,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1911
+Index: geneve-ut-1944
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20102,7 +20411,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1914
+Index: geneve-ut-1947
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20144,7 +20453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1916
+Index: geneve-ut-1949
 
 ```python
 host.os.type:"linux" and 
@@ -20172,7 +20481,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1919
+Index: geneve-ut-1952
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20196,7 +20505,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1920
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20236,7 +20545,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1921
+Index: geneve-ut-1954
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20283,7 +20592,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1925
+Index: geneve-ut-1958
 
 ```python
 sequence by process.entity_id
@@ -20320,7 +20629,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1957
+Index: geneve-ut-1990
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20334,7 +20643,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1958
+Index: geneve-ut-1991
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20377,7 +20686,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1959
+Index: geneve-ut-1992
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20390,7 +20699,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1961
+Index: geneve-ut-1994
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20404,7 +20713,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1962
+Index: geneve-ut-1995
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20417,7 +20726,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1966
+Index: geneve-ut-1999
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20442,7 +20751,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1967
+Index: geneve-ut-2000
 
 ```python
 process where event.type == "start" and
@@ -20457,7 +20766,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1968
+Index: geneve-ut-2001
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20474,7 +20783,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1969
+Index: geneve-ut-2002
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20488,7 +20797,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1970
+Index: geneve-ut-2003
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20504,7 +20813,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1971
+Index: geneve-ut-2004
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20518,7 +20827,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1972
+Index: geneve-ut-2005
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20545,7 +20854,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1974
+Index: geneve-ut-2007
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20557,7 +20866,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1975
+Index: geneve-ut-2008
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20573,7 +20882,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1976
+Index: geneve-ut-2009
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20596,7 +20905,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1977
+Index: geneve-ut-2010
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20609,7 +20918,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1978
+Index: geneve-ut-2011
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20621,7 +20930,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1979
+Index: geneve-ut-2012
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20633,7 +20942,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1980
+Index: geneve-ut-2013
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20645,7 +20954,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1981
+Index: geneve-ut-2014
 
 ```python
 web where (
@@ -20673,7 +20982,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-1987
+Index: geneve-ut-2020
 
 ```python
 any where (
@@ -20745,7 +21054,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1989
+Index: geneve-ut-2022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20766,7 +21075,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1992
+Index: geneve-ut-2025
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -20780,7 +21089,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1993
+Index: geneve-ut-2026
 
 ```python
 file where event.type == "deletion" and
@@ -20797,7 +21106,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1994
+Index: geneve-ut-2027
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20815,7 +21124,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1996
+Index: geneve-ut-2029
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20853,7 +21162,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1998
+Index: geneve-ut-2031
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20890,7 +21199,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1999
+Index: geneve-ut-2032
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20905,7 +21214,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2000
+Index: geneve-ut-2033
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -20918,7 +21227,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2001
+Index: geneve-ut-2034
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20937,10 +21246,10 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2002
+Index: geneve-ut-2035
 
 ```python
-sequence with maxspan=1m
+sequence by host.id with maxspan=1m
   [registry where host.os.type == "windows" and event.type == "change" and process.name : "msiexec.exe" and
    (
     (registry.value : "InstallSource" and
@@ -20962,7 +21271,7 @@ sequence with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2003
+Index: geneve-ut-2036
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20988,7 +21297,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2004
+Index: geneve-ut-2037
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21010,7 +21319,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2005
+Index: geneve-ut-2038
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21027,7 +21336,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2007
+Index: geneve-ut-2040
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21046,7 +21355,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2008
+Index: geneve-ut-2041
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21086,7 +21395,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2009
+Index: geneve-ut-2042
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21103,7 +21412,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2011
+Index: geneve-ut-2044
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21116,7 +21425,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2012
+Index: geneve-ut-2045
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21130,7 +21439,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2013
+Index: geneve-ut-2046
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21158,7 +21467,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2014
+Index: geneve-ut-2047
 
 ```python
 process where event.type == "start" and
@@ -21183,7 +21492,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2015
+Index: geneve-ut-2048
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21197,7 +21506,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2016
+Index: geneve-ut-2049
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21213,7 +21522,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2017
+Index: geneve-ut-2050
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21248,7 +21557,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2018
+Index: geneve-ut-2051
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21266,7 +21575,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2021
+Index: geneve-ut-2054
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.4.md
+++ b/tests/reports/alerts_from_rules-9.4.md
@@ -5,22 +5,22 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.8
+Rules version: 9.4.9
 
 ## Table of contents
-   1. [Failed rules (23)](#failed-rules-23)
-   1. [Unsuccessful rules with signals (23)](#unsuccessful-rules-with-signals-23)
+   1. [Failed rules (24)](#failed-rules-24)
+   1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
-   1. [Rules with too few signals (27)](#rules-with-too-few-signals-27)
+   1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
    1. [Rules with the correct signals (804)](#rules-with-the-correct-signals-804)
 
-## Failed rules (23)
+## Failed rules (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0352  
+Index: geneve-ut-0367  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -66,7 +66,122 @@ process.args like~ (
   "*/.config/gcloud/*", "*application_default_credentials.json*",
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*",
   "*/var/run/secrets/google/*", "*GOOGLE_APPLICATION_CREDENTIALS*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
+```
+
+
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0378  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
 ```
 
 
@@ -75,7 +190,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0630  
+Index: geneve-ut-0646  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -144,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0655  
+Index: geneve-ut-0671  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -173,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0780  
+Index: geneve-ut-0805  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -204,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0975  
+Index: geneve-ut-0998  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -257,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1119  
+Index: geneve-ut-1143  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -290,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1147  
+Index: geneve-ut-1173  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -324,7 +439,7 @@ process.args like~ (
   "-*e*",
   /* file transfer via stdout/pipe */
   ">","<", "|"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -333,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1219  
+Index: geneve-ut-1245  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -374,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1248  
+Index: geneve-ut-1274  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -400,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1265  
+Index: geneve-ut-1292  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -438,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1327  
+Index: geneve-ut-1356  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -460,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1342  
+Index: geneve-ut-1371  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -501,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1431  
+Index: geneve-ut-1461  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -564,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1671  
+Index: geneve-ut-1705  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -601,7 +716,7 @@ process.args like~ (
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*", "*/var/run/secrets/google/*",
   "*GOOGLE_APPLICATION_CREDENTIALS*", "*AZURE_CLIENT_ID*", "*AZURE_TENANT_ID*", "*AZURE_CLIENT_SECRET*",
   "*AZURE_FEDERATED_TOKEN_FILE*", "*IDENTITY_ENDPOINT*", "*IDENTITY_HEADER*", "*MSI_ENDPOINT*", "*MSI_SECRET*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -610,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1675  
+Index: geneve-ut-1709  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -644,7 +759,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 process.args like~ (
   "*BEGIN PRIVATE*", "*BEGIN OPENSSH PRIVATE*", "*BEGIN RSA PRIVATE*", "*BEGIN DSA PRIVATE*", "*BEGIN EC PRIVATE*",
   "*password*", "*ssh*", "*id_rsa*", "*id_dsa*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -653,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1758  
+Index: geneve-ut-1793  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -701,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1773  
+Index: geneve-ut-1808  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -736,13 +851,13 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1786  
+Index: geneve-ut-1821  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
 process.args in ("-lc", "-c", "-cl") and process.args like ("*echo *", "*printf *") and
 process.args like (
@@ -761,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1796  
+Index: geneve-ut-1831  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -824,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1802  
+Index: geneve-ut-1837  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -852,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1811  
+Index: geneve-ut-1846  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -884,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1907  
+Index: geneve-ut-1943  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -949,7 +1064,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -959,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1937  
+Index: geneve-ut-1974  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -997,18 +1112,18 @@ process.args in (
   "nmap", "zenmap", "nuclei", "netdiscover", "legion", "masscan", "zmap", "zgrab", "ngrep", "telnet", "mitmproxy", "zmap",
   "masscan", "zgrab"
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
 
-## Unsuccessful rules with signals (23)
+## Unsuccessful rules with signals (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0352
+Index: geneve-ut-0367
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1051,7 +1166,119 @@ process.args like~ (
   "*/.config/gcloud/*", "*application_default_credentials.json*",
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*",
   "*/var/run/secrets/google/*", "*GOOGLE_APPLICATION_CREDENTIALS*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
+```
+
+
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0378
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
 ```
 
 
@@ -1060,7 +1287,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0630
+Index: geneve-ut-0646
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1126,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0655
+Index: geneve-ut-0671
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1152,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0780
+Index: geneve-ut-0805
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1180,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0975
+Index: geneve-ut-0998
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1230,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1119
+Index: geneve-ut-1143
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1260,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1147
+Index: geneve-ut-1173
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1291,7 +1518,7 @@ process.args like~ (
   "-*e*",
   /* file transfer via stdout/pipe */
   ">","<", "|"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -1300,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1219
+Index: geneve-ut-1245
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1338,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1248
+Index: geneve-ut-1274
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1361,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1265
+Index: geneve-ut-1292
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1396,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1327
+Index: geneve-ut-1356
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1415,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1342
+Index: geneve-ut-1371
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1453,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1431
+Index: geneve-ut-1461
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1513,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1671
+Index: geneve-ut-1705
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1547,7 +1774,7 @@ process.args like~ (
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*", "*/var/run/secrets/google/*",
   "*GOOGLE_APPLICATION_CREDENTIALS*", "*AZURE_CLIENT_ID*", "*AZURE_TENANT_ID*", "*AZURE_CLIENT_SECRET*",
   "*AZURE_FEDERATED_TOKEN_FILE*", "*IDENTITY_ENDPOINT*", "*IDENTITY_HEADER*", "*MSI_ENDPOINT*", "*MSI_SECRET*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -1556,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1675
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1587,7 +1814,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 process.args like~ (
   "*BEGIN PRIVATE*", "*BEGIN OPENSSH PRIVATE*", "*BEGIN RSA PRIVATE*", "*BEGIN DSA PRIVATE*", "*BEGIN EC PRIVATE*",
   "*password*", "*ssh*", "*id_rsa*", "*id_dsa*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -1596,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1758
+Index: geneve-ut-1793
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1641,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1773
+Index: geneve-ut-1808
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1673,10 +1900,10 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1786
+Index: geneve-ut-1821
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
 process.args in ("-lc", "-c", "-cl") and process.args like ("*echo *", "*printf *") and
 process.args like (
@@ -1695,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1796
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1755,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1802
+Index: geneve-ut-1837
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1780,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1811
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -1809,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1907
+Index: geneve-ut-1943
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -1871,7 +2098,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -1881,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1937
+Index: geneve-ut-1974
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1916,7 +2143,7 @@ process.args in (
   "nmap", "zenmap", "nuclei", "netdiscover", "legion", "masscan", "zmap", "zgrab", "ngrep", "telnet", "mitmproxy", "zmap",
   "masscan", "zgrab"
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -1927,7 +2154,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0232
+Index: geneve-ut-0239
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1941,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0976
+Index: geneve-ut-0999
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1953,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0996
+Index: geneve-ut-1019
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1965,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1378
+Index: geneve-ut-1408
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1983,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1575
+Index: geneve-ut-1609
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -1994,13 +2221,13 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 
 
-## Rules with too few signals (27)
+## Rules with too few signals (28)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0352  
+Index: geneve-ut-0367  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2045,7 +2272,121 @@ process.args like~ (
   "*/.config/gcloud/*", "*application_default_credentials.json*",
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*",
   "*/var/run/secrets/google/*", "*GOOGLE_APPLICATION_CREDENTIALS*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
+```
+
+
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0378  
+Failure message(s):  
+  got 1000 signals, expected 1680  
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
 ```
 
 
@@ -2054,7 +2395,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0630  
+Index: geneve-ut-0646  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2122,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0655  
+Index: geneve-ut-0671  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2150,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0780  
+Index: geneve-ut-0805  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2180,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0948  
+Index: geneve-ut-0971  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2199,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0975  
+Index: geneve-ut-0998  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2251,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1097  
+Index: geneve-ut-1121  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2271,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1119  
+Index: geneve-ut-1143  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2303,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1147  
+Index: geneve-ut-1173  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2336,7 +2677,7 @@ process.args like~ (
   "-*e*",
   /* file transfer via stdout/pipe */
   ">","<", "|"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -2345,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1219  
+Index: geneve-ut-1245  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2385,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1248  
+Index: geneve-ut-1274  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2410,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1265  
+Index: geneve-ut-1292  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2447,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1327  
+Index: geneve-ut-1356  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2468,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1342  
+Index: geneve-ut-1371  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2508,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1422  
+Index: geneve-ut-1452  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2525,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1431  
+Index: geneve-ut-1461  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2587,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1542  
+Index: geneve-ut-1576  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2612,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1671  
+Index: geneve-ut-1705  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2648,7 +2989,7 @@ process.args like~ (
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*", "*/var/run/secrets/google/*",
   "*GOOGLE_APPLICATION_CREDENTIALS*", "*AZURE_CLIENT_ID*", "*AZURE_TENANT_ID*", "*AZURE_CLIENT_SECRET*",
   "*AZURE_FEDERATED_TOKEN_FILE*", "*IDENTITY_ENDPOINT*", "*IDENTITY_HEADER*", "*MSI_ENDPOINT*", "*MSI_SECRET*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -2657,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1675  
+Index: geneve-ut-1709  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -2690,7 +3031,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 process.args like~ (
   "*BEGIN PRIVATE*", "*BEGIN OPENSSH PRIVATE*", "*BEGIN RSA PRIVATE*", "*BEGIN DSA PRIVATE*", "*BEGIN EC PRIVATE*",
   "*password*", "*ssh*", "*id_rsa*", "*id_dsa*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -2699,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1758  
+Index: geneve-ut-1793  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -2746,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1773  
+Index: geneve-ut-1808  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -2780,12 +3121,12 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1786  
+Index: geneve-ut-1821  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
 process.args in ("-lc", "-c", "-cl") and process.args like ("*echo *", "*printf *") and
 process.args like (
@@ -2804,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1796  
+Index: geneve-ut-1831  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -2866,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1802  
+Index: geneve-ut-1837  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -2893,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1811  
+Index: geneve-ut-1846  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -2924,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1907  
+Index: geneve-ut-1943  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -2988,7 +3329,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -2998,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1937  
+Index: geneve-ut-1974  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3035,7 +3376,7 @@ process.args in (
   "nmap", "zenmap", "nuclei", "netdiscover", "legion", "masscan", "zmap", "zgrab", "ngrep", "telnet", "mitmproxy", "zmap",
   "masscan", "zgrab"
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -3133,7 +3474,7 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0050
+Index: geneve-ut-0052
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -3151,7 +3492,7 @@ process.command_line like~ (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0067
+Index: geneve-ut-0069
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3168,7 +3509,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0099
+Index: geneve-ut-0102
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3187,7 +3528,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0106
+Index: geneve-ut-0109
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
@@ -3200,7 +3541,7 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0117
+Index: geneve-ut-0121
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3232,7 +3573,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0125
+Index: geneve-ut-0130
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3248,7 +3589,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0127
+Index: geneve-ut-0132
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3263,7 +3604,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0147
+Index: geneve-ut-0152
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
@@ -3276,7 +3617,7 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0183
+Index: geneve-ut-0189
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3292,7 +3633,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0184
+Index: geneve-ut-0190
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -3307,7 +3648,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0194
+Index: geneve-ut-0201
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -3322,7 +3663,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0203
+Index: geneve-ut-0210
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3346,7 +3687,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0204
+Index: geneve-ut-0211
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -3381,7 +3722,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0205
+Index: geneve-ut-0212
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -3398,7 +3739,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0206
+Index: geneve-ut-0213
 
 ```python
 any where host.os.type == "windows" and
@@ -3423,7 +3764,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0208
+Index: geneve-ut-0215
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -3451,7 +3792,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0210
+Index: geneve-ut-0217
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3464,7 +3805,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0212
+Index: geneve-ut-0219
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -3480,7 +3821,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0213
+Index: geneve-ut-0220
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3500,7 +3841,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0214
+Index: geneve-ut-0221
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3521,7 +3862,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0215
+Index: geneve-ut-0222
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3533,7 +3874,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0218
+Index: geneve-ut-0225
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3545,7 +3886,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0230
+Index: geneve-ut-0237
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3562,7 +3903,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0231
+Index: geneve-ut-0238
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3574,7 +3915,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0233
+Index: geneve-ut-0240
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3594,7 +3935,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0234
+Index: geneve-ut-0241
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3608,7 +3949,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0238
+Index: geneve-ut-0245
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3639,7 +3980,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0239
+Index: geneve-ut-0246
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3651,7 +3992,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0240
+Index: geneve-ut-0247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3665,7 +4006,7 @@ process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clea
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0241
+Index: geneve-ut-0248
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3680,7 +4021,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0251
+Index: geneve-ut-0258
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -3699,7 +4040,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0252
+Index: geneve-ut-0259
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3713,7 +4054,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0254
+Index: geneve-ut-0261
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -3744,7 +4085,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0255
+Index: geneve-ut-0262
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3767,7 +4108,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0256
+Index: geneve-ut-0263
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3781,7 +4122,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0257
+Index: geneve-ut-0264
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3800,7 +4141,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0258
+Index: geneve-ut-0265
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3814,7 +4155,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0259
+Index: geneve-ut-0266
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3839,7 +4180,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0264
+Index: geneve-ut-0271
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3858,7 +4199,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0267
+Index: geneve-ut-0274
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3871,7 +4212,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0269
+Index: geneve-ut-0276
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3913,7 +4254,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0276
+Index: geneve-ut-0283
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -3928,7 +4269,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0309
+Index: geneve-ut-0323
 
 ```python
 event.dataset:azure.activitylogs and
@@ -3942,7 +4283,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0312
+Index: geneve-ut-0326
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -3960,7 +4301,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0330
+Index: geneve-ut-0344
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3978,7 +4319,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0331
+Index: geneve-ut-0345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3996,7 +4337,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0332
+Index: geneve-ut-0346
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4011,7 +4352,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0333
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4025,7 +4366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0334
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4040,7 +4381,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0337
+Index: geneve-ut-0351
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4057,7 +4398,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0338
+Index: geneve-ut-0352
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4069,7 +4410,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0339
+Index: geneve-ut-0353
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4081,7 +4422,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0340
+Index: geneve-ut-0354
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4096,7 +4437,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0341
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4116,7 +4457,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0342
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4138,7 +4479,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0344
+Index: geneve-ut-0358
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4184,7 +4525,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0345
+Index: geneve-ut-0359
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4218,7 +4559,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0346
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4241,7 +4582,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0347
+Index: geneve-ut-0362
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4263,7 +4604,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0348
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4291,7 +4632,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0349
+Index: geneve-ut-0364
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4307,7 +4648,7 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0351
+Index: geneve-ut-0366
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4332,7 +4673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0353
+Index: geneve-ut-0368
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4362,7 +4703,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0355
+Index: geneve-ut-0370
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4376,7 +4717,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0356
+Index: geneve-ut-0371
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4398,7 +4739,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0357
+Index: geneve-ut-0372
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4412,7 +4753,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0358
+Index: geneve-ut-0373
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4432,7 +4773,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0361
+Index: geneve-ut-0376
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4445,95 +4786,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Component Object Model Hijacking
-
-Branch count: 60  
-Document count: 60  
-Index: geneve-ut-0363
-
-```python
-registry where host.os.type == "windows" and event.type == "change" and
-  /* not necessary but good for filtering privileged installations */
-  user.domain != "NT AUTHORITY" and process.executable != null and 
-  (
-    (
-      registry.path : "HK*\\InprocServer32\\" and
-      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
-      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
-    ) or
-
-    (
-      registry.path : "HKLM\\*\\InProcServer32\\*" and
-        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
-    ) or
-
-    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
-    (
-      registry.path : (
-        "HKEY_USERS\\*\\InprocServer32\\",
-        "HKEY_USERS\\*\\LocalServer32\\",
-        "HKEY_USERS\\*\\DelegateExecute",
-        "HKEY_USERS\\*\\TreatAs\\",
-        "HKEY_USERS\\*\\ScriptletURL*", 
-        "HKEY_USERS\\*\\TypeLib*\\Win*"
-      ) and
-      not registry.data.strings : (
-            /* COM related to Windows Spotlight feature */
-            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
-
-            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
-            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
-            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
-            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
-      )
-    )
-  ) and 
-
-  not (
-    process.code_signature.trusted == true and
-    process.code_signature.subject_name in (
-        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
-        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
-        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
-        "Vivaldi Technologies AS"
-    )
-  ) and 
-
-  /* excludes Microsoft signed noisy processes */
-  not
-  (
-    process.name : (
-      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
-      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
-    ) and
-    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
-  ) and
-
-  not process.executable : (
-        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
-        "?:\\Program Files (x86)\\*.exe",
-        "?:\\Program Files\\*.exe",
-        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
-        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
-        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
-        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
-        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
-        "?:\\Windows\\System32\\FMToastNotification.exe",
-        "?:\\Windows\\System32\\msiexec.exe",
-        "?:\\Windows\\System32\\svchost.exe",
-        "?:\\Windows\\SysWOW64\\regsvr32.exe",
-        "?:\\Windows\\System32\\regsvr32.exe",
-        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
-  )
-```
-
-
-
 ### Compression DLL Loaded by Unusual Process
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0364
+Index: geneve-ut-0379
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4563,7 +4820,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0367
+Index: geneve-ut-0382
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4588,7 +4845,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0369
+Index: geneve-ut-0384
 
 ```python
 sequence by process.entity_id
@@ -4609,7 +4866,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0370
+Index: geneve-ut-0385
 
 ```python
 sequence by process.entity_id
@@ -4630,7 +4887,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0373
+Index: geneve-ut-0388
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4661,7 +4918,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0374
+Index: geneve-ut-0389
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4673,7 +4930,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0375
+Index: geneve-ut-0390
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4696,7 +4953,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0378
+Index: geneve-ut-0393
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4709,7 +4966,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0379
+Index: geneve-ut-0394
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4722,7 +4979,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0381
+Index: geneve-ut-0396
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4739,7 +4996,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0382
+Index: geneve-ut-0397
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -4752,7 +5009,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0383
+Index: geneve-ut-0398
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -4769,7 +5026,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0384
+Index: geneve-ut-0399
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -4781,7 +5038,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0385
+Index: geneve-ut-0400
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -4849,7 +5106,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0386
+Index: geneve-ut-0401
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -4867,7 +5124,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0387
+Index: geneve-ut-0402
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -4880,7 +5137,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0388
+Index: geneve-ut-0403
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4898,7 +5155,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0389
+Index: geneve-ut-0404
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4910,7 +5167,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0390
+Index: geneve-ut-0405
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4922,7 +5179,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0391
+Index: geneve-ut-0406
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4934,7 +5191,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0392
+Index: geneve-ut-0407
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4946,7 +5203,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0393
+Index: geneve-ut-0408
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -4991,7 +5248,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0395
+Index: geneve-ut-0410
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5011,7 +5268,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0396
+Index: geneve-ut-0411
 
 ```python
 sequence with maxspan=10s
@@ -5031,7 +5288,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0397
+Index: geneve-ut-0412
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5058,12 +5315,12 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0398
+Index: geneve-ut-0413
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
 process.name == "curl" and process.args like ("--socks5-hostname", "--proxy", "--preproxy", "socks5*", "-x") and
-process.interactive == true and container.id like "?*"
+container.id like "?*"
 ```
 
 
@@ -5072,7 +5329,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0401
+Index: geneve-ut-0416
 
 ```python
 process where event.type == "start" and
@@ -5097,7 +5354,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0404
+Index: geneve-ut-0419
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5141,7 +5398,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0405
+Index: geneve-ut-0420
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5175,11 +5432,11 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0407
+Index: geneve-ut-0422
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.interactive == true and container.id like "*" and 
+container.id like "*" and 
 (
   /* getent hosts is often used without a target arg */
   (process.name == "getent" and process.args == "hosts") or
@@ -5220,7 +5477,7 @@ process.interactive == true and container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0408
+Index: geneve-ut-0423
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5236,7 +5493,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0409
+Index: geneve-ut-0424
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5261,7 +5518,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0410
+Index: geneve-ut-0425
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5280,7 +5537,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0412
+Index: geneve-ut-0427
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5407,7 +5664,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0413
+Index: geneve-ut-0428
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5425,7 +5682,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0415
+Index: geneve-ut-0430
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5438,7 +5695,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0416
+Index: geneve-ut-0431
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5459,7 +5716,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
   )
 ) and
 process.args like "/dev/sd*" and not process.args == "-R" and
-container.security_context.privileged == true and process.interactive == true and container.id like "*"
+container.security_context.privileged == true and container.id like "*"
 ```
 
 
@@ -5468,7 +5725,7 @@ container.security_context.privileged == true and process.interactive == true an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0422
+Index: geneve-ut-0437
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5482,7 +5739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0434
+Index: geneve-ut-0449
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5503,7 +5760,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0441
+Index: geneve-ut-0456
 
 ```python
 registry where host.os.type == "windows" and
@@ -5517,7 +5774,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0453
+Index: geneve-ut-0468
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5537,52 +5794,11 @@ event.category: "process" and host.os.type:windows and
 
 
 
-### Deprecated - Potential CVE-2025-41244 vmtoolsd LPE Exploitation Attempt
-
-Branch count: 54  
-Document count: 54  
-Index: geneve-ut-0456
-
-```python
-process where host.os.type == "linux" and event.type == "start" and
-event.action in ("exec", "exec_event", "start", "executed", "process_started", "ProcessRollup2") and
-(
-  (
-    process.parent.name == "vmtoolsd"
-  ) or
-  (
-    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
-    ?process.parent.args like ("/*/open-vm-tools/serviceDiscovery/scripts/get-versions.sh")
-  )
-) and not (
-  process.executable == null or
-  ?process.parent.args == "--version" or
-  process.args like (
-    "/etc/vmware-tools/resume-vm-default",
-    "/etc/vmware-tools/suspend-vm-default",
-    "/sbin/shutdown",
-    "/sbin/shutdown*",
-    "/etc/vmware-tools/poweroff-vm-default",
-    "/etc/vmware-tools/poweroff-vm-default",
-    "/bin/touch",
-    "/tmp/vmware-administrator_*",
-    "/tmp/vmware-root_*",
-    "/etc/vmware-tools/scripts/vmware/network",
-    "/etc/vmware-tools/poweron-vm-default"
-  ) or
-  process.executable == "/usr/sbin/unix_chkpwd" or
-  ?process.working_directory like ("/var/opt/ds_agent", "/tmp/vmware-root_*/tmpvmware*") or
-  process.command_line like ("*/usr/bin/lsb_release*", "*/bin/touch*", "*/tmp/vmware-root_*")
-)
-```
-
-
-
-### Direct Interactive Kubernetes API Request Detected via Defend for Containers
+### Direct Kubernetes API Request Detected via Defend for Containers
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0491
+Index: geneve-ut-0507
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5627,7 +5843,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
   (process.name == "ncat" and process.args like "--ssl*") or
   (process.name == "kubectl" and process.args in ("get", "list", "watch", "create", "patch", "update"))
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -5636,7 +5852,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0494
+Index: geneve-ut-0509
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5652,7 +5868,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0495
+Index: geneve-ut-0510
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5680,7 +5896,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0496
+Index: geneve-ut-0511
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5697,7 +5913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0497
+Index: geneve-ut-0512
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5714,7 +5930,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0498
+Index: geneve-ut-0513
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5735,7 +5951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0500
+Index: geneve-ut-0515
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5755,7 +5971,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0501
+Index: geneve-ut-0516
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5770,7 +5986,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0503
+Index: geneve-ut-0518
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5783,7 +5999,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0504
+Index: geneve-ut-0519
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5803,7 +6019,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0507
+Index: geneve-ut-0522
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -5816,7 +6032,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0508
+Index: geneve-ut-0523
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5854,7 +6070,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0509
+Index: geneve-ut-0524
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -5874,7 +6090,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0510
+Index: geneve-ut-0525
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5887,7 +6103,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0511
+Index: geneve-ut-0526
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5910,7 +6126,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0513
+Index: geneve-ut-0528
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5941,7 +6157,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0514
+Index: geneve-ut-0529
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -5960,7 +6176,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0515
+Index: geneve-ut-0530
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6003,12 +6219,12 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0516
+Index: geneve-ut-0531
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
 file.path like ("/etc/ld.so.preload", "/etc/ld.so.conf.d/*", "/etc/ld.so.conf") and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -6017,7 +6233,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0518
+Index: geneve-ut-0533
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6032,7 +6248,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0519
+Index: geneve-ut-0534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6048,7 +6264,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0520
+Index: geneve-ut-0535
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6062,7 +6278,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0521
+Index: geneve-ut-0536
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6088,7 +6304,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0522
+Index: geneve-ut-0537
 
 ```python
 process where event.type == "start" and
@@ -6126,11 +6342,11 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0529
+Index: geneve-ut-0544
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
- file.path like ("/private/etc/emond.d/rules/*.plist", "/etc/emon.d/rules/*.plist", "/private/var/db/emondClients/*")
+ file.path like ("/private/etc/emond.d/rules/*.plist", "/etc/emond.d/rules/*.plist", "/private/var/db/emondClients/*")
 ```
 
 
@@ -6139,7 +6355,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0530
+Index: geneve-ut-0545
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6153,10 +6369,10 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0531
+Index: geneve-ut-0546
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (process.name in ("base64", "base64plain", "base64url", "base64mime", "base64pem", "base32", "base16") and process.args like~ "*-*d*") or
   (process.name == "xxd" and process.args like~ ("-*r*", "-*p*")) or
   (process.name == "openssl" and process.args == "enc" and process.args in ("-d", "-base64", "-a")) or
@@ -6175,7 +6391,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0532
+Index: geneve-ut-0547
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6210,7 +6426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0533
+Index: geneve-ut-0548
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6222,7 +6438,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0581
+Index: geneve-ut-0596
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6234,7 +6450,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0607
+Index: geneve-ut-0622
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6248,7 +6464,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0610
+Index: geneve-ut-0625
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6275,7 +6491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0613
+Index: geneve-ut-0628
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6296,7 +6512,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0614
+Index: geneve-ut-0629
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6317,7 +6533,25 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     )
   )
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
+```
+
+
+
+### Exec Into Container Detected via Defend for Containers
+
+Branch count: 9  
+Document count: 9  
+Index: geneve-ut-0632
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "busybox") and
+process.entry_leader.entry_meta.type == "container" and
+
+/* process is the initial process run in a container */
+process.entry_leader.same_as_process == true and
+container.id like "*"
 ```
 
 
@@ -6326,7 +6560,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0617
+Index: geneve-ut-0633
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6359,7 +6593,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0619
+Index: geneve-ut-0635
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6376,7 +6610,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0620
+Index: geneve-ut-0636
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6404,7 +6638,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0621
+Index: geneve-ut-0637
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6417,7 +6651,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0623
+Index: geneve-ut-0639
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6437,7 +6671,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0624
+Index: geneve-ut-0640
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6463,7 +6697,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0625
+Index: geneve-ut-0641
 
 ```python
 sequence with maxspan=2h
@@ -6485,7 +6719,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0626
+Index: geneve-ut-0642
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6514,7 +6748,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0629
+Index: geneve-ut-0645
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6527,7 +6761,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0633
+Index: geneve-ut-0649
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6542,7 +6776,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0634
+Index: geneve-ut-0650
 
 ```python
 process where event.type == "start" and
@@ -6564,7 +6798,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0636
+Index: geneve-ut-0652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6576,7 +6810,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0637
+Index: geneve-ut-0653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6598,7 +6832,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0639
+Index: geneve-ut-0655
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6615,7 +6849,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0640
+Index: geneve-ut-0656
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6629,7 +6863,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0641
+Index: geneve-ut-0657
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6642,7 +6876,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0642
+Index: geneve-ut-0658
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6654,7 +6888,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0643
+Index: geneve-ut-0659
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6666,7 +6900,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0644
+Index: geneve-ut-0660
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6680,7 +6914,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0645
+Index: geneve-ut-0661
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6690,15 +6924,15 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 ### External IP Address Discovery via Curl
 
-Branch count: 304  
-Document count: 304  
-Index: geneve-ut-0646
+Branch count: 342  
+Document count: 342  
+Index: geneve-ut-0662
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
   ((process.parent.executable like ("/Applications/*", "/Volumes/*", "/private/var/folders/*")) or
    (process.parent.name in ("bash", "sh", "zsh") and process.parent.command_line like "*http*") or
-   (process.parent.code_signature.trusted == false or process.code_signature.exists == false)) and
+   (process.parent.code_signature.trusted == false or process.parent.code_signature.exists == false or process.code_signature.exists == false)) and
   process.name in ("curl", "nscurl") and
   process.args_count <= 5 and
   process.command_line like ("*ip-api.com*", "*ipwho.is*", "*checkip.dyndns.org*", "*api.ipify.org*",
@@ -6714,7 +6948,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0650
+Index: geneve-ut-0666
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6763,15 +6997,15 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0651
+Index: geneve-ut-0667
 
 ```python
 sequence by container.id, user.id with maxspan=3s
-  [file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and container.id like "?*" and
+  [file where host.os.type == "linux" and event.type == "creation" and container.id like "?*" and
    file.path like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/root/*", "/home/*") and
    not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf", "apk", "pacman", "rpm", "dpkg")] by file.path
   [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-   process.interactive == true and container.id like "?*"] by process.executable
+   container.id like "?*"] by process.executable
 ```
 
 
@@ -6780,7 +7014,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0652
+Index: geneve-ut-0668
 
 ```python
 sequence by host.id with maxspan=10s
@@ -6800,10 +7034,10 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0657
+Index: geneve-ut-0673
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (
     (process.name == "curl" or process.args in ("curl", "/bin/curl", "/usr/bin/curl", "/usr/local/bin/curl")) and
     process.args in ("-o", "-O", "--output", "--remote-name", "--remote-name-all", "--output-dir")
@@ -6822,7 +7056,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0660
+Index: geneve-ut-0676
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -6837,7 +7071,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0661
+Index: geneve-ut-0677
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6851,7 +7085,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0663
+Index: geneve-ut-0679
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6873,7 +7107,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0665
+Index: geneve-ut-0681
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -6894,7 +7128,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0666
+Index: geneve-ut-0682
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6920,7 +7154,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0667
+Index: geneve-ut-0683
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -6948,7 +7182,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0670
+Index: geneve-ut-0686
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -6962,7 +7196,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0705
+Index: geneve-ut-0724
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -6979,7 +7213,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0706
+Index: geneve-ut-0725
 
 ```python
 registry where host.os.type == "windows" and
@@ -6997,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0770
+Index: geneve-ut-0795
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7036,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0771
+Index: geneve-ut-0796
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7063,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0772
+Index: geneve-ut-0797
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7078,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0773
+Index: geneve-ut-0798
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7165,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0781
+Index: geneve-ut-0806
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7183,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0782
+Index: geneve-ut-0807
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7214,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0783
+Index: geneve-ut-0808
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7241,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0784
+Index: geneve-ut-0809
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7261,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0788
+Index: geneve-ut-0813
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7274,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0791
+Index: geneve-ut-0816
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7286,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0794
+Index: geneve-ut-0819
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7298,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0798
+Index: geneve-ut-0823
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7310,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0800
+Index: geneve-ut-0825
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7327,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0826
+Index: geneve-ut-0851
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7340,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0829
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7364,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0830
+Index: geneve-ut-0855
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7376,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0843
+Index: geneve-ut-0868
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7394,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0844
+Index: geneve-ut-0869
 
 ```python
 any where process.executable != null and
@@ -7443,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0845
+Index: geneve-ut-0870
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7457,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0849
+Index: geneve-ut-0874
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7472,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0855
+Index: geneve-ut-0880
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7489,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0857
+Index: geneve-ut-0882
 
 ```python
 sequence with maxspan=1m
@@ -7508,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0858
+Index: geneve-ut-0883
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7526,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0859
+Index: geneve-ut-0884
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7545,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0860
+Index: geneve-ut-0885
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7561,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0861
+Index: geneve-ut-0886
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7577,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0862
+Index: geneve-ut-0887
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7590,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0867
+Index: geneve-ut-0892
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7607,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0869
+Index: geneve-ut-0894
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7620,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0870
+Index: geneve-ut-0895
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7636,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0871
+Index: geneve-ut-0896
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7663,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0872
+Index: geneve-ut-0897
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7683,59 +7917,11 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 
 
-### Interactive Exec Into Container Detected via Defend for Containers
-
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-0873
-
-```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "busybox") and
-process.entry_leader.entry_meta.type == "container" and
-
-/* process is the inital process run in a container */
-process.entry_leader.same_as_process == true and
-
-/* interactive process */
-process.interactive == true and container.id like "*"
-```
-
-
-
-### Interactive Privilege Boundary Enumeration Detected via Defend for Containers
-
-Branch count: 25  
-Document count: 25  
-Index: geneve-ut-0875
-
-```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
-  (process.name in ("id", "whoami", "capsh", "getcap", "lsns")) or
-  (process.args in (
-     "id", "/bin/id", "/usr/bin/id", "/usr/local/bin/id",
-     "whoami", "/bin/whoami", "/usr/bin/whoami", "/usr/local/bin/whoami",
-     "capsh", "/bin/capsh", "/usr/bin/capsh", "/usr/local/bin/capsh",
-     "getcap", "/bin/getcap", "/usr/bin/getcap", "/usr/local/bin/getcap",
-     "lsns", "/bin/lsns", "/usr/bin/lsns", "/usr/local/bin/lsns"
-   ) and
-    /* default exclusion list to not FP on default multi-process commands */
-    not process.args in (
-      "man", "/bin/man", "/usr/bin/man", "/usr/local/bin/man",
-      "chmod", "/bin/chmod", "/usr/bin/chmod", "/usr/local/bin/chmod",
-      "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
-    )
-  )
-) and container.id like "?*"
-```
-
-
-
 ### Interactive Terminal Spawned via Python
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0879
+Index: geneve-ut-0902
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7759,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0881
+Index: geneve-ut-0904
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7795,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0882
+Index: geneve-ut-0905
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7807,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0883
+Index: geneve-ut-0906
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -7821,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0884
+Index: geneve-ut-0907
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -7834,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0885
+Index: geneve-ut-0908
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -7893,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0886
+Index: geneve-ut-0909
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -7906,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0887
+Index: geneve-ut-0910
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -7919,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0888
+Index: geneve-ut-0911
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7940,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0889
+Index: geneve-ut-0912
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7958,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0890
+Index: geneve-ut-0913
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7992,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0892
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8014,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0894
+Index: geneve-ut-0917
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8041,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0895
+Index: geneve-ut-0918
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8067,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0896
+Index: geneve-ut-0919
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8083,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0897
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8099,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0899
+Index: geneve-ut-0922
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8111,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0900
+Index: geneve-ut-0923
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8139,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0902
+Index: geneve-ut-0925
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8155,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0904
+Index: geneve-ut-0927
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8180,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0905
+Index: geneve-ut-0928
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8194,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0907
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8217,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0908
+Index: geneve-ut-0931
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8250,10 +8436,10 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0909
+Index: geneve-ut-0932
 
 ```python
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where host.os.type == "linux" and container.id like "*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and file.path like "/var/lib/kubelet/pki/*") or
   (event.category == "process" and event.type == "start" and event.action == "exec" and
   (
@@ -8277,7 +8463,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0912
+Index: geneve-ut-0935
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8298,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0913
+Index: geneve-ut-0936
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8325,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0923
+Index: geneve-ut-0946
 
 ```python
 process where event.type == "start" and
@@ -8347,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0949
+Index: geneve-ut-0972
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8366,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0952
+Index: geneve-ut-0975
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8410,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0954
+Index: geneve-ut-0977
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8435,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0966
+Index: geneve-ut-0989
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8473,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0971
+Index: geneve-ut-0994
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8491,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0972
+Index: geneve-ut-0995
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8505,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0977
+Index: geneve-ut-1000
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8520,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0992
+Index: geneve-ut-1015
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8534,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0995
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8548,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0997
+Index: geneve-ut-1020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8569,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-0998
+Index: geneve-ut-1021
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8599,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1002
+Index: geneve-ut-1025
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8646,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1003
+Index: geneve-ut-1026
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8673,36 +8859,11 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 
 
-### Local Scheduled Task Creation
-
-Branch count: 600  
-Document count: 1200  
-Index: geneve-ut-1004
-
-```python
-sequence with maxspan=1m
-  [process where host.os.type == "windows" and event.type == "start" and
-    ((process.name : ("cmd.exe", "wscript.exe", "rundll32.exe", "regsvr32.exe", "wmic.exe", "mshta.exe",
-                      "powershell.exe", "pwsh.exe", "powershell_ise.exe", "WmiPrvSe.exe", "wsmprovhost.exe", "winrshost.exe") or
-    process.pe.original_file_name : ("cmd.exe", "wscript.exe", "rundll32.exe", "regsvr32.exe", "wmic.exe", "mshta.exe",
-                                     "powershell.exe", "pwsh.dll", "powershell_ise.exe", "WmiPrvSe.exe", "wsmprovhost.exe",
-                                     "winrshost.exe")) or
-    ?process.code_signature.trusted == false)] by process.entity_id
-  [process where host.os.type == "windows" and event.type == "start" and
-    (process.name : "schtasks.exe" or process.pe.original_file_name == "schtasks.exe") and
-    process.args : ("/create", "-create") and process.args : ("/RU", "/SC", "/TN", "/TR", "/F", "/XML") and
-    /* exclude SYSTEM Integrity Level - look for task creations by non-SYSTEM user */
-    not (?process.Ext.token.integrity_level_name : "System" or ?winlog.event_data.IntegrityLevel : "System")
-  ] by process.parent.entity_id
-```
-
-
-
 ### M365 AIR Investigation Signal
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1006
+Index: geneve-ut-1029
 
 ```python
 event.dataset:o365.audit and
@@ -8715,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1008
+Index: geneve-ut-1031
 
 ```python
 event.dataset:o365.audit and
@@ -8728,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1009
+Index: geneve-ut-1032
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8740,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1045
+Index: geneve-ut-1068
 
 ```python
 event.dataset:o365.audit and
@@ -8753,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1046
+Index: geneve-ut-1069
 
 ```python
 event.dataset:o365.audit and
@@ -8766,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1047
+Index: geneve-ut-1070
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8778,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1048
+Index: geneve-ut-1071
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8790,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1049
+Index: geneve-ut-1072
 
 ```python
 event.dataset:o365.audit and
@@ -8803,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1057
+Index: geneve-ut-1080
 
 ```python
 event.dataset: "o365.audit" and
@@ -8816,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1060
+Index: geneve-ut-1083
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8836,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1061
+Index: geneve-ut-1084
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -8848,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1062
+Index: geneve-ut-1085
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -8860,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1066
+Index: geneve-ut-1089
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -8872,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1067
+Index: geneve-ut-1090
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -8884,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1069
+Index: geneve-ut-1092
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -8896,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1070
+Index: geneve-ut-1093
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -8908,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1071
+Index: geneve-ut-1094
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8933,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1072
+Index: geneve-ut-1095
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8953,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1073
+Index: geneve-ut-1096
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -8966,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1074
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8977,11 +9138,36 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 
 
+### Mark-of-the-Web Removal by an Unusual Process
+
+Branch count: 12  
+Document count: 12  
+Index: geneve-ut-1098
+
+```python
+file where host.os.type == "windows" and event.type == "deletion" and
+  file.path : (
+    "*.exe:Zone.Identifier",
+    "*.exe:Zone.Identifier:$DATA",
+    "*.msi:Zone.Identifier",
+    "*.msi:Zone.Identifier:$DATA"
+  ) and
+
+  /* Explorer may remove MOTW after SmartScreen */
+  not (
+    process.executable : "?:\\Windows\\explorer.exe" and
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name : "Microsoft Windows"
+  )
+```
+
+
+
 ### Member Removed From GitHub Organization
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1076
+Index: geneve-ut-1100
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -8993,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1079
+Index: geneve-ut-1103
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9005,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1080
+Index: geneve-ut-1104
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9017,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1081
+Index: geneve-ut-1105
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9051,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1084
+Index: geneve-ut-1108
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9065,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1085
+Index: geneve-ut-1109
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9086,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1086
+Index: geneve-ut-1110
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9100,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1090
+Index: geneve-ut-1114
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9135,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1091
+Index: geneve-ut-1115
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9160,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1092
+Index: geneve-ut-1116
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9177,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1096
+Index: geneve-ut-1120
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9191,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1098
+Index: geneve-ut-1122
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9222,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1100
+Index: geneve-ut-1124
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9276,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1101
+Index: geneve-ut-1125
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9288,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1103
+Index: geneve-ut-1127
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9306,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1104
+Index: geneve-ut-1128
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9323,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1106
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9338,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1107
+Index: geneve-ut-1131
 
 ```python
 file where event.type != "deletion" and
@@ -9388,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1109
+Index: geneve-ut-1133
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9404,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1110
+Index: geneve-ut-1134
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9416,22 +9602,28 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 ### Mofcomp Activity
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1112
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.name : "mofcomp.exe" and process.args : "*.mof" and
   not user.id : "S-1-5-18" and
-  not
-  (
-    process.parent.name : "ScenarioEngine.exe" and
-    process.args : (
-      "*\\MSSQL\\Binn\\*.mof",
-      "*\\Microsoft SQL Server\\???\\Shared\\*.mof",
-      "*\\OLAP\\bin\\*.mof"
-    )
+  not process.args : (
+    "?:\\Program Files (x86)\\Microsoft Power BI Report Server\\*.mof",
+    "?:\\Program Files (x86)\\Microsoft SQL Server Reporting Services\\*.mof",
+    "?:\\Program Files (x86)\\Microsoft SQL Server\\*.mof",
+    "?:\\Program Files\\Microsoft Policy Platform\\*.mof",
+    "?:\\Program Files\\Microsoft Power BI Report Server\\*.mof",
+    "?:\\Program Files\\Microsoft SQL Server Reporting Services\\*.mof",
+    "?:\\Program Files\\Microsoft SQL Server\\*.mof",
+    "?:\\Windows\\System32\\wbem\\com.hp.provider.*.mof",
+    "?:\\Windows\\System32\\wbem\\CxAudioSvc_*.mof",
+    "?:\\Windows\\System32\\wbem\\Framework\\root\\*.mof",
+    "?:\\Windows\\System32\\wbem\\Veeam.Backup.*.mof",
+    "?:\\Windows\\System32\\wbem\\ZTITatoo.mof",
+    "?:\\Windows\\SysWOW64\\wbem\\Framework\\root\\*.mof"
   )
 ```
 
@@ -9441,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1113
+Index: geneve-ut-1137
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9460,7 +9652,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
       "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
     )
   )
-) and container.security_context.privileged == true and process.interactive == true and container.id like "*"
+) and container.security_context.privileged == true and container.id like "*"
 ```
 
 
@@ -9469,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1114
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9491,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1115
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9510,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1116
+Index: geneve-ut-1140
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9543,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1117
+Index: geneve-ut-1141
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9561,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1118
+Index: geneve-ut-1142
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9602,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1131
+Index: geneve-ut-1155
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9628,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1139
+Index: geneve-ut-1164
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9652,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1142
+Index: geneve-ut-1168
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9666,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1143
+Index: geneve-ut-1169
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9685,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1144
+Index: geneve-ut-1170
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9705,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1145
+Index: geneve-ut-1171
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9728,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1146
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9749,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1148
+Index: geneve-ut-1174
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9764,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1149
+Index: geneve-ut-1175
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9781,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1151
+Index: geneve-ut-1177
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9805,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1153
+Index: geneve-ut-1179
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -9851,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1154
+Index: geneve-ut-1180
 
 ```python
 sequence by host.id with maxspan=1s
@@ -9893,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1155
+Index: geneve-ut-1181
 
 ```python
 sequence by host.id with maxspan=10s
@@ -9910,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1157
+Index: geneve-ut-1183
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9925,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1158
+Index: geneve-ut-1184
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -9944,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1159
+Index: geneve-ut-1185
 
 ```python
 sequence by process.entity_id
@@ -9964,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1160
+Index: geneve-ut-1186
 
 ```python
 sequence by process.entity_id
@@ -9983,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1162
+Index: geneve-ut-1188
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10012,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1163
+Index: geneve-ut-1189
 
 ```python
 sequence by process.entity_id
@@ -10037,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1164
+Index: geneve-ut-1190
 
 ```python
 sequence by process.entity_id
@@ -10059,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1165
+Index: geneve-ut-1191
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10092,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1166
+Index: geneve-ut-1192
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10122,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1170
+Index: geneve-ut-1196
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10139,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1171
+Index: geneve-ut-1197
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10176,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1172
+Index: geneve-ut-1198
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10189,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1177
+Index: geneve-ut-1203
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10201,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1180
+Index: geneve-ut-1206
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10213,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1189
+Index: geneve-ut-1215
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10227,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1190
+Index: geneve-ut-1216
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10241,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1191
+Index: geneve-ut-1217
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10255,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1192
+Index: geneve-ut-1218
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10275,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1194
+Index: geneve-ut-1220
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10288,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1195
+Index: geneve-ut-1221
 
 ```python
 event.dataset: "okta.system"
@@ -10303,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1197
+Index: geneve-ut-1223
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10325,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1206
+Index: geneve-ut-1232
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10352,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1207
+Index: geneve-ut-1233
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10372,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1208
+Index: geneve-ut-1234
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10387,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1209
+Index: geneve-ut-1235
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10414,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1210
+Index: geneve-ut-1236
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10429,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1211
+Index: geneve-ut-1237
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10445,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1212
+Index: geneve-ut-1238
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10459,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1213
+Index: geneve-ut-1239
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10469,7 +10661,7 @@ file where host.os.type == "linux" and event.type in ("creation", "change") and 
   ) or
   process.name like ("php-fpm*", "lsphp*", "*.cgi", "*.fcgi")
 ) and
-file.path like~ "*/wp-content/plugins/*.php*"
+file.path like~ "*/wp-content/plugins/*"
 ```
 
 
@@ -10478,7 +10670,7 @@ file.path like~ "*/wp-content/plugins/*.php*"
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1220
+Index: geneve-ut-1246
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10493,7 +10685,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1221
+Index: geneve-ut-1247
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10507,7 +10699,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1222
+Index: geneve-ut-1248
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10526,7 +10718,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1223
+Index: geneve-ut-1249
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10538,7 +10730,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1224
+Index: geneve-ut-1250
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10550,7 +10742,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1225
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10568,7 +10760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1226
+Index: geneve-ut-1252
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10581,7 +10773,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1227
+Index: geneve-ut-1253
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10596,7 +10788,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1228
+Index: geneve-ut-1254
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10611,7 +10803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1231
+Index: geneve-ut-1257
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10631,7 +10823,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1232
+Index: geneve-ut-1258
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10655,7 +10847,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1233
+Index: geneve-ut-1259
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10669,7 +10861,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1234
+Index: geneve-ut-1260
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10686,9 +10878,9 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 ### Persistence via Scheduled Job Creation
 
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-1235
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1261
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10698,12 +10890,14 @@ file where host.os.type == "windows" and event.type != "deletion" and
       process.executable : "?:\\Program Files\\CCleaner\\CCleaner64.exe" and
       file.path : "?:\\Windows\\Tasks\\CCleanerCrashReporting.job"
     ) or
-    (
-      process.executable : (
-        "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\bin\\dcagentregister.exe",
-        "?:\\Program Files (x86)\\DesktopCentral_Agent\\bin\\dcagentregister.exe"
-      ) and
-      file.path : "?:\\Windows\\Tasks\\DCAgentUpdater.job"
+    process.executable : (
+      "?:\\Program Files (x86)\\DesktopCentral_Agent\\bin\\dcagentregister.exe",
+      "?:\\Program Files (x86)\\epson\\Epson Scan 2\\Update\\e_dtsksd.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\bin\\dcagentregister.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\dcconfig.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\Updates\\UemsComponentUpgrader.exe",
+      "?:\\Program Files (x86)\\Skillbrains\\Updater\\*\\Updater.exe",
+      "?:\\Windows\\System32\\drivers\\RivetNetworks\\Killer\\CustomizeInstallFirstRun.exe"
     )
   )
 ```
@@ -10714,7 +10908,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1236
+Index: geneve-ut-1262
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10743,7 +10937,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1237
+Index: geneve-ut-1263
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10762,7 +10956,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1238
+Index: geneve-ut-1264
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10790,7 +10984,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1239
+Index: geneve-ut-1265
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10805,7 +10999,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1240
+Index: geneve-ut-1266
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10868,7 +11062,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1241
+Index: geneve-ut-1267
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -10889,7 +11083,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1242
+Index: geneve-ut-1268
 
 ```python
 any where host.os.type == "windows" and
@@ -10951,7 +11145,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1244
+Index: geneve-ut-1270
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -10980,7 +11174,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1245
+Index: geneve-ut-1271
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -10994,7 +11188,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1246
+Index: geneve-ut-1272
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11027,7 +11221,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1249
+Index: geneve-ut-1275
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11074,7 +11268,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1250
+Index: geneve-ut-1276
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11101,7 +11295,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1251
+Index: geneve-ut-1277
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11114,7 +11308,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1261
+Index: geneve-ut-1288
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11131,7 +11325,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1263
+Index: geneve-ut-1290
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11156,7 +11350,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1268
+Index: geneve-ut-1295
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11172,7 +11366,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1269
+Index: geneve-ut-1296
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11193,7 +11387,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1270
+Index: geneve-ut-1298
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11210,11 +11404,11 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1271
+Index: geneve-ut-1299
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
-process.interactive == true and container.id like "?*"
+container.id like "?*"
 ```
 
 
@@ -11223,7 +11417,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1272
+Index: geneve-ut-1300
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11247,7 +11441,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1274
+Index: geneve-ut-1302
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11276,7 +11470,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1276
+Index: geneve-ut-1304
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11303,7 +11497,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1277
+Index: geneve-ut-1305
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11327,7 +11521,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1280
+Index: geneve-ut-1308
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11345,7 +11539,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1281
+Index: geneve-ut-1309
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11368,7 +11562,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1282
+Index: geneve-ut-1310
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11425,7 +11619,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1283
+Index: geneve-ut-1311
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11442,7 +11636,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1284
+Index: geneve-ut-1312
 
 ```python
 sequence by process.entity_id
@@ -11456,7 +11650,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1299
+Index: geneve-ut-1327
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11471,7 +11665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1300
+Index: geneve-ut-1328
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11502,7 +11696,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1301
+Index: geneve-ut-1329
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11516,7 +11710,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1302
+Index: geneve-ut-1330
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11529,7 +11723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1303
+Index: geneve-ut-1331
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11541,7 +11735,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1304
+Index: geneve-ut-1332
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11554,7 +11748,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1306
+Index: geneve-ut-1334
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11573,7 +11767,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1307
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11586,7 +11780,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1308
+Index: geneve-ut-1336
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11607,7 +11801,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1309
+Index: geneve-ut-1337
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11617,11 +11811,31 @@ process.name == "setenforce" and process.args == "0"
 
 
 
+### Potential EDR-Freeze via WerFaultSecure Abuse
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1340
+
+```python
+process where host.os.type == "windows" and event.type == "start" and
+  process.executable : "?:\\Windows\\System32\\WerFaultSecure.exe" and
+
+  /* WerFaultSecure secure dumps are normally initiated by the WER service hosted in svchost.exe */
+  process.parent.executable != null and
+  not process.parent.executable : ("?:\\Windows\\System32\\svchost.exe", "?:\\Windows\\System32\\wermgr.exe", "?:\\Windows\\System32\\WerFault.exe", "?:\\Windows\\System32\\WerFaultSecure.exe") and
+
+  /* arguments used to take a secure memory dump of a target process (e.g. /pid <target> /encfile <handle> /type 268310) */
+  process.args : "/pid" and process.args : "/encfile"
+```
+
+
+
 ### Potential Enumeration via Active Directory Web Service
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1312
+Index: geneve-ut-1341
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11645,7 +11859,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1313
+Index: geneve-ut-1342
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11661,7 +11875,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1314
+Index: geneve-ut-1343
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11678,7 +11892,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1315
+Index: geneve-ut-1344
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11699,7 +11913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1317
+Index: geneve-ut-1346
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11712,7 +11926,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1319
+Index: geneve-ut-1348
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11740,7 +11954,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1322
+Index: geneve-ut-1351
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11756,7 +11970,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1323
+Index: geneve-ut-1352
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11779,7 +11993,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1324
+Index: geneve-ut-1353
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11792,7 +12006,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1326
+Index: geneve-ut-1355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11805,7 +12019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1331
+Index: geneve-ut-1360
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11819,7 +12033,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1332
+Index: geneve-ut-1361
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11834,7 +12048,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1334
+Index: geneve-ut-1363
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -11857,7 +12071,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1337
+Index: geneve-ut-1366
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11900,7 +12114,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1338
+Index: geneve-ut-1367
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11918,7 +12132,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1339
+Index: geneve-ut-1368
 
 ```python
 host.os.type:"windows" and
@@ -11934,7 +12148,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1341
+Index: geneve-ut-1370
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -11946,7 +12160,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1343
+Index: geneve-ut-1372
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -11962,14 +12176,14 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1344
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (process.name == "kubeletctl" or process.args like "*kubeletctl*") or
   (process.args in ("-s", "--server") and process.args in ("run", "portForward", "scan", "attach", "exec", "pods", "runningpods", "cri", "pid2pod"))
 ) and
-process.interactive == true and container.id like "?*"
+container.id like "?*"
 ```
 
 
@@ -11978,7 +12192,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1345
+Index: geneve-ut-1374
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11996,7 +12210,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1346
+Index: geneve-ut-1375
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12010,7 +12224,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1348
+Index: geneve-ut-1377
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12020,7 +12234,11 @@ sequence by host.id with maxspan=30s
   ] by process.entity_id
   /* add more executable / script extensions here if they are not noisy in your environment */
   [file where host.os.type == "windows" and event.type in ("creation", "change") and process.pid == 4 and user.id like ("S-1-5-21*", "S-1-12-*") and 
-   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl"))] by process.entity_id
+   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl")) and
+   not file.path : (
+     "?:\\Windows\\VeeamVssSupport\\*",
+     "?:\\Windows\\VeeamLogShipper\\*"
+   )] by process.entity_id
 ```
 
 
@@ -12029,7 +12247,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1350
+Index: geneve-ut-1379
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12045,7 +12263,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1351
+Index: geneve-ut-1380
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12058,7 +12276,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1352
+Index: geneve-ut-1381
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12088,7 +12306,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1358
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12111,7 +12329,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1359
+Index: geneve-ut-1388
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12130,7 +12348,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1364
+Index: geneve-ut-1393
 
 ```python
 process where host.os.type == "windows" and 
@@ -12272,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1365
+Index: geneve-ut-1394
 
 ```python
 process where host.os.type == "windows" and
@@ -12349,7 +12567,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1369
+Index: geneve-ut-1398
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12366,7 +12584,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1370
+Index: geneve-ut-1399
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12400,7 +12618,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1372
+Index: geneve-ut-1401
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12412,7 +12630,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1373
+Index: geneve-ut-1402
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12451,7 +12669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1375
+Index: geneve-ut-1405
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12464,7 +12682,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1380
+Index: geneve-ut-1410
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12478,7 +12696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1387
+Index: geneve-ut-1417
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12516,7 +12734,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1388
+Index: geneve-ut-1418
 
 ```python
 network where host.os.type == "windows" and
@@ -12542,7 +12760,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1391
+Index: geneve-ut-1421
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12557,7 +12775,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1394
+Index: geneve-ut-1424
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12571,7 +12789,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1395
+Index: geneve-ut-1425
 
 ```python
 file where host.os.type == "windows" and
@@ -12585,7 +12803,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1396
+Index: geneve-ut-1426
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12598,7 +12816,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1397
+Index: geneve-ut-1427
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12618,7 +12836,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1398
+Index: geneve-ut-1428
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12638,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1400
+Index: geneve-ut-1430
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12677,7 +12895,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1401
+Index: geneve-ut-1431
 
 ```python
 event.category:process and host.os.type:windows and
@@ -12872,7 +13090,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1416
+Index: geneve-ut-1446
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12888,7 +13106,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1417
+Index: geneve-ut-1447
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -12902,7 +13120,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1418
+Index: geneve-ut-1448
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -12916,7 +13134,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1419
+Index: geneve-ut-1449
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -12933,7 +13151,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1420
+Index: geneve-ut-1450
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -12947,7 +13165,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1421
+Index: geneve-ut-1451
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12963,7 +13181,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1426
+Index: geneve-ut-1456
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -12975,7 +13193,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1427
+Index: geneve-ut-1457
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -12991,7 +13209,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1428
+Index: geneve-ut-1458
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13011,7 +13229,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1430
+Index: geneve-ut-1460
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13051,7 +13269,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1432
+Index: geneve-ut-1462
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13063,7 +13281,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1433
+Index: geneve-ut-1463
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13084,7 +13302,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1434
+Index: geneve-ut-1464
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13105,7 +13323,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1435
+Index: geneve-ut-1465
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13126,7 +13344,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1436
+Index: geneve-ut-1466
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13152,7 +13370,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1437
+Index: geneve-ut-1467
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13168,7 +13386,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1438
+Index: geneve-ut-1468
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13182,7 +13400,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1440
+Index: geneve-ut-1470
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13205,7 +13423,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1442
+Index: geneve-ut-1472
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13222,7 +13440,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1443
+Index: geneve-ut-1473
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13245,7 +13463,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1444
+Index: geneve-ut-1474
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13258,7 +13476,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1445
+Index: geneve-ut-1475
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13272,7 +13490,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1446
+Index: geneve-ut-1476
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13289,7 +13507,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1447
+Index: geneve-ut-1477
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13343,7 +13561,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1448
+Index: geneve-ut-1478
 
 ```python
 any where host.os.type == "windows" and
@@ -13370,7 +13588,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1454
+Index: geneve-ut-1484
 
 ```python
 file where host.os.type == "windows" and
@@ -13385,7 +13603,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1455
+Index: geneve-ut-1485
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13416,7 +13634,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1456
+Index: geneve-ut-1486
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13430,7 +13648,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1457
+Index: geneve-ut-1487
 
 ```python
 sequence with maxspan=1m
@@ -13472,7 +13690,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1458
+Index: geneve-ut-1488
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13497,7 +13715,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1459
+Index: geneve-ut-1489
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13551,7 +13769,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1460
+Index: geneve-ut-1490
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13571,7 +13789,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1461
+Index: geneve-ut-1491
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13592,7 +13810,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1462
+Index: geneve-ut-1492
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13607,7 +13825,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1463
+Index: geneve-ut-1493
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13627,7 +13845,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1464
+Index: geneve-ut-1494
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13669,7 +13887,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1468
+Index: geneve-ut-1498
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13684,7 +13902,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1469
+Index: geneve-ut-1499
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13719,7 +13937,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1470
+Index: geneve-ut-1500
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13736,7 +13954,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1473
+Index: geneve-ut-1505
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13750,7 +13968,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1476
+Index: geneve-ut-1508
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13763,7 +13981,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1477
+Index: geneve-ut-1509
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13775,7 +13993,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1478
+Index: geneve-ut-1510
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -13790,7 +14008,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1480
+Index: geneve-ut-1512
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -13818,7 +14036,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1482
+Index: geneve-ut-1514
 
 ```python
 sequence by host.id with maxspan=1s
@@ -13843,7 +14061,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1486
+Index: geneve-ut-1518
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -13880,7 +14098,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1487
+Index: geneve-ut-1519
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13894,7 +14112,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1488
+Index: geneve-ut-1520
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -13910,7 +14128,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1489
+Index: geneve-ut-1521
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13924,7 +14142,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1490
+Index: geneve-ut-1522
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -13954,7 +14172,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1491
+Index: geneve-ut-1523
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -13983,7 +14201,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1492
+Index: geneve-ut-1524
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13999,7 +14217,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1493
+Index: geneve-ut-1525
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14013,7 +14231,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1494
+Index: geneve-ut-1526
 
 ```python
 file where host.os.type == "windows" and
@@ -14045,11 +14263,25 @@ file where host.os.type == "windows" and
 
 
 
+### Potential Tunneling via Tailscaled
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1529
+
+```python
+process where event.type == "start" and
+process.name like~ ("tailscaled", "tailscaled.exe") and
+process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
+```
+
+
+
 ### Potential Unauthorized Access via Wildcard Injection Detected
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1497
+Index: geneve-ut-1530
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14063,7 +14295,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1498
+Index: geneve-ut-1531
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14083,7 +14315,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1500
+Index: geneve-ut-1533
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14100,7 +14332,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1501
+Index: geneve-ut-1534
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14112,7 +14344,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1502
+Index: geneve-ut-1535
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14129,7 +14361,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1503
+Index: geneve-ut-1536
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14147,11 +14379,11 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1510
+Index: geneve-ut-1543
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
-file.name == "notify_on_release" and process.interactive == true and container.id like "*"
+file.name == "notify_on_release" and container.id like "*"
 ```
 
 
@@ -14160,7 +14392,7 @@ file.name == "notify_on_release" and process.interactive == true and container.i
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1511
+Index: geneve-ut-1544
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14187,11 +14419,11 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1512
+Index: geneve-ut-1545
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
-file.name == "release_agent" and process.interactive == true and container.id like "*"
+file.name == "release_agent" and container.id like "*"
 ```
 
 
@@ -14200,7 +14432,7 @@ file.name == "release_agent" and process.interactive == true and container.id li
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1513
+Index: geneve-ut-1546
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14214,7 +14446,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1515
+Index: geneve-ut-1548
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14463,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1516
+Index: geneve-ut-1549
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14254,7 +14486,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1518
+Index: geneve-ut-1551
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14271,7 +14503,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1521
+Index: geneve-ut-1554
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14284,7 +14516,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1523
+Index: geneve-ut-1556
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14308,7 +14540,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1524
+Index: geneve-ut-1557
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14336,7 +14568,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1540
+Index: geneve-ut-1573
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14353,11 +14585,39 @@ process where host.os.type == "linux" and event.type == "start" and
 
 
 
+### Privilege Boundary Enumeration Detected via Defend for Containers
+
+Branch count: 25  
+Document count: 25  
+Index: geneve-ut-1575
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.name in ("id", "whoami", "capsh", "getcap", "lsns")) or
+  (process.args in (
+     "id", "/bin/id", "/usr/bin/id", "/usr/local/bin/id",
+     "whoami", "/bin/whoami", "/usr/bin/whoami", "/usr/local/bin/whoami",
+     "capsh", "/bin/capsh", "/usr/bin/capsh", "/usr/local/bin/capsh",
+     "getcap", "/bin/getcap", "/usr/bin/getcap", "/usr/local/bin/getcap",
+     "lsns", "/bin/lsns", "/usr/bin/lsns", "/usr/local/bin/lsns"
+   ) and
+    /* default exclusion list to not FP on default multi-process commands */
+    not process.args in (
+      "man", "/bin/man", "/usr/bin/man", "/usr/local/bin/man",
+      "chmod", "/bin/chmod", "/usr/bin/chmod", "/usr/local/bin/chmod",
+      "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
+    )
+  )
+) and container.id like "?*"
+```
+
+
+
 ### Privilege Escalation via CAP_SETUID/SETGID Capabilities
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1543
+Index: geneve-ut-1577
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14397,7 +14657,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1544
+Index: geneve-ut-1578
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14414,7 +14674,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1545
+Index: geneve-ut-1579
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14428,7 +14688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1546
+Index: geneve-ut-1580
 
 ```python
 file where host.os.type == "windows" and
@@ -14447,7 +14707,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1547
+Index: geneve-ut-1581
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14461,7 +14721,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1549
+Index: geneve-ut-1583
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14479,7 +14739,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1551
+Index: geneve-ut-1585
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14497,7 +14757,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1554
+Index: geneve-ut-1588
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14511,7 +14771,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1556
+Index: geneve-ut-1590
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14526,7 +14786,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1557
+Index: geneve-ut-1591
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14549,7 +14809,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1559
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14631,7 +14891,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1560
+Index: geneve-ut-1594
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14652,7 +14912,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1561
+Index: geneve-ut-1595
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14678,7 +14938,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1564
+Index: geneve-ut-1598
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14731,7 +14991,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1565
+Index: geneve-ut-1599
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -14743,7 +15003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1566
+Index: geneve-ut-1600
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -14755,7 +15015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1567
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and
@@ -14770,7 +15030,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1568
+Index: geneve-ut-1602
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -14800,7 +15060,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1569
+Index: geneve-ut-1603
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -14860,7 +15120,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1572
+Index: geneve-ut-1606
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -14873,7 +15133,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1573
+Index: geneve-ut-1607
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14905,7 +15165,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1574
+Index: geneve-ut-1608
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -14929,7 +15189,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1576
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14962,7 +15222,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1577
+Index: geneve-ut-1611
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -14979,7 +15239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1579
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15008,7 +15268,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1580
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15022,7 +15282,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1581
+Index: geneve-ut-1615
 
 ```python
 sequence by process.entity_id
@@ -15047,7 +15307,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1582
+Index: geneve-ut-1616
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15081,7 +15341,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1583
+Index: geneve-ut-1617
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15109,7 +15369,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1584
+Index: geneve-ut-1618
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15128,7 +15388,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1590
+Index: geneve-ut-1624
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15156,7 +15416,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1591
+Index: geneve-ut-1625
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15175,7 +15435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1595
+Index: geneve-ut-1629
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15187,7 +15447,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1596
+Index: geneve-ut-1630
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15199,7 +15459,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1597
+Index: geneve-ut-1631
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15211,7 +15471,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1598
+Index: geneve-ut-1632
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15223,7 +15483,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1609
+Index: geneve-ut-1643
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15236,7 +15496,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1610
+Index: geneve-ut-1644
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15274,7 +15534,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1612
+Index: geneve-ut-1646
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15289,7 +15549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1613
+Index: geneve-ut-1647
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15308,7 +15568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1614
+Index: geneve-ut-1648
 
 ```python
 sequence with maxspan=1m
@@ -15356,7 +15616,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1616
+Index: geneve-ut-1650
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15379,7 +15639,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1618
+Index: geneve-ut-1652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15393,7 +15653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1619
+Index: geneve-ut-1653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15407,7 +15667,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1621
+Index: geneve-ut-1655
 
 ```python
 sequence by host.id, process.entity_id
@@ -15424,7 +15684,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1622
+Index: geneve-ut-1656
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15438,7 +15698,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1623
+Index: geneve-ut-1657
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15458,7 +15718,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1624
+Index: geneve-ut-1658
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15487,7 +15747,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1625
+Index: geneve-ut-1659
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15507,7 +15767,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1626
+Index: geneve-ut-1660
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15520,7 +15780,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1628
+Index: geneve-ut-1662
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15562,7 +15822,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1629
+Index: geneve-ut-1663
 
 ```python
 sequence with maxspan=1m
@@ -15585,7 +15845,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1630
+Index: geneve-ut-1664
 
 ```python
 sequence with maxspan=1s
@@ -15633,7 +15893,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1631
+Index: geneve-ut-1665
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15650,7 +15910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1633
+Index: geneve-ut-1667
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15679,7 +15939,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1635
+Index: geneve-ut-1669
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15707,7 +15967,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1636
+Index: geneve-ut-1670
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15724,7 +15984,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1638
+Index: geneve-ut-1672
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -15743,7 +16003,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1639
+Index: geneve-ut-1673
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -15764,12 +16024,12 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1648
+Index: geneve-ut-1682
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
 file.name in ("authorized_keys", "authorized_keys2") and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -15778,7 +16038,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1650
+Index: geneve-ut-1684
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -15797,7 +16057,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1651
+Index: geneve-ut-1685
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -15811,7 +16071,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1652
+Index: geneve-ut-1686
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -15831,7 +16091,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1654
+Index: geneve-ut-1688
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15849,7 +16109,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1655
+Index: geneve-ut-1689
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -15870,7 +16130,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1657
+Index: geneve-ut-1691
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15884,7 +16144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1658
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15899,7 +16159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1659
+Index: geneve-ut-1693
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -15940,7 +16200,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1661
+Index: geneve-ut-1695
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15965,7 +16225,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1662
+Index: geneve-ut-1696
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16004,7 +16264,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1663
+Index: geneve-ut-1697
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16018,7 +16278,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1664
+Index: geneve-ut-1698
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16057,7 +16317,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1665
+Index: geneve-ut-1699
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16071,7 +16331,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1666
+Index: geneve-ut-1700
 
 ```python
 process where event.type == "start" and
@@ -16143,7 +16403,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1670
+Index: geneve-ut-1704
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16164,7 +16424,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1673
+Index: geneve-ut-1707
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16181,7 +16441,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1676
+Index: geneve-ut-1710
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16199,7 +16459,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1677
+Index: geneve-ut-1711
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16211,7 +16471,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1678
+Index: geneve-ut-1712
 
 ```python
 file where host.os.type == "windows" and
@@ -16244,10 +16504,10 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1681
+Index: geneve-ut-1715
 
 ```python
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where host.os.type == "linux" and container.id like "*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and
   file.path in (
     "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
@@ -16276,10 +16536,10 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1683
+Index: geneve-ut-1717
 
 ```python
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where host.os.type == "linux" and container.id like "*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and
   file.path in (
     "/var/run/secrets/kubernetes.io/serviceaccount/token",
@@ -16312,7 +16572,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1684
+Index: geneve-ut-1718
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16329,7 +16589,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1685
+Index: geneve-ut-1719
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16349,7 +16609,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1687
+Index: geneve-ut-1721
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16364,7 +16624,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1688
+Index: geneve-ut-1722
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16385,7 +16645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1689
+Index: geneve-ut-1723
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16408,7 +16668,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1690
+Index: geneve-ut-1724
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16421,7 +16681,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1691
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16438,7 +16698,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1694
+Index: geneve-ut-1728
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16463,10 +16723,10 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1697
+Index: geneve-ut-1731
 
 ```python
-any where host.os.type == "linux" and event.category in ("file", "process") and process.interactive == true and container.id like "?*" and (
+any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
   (event.category == "file" and event.type == "deletion" and file.name in (".bash_history", ".sh_history",  ".zsh_history")) or
   (event.category == "process" and event.type == "start" and event.action == "exec" and (
     (
@@ -16494,7 +16754,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1698
+Index: geneve-ut-1732
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16543,7 +16803,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1699
+Index: geneve-ut-1733
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16557,7 +16817,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1700
+Index: geneve-ut-1734
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16572,7 +16832,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1701
+Index: geneve-ut-1735
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16587,7 +16847,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1702
+Index: geneve-ut-1736
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16609,7 +16869,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1703
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16630,7 +16890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1707
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16644,7 +16904,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1708
+Index: geneve-ut-1742
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16667,7 +16927,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1738
+Index: geneve-ut-1772
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16692,7 +16952,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1739
+Index: geneve-ut-1773
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16725,7 +16985,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1740
+Index: geneve-ut-1774
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -16784,7 +17044,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1742
+Index: geneve-ut-1776
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -16802,7 +17062,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1743
+Index: geneve-ut-1777
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -16814,7 +17074,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1746
+Index: geneve-ut-1780
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -16839,7 +17099,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1751
+Index: geneve-ut-1786
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16854,7 +17114,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1752
+Index: geneve-ut-1787
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -16877,7 +17137,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1755
+Index: geneve-ut-1790
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16891,7 +17151,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1757
+Index: geneve-ut-1792
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16913,7 +17173,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1759
+Index: geneve-ut-1794
 
 ```python
 sequence by host.id with maxspan=5s
@@ -16940,7 +17200,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1763
+Index: geneve-ut-1798
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -16979,7 +17239,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1764
+Index: geneve-ut-1799
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17002,7 +17262,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1765
+Index: geneve-ut-1800
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17016,7 +17276,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1766
+Index: geneve-ut-1801
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17032,7 +17292,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1767
+Index: geneve-ut-1802
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17048,7 +17308,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1768
+Index: geneve-ut-1803
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17062,7 +17322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1770
+Index: geneve-ut-1805
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17085,7 +17345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1771
+Index: geneve-ut-1806
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17113,7 +17373,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1772
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17128,7 +17388,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1775
+Index: geneve-ut-1810
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17155,7 +17415,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1777
+Index: geneve-ut-1812
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17186,7 +17446,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1778
+Index: geneve-ut-1813
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17202,7 +17462,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1779
+Index: geneve-ut-1814
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17215,7 +17475,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1781
+Index: geneve-ut-1816
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17231,7 +17491,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1782
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17247,7 +17507,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1783
+Index: geneve-ut-1818
 
 ```python
 any where host.os.type == "windows" and 
@@ -17314,7 +17574,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1785
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17330,7 +17590,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1787
+Index: geneve-ut-1822
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17366,7 +17626,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1788
+Index: geneve-ut-1823
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17404,7 +17664,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1789
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17439,7 +17699,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1790
+Index: geneve-ut-1825
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17473,7 +17733,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1792
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17492,9 +17752,9 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 ### Suspicious Execution via Windows Subsystem for Linux
 
-Branch count: 14  
-Document count: 14  
-Index: geneve-ut-1797
+Branch count: 201  
+Document count: 201  
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17508,9 +17768,58 @@ process where host.os.type == "windows" and event.type : "start" and
       process.parent.name : "wsl.exe" and process.parent.command_line : "bash*" and not process.name : "wslhost.exe"
     ) or
     (
-      process.name : "wsl.exe" and process.args : (
-        "curl", "/etc/shadow", "/etc/passwd", "cat", "--system", "root", "-e", "--exec", "bash", "/mnt/c/*"
-      ) and not process.args : ("wsl-bootstrap", "docker-desktop-data", "*.vscode-server*")
+      process.name : "wsl.exe" and
+      (
+        process.args : "--system" or
+        (
+          process.args : "--manage" and process.args : "--set-default-user" and process.args : "root"
+        ) or
+        (
+          (process.args : ("curl", "wget") and process.args : ("http://*", "https://*")) or
+          process.args : ("*curl*http://*", "*curl*https://*", "*wget*http://*", "*wget*https://*")
+        ) or
+        (
+          (
+            process.args like~ ("*/dev/tcp/*", "*/dev/udp/*", "*zsh/net/tcp*") and
+            process.args like ("*&>*", "*<>*", "*>&*", "*<&*")
+          ) or
+          (
+            process.args : ("nc", "netcat", "nc.traditional", "ncat", "*/nc", "*/netcat", "*/nc.traditional", "*/ncat") and
+            process.args : ("sh", "/bin/sh", "bash", "/bin/bash") and
+            process.args : ("-e", "--exec", "-c", "--sh-exec")
+          ) or
+          (
+            process.args like~ "*socat*" and
+            process.args like~ ("*exec:*", "*system:*", "*shell:*") and
+            process.args like~ ("*tcp*", "*udp*", "*openssl*")
+          )
+        ) or
+        (
+          process.args : ("-e", "--exec") and
+          process.args : (
+            "/mnt/c/*.exe", "/mnt/c/*.ps1", "/mnt/c/*.bat", "/mnt/c/*.cmd", "/mnt/c/*.vbs", "/mnt/c/*.js",
+            "/mnt/c/*.hta"
+          ) and
+          not process.args : "*wslpath*"
+        ) or
+        process.args : (
+          "*/etc/passwd*", "*/etc/shadow*", "*/etc/sudoers*", "*/etc/sudoers.d/*", "*/root/.ssh/*", "*/home/*/.ssh/*",
+          "*/root/.aws/credentials*", "*/home/*/.aws/credentials*", "*/root/.kube/config*", "*/home/*/.kube/config*",
+          "*/mnt/c/Windows/System32/config/SAM*",
+          "*/mnt/c/Windows/System32/config/SECURITY*",
+          "*/mnt/c/Windows/System32/config/SYSTEM", "*/mnt/c/Windows/System32/config/SYSTEM.*",
+          "*/mnt/c/Windows/NTDS/ntds.dit*",
+          "*/mnt/c/Users/*/AppData/Roaming/Microsoft/Credentials/*",
+          "*/mnt/c/Users/*/AppData/Local/Microsoft/Credentials/*",
+          "*/mnt/c/Users/*/AppData/Roaming/Microsoft/Protect/*",
+          "*/mnt/c/Users/*/.ssh/*",
+          "*/mnt/c/Users/*/.aws/credentials",
+          "*/mnt/c/Users/*/.azure/*",
+          "*/mnt/c/Users/*/.config/gcloud/*",
+          "*/mnt/c/Users/*/AppData/Local/Google/Chrome/User Data/*/Login Data*",
+          "*/mnt/c/Users/*/AppData/Local/Microsoft/Edge/User Data/*/Login Data*"
+        )
+      )
     )
   ) and
     not process.parent.executable : ("?:\\Program Files\\Docker\\*.exe", "?:\\Program Files (x86)\\Docker\\*.exe")
@@ -17520,21 +17829,21 @@ process where host.os.type == "windows" and event.type : "start" and
 
 ### Suspicious Execution with NodeJS
 
-Branch count: 18  
-Document count: 18  
-Index: geneve-ut-1798
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1833
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
 
-(process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or ?process.code_signature.subject_name : "OpenJS Foundation") and
+(process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or
+ ?process.code_signature.subject_name : ("OpenJS Foundation", "Node.js Foundation")) and
 
 (
-  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
+  (process.args : ("-r", "--require", "--require=*") and
+   process.parent.name : ("powershell.exe", "pwsh.exe")) or
 
-  (process.args : "-r" and process.parent.name : "powershell.exe") or
-
-   process.command_line : ("*eval(*", "*atob(*", "*require*child_process*")
+  process.command_line : ("*eval(*", "*atob(*", "*require*child_process*")
 )
 ```
 
@@ -17544,7 +17853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1799
+Index: geneve-ut-1834
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17568,7 +17877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1801
+Index: geneve-ut-1836
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17589,7 +17898,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1804
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17604,7 +17913,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1807
+Index: geneve-ut-1842
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17617,7 +17926,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1808
+Index: geneve-ut-1843
 
 ```python
 any where host.os.type == "windows" and
@@ -17632,7 +17941,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1809
+Index: geneve-ut-1844
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17648,7 +17957,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1810
+Index: geneve-ut-1845
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17662,10 +17971,10 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1814
+Index: geneve-ut-1849
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
 process.parent.executable != null and (
   (
     process.executable like ("/bin/perl*", "/usr/bin/perl*", "/usr/local/bin/perl*") and
@@ -17719,7 +18028,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1815
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +18042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1817
+Index: geneve-ut-1852
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -17765,7 +18074,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1819
+Index: geneve-ut-1854
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -17778,7 +18087,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1820
+Index: geneve-ut-1855
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -17797,7 +18106,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1821
+Index: geneve-ut-1856
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -17843,7 +18152,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1823
+Index: geneve-ut-1858
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17864,7 +18173,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1824
+Index: geneve-ut-1859
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -17884,7 +18193,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1825
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17898,7 +18207,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1826
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17930,7 +18239,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1829
+Index: geneve-ut-1864
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -17951,7 +18260,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1831
+Index: geneve-ut-1866
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18052,7 +18361,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1835
+Index: geneve-ut-1870
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18100,7 +18409,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1838
+Index: geneve-ut-1873
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18126,7 +18435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1839
+Index: geneve-ut-1874
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18171,7 +18480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1840
+Index: geneve-ut-1875
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18195,7 +18504,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1841
+Index: geneve-ut-1876
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18211,7 +18520,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1843
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18236,7 +18545,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1844
+Index: geneve-ut-1879
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18251,7 +18560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1847
+Index: geneve-ut-1882
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18265,7 +18574,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1848
+Index: geneve-ut-1883
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18285,7 +18594,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1849
+Index: geneve-ut-1884
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18320,10 +18629,10 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1853
+Index: geneve-ut-1888
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where event.type == "start" and event.action == "exec" and (
   process.executable like (
     "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/*", "/var/run/*", "/mnt/*", "/media/*", "/boot/*"
   ) or
@@ -18338,7 +18647,7 @@ process where event.type == "start" and event.action == "exec" and process.inter
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1854
+Index: geneve-ut-1889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18351,7 +18660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1857
+Index: geneve-ut-1892
 
 ```python
 any where host.os.type == "windows" and
@@ -18384,7 +18693,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1859
+Index: geneve-ut-1894
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18402,7 +18711,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1860
+Index: geneve-ut-1895
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18424,7 +18733,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1863
+Index: geneve-ut-1898
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18463,7 +18772,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1864
+Index: geneve-ut-1899
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18493,7 +18802,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1865
+Index: geneve-ut-1900
 
 ```python
 any where host.os.type == "windows" and
@@ -18527,7 +18836,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1866
+Index: geneve-ut-1901
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18541,7 +18850,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1869
+Index: geneve-ut-1904
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18572,7 +18881,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1870
+Index: geneve-ut-1905
 
 ```python
 any where host.os.type == "windows" and
@@ -18592,7 +18901,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1871
+Index: geneve-ut-1906
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18633,7 +18942,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1872
+Index: geneve-ut-1907
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18649,7 +18958,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1873
+Index: geneve-ut-1908
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18679,7 +18988,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1877
+Index: geneve-ut-1912
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -18692,7 +19001,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1878
+Index: geneve-ut-1913
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -18716,7 +19025,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1880
+Index: geneve-ut-1916
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18734,7 +19043,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1882
+Index: geneve-ut-1918
 
 ```python
 any where host.os.type == "windows" and
@@ -18749,7 +19058,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1883
+Index: geneve-ut-1919
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -18767,7 +19076,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1884
+Index: geneve-ut-1920
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -18788,7 +19097,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1885
+Index: geneve-ut-1921
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18807,7 +19116,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1888
+Index: geneve-ut-1924
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18832,7 +19141,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1889
+Index: geneve-ut-1925
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18845,7 +19154,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1891
+Index: geneve-ut-1927
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -18858,7 +19167,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1893
+Index: geneve-ut-1929
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18881,7 +19190,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1895
+Index: geneve-ut-1931
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18900,7 +19209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1896
+Index: geneve-ut-1932
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -18922,7 +19231,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1897
+Index: geneve-ut-1933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -18955,7 +19264,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1899
+Index: geneve-ut-1935
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18973,7 +19282,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1900
+Index: geneve-ut-1936
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -18987,7 +19296,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1901
+Index: geneve-ut-1937
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19011,7 +19320,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1902
+Index: geneve-ut-1938
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19034,7 +19343,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1903
+Index: geneve-ut-1939
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19053,10 +19362,10 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1906
+Index: geneve-ut-1942
 
 ```python
-file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and
+file where host.os.type == "linux" and event.type == "creation" and
 file.path like (
   "/etc/*", "/root/*", "/bin/*", "/usr/bin/*", "/usr/local/bin/*", "/entrypoint*"
 ) and (
@@ -19072,7 +19381,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1908
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19107,7 +19416,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1909
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19124,7 +19433,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1910
+Index: geneve-ut-1946
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19144,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1911
+Index: geneve-ut-1947
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19184,7 +19493,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1912
+Index: geneve-ut-1948
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19200,7 +19509,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1913
+Index: geneve-ut-1949
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19214,7 +19523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1914
+Index: geneve-ut-1950
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19252,7 +19561,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1915
+Index: geneve-ut-1951
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19306,7 +19615,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1916
+Index: geneve-ut-1952
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19334,7 +19643,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1918
+Index: geneve-ut-1954
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19348,7 +19657,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1919
+Index: geneve-ut-1955
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19394,7 +19703,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1920
+Index: geneve-ut-1956
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19433,7 +19742,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1921
+Index: geneve-ut-1957
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19446,7 +19755,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1925
+Index: geneve-ut-1961
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19479,7 +19788,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1926
+Index: geneve-ut-1962
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19493,7 +19802,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1927
+Index: geneve-ut-1963
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19507,7 +19816,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1928
+Index: geneve-ut-1964
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19521,7 +19830,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1929
+Index: geneve-ut-1965
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19560,7 +19869,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1936
+Index: geneve-ut-1973
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19602,10 +19911,10 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1938
+Index: geneve-ut-1975
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf") and process.args == "install") or
   (process.name == "apk" and process.args == "add") or
   (process.name == "pacman" and process.args like "-*S*") or
@@ -19624,7 +19933,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1940
+Index: geneve-ut-1977
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19637,7 +19946,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1943
+Index: geneve-ut-1980
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19654,7 +19963,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1944
+Index: geneve-ut-1981
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19670,7 +19979,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1945
+Index: geneve-ut-1982
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19683,7 +19992,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1946
+Index: geneve-ut-1983
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -19698,7 +20007,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1947
+Index: geneve-ut-1984
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19721,7 +20030,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1948
+Index: geneve-ut-1985
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19737,7 +20046,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1949
+Index: geneve-ut-1986
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19753,7 +20062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1955
+Index: geneve-ut-1992
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -19765,7 +20074,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1956
+Index: geneve-ut-1993
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19794,7 +20103,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1958
+Index: geneve-ut-1995
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -19808,7 +20117,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1963
+Index: geneve-ut-2000
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -19828,7 +20137,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1964
+Index: geneve-ut-2001
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -19853,7 +20162,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1971
+Index: geneve-ut-2008
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19867,7 +20176,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1972
+Index: geneve-ut-2009
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19890,7 +20199,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1981
+Index: geneve-ut-2018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19924,7 +20233,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1983
+Index: geneve-ut-2020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -19943,7 +20252,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-1990
+Index: geneve-ut-2027
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -19962,7 +20271,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2004
+Index: geneve-ut-2042
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -19979,7 +20288,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2007
+Index: geneve-ut-2045
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -19996,7 +20305,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2023
+Index: geneve-ut-2061
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20015,7 +20324,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2027
+Index: geneve-ut-2065
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20057,7 +20366,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2028
+Index: geneve-ut-2066
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20102,7 +20411,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2031
+Index: geneve-ut-2069
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20144,7 +20453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2033
+Index: geneve-ut-2071
 
 ```python
 host.os.type:"linux" and 
@@ -20172,7 +20481,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2037
+Index: geneve-ut-2075
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20196,7 +20505,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2038
+Index: geneve-ut-2076
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20236,7 +20545,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2039
+Index: geneve-ut-2077
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20283,7 +20592,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2043
+Index: geneve-ut-2081
 
 ```python
 sequence by process.entity_id
@@ -20320,7 +20629,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2075
+Index: geneve-ut-2113
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20334,7 +20643,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2076
+Index: geneve-ut-2114
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20377,7 +20686,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2077
+Index: geneve-ut-2115
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20390,7 +20699,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2080
+Index: geneve-ut-2118
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20404,7 +20713,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2081
+Index: geneve-ut-2119
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20417,7 +20726,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2085
+Index: geneve-ut-2123
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20442,7 +20751,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2086
+Index: geneve-ut-2124
 
 ```python
 process where event.type == "start" and
@@ -20457,7 +20766,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2087
+Index: geneve-ut-2125
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20474,7 +20783,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2088
+Index: geneve-ut-2126
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20488,7 +20797,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2089
+Index: geneve-ut-2127
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20504,7 +20813,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2090
+Index: geneve-ut-2128
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20518,7 +20827,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2091
+Index: geneve-ut-2129
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20545,7 +20854,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2093
+Index: geneve-ut-2131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20557,7 +20866,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2094
+Index: geneve-ut-2132
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20573,7 +20882,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2095
+Index: geneve-ut-2133
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20596,7 +20905,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2096
+Index: geneve-ut-2134
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20609,7 +20918,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2098
+Index: geneve-ut-2136
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20621,7 +20930,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2099
+Index: geneve-ut-2137
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20633,7 +20942,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2100
+Index: geneve-ut-2138
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20645,7 +20954,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2101
+Index: geneve-ut-2139
 
 ```python
 web where (
@@ -20673,7 +20982,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2107
+Index: geneve-ut-2145
 
 ```python
 any where (
@@ -20745,7 +21054,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2109
+Index: geneve-ut-2147
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20766,7 +21075,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2112
+Index: geneve-ut-2150
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -20780,7 +21089,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2113
+Index: geneve-ut-2151
 
 ```python
 file where event.type == "deletion" and
@@ -20797,7 +21106,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2114
+Index: geneve-ut-2152
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20815,7 +21124,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2117
+Index: geneve-ut-2155
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20853,7 +21162,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2119
+Index: geneve-ut-2157
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20890,7 +21199,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2120
+Index: geneve-ut-2158
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20905,7 +21214,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2121
+Index: geneve-ut-2159
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -20918,7 +21227,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2122
+Index: geneve-ut-2160
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20937,10 +21246,10 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2123
+Index: geneve-ut-2161
 
 ```python
-sequence with maxspan=1m
+sequence by host.id with maxspan=1m
   [registry where host.os.type == "windows" and event.type == "change" and process.name : "msiexec.exe" and
    (
     (registry.value : "InstallSource" and
@@ -20962,7 +21271,7 @@ sequence with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2124
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20988,7 +21297,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2125
+Index: geneve-ut-2163
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21010,7 +21319,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2126
+Index: geneve-ut-2164
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21027,7 +21336,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2128
+Index: geneve-ut-2166
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21046,7 +21355,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2129
+Index: geneve-ut-2167
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21086,7 +21395,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2130
+Index: geneve-ut-2168
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21103,7 +21412,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2132
+Index: geneve-ut-2170
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21116,7 +21425,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2133
+Index: geneve-ut-2171
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21130,7 +21439,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2134
+Index: geneve-ut-2172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21158,7 +21467,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2135
+Index: geneve-ut-2173
 
 ```python
 process where event.type == "start" and
@@ -21183,7 +21492,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2136
+Index: geneve-ut-2174
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21197,7 +21506,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2137
+Index: geneve-ut-2175
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21213,7 +21522,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2138
+Index: geneve-ut-2176
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21248,7 +21557,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2139
+Index: geneve-ut-2177
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21266,7 +21575,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2142
+Index: geneve-ut-2180
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-serverless.md
+++ b/tests/reports/alerts_from_rules-serverless.md
@@ -5,22 +5,22 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.8
+Rules version: 9.5.2
 
 ## Table of contents
-   1. [Failed rules (23)](#failed-rules-23)
-   1. [Unsuccessful rules with signals (23)](#unsuccessful-rules-with-signals-23)
+   1. [Failed rules (24)](#failed-rules-24)
+   1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
-   1. [Rules with too few signals (27)](#rules-with-too-few-signals-27)
+   1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
    1. [Rules with the correct signals (804)](#rules-with-the-correct-signals-804)
 
-## Failed rules (23)
+## Failed rules (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0352  
+Index: geneve-ut-0367  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -66,7 +66,122 @@ process.args like~ (
   "*/.config/gcloud/*", "*application_default_credentials.json*",
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*",
   "*/var/run/secrets/google/*", "*GOOGLE_APPLICATION_CREDENTIALS*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
+```
+
+
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0378  
+Failure message(s):  
+  SDE says:
+> This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
 ```
 
 
@@ -75,7 +190,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0630  
+Index: geneve-ut-0646  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -144,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0655  
+Index: geneve-ut-0671  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -173,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0780  
+Index: geneve-ut-0805  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -204,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0975  
+Index: geneve-ut-0998  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -257,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1119  
+Index: geneve-ut-1143  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -290,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1147  
+Index: geneve-ut-1173  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -324,7 +439,7 @@ process.args like~ (
   "-*e*",
   /* file transfer via stdout/pipe */
   ">","<", "|"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -333,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1219  
+Index: geneve-ut-1245  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -374,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1248  
+Index: geneve-ut-1274  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -400,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1265  
+Index: geneve-ut-1292  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -438,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1327  
+Index: geneve-ut-1356  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -460,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1342  
+Index: geneve-ut-1371  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -501,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1431  
+Index: geneve-ut-1461  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -564,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1671  
+Index: geneve-ut-1705  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -601,7 +716,7 @@ process.args like~ (
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*", "*/var/run/secrets/google/*",
   "*GOOGLE_APPLICATION_CREDENTIALS*", "*AZURE_CLIENT_ID*", "*AZURE_TENANT_ID*", "*AZURE_CLIENT_SECRET*",
   "*AZURE_FEDERATED_TOKEN_FILE*", "*IDENTITY_ENDPOINT*", "*IDENTITY_HEADER*", "*MSI_ENDPOINT*", "*MSI_SECRET*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -610,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1675  
+Index: geneve-ut-1709  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -644,7 +759,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 process.args like~ (
   "*BEGIN PRIVATE*", "*BEGIN OPENSSH PRIVATE*", "*BEGIN RSA PRIVATE*", "*BEGIN DSA PRIVATE*", "*BEGIN EC PRIVATE*",
   "*password*", "*ssh*", "*id_rsa*", "*id_dsa*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -653,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1758  
+Index: geneve-ut-1793  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -701,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1773  
+Index: geneve-ut-1808  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -736,13 +851,13 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1786  
+Index: geneve-ut-1821  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
 process.args in ("-lc", "-c", "-cl") and process.args like ("*echo *", "*printf *") and
 process.args like (
@@ -761,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1796  
+Index: geneve-ut-1831  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -824,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1802  
+Index: geneve-ut-1837  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -852,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1811  
+Index: geneve-ut-1846  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -884,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1907  
+Index: geneve-ut-1943  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -949,7 +1064,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -959,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1937  
+Index: geneve-ut-1974  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -997,18 +1112,18 @@ process.args in (
   "nmap", "zenmap", "nuclei", "netdiscover", "legion", "masscan", "zmap", "zgrab", "ngrep", "telnet", "mitmproxy", "zmap",
   "masscan", "zgrab"
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
 
-## Unsuccessful rules with signals (23)
+## Unsuccessful rules with signals (24)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0352
+Index: geneve-ut-0367
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1051,7 +1166,119 @@ process.args like~ (
   "*/.config/gcloud/*", "*application_default_credentials.json*",
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*",
   "*/var/run/secrets/google/*", "*GOOGLE_APPLICATION_CREDENTIALS*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
+```
+
+
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0378
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
 ```
 
 
@@ -1060,7 +1287,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0630
+Index: geneve-ut-0646
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1126,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0655
+Index: geneve-ut-0671
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1152,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0780
+Index: geneve-ut-0805
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1180,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0975
+Index: geneve-ut-0998
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1230,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1119
+Index: geneve-ut-1143
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1260,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1147
+Index: geneve-ut-1173
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1291,7 +1518,7 @@ process.args like~ (
   "-*e*",
   /* file transfer via stdout/pipe */
   ">","<", "|"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -1300,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1219
+Index: geneve-ut-1245
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1338,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1248
+Index: geneve-ut-1274
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1361,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1265
+Index: geneve-ut-1292
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1396,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1327
+Index: geneve-ut-1356
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1415,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1342
+Index: geneve-ut-1371
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1453,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1431
+Index: geneve-ut-1461
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1513,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1671
+Index: geneve-ut-1705
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1547,7 +1774,7 @@ process.args like~ (
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*", "*/var/run/secrets/google/*",
   "*GOOGLE_APPLICATION_CREDENTIALS*", "*AZURE_CLIENT_ID*", "*AZURE_TENANT_ID*", "*AZURE_CLIENT_SECRET*",
   "*AZURE_FEDERATED_TOKEN_FILE*", "*IDENTITY_ENDPOINT*", "*IDENTITY_HEADER*", "*MSI_ENDPOINT*", "*MSI_SECRET*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -1556,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1675
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1587,7 +1814,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 process.args like~ (
   "*BEGIN PRIVATE*", "*BEGIN OPENSSH PRIVATE*", "*BEGIN RSA PRIVATE*", "*BEGIN DSA PRIVATE*", "*BEGIN EC PRIVATE*",
   "*password*", "*ssh*", "*id_rsa*", "*id_dsa*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -1596,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1758
+Index: geneve-ut-1793
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1641,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1773
+Index: geneve-ut-1808
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1673,10 +1900,10 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1786
+Index: geneve-ut-1821
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
 process.args in ("-lc", "-c", "-cl") and process.args like ("*echo *", "*printf *") and
 process.args like (
@@ -1695,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1796
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1755,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1802
+Index: geneve-ut-1837
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1780,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1811
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -1809,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1907
+Index: geneve-ut-1943
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -1871,7 +2098,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -1881,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1937
+Index: geneve-ut-1974
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1916,7 +2143,7 @@ process.args in (
   "nmap", "zenmap", "nuclei", "netdiscover", "legion", "masscan", "zmap", "zgrab", "ngrep", "telnet", "mitmproxy", "zmap",
   "masscan", "zgrab"
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -1927,7 +2154,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0232
+Index: geneve-ut-0239
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1941,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0976
+Index: geneve-ut-0999
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1953,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0996
+Index: geneve-ut-1019
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1965,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1378
+Index: geneve-ut-1408
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1983,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1575
+Index: geneve-ut-1609
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -1994,13 +2221,13 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 
 
-## Rules with too few signals (27)
+## Rules with too few signals (28)
 
 ### Cloud Credential Search Detected via Defend for Containers
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0352  
+Index: geneve-ut-0367  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2045,7 +2272,121 @@ process.args like~ (
   "*/.config/gcloud/*", "*application_default_credentials.json*",
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*",
   "*/var/run/secrets/google/*", "*GOOGLE_APPLICATION_CREDENTIALS*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
+```
+
+
+
+### Component Object Model Hijacking
+
+Branch count: 1680  
+Document count: 1680  
+Index: geneve-ut-0378  
+Failure message(s):  
+  got 1000 signals, expected 1680  
+
+```python
+registry where host.os.type == "windows" and event.type == "change" and
+  /* not necessary but good for filtering privileged installations */
+  user.domain != "NT AUTHORITY" and process.executable != null and 
+  (
+    (
+      registry.path : "HK*\\InprocServer32\\" and
+      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
+      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
+    ) or
+
+    (
+      registry.path : "HKLM\\*\\InProcServer32\\*" and
+        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
+    ) or
+
+    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
+    (
+      registry.path : (
+        "HKEY_USERS\\*\\InprocServer32\\",
+        "HKEY_USERS\\*\\LocalServer32\\",
+        "HKEY_USERS\\*\\DelegateExecute",
+        "HKEY_USERS\\*\\TreatAs\\",
+        "HKEY_USERS\\*\\ScriptletURL*", 
+        "HKEY_USERS\\*\\TypeLib*\\Win*"
+      ) and
+      not registry.data.strings : (
+            /* COM related to Windows Spotlight feature */
+            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
+
+            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
+            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
+            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
+            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
+      )
+    )
+  ) and 
+
+  not (
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name in (
+        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
+        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
+        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
+        "Vivaldi Technologies AS"
+    )
+  ) and 
+
+  /* excludes trusted applications registering their own COM components */
+  not (
+    process.code_signature.trusted == true and
+    (
+      (
+        process.name : "OneDrive.Sync.Service.exe" and
+        process.code_signature.subject_name == "Microsoft Corporation" and
+        registry.data.strings : (
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.exe*",
+          "*\\Microsoft\\OneDrive\\*\\OneDrive.Sync.Service.dll*"
+        )
+      ) or
+      (
+        process.executable : "?:\\Users\\*\\AppData\\Local\\Kingsoft\\WPS Office\\*\\office6\\ksomisc.exe" and
+        process.code_signature.subject_name == "WPS SOFTWARE PTE. LTD." and
+        registry.data.strings : "*\\Kingsoft\\WPS Office\\*"
+      ) or
+      (
+        process.name : "claude.exe" and
+        process.code_signature.subject_name == "Anthropic, PBC" and
+        registry.data.strings : (
+          "*\\Users\\*\\AppData\\Local\\AnthropicClaude\\app-*\\claude.exe*",
+          "*\\ProgramData\\*\\AnthropicClaude\\app-*\\claude.exe*"
+        )
+      )
+    )
+  ) and
+
+  /* excludes Microsoft signed noisy processes */
+  not
+  (
+    process.name : (
+      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
+      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
+    ) and
+    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
+  ) and
+
+  not process.executable : (
+        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
+        "?:\\Program Files (x86)\\*.exe",
+        "?:\\Program Files\\*.exe",
+        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
+        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
+        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
+        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
+        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
+        "?:\\Windows\\System32\\FMToastNotification.exe",
+        "?:\\Windows\\System32\\msiexec.exe",
+        "?:\\Windows\\System32\\svchost.exe",
+        "?:\\Windows\\SysWOW64\\regsvr32.exe",
+        "?:\\Windows\\System32\\regsvr32.exe",
+        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
+  )
 ```
 
 
@@ -2054,7 +2395,7 @@ process.args like~ (
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0630  
+Index: geneve-ut-0646  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2122,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0655  
+Index: geneve-ut-0671  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2150,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0780  
+Index: geneve-ut-0805  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2180,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0948  
+Index: geneve-ut-0971  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2199,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0975  
+Index: geneve-ut-0998  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2251,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1097  
+Index: geneve-ut-1121  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2271,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1119  
+Index: geneve-ut-1143  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2303,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1147  
+Index: geneve-ut-1173  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2336,7 +2677,7 @@ process.args like~ (
   "-*e*",
   /* file transfer via stdout/pipe */
   ">","<", "|"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -2345,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1219  
+Index: geneve-ut-1245  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2385,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1248  
+Index: geneve-ut-1274  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2410,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1265  
+Index: geneve-ut-1292  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2447,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1327  
+Index: geneve-ut-1356  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2468,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1342  
+Index: geneve-ut-1371  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2508,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1422  
+Index: geneve-ut-1452  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2525,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1431  
+Index: geneve-ut-1461  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2587,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1542  
+Index: geneve-ut-1576  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2612,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1671  
+Index: geneve-ut-1705  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2648,7 +2989,7 @@ process.args like~ (
   "*type: service_account*", "*client_email*", "*private_key_id*", "*private_key*", "*/var/run/secrets/google/*",
   "*GOOGLE_APPLICATION_CREDENTIALS*", "*AZURE_CLIENT_ID*", "*AZURE_TENANT_ID*", "*AZURE_CLIENT_SECRET*",
   "*AZURE_FEDERATED_TOKEN_FILE*", "*IDENTITY_ENDPOINT*", "*IDENTITY_HEADER*", "*MSI_ENDPOINT*", "*MSI_SECRET*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -2657,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1675  
+Index: geneve-ut-1709  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -2690,7 +3031,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 process.args like~ (
   "*BEGIN PRIVATE*", "*BEGIN OPENSSH PRIVATE*", "*BEGIN RSA PRIVATE*", "*BEGIN DSA PRIVATE*", "*BEGIN EC PRIVATE*",
   "*password*", "*ssh*", "*id_rsa*", "*id_dsa*"
-) and process.interactive == true and container.id like "*"
+) and container.id like "*"
 ```
 
 
@@ -2699,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1758  
+Index: geneve-ut-1793  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -2746,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1773  
+Index: geneve-ut-1808  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -2780,12 +3121,12 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1786  
+Index: geneve-ut-1821  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and
+process where event.type == "start" and event.action == "exec" and
 process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
 process.args in ("-lc", "-c", "-cl") and process.args like ("*echo *", "*printf *") and
 process.args like (
@@ -2804,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1796  
+Index: geneve-ut-1831  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -2866,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1802  
+Index: geneve-ut-1837  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -2893,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1811  
+Index: geneve-ut-1846  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -2924,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1907  
+Index: geneve-ut-1943  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -2988,7 +3329,7 @@ not (
   process.executable : (
     "?:\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe",
     "\\Device\\HarddiskVolume*\\ProgramData\\Microsoft\\Windows Defender\\platform\\*\\*.exe"
-  ) and user.id == "S-1-5-18"
+  ) and user.id in ("S-1-5-18", "S-1-5-19")
 )
 ```
 
@@ -2998,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1937  
+Index: geneve-ut-1974  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3035,7 +3376,7 @@ process.args in (
   "nmap", "zenmap", "nuclei", "netdiscover", "legion", "masscan", "zmap", "zgrab", "ngrep", "telnet", "mitmproxy", "zmap",
   "masscan", "zgrab"
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -3133,7 +3474,7 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0050
+Index: geneve-ut-0052
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -3151,7 +3492,7 @@ process.command_line like~ (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0067
+Index: geneve-ut-0069
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3168,7 +3509,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0099
+Index: geneve-ut-0102
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3187,7 +3528,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0106
+Index: geneve-ut-0109
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
@@ -3200,7 +3541,7 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0117
+Index: geneve-ut-0121
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3232,7 +3573,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0125
+Index: geneve-ut-0130
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3248,7 +3589,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0127
+Index: geneve-ut-0132
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3263,7 +3604,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0147
+Index: geneve-ut-0152
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
@@ -3276,7 +3617,7 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0183
+Index: geneve-ut-0189
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3292,7 +3633,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0184
+Index: geneve-ut-0190
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -3307,7 +3648,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0194
+Index: geneve-ut-0201
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -3322,7 +3663,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0203
+Index: geneve-ut-0210
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3346,7 +3687,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0204
+Index: geneve-ut-0211
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -3381,7 +3722,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0205
+Index: geneve-ut-0212
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -3398,7 +3739,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0206
+Index: geneve-ut-0213
 
 ```python
 any where host.os.type == "windows" and
@@ -3423,7 +3764,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0208
+Index: geneve-ut-0215
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -3451,7 +3792,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0210
+Index: geneve-ut-0217
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3464,7 +3805,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0212
+Index: geneve-ut-0219
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -3480,7 +3821,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0213
+Index: geneve-ut-0220
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3500,7 +3841,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0214
+Index: geneve-ut-0221
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3521,7 +3862,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0215
+Index: geneve-ut-0222
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3533,7 +3874,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0218
+Index: geneve-ut-0225
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3545,7 +3886,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0230
+Index: geneve-ut-0237
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3562,7 +3903,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0231
+Index: geneve-ut-0238
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3574,7 +3915,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0233
+Index: geneve-ut-0240
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3594,7 +3935,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0234
+Index: geneve-ut-0241
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3608,7 +3949,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0238
+Index: geneve-ut-0245
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3639,7 +3980,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0239
+Index: geneve-ut-0246
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3651,7 +3992,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0240
+Index: geneve-ut-0247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3665,7 +4006,7 @@ process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clea
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0241
+Index: geneve-ut-0248
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3680,7 +4021,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0251
+Index: geneve-ut-0258
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -3699,7 +4040,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0252
+Index: geneve-ut-0259
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3713,7 +4054,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0254
+Index: geneve-ut-0261
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -3744,7 +4085,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0255
+Index: geneve-ut-0262
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3767,7 +4108,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0256
+Index: geneve-ut-0263
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3781,7 +4122,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0257
+Index: geneve-ut-0264
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3800,7 +4141,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0258
+Index: geneve-ut-0265
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3814,7 +4155,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0259
+Index: geneve-ut-0266
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3839,7 +4180,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0264
+Index: geneve-ut-0271
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3858,7 +4199,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0267
+Index: geneve-ut-0274
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3871,7 +4212,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0269
+Index: geneve-ut-0276
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3913,7 +4254,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0276
+Index: geneve-ut-0283
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -3928,7 +4269,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0309
+Index: geneve-ut-0323
 
 ```python
 event.dataset:azure.activitylogs and
@@ -3942,7 +4283,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0312
+Index: geneve-ut-0326
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -3960,7 +4301,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0330
+Index: geneve-ut-0344
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3978,7 +4319,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0331
+Index: geneve-ut-0345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3996,7 +4337,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0332
+Index: geneve-ut-0346
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4011,7 +4352,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0333
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4025,7 +4366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0334
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4040,7 +4381,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0337
+Index: geneve-ut-0351
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4057,7 +4398,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0338
+Index: geneve-ut-0352
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4069,7 +4410,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0339
+Index: geneve-ut-0353
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4081,7 +4422,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0340
+Index: geneve-ut-0354
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4096,7 +4437,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0341
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4116,7 +4457,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0342
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4138,7 +4479,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0344
+Index: geneve-ut-0358
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4184,7 +4525,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0345
+Index: geneve-ut-0359
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4218,7 +4559,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0346
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4241,7 +4582,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0347
+Index: geneve-ut-0362
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4263,7 +4604,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0348
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4291,7 +4632,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0349
+Index: geneve-ut-0364
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4307,7 +4648,7 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0351
+Index: geneve-ut-0366
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4332,7 +4673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0353
+Index: geneve-ut-0368
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4362,7 +4703,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0355
+Index: geneve-ut-0370
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4376,7 +4717,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0356
+Index: geneve-ut-0371
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4398,7 +4739,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0357
+Index: geneve-ut-0372
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4412,7 +4753,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0358
+Index: geneve-ut-0373
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4432,7 +4773,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0361
+Index: geneve-ut-0376
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4445,95 +4786,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Component Object Model Hijacking
-
-Branch count: 60  
-Document count: 60  
-Index: geneve-ut-0363
-
-```python
-registry where host.os.type == "windows" and event.type == "change" and
-  /* not necessary but good for filtering privileged installations */
-  user.domain != "NT AUTHORITY" and process.executable != null and 
-  (
-    (
-      registry.path : "HK*\\InprocServer32\\" and
-      registry.data.strings: ("scrobj.dll", "?:\\*\\scrobj.dll") and
-      not registry.path : "*\\{06290BD*-48AA-11D2-8432-006008C3FBFC}\\*"
-    ) or
-
-    (
-      registry.path : "HKLM\\*\\InProcServer32\\*" and
-        registry.data.strings : ("*\\Users\\*", "*\\ProgramData\\*")
-    ) or
-
-    /* in general COM Registry changes on Users Hive is less noisy and worth alerting */
-    (
-      registry.path : (
-        "HKEY_USERS\\*\\InprocServer32\\",
-        "HKEY_USERS\\*\\LocalServer32\\",
-        "HKEY_USERS\\*\\DelegateExecute",
-        "HKEY_USERS\\*\\TreatAs\\",
-        "HKEY_USERS\\*\\ScriptletURL*", 
-        "HKEY_USERS\\*\\TypeLib*\\Win*"
-      ) and
-      not registry.data.strings : (
-            /* COM related to Windows Spotlight feature */
-            "{4813071a-41ad-44a2-9835-886d2f63ca30}",
-
-            /* AppX/MSIX DelegateExecute handlers: execute, protocol, file */
-            "{A56A841F-E974-45C1-8001-7E3F8A085917}",
-            "{4ED3A719-CEA8-4BD9-910D-E252F997AFC2}",
-            "{BFEC0C93-0B7D-4F2C-B09C-AFFFC4BDAE78}"
-      )
-    )
-  ) and 
-
-  not (
-    process.code_signature.trusted == true and
-    process.code_signature.subject_name in (
-        "Island Technology Inc.", "Google LLC", "Grammarly, Inc.", "Dropbox, Inc", "REFINITIV US LLC", "HP Inc.", "Adobe Inc.",
-        "Citrix Systems, Inc.", "Veeam Software Group GmbH", "Zhuhai Kingsoft Office Software Co., Ltd.", "Oracle America, Inc.",
-        "Brave Software, Inc.", "DeepL SE", "Opera Norway AS", "Thomas Braun", "Slack Technologies, LLC", "Spotify AB",
-        "Vivaldi Technologies AS"
-    )
-  ) and 
-
-  /* excludes Microsoft signed noisy processes */
-  not
-  (
-    process.name : (
-      "OneDrive.exe", "OneDriveSetup.exe", "FileSyncConfig.exe", "Teams.exe", "MicrosoftEdgeUpdate.exe", "msrdcw.exe",
-      "MicrosoftEdgeUpdateComRegisterShell64.exe", "setup.exe", "PowerToys.PowerLauncher.exe"
-    ) and
-    process.code_signature.trusted == true and process.code_signature.subject_name in ("Microsoft Windows", "Microsoft Corporation")
-  ) and
-
-  not process.executable : (
-        "?:\\$WINDOWS.~BT\\Sources\\SetupHost.exe",
-        "?:\\Program Files (x86)\\*.exe",
-        "?:\\Program Files\\*.exe",
-        "?:\\ProgramData\\4Team\\4Team-Updater\\4Team-Updater-Helper.exe",
-        "?:\\ProgramData\\Lenovo\\Udc\\Hosts\\x64\\MessagingPlugin.exe",
-        "?:\\ProgramData\\Microsoft\\Windows Defender\\Platform\\*\\MsMpEng.exe",
-        "?:\\Users\\*\\AppData\\Local\\Wondershare\\Wondershare NativePush\\WsToastNotification.exe",
-        "?:\\Windows\\System32\\DriverStore\\FileRepository\\*.exe",
-        "?:\\Windows\\System32\\FMToastNotification.exe",
-        "?:\\Windows\\System32\\msiexec.exe",
-        "?:\\Windows\\System32\\svchost.exe",
-        "?:\\Windows\\SysWOW64\\regsvr32.exe",
-        "?:\\Windows\\System32\\regsvr32.exe",
-        "\\Device\\Mup\\*\\Kufer\\KuferSQL\\BasysSQL.exe"
-  )
-```
-
-
-
 ### Compression DLL Loaded by Unusual Process
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0364
+Index: geneve-ut-0379
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4563,7 +4820,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0367
+Index: geneve-ut-0382
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4588,7 +4845,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0369
+Index: geneve-ut-0384
 
 ```python
 sequence by process.entity_id
@@ -4609,7 +4866,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0370
+Index: geneve-ut-0385
 
 ```python
 sequence by process.entity_id
@@ -4630,7 +4887,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0373
+Index: geneve-ut-0388
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4661,7 +4918,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0374
+Index: geneve-ut-0389
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4673,7 +4930,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0375
+Index: geneve-ut-0390
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4696,7 +4953,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0378
+Index: geneve-ut-0393
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4709,7 +4966,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0379
+Index: geneve-ut-0394
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4722,7 +4979,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0381
+Index: geneve-ut-0396
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4739,7 +4996,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0382
+Index: geneve-ut-0397
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -4752,7 +5009,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0383
+Index: geneve-ut-0398
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -4769,7 +5026,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0384
+Index: geneve-ut-0399
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -4781,7 +5038,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0385
+Index: geneve-ut-0400
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -4849,7 +5106,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0386
+Index: geneve-ut-0401
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -4867,7 +5124,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0387
+Index: geneve-ut-0402
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -4880,7 +5137,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0388
+Index: geneve-ut-0403
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4898,7 +5155,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0389
+Index: geneve-ut-0404
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4910,7 +5167,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0390
+Index: geneve-ut-0405
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4922,7 +5179,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0391
+Index: geneve-ut-0406
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4934,7 +5191,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0392
+Index: geneve-ut-0407
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4946,7 +5203,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0393
+Index: geneve-ut-0408
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -4991,7 +5248,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0395
+Index: geneve-ut-0410
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5011,7 +5268,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0396
+Index: geneve-ut-0411
 
 ```python
 sequence with maxspan=10s
@@ -5031,7 +5288,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0397
+Index: geneve-ut-0412
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5058,12 +5315,12 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0398
+Index: geneve-ut-0413
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
 process.name == "curl" and process.args like ("--socks5-hostname", "--proxy", "--preproxy", "socks5*", "-x") and
-process.interactive == true and container.id like "?*"
+container.id like "?*"
 ```
 
 
@@ -5072,7 +5329,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0401
+Index: geneve-ut-0416
 
 ```python
 process where event.type == "start" and
@@ -5097,7 +5354,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0404
+Index: geneve-ut-0419
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5141,7 +5398,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0405
+Index: geneve-ut-0420
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5175,11 +5432,11 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0407
+Index: geneve-ut-0422
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.interactive == true and container.id like "*" and 
+container.id like "*" and 
 (
   /* getent hosts is often used without a target arg */
   (process.name == "getent" and process.args == "hosts") or
@@ -5220,7 +5477,7 @@ process.interactive == true and container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0408
+Index: geneve-ut-0423
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5236,7 +5493,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0409
+Index: geneve-ut-0424
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5261,7 +5518,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0410
+Index: geneve-ut-0425
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5280,7 +5537,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0412
+Index: geneve-ut-0427
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5407,7 +5664,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0413
+Index: geneve-ut-0428
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5425,7 +5682,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0415
+Index: geneve-ut-0430
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5438,7 +5695,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0416
+Index: geneve-ut-0431
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5459,7 +5716,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
   )
 ) and
 process.args like "/dev/sd*" and not process.args == "-R" and
-container.security_context.privileged == true and process.interactive == true and container.id like "*"
+container.security_context.privileged == true and container.id like "*"
 ```
 
 
@@ -5468,7 +5725,7 @@ container.security_context.privileged == true and process.interactive == true an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0422
+Index: geneve-ut-0437
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5482,7 +5739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0434
+Index: geneve-ut-0449
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5503,7 +5760,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0441
+Index: geneve-ut-0456
 
 ```python
 registry where host.os.type == "windows" and
@@ -5517,7 +5774,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0453
+Index: geneve-ut-0468
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5537,52 +5794,11 @@ event.category: "process" and host.os.type:windows and
 
 
 
-### Deprecated - Potential CVE-2025-41244 vmtoolsd LPE Exploitation Attempt
-
-Branch count: 54  
-Document count: 54  
-Index: geneve-ut-0456
-
-```python
-process where host.os.type == "linux" and event.type == "start" and
-event.action in ("exec", "exec_event", "start", "executed", "process_started", "ProcessRollup2") and
-(
-  (
-    process.parent.name == "vmtoolsd"
-  ) or
-  (
-    process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and
-    ?process.parent.args like ("/*/open-vm-tools/serviceDiscovery/scripts/get-versions.sh")
-  )
-) and not (
-  process.executable == null or
-  ?process.parent.args == "--version" or
-  process.args like (
-    "/etc/vmware-tools/resume-vm-default",
-    "/etc/vmware-tools/suspend-vm-default",
-    "/sbin/shutdown",
-    "/sbin/shutdown*",
-    "/etc/vmware-tools/poweroff-vm-default",
-    "/etc/vmware-tools/poweroff-vm-default",
-    "/bin/touch",
-    "/tmp/vmware-administrator_*",
-    "/tmp/vmware-root_*",
-    "/etc/vmware-tools/scripts/vmware/network",
-    "/etc/vmware-tools/poweron-vm-default"
-  ) or
-  process.executable == "/usr/sbin/unix_chkpwd" or
-  ?process.working_directory like ("/var/opt/ds_agent", "/tmp/vmware-root_*/tmpvmware*") or
-  process.command_line like ("*/usr/bin/lsb_release*", "*/bin/touch*", "*/tmp/vmware-root_*")
-)
-```
-
-
-
-### Direct Interactive Kubernetes API Request Detected via Defend for Containers
+### Direct Kubernetes API Request Detected via Defend for Containers
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0491
+Index: geneve-ut-0507
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5627,7 +5843,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
   (process.name == "ncat" and process.args like "--ssl*") or
   (process.name == "kubectl" and process.args in ("get", "list", "watch", "create", "patch", "update"))
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -5636,7 +5852,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0494
+Index: geneve-ut-0509
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5652,7 +5868,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0495
+Index: geneve-ut-0510
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5680,7 +5896,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0496
+Index: geneve-ut-0511
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5697,7 +5913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0497
+Index: geneve-ut-0512
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5714,7 +5930,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0498
+Index: geneve-ut-0513
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5735,7 +5951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0500
+Index: geneve-ut-0515
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5755,7 +5971,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0501
+Index: geneve-ut-0516
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5770,7 +5986,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0503
+Index: geneve-ut-0518
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5783,7 +5999,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0504
+Index: geneve-ut-0519
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5803,7 +6019,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0507
+Index: geneve-ut-0522
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -5816,7 +6032,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0508
+Index: geneve-ut-0523
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5854,7 +6070,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0509
+Index: geneve-ut-0524
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -5874,7 +6090,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0510
+Index: geneve-ut-0525
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5887,7 +6103,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0511
+Index: geneve-ut-0526
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5910,7 +6126,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0513
+Index: geneve-ut-0528
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5941,7 +6157,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0514
+Index: geneve-ut-0529
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -5960,7 +6176,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0515
+Index: geneve-ut-0530
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6003,12 +6219,12 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0516
+Index: geneve-ut-0531
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
 file.path like ("/etc/ld.so.preload", "/etc/ld.so.conf.d/*", "/etc/ld.so.conf") and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -6017,7 +6233,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0518
+Index: geneve-ut-0533
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6032,7 +6248,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0519
+Index: geneve-ut-0534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6048,7 +6264,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0520
+Index: geneve-ut-0535
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6062,7 +6278,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0521
+Index: geneve-ut-0536
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6088,7 +6304,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0522
+Index: geneve-ut-0537
 
 ```python
 process where event.type == "start" and
@@ -6126,11 +6342,11 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0529
+Index: geneve-ut-0544
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
- file.path like ("/private/etc/emond.d/rules/*.plist", "/etc/emon.d/rules/*.plist", "/private/var/db/emondClients/*")
+ file.path like ("/private/etc/emond.d/rules/*.plist", "/etc/emond.d/rules/*.plist", "/private/var/db/emondClients/*")
 ```
 
 
@@ -6139,7 +6355,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0530
+Index: geneve-ut-0545
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6153,10 +6369,10 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0531
+Index: geneve-ut-0546
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (process.name in ("base64", "base64plain", "base64url", "base64mime", "base64pem", "base32", "base16") and process.args like~ "*-*d*") or
   (process.name == "xxd" and process.args like~ ("-*r*", "-*p*")) or
   (process.name == "openssl" and process.args == "enc" and process.args in ("-d", "-base64", "-a")) or
@@ -6175,7 +6391,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0532
+Index: geneve-ut-0547
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6210,7 +6426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0533
+Index: geneve-ut-0548
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6222,7 +6438,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0581
+Index: geneve-ut-0596
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6234,7 +6450,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0607
+Index: geneve-ut-0622
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6248,7 +6464,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0610
+Index: geneve-ut-0625
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6275,7 +6491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0613
+Index: geneve-ut-0628
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6296,7 +6512,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0614
+Index: geneve-ut-0629
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6317,7 +6533,25 @@ process where host.os.type == "linux" and event.type == "start" and event.action
     )
   )
 ) and
-process.interactive == true and container.id like "*"
+container.id like "*"
+```
+
+
+
+### Exec Into Container Detected via Defend for Containers
+
+Branch count: 9  
+Document count: 9  
+Index: geneve-ut-0632
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
+process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "busybox") and
+process.entry_leader.entry_meta.type == "container" and
+
+/* process is the initial process run in a container */
+process.entry_leader.same_as_process == true and
+container.id like "*"
 ```
 
 
@@ -6326,7 +6560,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0617
+Index: geneve-ut-0633
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6359,7 +6593,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0619
+Index: geneve-ut-0635
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6376,7 +6610,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0620
+Index: geneve-ut-0636
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6404,7 +6638,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0621
+Index: geneve-ut-0637
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6417,7 +6651,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0623
+Index: geneve-ut-0639
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6437,7 +6671,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0624
+Index: geneve-ut-0640
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6463,7 +6697,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0625
+Index: geneve-ut-0641
 
 ```python
 sequence with maxspan=2h
@@ -6485,7 +6719,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0626
+Index: geneve-ut-0642
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6514,7 +6748,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0629
+Index: geneve-ut-0645
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6527,7 +6761,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0633
+Index: geneve-ut-0649
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6542,7 +6776,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0634
+Index: geneve-ut-0650
 
 ```python
 process where event.type == "start" and
@@ -6564,7 +6798,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0636
+Index: geneve-ut-0652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6576,7 +6810,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0637
+Index: geneve-ut-0653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6598,7 +6832,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0639
+Index: geneve-ut-0655
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6615,7 +6849,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0640
+Index: geneve-ut-0656
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6629,7 +6863,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0641
+Index: geneve-ut-0657
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6642,7 +6876,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0642
+Index: geneve-ut-0658
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6654,7 +6888,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0643
+Index: geneve-ut-0659
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6666,7 +6900,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0644
+Index: geneve-ut-0660
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6680,7 +6914,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0645
+Index: geneve-ut-0661
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6690,15 +6924,15 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 ### External IP Address Discovery via Curl
 
-Branch count: 304  
-Document count: 304  
-Index: geneve-ut-0646
+Branch count: 342  
+Document count: 342  
+Index: geneve-ut-0662
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
   ((process.parent.executable like ("/Applications/*", "/Volumes/*", "/private/var/folders/*")) or
    (process.parent.name in ("bash", "sh", "zsh") and process.parent.command_line like "*http*") or
-   (process.parent.code_signature.trusted == false or process.code_signature.exists == false)) and
+   (process.parent.code_signature.trusted == false or process.parent.code_signature.exists == false or process.code_signature.exists == false)) and
   process.name in ("curl", "nscurl") and
   process.args_count <= 5 and
   process.command_line like ("*ip-api.com*", "*ipwho.is*", "*checkip.dyndns.org*", "*api.ipify.org*",
@@ -6714,7 +6948,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0650
+Index: geneve-ut-0666
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6763,15 +6997,15 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0651
+Index: geneve-ut-0667
 
 ```python
 sequence by container.id, user.id with maxspan=3s
-  [file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and container.id like "?*" and
+  [file where host.os.type == "linux" and event.type == "creation" and container.id like "?*" and
    file.path like ("/tmp/*", "/var/tmp/*", "/dev/shm/*", "/root/*", "/home/*") and
    not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf", "apk", "pacman", "rpm", "dpkg")] by file.path
   [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-   process.interactive == true and container.id like "?*"] by process.executable
+   container.id like "?*"] by process.executable
 ```
 
 
@@ -6780,7 +7014,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0652
+Index: geneve-ut-0668
 
 ```python
 sequence by host.id with maxspan=10s
@@ -6800,10 +7034,10 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0657
+Index: geneve-ut-0673
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (
     (process.name == "curl" or process.args in ("curl", "/bin/curl", "/usr/bin/curl", "/usr/local/bin/curl")) and
     process.args in ("-o", "-O", "--output", "--remote-name", "--remote-name-all", "--output-dir")
@@ -6822,7 +7056,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0660
+Index: geneve-ut-0676
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -6837,7 +7071,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0661
+Index: geneve-ut-0677
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6851,7 +7085,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0663
+Index: geneve-ut-0679
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6873,7 +7107,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0665
+Index: geneve-ut-0681
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -6894,7 +7128,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0666
+Index: geneve-ut-0682
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6920,7 +7154,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0667
+Index: geneve-ut-0683
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -6948,7 +7182,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0670
+Index: geneve-ut-0686
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -6962,7 +7196,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0705
+Index: geneve-ut-0724
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -6979,7 +7213,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0706
+Index: geneve-ut-0725
 
 ```python
 registry where host.os.type == "windows" and
@@ -6997,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0770
+Index: geneve-ut-0795
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7036,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0771
+Index: geneve-ut-0796
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7063,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0772
+Index: geneve-ut-0797
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7078,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0773
+Index: geneve-ut-0798
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7165,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0781
+Index: geneve-ut-0806
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7183,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0782
+Index: geneve-ut-0807
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7214,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0783
+Index: geneve-ut-0808
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7241,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0784
+Index: geneve-ut-0809
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7261,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0788
+Index: geneve-ut-0813
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7274,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0791
+Index: geneve-ut-0816
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7286,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0794
+Index: geneve-ut-0819
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7298,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0798
+Index: geneve-ut-0823
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7310,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0800
+Index: geneve-ut-0825
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7327,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0826
+Index: geneve-ut-0851
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7340,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0829
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7364,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0830
+Index: geneve-ut-0855
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7376,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0843
+Index: geneve-ut-0868
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7394,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0844
+Index: geneve-ut-0869
 
 ```python
 any where process.executable != null and
@@ -7443,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0845
+Index: geneve-ut-0870
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7457,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0849
+Index: geneve-ut-0874
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7472,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0855
+Index: geneve-ut-0880
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7489,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0857
+Index: geneve-ut-0882
 
 ```python
 sequence with maxspan=1m
@@ -7508,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0858
+Index: geneve-ut-0883
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7526,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0859
+Index: geneve-ut-0884
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7545,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0860
+Index: geneve-ut-0885
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7561,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0861
+Index: geneve-ut-0886
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7577,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0862
+Index: geneve-ut-0887
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7590,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0867
+Index: geneve-ut-0892
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7607,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0869
+Index: geneve-ut-0894
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7620,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0870
+Index: geneve-ut-0895
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7636,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0871
+Index: geneve-ut-0896
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7663,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0872
+Index: geneve-ut-0897
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7683,59 +7917,11 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 
 
-### Interactive Exec Into Container Detected via Defend for Containers
-
-Branch count: 9  
-Document count: 9  
-Index: geneve-ut-0873
-
-```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
-process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish", "busybox") and
-process.entry_leader.entry_meta.type == "container" and
-
-/* process is the inital process run in a container */
-process.entry_leader.same_as_process == true and
-
-/* interactive process */
-process.interactive == true and container.id like "*"
-```
-
-
-
-### Interactive Privilege Boundary Enumeration Detected via Defend for Containers
-
-Branch count: 25  
-Document count: 25  
-Index: geneve-ut-0875
-
-```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
-  (process.name in ("id", "whoami", "capsh", "getcap", "lsns")) or
-  (process.args in (
-     "id", "/bin/id", "/usr/bin/id", "/usr/local/bin/id",
-     "whoami", "/bin/whoami", "/usr/bin/whoami", "/usr/local/bin/whoami",
-     "capsh", "/bin/capsh", "/usr/bin/capsh", "/usr/local/bin/capsh",
-     "getcap", "/bin/getcap", "/usr/bin/getcap", "/usr/local/bin/getcap",
-     "lsns", "/bin/lsns", "/usr/bin/lsns", "/usr/local/bin/lsns"
-   ) and
-    /* default exclusion list to not FP on default multi-process commands */
-    not process.args in (
-      "man", "/bin/man", "/usr/bin/man", "/usr/local/bin/man",
-      "chmod", "/bin/chmod", "/usr/bin/chmod", "/usr/local/bin/chmod",
-      "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
-    )
-  )
-) and container.id like "?*"
-```
-
-
-
 ### Interactive Terminal Spawned via Python
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0879
+Index: geneve-ut-0902
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7759,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0881
+Index: geneve-ut-0904
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7795,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0882
+Index: geneve-ut-0905
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7807,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0883
+Index: geneve-ut-0906
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -7821,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0884
+Index: geneve-ut-0907
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -7834,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0885
+Index: geneve-ut-0908
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -7893,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0886
+Index: geneve-ut-0909
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -7906,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0887
+Index: geneve-ut-0910
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -7919,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0888
+Index: geneve-ut-0911
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7940,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0889
+Index: geneve-ut-0912
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7958,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0890
+Index: geneve-ut-0913
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7992,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0892
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8014,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0894
+Index: geneve-ut-0917
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8041,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0895
+Index: geneve-ut-0918
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8067,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0896
+Index: geneve-ut-0919
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8083,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0897
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8099,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0899
+Index: geneve-ut-0922
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8111,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0900
+Index: geneve-ut-0923
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8139,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0902
+Index: geneve-ut-0925
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8155,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0904
+Index: geneve-ut-0927
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8180,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0905
+Index: geneve-ut-0928
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8194,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0907
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8217,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0908
+Index: geneve-ut-0931
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8250,10 +8436,10 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0909
+Index: geneve-ut-0932
 
 ```python
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where host.os.type == "linux" and container.id like "*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and file.path like "/var/lib/kubelet/pki/*") or
   (event.category == "process" and event.type == "start" and event.action == "exec" and
   (
@@ -8277,7 +8463,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0912
+Index: geneve-ut-0935
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8298,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0913
+Index: geneve-ut-0936
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8325,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0923
+Index: geneve-ut-0946
 
 ```python
 process where event.type == "start" and
@@ -8347,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0949
+Index: geneve-ut-0972
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8366,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0952
+Index: geneve-ut-0975
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8410,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0954
+Index: geneve-ut-0977
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8435,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0966
+Index: geneve-ut-0989
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8473,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0971
+Index: geneve-ut-0994
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8491,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0972
+Index: geneve-ut-0995
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8505,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0977
+Index: geneve-ut-1000
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8520,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0992
+Index: geneve-ut-1015
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8534,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0995
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8548,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0997
+Index: geneve-ut-1020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8569,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-0998
+Index: geneve-ut-1021
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8599,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1002
+Index: geneve-ut-1025
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8646,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1003
+Index: geneve-ut-1026
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8673,36 +8859,11 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 
 
-### Local Scheduled Task Creation
-
-Branch count: 600  
-Document count: 1200  
-Index: geneve-ut-1004
-
-```python
-sequence with maxspan=1m
-  [process where host.os.type == "windows" and event.type == "start" and
-    ((process.name : ("cmd.exe", "wscript.exe", "rundll32.exe", "regsvr32.exe", "wmic.exe", "mshta.exe",
-                      "powershell.exe", "pwsh.exe", "powershell_ise.exe", "WmiPrvSe.exe", "wsmprovhost.exe", "winrshost.exe") or
-    process.pe.original_file_name : ("cmd.exe", "wscript.exe", "rundll32.exe", "regsvr32.exe", "wmic.exe", "mshta.exe",
-                                     "powershell.exe", "pwsh.dll", "powershell_ise.exe", "WmiPrvSe.exe", "wsmprovhost.exe",
-                                     "winrshost.exe")) or
-    ?process.code_signature.trusted == false)] by process.entity_id
-  [process where host.os.type == "windows" and event.type == "start" and
-    (process.name : "schtasks.exe" or process.pe.original_file_name == "schtasks.exe") and
-    process.args : ("/create", "-create") and process.args : ("/RU", "/SC", "/TN", "/TR", "/F", "/XML") and
-    /* exclude SYSTEM Integrity Level - look for task creations by non-SYSTEM user */
-    not (?process.Ext.token.integrity_level_name : "System" or ?winlog.event_data.IntegrityLevel : "System")
-  ] by process.parent.entity_id
-```
-
-
-
 ### M365 AIR Investigation Signal
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1006
+Index: geneve-ut-1029
 
 ```python
 event.dataset:o365.audit and
@@ -8715,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1008
+Index: geneve-ut-1031
 
 ```python
 event.dataset:o365.audit and
@@ -8728,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1009
+Index: geneve-ut-1032
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8740,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1045
+Index: geneve-ut-1068
 
 ```python
 event.dataset:o365.audit and
@@ -8753,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1046
+Index: geneve-ut-1069
 
 ```python
 event.dataset:o365.audit and
@@ -8766,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1047
+Index: geneve-ut-1070
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8778,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1048
+Index: geneve-ut-1071
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8790,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1049
+Index: geneve-ut-1072
 
 ```python
 event.dataset:o365.audit and
@@ -8803,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1057
+Index: geneve-ut-1080
 
 ```python
 event.dataset: "o365.audit" and
@@ -8816,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1060
+Index: geneve-ut-1083
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8836,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1061
+Index: geneve-ut-1084
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -8848,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1062
+Index: geneve-ut-1085
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -8860,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1066
+Index: geneve-ut-1089
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -8872,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1067
+Index: geneve-ut-1090
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -8884,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1069
+Index: geneve-ut-1092
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -8896,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1070
+Index: geneve-ut-1093
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -8908,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1071
+Index: geneve-ut-1094
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8933,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1072
+Index: geneve-ut-1095
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8953,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1073
+Index: geneve-ut-1096
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -8966,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1074
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8977,11 +9138,36 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 
 
+### Mark-of-the-Web Removal by an Unusual Process
+
+Branch count: 12  
+Document count: 12  
+Index: geneve-ut-1098
+
+```python
+file where host.os.type == "windows" and event.type == "deletion" and
+  file.path : (
+    "*.exe:Zone.Identifier",
+    "*.exe:Zone.Identifier:$DATA",
+    "*.msi:Zone.Identifier",
+    "*.msi:Zone.Identifier:$DATA"
+  ) and
+
+  /* Explorer may remove MOTW after SmartScreen */
+  not (
+    process.executable : "?:\\Windows\\explorer.exe" and
+    process.code_signature.trusted == true and
+    process.code_signature.subject_name : "Microsoft Windows"
+  )
+```
+
+
+
 ### Member Removed From GitHub Organization
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1076
+Index: geneve-ut-1100
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -8993,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1079
+Index: geneve-ut-1103
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9005,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1080
+Index: geneve-ut-1104
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9017,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1081
+Index: geneve-ut-1105
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9051,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1084
+Index: geneve-ut-1108
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9065,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1085
+Index: geneve-ut-1109
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9086,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1086
+Index: geneve-ut-1110
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9100,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1090
+Index: geneve-ut-1114
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9135,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1091
+Index: geneve-ut-1115
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9160,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1092
+Index: geneve-ut-1116
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9177,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1096
+Index: geneve-ut-1120
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9191,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1098
+Index: geneve-ut-1122
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9222,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1100
+Index: geneve-ut-1124
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9276,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1101
+Index: geneve-ut-1125
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9288,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1103
+Index: geneve-ut-1127
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9306,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1104
+Index: geneve-ut-1128
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9323,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1106
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9338,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1107
+Index: geneve-ut-1131
 
 ```python
 file where event.type != "deletion" and
@@ -9388,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1109
+Index: geneve-ut-1133
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9404,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1110
+Index: geneve-ut-1134
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9416,22 +9602,28 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 ### Mofcomp Activity
 
-Branch count: 2  
-Document count: 2  
-Index: geneve-ut-1112
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
   process.name : "mofcomp.exe" and process.args : "*.mof" and
   not user.id : "S-1-5-18" and
-  not
-  (
-    process.parent.name : "ScenarioEngine.exe" and
-    process.args : (
-      "*\\MSSQL\\Binn\\*.mof",
-      "*\\Microsoft SQL Server\\???\\Shared\\*.mof",
-      "*\\OLAP\\bin\\*.mof"
-    )
+  not process.args : (
+    "?:\\Program Files (x86)\\Microsoft Power BI Report Server\\*.mof",
+    "?:\\Program Files (x86)\\Microsoft SQL Server Reporting Services\\*.mof",
+    "?:\\Program Files (x86)\\Microsoft SQL Server\\*.mof",
+    "?:\\Program Files\\Microsoft Policy Platform\\*.mof",
+    "?:\\Program Files\\Microsoft Power BI Report Server\\*.mof",
+    "?:\\Program Files\\Microsoft SQL Server Reporting Services\\*.mof",
+    "?:\\Program Files\\Microsoft SQL Server\\*.mof",
+    "?:\\Windows\\System32\\wbem\\com.hp.provider.*.mof",
+    "?:\\Windows\\System32\\wbem\\CxAudioSvc_*.mof",
+    "?:\\Windows\\System32\\wbem\\Framework\\root\\*.mof",
+    "?:\\Windows\\System32\\wbem\\Veeam.Backup.*.mof",
+    "?:\\Windows\\System32\\wbem\\ZTITatoo.mof",
+    "?:\\Windows\\SysWOW64\\wbem\\Framework\\root\\*.mof"
   )
 ```
 
@@ -9441,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1113
+Index: geneve-ut-1137
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9460,7 +9652,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
       "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
     )
   )
-) and container.security_context.privileged == true and process.interactive == true and container.id like "*"
+) and container.security_context.privileged == true and container.id like "*"
 ```
 
 
@@ -9469,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1114
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9491,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1115
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9510,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1116
+Index: geneve-ut-1140
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9543,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1117
+Index: geneve-ut-1141
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9561,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1118
+Index: geneve-ut-1142
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9602,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1131
+Index: geneve-ut-1155
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9628,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1139
+Index: geneve-ut-1164
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9652,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1142
+Index: geneve-ut-1168
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9666,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1143
+Index: geneve-ut-1169
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9685,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1144
+Index: geneve-ut-1170
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9705,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1145
+Index: geneve-ut-1171
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9728,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1146
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9749,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1148
+Index: geneve-ut-1174
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9764,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1149
+Index: geneve-ut-1175
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9781,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1151
+Index: geneve-ut-1177
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9805,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1153
+Index: geneve-ut-1179
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -9851,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1154
+Index: geneve-ut-1180
 
 ```python
 sequence by host.id with maxspan=1s
@@ -9893,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1155
+Index: geneve-ut-1181
 
 ```python
 sequence by host.id with maxspan=10s
@@ -9910,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1157
+Index: geneve-ut-1183
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9925,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1158
+Index: geneve-ut-1184
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -9944,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1159
+Index: geneve-ut-1185
 
 ```python
 sequence by process.entity_id
@@ -9964,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1160
+Index: geneve-ut-1186
 
 ```python
 sequence by process.entity_id
@@ -9983,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1162
+Index: geneve-ut-1188
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10012,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1163
+Index: geneve-ut-1189
 
 ```python
 sequence by process.entity_id
@@ -10037,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1164
+Index: geneve-ut-1190
 
 ```python
 sequence by process.entity_id
@@ -10059,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1165
+Index: geneve-ut-1191
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10092,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1166
+Index: geneve-ut-1192
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10122,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1170
+Index: geneve-ut-1196
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10139,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1171
+Index: geneve-ut-1197
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10176,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1172
+Index: geneve-ut-1198
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10189,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1177
+Index: geneve-ut-1203
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10201,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1180
+Index: geneve-ut-1206
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10213,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1189
+Index: geneve-ut-1215
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10227,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1190
+Index: geneve-ut-1216
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10241,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1191
+Index: geneve-ut-1217
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10255,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1192
+Index: geneve-ut-1218
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10275,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1194
+Index: geneve-ut-1220
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10288,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1195
+Index: geneve-ut-1221
 
 ```python
 event.dataset: "okta.system"
@@ -10303,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1197
+Index: geneve-ut-1223
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10325,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1206
+Index: geneve-ut-1232
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10352,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1207
+Index: geneve-ut-1233
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10372,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1208
+Index: geneve-ut-1234
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10387,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1209
+Index: geneve-ut-1235
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10414,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1210
+Index: geneve-ut-1236
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10429,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1211
+Index: geneve-ut-1237
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10445,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1212
+Index: geneve-ut-1238
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10459,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1213
+Index: geneve-ut-1239
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10469,7 +10661,7 @@ file where host.os.type == "linux" and event.type in ("creation", "change") and 
   ) or
   process.name like ("php-fpm*", "lsphp*", "*.cgi", "*.fcgi")
 ) and
-file.path like~ "*/wp-content/plugins/*.php*"
+file.path like~ "*/wp-content/plugins/*"
 ```
 
 
@@ -10478,7 +10670,7 @@ file.path like~ "*/wp-content/plugins/*.php*"
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1220
+Index: geneve-ut-1246
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10493,7 +10685,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1221
+Index: geneve-ut-1247
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10507,7 +10699,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1222
+Index: geneve-ut-1248
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10526,7 +10718,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1223
+Index: geneve-ut-1249
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10538,7 +10730,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1224
+Index: geneve-ut-1250
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10550,7 +10742,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1225
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10568,7 +10760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1226
+Index: geneve-ut-1252
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10581,7 +10773,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1227
+Index: geneve-ut-1253
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10596,7 +10788,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1228
+Index: geneve-ut-1254
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10611,7 +10803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1231
+Index: geneve-ut-1257
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10631,7 +10823,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1232
+Index: geneve-ut-1258
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10655,7 +10847,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1233
+Index: geneve-ut-1259
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10669,7 +10861,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1234
+Index: geneve-ut-1260
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10686,9 +10878,9 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 ### Persistence via Scheduled Job Creation
 
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-1235
+Branch count: 2  
+Document count: 2  
+Index: geneve-ut-1261
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10698,12 +10890,14 @@ file where host.os.type == "windows" and event.type != "deletion" and
       process.executable : "?:\\Program Files\\CCleaner\\CCleaner64.exe" and
       file.path : "?:\\Windows\\Tasks\\CCleanerCrashReporting.job"
     ) or
-    (
-      process.executable : (
-        "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\bin\\dcagentregister.exe",
-        "?:\\Program Files (x86)\\DesktopCentral_Agent\\bin\\dcagentregister.exe"
-      ) and
-      file.path : "?:\\Windows\\Tasks\\DCAgentUpdater.job"
+    process.executable : (
+      "?:\\Program Files (x86)\\DesktopCentral_Agent\\bin\\dcagentregister.exe",
+      "?:\\Program Files (x86)\\epson\\Epson Scan 2\\Update\\e_dtsksd.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\bin\\dcagentregister.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\dcconfig.exe",
+      "?:\\Program Files (x86)\\ManageEngine\\UEMS_Agent\\Updates\\UemsComponentUpgrader.exe",
+      "?:\\Program Files (x86)\\Skillbrains\\Updater\\*\\Updater.exe",
+      "?:\\Windows\\System32\\drivers\\RivetNetworks\\Killer\\CustomizeInstallFirstRun.exe"
     )
   )
 ```
@@ -10714,7 +10908,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1236
+Index: geneve-ut-1262
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10743,7 +10937,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1237
+Index: geneve-ut-1263
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10762,7 +10956,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1238
+Index: geneve-ut-1264
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10790,7 +10984,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1239
+Index: geneve-ut-1265
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10805,7 +10999,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1240
+Index: geneve-ut-1266
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10868,7 +11062,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1241
+Index: geneve-ut-1267
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -10889,7 +11083,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1242
+Index: geneve-ut-1268
 
 ```python
 any where host.os.type == "windows" and
@@ -10951,7 +11145,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1244
+Index: geneve-ut-1270
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -10980,7 +11174,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1245
+Index: geneve-ut-1271
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -10994,7 +11188,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1246
+Index: geneve-ut-1272
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11027,7 +11221,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1249
+Index: geneve-ut-1275
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11074,7 +11268,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1250
+Index: geneve-ut-1276
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11101,7 +11295,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1251
+Index: geneve-ut-1277
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11114,7 +11308,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1261
+Index: geneve-ut-1288
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11131,7 +11325,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1263
+Index: geneve-ut-1290
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11156,7 +11350,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1268
+Index: geneve-ut-1295
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11172,7 +11366,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1269
+Index: geneve-ut-1296
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11193,7 +11387,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1270
+Index: geneve-ut-1298
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11210,11 +11404,11 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1271
+Index: geneve-ut-1299
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
-process.interactive == true and container.id like "?*"
+container.id like "?*"
 ```
 
 
@@ -11223,7 +11417,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1272
+Index: geneve-ut-1300
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11247,7 +11441,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1274
+Index: geneve-ut-1302
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11276,7 +11470,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1276
+Index: geneve-ut-1304
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11303,7 +11497,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1277
+Index: geneve-ut-1305
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11327,7 +11521,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1280
+Index: geneve-ut-1308
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11345,7 +11539,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1281
+Index: geneve-ut-1309
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11368,7 +11562,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1282
+Index: geneve-ut-1310
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11425,7 +11619,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1283
+Index: geneve-ut-1311
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11442,7 +11636,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1284
+Index: geneve-ut-1312
 
 ```python
 sequence by process.entity_id
@@ -11456,7 +11650,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1299
+Index: geneve-ut-1327
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11471,7 +11665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1300
+Index: geneve-ut-1328
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11502,7 +11696,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1301
+Index: geneve-ut-1329
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11516,7 +11710,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1302
+Index: geneve-ut-1330
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11529,7 +11723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1303
+Index: geneve-ut-1331
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11541,7 +11735,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1304
+Index: geneve-ut-1332
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11554,7 +11748,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1306
+Index: geneve-ut-1334
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11573,7 +11767,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1307
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11586,7 +11780,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1308
+Index: geneve-ut-1336
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11607,7 +11801,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1309
+Index: geneve-ut-1337
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11617,11 +11811,31 @@ process.name == "setenforce" and process.args == "0"
 
 
 
+### Potential EDR-Freeze via WerFaultSecure Abuse
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-1340
+
+```python
+process where host.os.type == "windows" and event.type == "start" and
+  process.executable : "?:\\Windows\\System32\\WerFaultSecure.exe" and
+
+  /* WerFaultSecure secure dumps are normally initiated by the WER service hosted in svchost.exe */
+  process.parent.executable != null and
+  not process.parent.executable : ("?:\\Windows\\System32\\svchost.exe", "?:\\Windows\\System32\\wermgr.exe", "?:\\Windows\\System32\\WerFault.exe", "?:\\Windows\\System32\\WerFaultSecure.exe") and
+
+  /* arguments used to take a secure memory dump of a target process (e.g. /pid <target> /encfile <handle> /type 268310) */
+  process.args : "/pid" and process.args : "/encfile"
+```
+
+
+
 ### Potential Enumeration via Active Directory Web Service
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1312
+Index: geneve-ut-1341
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11645,7 +11859,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1313
+Index: geneve-ut-1342
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11661,7 +11875,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1314
+Index: geneve-ut-1343
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11678,7 +11892,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1315
+Index: geneve-ut-1344
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11699,7 +11913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1317
+Index: geneve-ut-1346
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11712,7 +11926,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1319
+Index: geneve-ut-1348
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11740,7 +11954,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1322
+Index: geneve-ut-1351
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11756,7 +11970,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1323
+Index: geneve-ut-1352
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11779,7 +11993,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1324
+Index: geneve-ut-1353
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11792,7 +12006,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1326
+Index: geneve-ut-1355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11805,7 +12019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1331
+Index: geneve-ut-1360
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11819,7 +12033,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1332
+Index: geneve-ut-1361
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11834,7 +12048,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1334
+Index: geneve-ut-1363
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -11857,7 +12071,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1337
+Index: geneve-ut-1366
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11900,7 +12114,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1338
+Index: geneve-ut-1367
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11918,7 +12132,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1339
+Index: geneve-ut-1368
 
 ```python
 host.os.type:"windows" and
@@ -11934,7 +12148,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1341
+Index: geneve-ut-1370
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -11946,7 +12160,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1343
+Index: geneve-ut-1372
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -11962,14 +12176,14 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1344
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (process.name == "kubeletctl" or process.args like "*kubeletctl*") or
   (process.args in ("-s", "--server") and process.args in ("run", "portForward", "scan", "attach", "exec", "pods", "runningpods", "cri", "pid2pod"))
 ) and
-process.interactive == true and container.id like "?*"
+container.id like "?*"
 ```
 
 
@@ -11978,7 +12192,7 @@ process.interactive == true and container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1345
+Index: geneve-ut-1374
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11996,7 +12210,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1346
+Index: geneve-ut-1375
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12010,7 +12224,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1348
+Index: geneve-ut-1377
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12020,7 +12234,11 @@ sequence by host.id with maxspan=30s
   ] by process.entity_id
   /* add more executable / script extensions here if they are not noisy in your environment */
   [file where host.os.type == "windows" and event.type in ("creation", "change") and process.pid == 4 and user.id like ("S-1-5-21*", "S-1-12-*") and 
-   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl"))] by process.entity_id
+   (file.Ext.header_bytes : "4d5a*" or file.extension : ("exe", "scr", "pif", "com", "dll", "bat", "cmd", "ps1", "vbs", "vbe", "js", "jse", "wsh", "wsf", "sct", "hta", "cpl")) and
+   not file.path : (
+     "?:\\Windows\\VeeamVssSupport\\*",
+     "?:\\Windows\\VeeamLogShipper\\*"
+   )] by process.entity_id
 ```
 
 
@@ -12029,7 +12247,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1350
+Index: geneve-ut-1379
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12045,7 +12263,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1351
+Index: geneve-ut-1380
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12058,7 +12276,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1352
+Index: geneve-ut-1381
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12088,7 +12306,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1358
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12111,7 +12329,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1359
+Index: geneve-ut-1388
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12130,7 +12348,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1364
+Index: geneve-ut-1393
 
 ```python
 process where host.os.type == "windows" and 
@@ -12272,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1365
+Index: geneve-ut-1394
 
 ```python
 process where host.os.type == "windows" and
@@ -12349,7 +12567,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1369
+Index: geneve-ut-1398
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12366,7 +12584,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1370
+Index: geneve-ut-1399
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12400,7 +12618,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1372
+Index: geneve-ut-1401
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12412,7 +12630,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1373
+Index: geneve-ut-1402
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12451,7 +12669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1375
+Index: geneve-ut-1405
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12464,7 +12682,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1380
+Index: geneve-ut-1410
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12478,7 +12696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1387
+Index: geneve-ut-1417
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12516,7 +12734,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1388
+Index: geneve-ut-1418
 
 ```python
 network where host.os.type == "windows" and
@@ -12542,7 +12760,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1391
+Index: geneve-ut-1421
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12557,7 +12775,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1394
+Index: geneve-ut-1424
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12571,7 +12789,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1395
+Index: geneve-ut-1425
 
 ```python
 file where host.os.type == "windows" and
@@ -12585,7 +12803,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1396
+Index: geneve-ut-1426
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12598,7 +12816,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1397
+Index: geneve-ut-1427
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12618,7 +12836,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1398
+Index: geneve-ut-1428
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12638,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1400
+Index: geneve-ut-1430
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12677,7 +12895,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1401
+Index: geneve-ut-1431
 
 ```python
 event.category:process and host.os.type:windows and
@@ -12872,7 +13090,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1416
+Index: geneve-ut-1446
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12888,7 +13106,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1417
+Index: geneve-ut-1447
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -12902,7 +13120,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1418
+Index: geneve-ut-1448
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -12916,7 +13134,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1419
+Index: geneve-ut-1449
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -12933,7 +13151,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1420
+Index: geneve-ut-1450
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -12947,7 +13165,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1421
+Index: geneve-ut-1451
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12963,7 +13181,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1426
+Index: geneve-ut-1456
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -12975,7 +13193,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1427
+Index: geneve-ut-1457
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -12991,7 +13209,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1428
+Index: geneve-ut-1458
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13011,7 +13229,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1430
+Index: geneve-ut-1460
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13051,7 +13269,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1432
+Index: geneve-ut-1462
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13063,7 +13281,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1433
+Index: geneve-ut-1463
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13084,7 +13302,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1434
+Index: geneve-ut-1464
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13105,7 +13323,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1435
+Index: geneve-ut-1465
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13126,7 +13344,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1436
+Index: geneve-ut-1466
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13152,7 +13370,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1437
+Index: geneve-ut-1467
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13168,7 +13386,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1438
+Index: geneve-ut-1468
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13182,7 +13400,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1440
+Index: geneve-ut-1470
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13205,7 +13423,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1442
+Index: geneve-ut-1472
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13222,7 +13440,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1443
+Index: geneve-ut-1473
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13245,7 +13463,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1444
+Index: geneve-ut-1474
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13258,7 +13476,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1445
+Index: geneve-ut-1475
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13272,7 +13490,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1446
+Index: geneve-ut-1476
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13289,7 +13507,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1447
+Index: geneve-ut-1477
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13343,7 +13561,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1448
+Index: geneve-ut-1478
 
 ```python
 any where host.os.type == "windows" and
@@ -13370,7 +13588,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1454
+Index: geneve-ut-1484
 
 ```python
 file where host.os.type == "windows" and
@@ -13385,7 +13603,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1455
+Index: geneve-ut-1485
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13416,7 +13634,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1456
+Index: geneve-ut-1486
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13430,7 +13648,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1457
+Index: geneve-ut-1487
 
 ```python
 sequence with maxspan=1m
@@ -13472,7 +13690,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1458
+Index: geneve-ut-1488
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13497,7 +13715,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1459
+Index: geneve-ut-1489
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13551,7 +13769,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1460
+Index: geneve-ut-1490
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13571,7 +13789,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1461
+Index: geneve-ut-1491
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13592,7 +13810,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1462
+Index: geneve-ut-1492
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13607,7 +13825,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1463
+Index: geneve-ut-1493
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13627,7 +13845,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1464
+Index: geneve-ut-1494
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13669,7 +13887,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1468
+Index: geneve-ut-1498
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13684,7 +13902,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1469
+Index: geneve-ut-1499
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13719,7 +13937,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1470
+Index: geneve-ut-1500
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13736,7 +13954,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1473
+Index: geneve-ut-1505
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13750,7 +13968,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1476
+Index: geneve-ut-1508
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13763,7 +13981,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1477
+Index: geneve-ut-1509
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13775,7 +13993,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1478
+Index: geneve-ut-1510
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -13790,7 +14008,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1480
+Index: geneve-ut-1512
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -13818,7 +14036,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1482
+Index: geneve-ut-1514
 
 ```python
 sequence by host.id with maxspan=1s
@@ -13843,7 +14061,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1486
+Index: geneve-ut-1518
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -13880,7 +14098,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1487
+Index: geneve-ut-1519
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13894,7 +14112,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1488
+Index: geneve-ut-1520
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -13910,7 +14128,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1489
+Index: geneve-ut-1521
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -13924,7 +14142,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1490
+Index: geneve-ut-1522
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -13954,7 +14172,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1491
+Index: geneve-ut-1523
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -13983,7 +14201,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1492
+Index: geneve-ut-1524
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13999,7 +14217,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1493
+Index: geneve-ut-1525
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14013,7 +14231,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1494
+Index: geneve-ut-1526
 
 ```python
 file where host.os.type == "windows" and
@@ -14045,11 +14263,25 @@ file where host.os.type == "windows" and
 
 
 
+### Potential Tunneling via Tailscaled
+
+Branch count: 4  
+Document count: 4  
+Index: geneve-ut-1529
+
+```python
+process where event.type == "start" and
+process.name like~ ("tailscaled", "tailscaled.exe") and
+process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
+```
+
+
+
 ### Potential Unauthorized Access via Wildcard Injection Detected
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1497
+Index: geneve-ut-1530
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14063,7 +14295,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1498
+Index: geneve-ut-1531
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14083,7 +14315,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1500
+Index: geneve-ut-1533
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14100,7 +14332,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1501
+Index: geneve-ut-1534
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14112,7 +14344,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1502
+Index: geneve-ut-1535
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14129,7 +14361,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1503
+Index: geneve-ut-1536
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14147,11 +14379,11 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1510
+Index: geneve-ut-1543
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
-file.name == "notify_on_release" and process.interactive == true and container.id like "*"
+file.name == "notify_on_release" and container.id like "*"
 ```
 
 
@@ -14160,7 +14392,7 @@ file.name == "notify_on_release" and process.interactive == true and container.i
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1511
+Index: geneve-ut-1544
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14187,11 +14419,11 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1512
+Index: geneve-ut-1545
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
-file.name == "release_agent" and process.interactive == true and container.id like "*"
+file.name == "release_agent" and container.id like "*"
 ```
 
 
@@ -14200,7 +14432,7 @@ file.name == "release_agent" and process.interactive == true and container.id li
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1513
+Index: geneve-ut-1546
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14214,7 +14446,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1515
+Index: geneve-ut-1548
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14463,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1516
+Index: geneve-ut-1549
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14254,7 +14486,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1518
+Index: geneve-ut-1551
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14271,7 +14503,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1521
+Index: geneve-ut-1554
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14284,7 +14516,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1523
+Index: geneve-ut-1556
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14308,7 +14540,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1524
+Index: geneve-ut-1557
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14336,7 +14568,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1540
+Index: geneve-ut-1573
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14353,11 +14585,39 @@ process where host.os.type == "linux" and event.type == "start" and
 
 
 
+### Privilege Boundary Enumeration Detected via Defend for Containers
+
+Branch count: 25  
+Document count: 25  
+Index: geneve-ut-1575
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
+  (process.name in ("id", "whoami", "capsh", "getcap", "lsns")) or
+  (process.args in (
+     "id", "/bin/id", "/usr/bin/id", "/usr/local/bin/id",
+     "whoami", "/bin/whoami", "/usr/bin/whoami", "/usr/local/bin/whoami",
+     "capsh", "/bin/capsh", "/usr/bin/capsh", "/usr/local/bin/capsh",
+     "getcap", "/bin/getcap", "/usr/bin/getcap", "/usr/local/bin/getcap",
+     "lsns", "/bin/lsns", "/usr/bin/lsns", "/usr/local/bin/lsns"
+   ) and
+    /* default exclusion list to not FP on default multi-process commands */
+    not process.args in (
+      "man", "/bin/man", "/usr/bin/man", "/usr/local/bin/man",
+      "chmod", "/bin/chmod", "/usr/bin/chmod", "/usr/local/bin/chmod",
+      "chown", "/bin/chown", "/usr/bin/chown", "/usr/local/bin/chown"
+    )
+  )
+) and container.id like "?*"
+```
+
+
+
 ### Privilege Escalation via CAP_SETUID/SETGID Capabilities
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1543
+Index: geneve-ut-1577
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14397,7 +14657,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1544
+Index: geneve-ut-1578
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14414,7 +14674,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1545
+Index: geneve-ut-1579
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14428,7 +14688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1546
+Index: geneve-ut-1580
 
 ```python
 file where host.os.type == "windows" and
@@ -14447,7 +14707,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1547
+Index: geneve-ut-1581
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14461,7 +14721,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1549
+Index: geneve-ut-1583
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14479,7 +14739,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1551
+Index: geneve-ut-1585
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14497,7 +14757,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1554
+Index: geneve-ut-1588
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14511,7 +14771,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1556
+Index: geneve-ut-1590
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14526,7 +14786,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1557
+Index: geneve-ut-1591
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14549,7 +14809,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1559
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14631,7 +14891,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1560
+Index: geneve-ut-1594
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14652,7 +14912,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1561
+Index: geneve-ut-1595
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14678,7 +14938,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1564
+Index: geneve-ut-1598
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14731,7 +14991,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1565
+Index: geneve-ut-1599
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -14743,7 +15003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1566
+Index: geneve-ut-1600
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -14755,7 +15015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1567
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and
@@ -14770,7 +15030,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1568
+Index: geneve-ut-1602
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -14800,7 +15060,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1569
+Index: geneve-ut-1603
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -14860,7 +15120,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1572
+Index: geneve-ut-1606
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -14873,7 +15133,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1573
+Index: geneve-ut-1607
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14905,7 +15165,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1574
+Index: geneve-ut-1608
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -14929,7 +15189,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1576
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14962,7 +15222,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1577
+Index: geneve-ut-1611
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -14979,7 +15239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1579
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15008,7 +15268,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1580
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15022,7 +15282,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1581
+Index: geneve-ut-1615
 
 ```python
 sequence by process.entity_id
@@ -15047,7 +15307,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1582
+Index: geneve-ut-1616
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15081,7 +15341,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1583
+Index: geneve-ut-1617
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15109,7 +15369,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1584
+Index: geneve-ut-1618
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15128,7 +15388,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1590
+Index: geneve-ut-1624
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15156,7 +15416,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1591
+Index: geneve-ut-1625
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15175,7 +15435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1595
+Index: geneve-ut-1629
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15187,7 +15447,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1596
+Index: geneve-ut-1630
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15199,7 +15459,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1597
+Index: geneve-ut-1631
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15211,7 +15471,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1598
+Index: geneve-ut-1632
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15223,7 +15483,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1609
+Index: geneve-ut-1643
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15236,7 +15496,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1610
+Index: geneve-ut-1644
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15274,7 +15534,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1612
+Index: geneve-ut-1646
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15289,7 +15549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1613
+Index: geneve-ut-1647
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15308,7 +15568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1614
+Index: geneve-ut-1648
 
 ```python
 sequence with maxspan=1m
@@ -15356,7 +15616,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1616
+Index: geneve-ut-1650
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15379,7 +15639,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1618
+Index: geneve-ut-1652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15393,7 +15653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1619
+Index: geneve-ut-1653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15407,7 +15667,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1621
+Index: geneve-ut-1655
 
 ```python
 sequence by host.id, process.entity_id
@@ -15424,7 +15684,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1622
+Index: geneve-ut-1656
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15438,7 +15698,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1623
+Index: geneve-ut-1657
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15458,7 +15718,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1624
+Index: geneve-ut-1658
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15487,7 +15747,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1625
+Index: geneve-ut-1659
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15507,7 +15767,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1626
+Index: geneve-ut-1660
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15520,7 +15780,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1628
+Index: geneve-ut-1662
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15562,7 +15822,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1629
+Index: geneve-ut-1663
 
 ```python
 sequence with maxspan=1m
@@ -15585,7 +15845,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1630
+Index: geneve-ut-1664
 
 ```python
 sequence with maxspan=1s
@@ -15633,7 +15893,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1631
+Index: geneve-ut-1665
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15650,7 +15910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1633
+Index: geneve-ut-1667
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15679,7 +15939,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1635
+Index: geneve-ut-1669
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15707,7 +15967,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1636
+Index: geneve-ut-1670
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15724,7 +15984,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1638
+Index: geneve-ut-1672
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -15743,7 +16003,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1639
+Index: geneve-ut-1673
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -15764,12 +16024,12 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1648
+Index: geneve-ut-1682
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
 file.name in ("authorized_keys", "authorized_keys2") and
-process.interactive == true and container.id like "*"
+container.id like "*"
 ```
 
 
@@ -15778,7 +16038,7 @@ process.interactive == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1650
+Index: geneve-ut-1684
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -15797,7 +16057,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1651
+Index: geneve-ut-1685
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -15811,7 +16071,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1652
+Index: geneve-ut-1686
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -15831,7 +16091,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1654
+Index: geneve-ut-1688
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15849,7 +16109,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1655
+Index: geneve-ut-1689
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -15870,7 +16130,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1657
+Index: geneve-ut-1691
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15884,7 +16144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1658
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15899,7 +16159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1659
+Index: geneve-ut-1693
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -15940,7 +16200,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1661
+Index: geneve-ut-1695
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15965,7 +16225,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1662
+Index: geneve-ut-1696
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16004,7 +16264,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1663
+Index: geneve-ut-1697
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16018,7 +16278,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1664
+Index: geneve-ut-1698
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16057,7 +16317,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1665
+Index: geneve-ut-1699
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16071,7 +16331,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1666
+Index: geneve-ut-1700
 
 ```python
 process where event.type == "start" and
@@ -16143,7 +16403,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1670
+Index: geneve-ut-1704
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16164,7 +16424,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1673
+Index: geneve-ut-1707
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16181,7 +16441,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1676
+Index: geneve-ut-1710
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16199,7 +16459,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1677
+Index: geneve-ut-1711
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16211,7 +16471,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1678
+Index: geneve-ut-1712
 
 ```python
 file where host.os.type == "windows" and
@@ -16244,10 +16504,10 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1681
+Index: geneve-ut-1715
 
 ```python
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where host.os.type == "linux" and container.id like "*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and
   file.path in (
     "/var/run/secrets/kubernetes.io/serviceaccount/namespace",
@@ -16276,10 +16536,10 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1683
+Index: geneve-ut-1717
 
 ```python
-any where host.os.type == "linux" and process.interactive == true and container.id like "*" and (
+any where host.os.type == "linux" and container.id like "*" and (
   (event.category == "file" and event.type == "change" and event.action == "open" and
   file.path in (
     "/var/run/secrets/kubernetes.io/serviceaccount/token",
@@ -16312,7 +16572,7 @@ any where host.os.type == "linux" and process.interactive == true and container.
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1684
+Index: geneve-ut-1718
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16329,7 +16589,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1685
+Index: geneve-ut-1719
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16349,7 +16609,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1687
+Index: geneve-ut-1721
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16364,7 +16624,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1688
+Index: geneve-ut-1722
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16385,7 +16645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1689
+Index: geneve-ut-1723
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16408,7 +16668,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1690
+Index: geneve-ut-1724
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16421,7 +16681,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1691
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16438,7 +16698,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1694
+Index: geneve-ut-1728
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16463,10 +16723,10 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1697
+Index: geneve-ut-1731
 
 ```python
-any where host.os.type == "linux" and event.category in ("file", "process") and process.interactive == true and container.id like "?*" and (
+any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
   (event.category == "file" and event.type == "deletion" and file.name in (".bash_history", ".sh_history",  ".zsh_history")) or
   (event.category == "process" and event.type == "start" and event.action == "exec" and (
     (
@@ -16494,7 +16754,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1698
+Index: geneve-ut-1732
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16543,7 +16803,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1699
+Index: geneve-ut-1733
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16557,7 +16817,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1700
+Index: geneve-ut-1734
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16572,7 +16832,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1701
+Index: geneve-ut-1735
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16587,7 +16847,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1702
+Index: geneve-ut-1736
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16609,7 +16869,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1703
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16630,7 +16890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1707
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16644,7 +16904,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1708
+Index: geneve-ut-1742
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16667,7 +16927,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1738
+Index: geneve-ut-1772
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16692,7 +16952,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1739
+Index: geneve-ut-1773
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16725,7 +16985,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1740
+Index: geneve-ut-1774
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -16784,7 +17044,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1742
+Index: geneve-ut-1776
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -16802,7 +17062,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1743
+Index: geneve-ut-1777
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -16814,7 +17074,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1746
+Index: geneve-ut-1780
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -16839,7 +17099,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1751
+Index: geneve-ut-1786
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16854,7 +17114,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1752
+Index: geneve-ut-1787
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -16877,7 +17137,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1755
+Index: geneve-ut-1790
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16891,7 +17151,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1757
+Index: geneve-ut-1792
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16913,7 +17173,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1759
+Index: geneve-ut-1794
 
 ```python
 sequence by host.id with maxspan=5s
@@ -16940,7 +17200,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1763
+Index: geneve-ut-1798
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -16979,7 +17239,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1764
+Index: geneve-ut-1799
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17002,7 +17262,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1765
+Index: geneve-ut-1800
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17016,7 +17276,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1766
+Index: geneve-ut-1801
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17032,7 +17292,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1767
+Index: geneve-ut-1802
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17048,7 +17308,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1768
+Index: geneve-ut-1803
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17062,7 +17322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1770
+Index: geneve-ut-1805
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17085,7 +17345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1771
+Index: geneve-ut-1806
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17113,7 +17373,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1772
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17128,7 +17388,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1775
+Index: geneve-ut-1810
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17155,7 +17415,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1777
+Index: geneve-ut-1812
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17186,7 +17446,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1778
+Index: geneve-ut-1813
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17202,7 +17462,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1779
+Index: geneve-ut-1814
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17215,7 +17475,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1781
+Index: geneve-ut-1816
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17231,7 +17491,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1782
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17247,7 +17507,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1783
+Index: geneve-ut-1818
 
 ```python
 any where host.os.type == "windows" and 
@@ -17314,7 +17574,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1785
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17330,7 +17590,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1787
+Index: geneve-ut-1822
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17366,7 +17626,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1788
+Index: geneve-ut-1823
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17404,7 +17664,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1789
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17439,7 +17699,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1790
+Index: geneve-ut-1825
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17473,7 +17733,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1792
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17492,9 +17752,9 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 ### Suspicious Execution via Windows Subsystem for Linux
 
-Branch count: 14  
-Document count: 14  
-Index: geneve-ut-1797
+Branch count: 201  
+Document count: 201  
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17508,9 +17768,58 @@ process where host.os.type == "windows" and event.type : "start" and
       process.parent.name : "wsl.exe" and process.parent.command_line : "bash*" and not process.name : "wslhost.exe"
     ) or
     (
-      process.name : "wsl.exe" and process.args : (
-        "curl", "/etc/shadow", "/etc/passwd", "cat", "--system", "root", "-e", "--exec", "bash", "/mnt/c/*"
-      ) and not process.args : ("wsl-bootstrap", "docker-desktop-data", "*.vscode-server*")
+      process.name : "wsl.exe" and
+      (
+        process.args : "--system" or
+        (
+          process.args : "--manage" and process.args : "--set-default-user" and process.args : "root"
+        ) or
+        (
+          (process.args : ("curl", "wget") and process.args : ("http://*", "https://*")) or
+          process.args : ("*curl*http://*", "*curl*https://*", "*wget*http://*", "*wget*https://*")
+        ) or
+        (
+          (
+            process.args like~ ("*/dev/tcp/*", "*/dev/udp/*", "*zsh/net/tcp*") and
+            process.args like ("*&>*", "*<>*", "*>&*", "*<&*")
+          ) or
+          (
+            process.args : ("nc", "netcat", "nc.traditional", "ncat", "*/nc", "*/netcat", "*/nc.traditional", "*/ncat") and
+            process.args : ("sh", "/bin/sh", "bash", "/bin/bash") and
+            process.args : ("-e", "--exec", "-c", "--sh-exec")
+          ) or
+          (
+            process.args like~ "*socat*" and
+            process.args like~ ("*exec:*", "*system:*", "*shell:*") and
+            process.args like~ ("*tcp*", "*udp*", "*openssl*")
+          )
+        ) or
+        (
+          process.args : ("-e", "--exec") and
+          process.args : (
+            "/mnt/c/*.exe", "/mnt/c/*.ps1", "/mnt/c/*.bat", "/mnt/c/*.cmd", "/mnt/c/*.vbs", "/mnt/c/*.js",
+            "/mnt/c/*.hta"
+          ) and
+          not process.args : "*wslpath*"
+        ) or
+        process.args : (
+          "*/etc/passwd*", "*/etc/shadow*", "*/etc/sudoers*", "*/etc/sudoers.d/*", "*/root/.ssh/*", "*/home/*/.ssh/*",
+          "*/root/.aws/credentials*", "*/home/*/.aws/credentials*", "*/root/.kube/config*", "*/home/*/.kube/config*",
+          "*/mnt/c/Windows/System32/config/SAM*",
+          "*/mnt/c/Windows/System32/config/SECURITY*",
+          "*/mnt/c/Windows/System32/config/SYSTEM", "*/mnt/c/Windows/System32/config/SYSTEM.*",
+          "*/mnt/c/Windows/NTDS/ntds.dit*",
+          "*/mnt/c/Users/*/AppData/Roaming/Microsoft/Credentials/*",
+          "*/mnt/c/Users/*/AppData/Local/Microsoft/Credentials/*",
+          "*/mnt/c/Users/*/AppData/Roaming/Microsoft/Protect/*",
+          "*/mnt/c/Users/*/.ssh/*",
+          "*/mnt/c/Users/*/.aws/credentials",
+          "*/mnt/c/Users/*/.azure/*",
+          "*/mnt/c/Users/*/.config/gcloud/*",
+          "*/mnt/c/Users/*/AppData/Local/Google/Chrome/User Data/*/Login Data*",
+          "*/mnt/c/Users/*/AppData/Local/Microsoft/Edge/User Data/*/Login Data*"
+        )
+      )
     )
   ) and
     not process.parent.executable : ("?:\\Program Files\\Docker\\*.exe", "?:\\Program Files (x86)\\Docker\\*.exe")
@@ -17520,21 +17829,21 @@ process where host.os.type == "windows" and event.type : "start" and
 
 ### Suspicious Execution with NodeJS
 
-Branch count: 18  
-Document count: 18  
-Index: geneve-ut-1798
+Branch count: 36  
+Document count: 36  
+Index: geneve-ut-1833
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
 
-(process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or ?process.code_signature.subject_name : "OpenJS Foundation") and
+(process.name : "node.exe" or ?process.pe.original_file_name == "node.exe" or
+ ?process.code_signature.subject_name : ("OpenJS Foundation", "Node.js Foundation")) and
 
 (
-  (process.executable : ("?:\\Users\\*\\AppData\\*\\node.exe", "\\Device\\HarddiskVolume*\\Users\\*\\AppData\\*\\node.exe") and process.args : "*.js") or
+  (process.args : ("-r", "--require", "--require=*") and
+   process.parent.name : ("powershell.exe", "pwsh.exe")) or
 
-  (process.args : "-r" and process.parent.name : "powershell.exe") or
-
-   process.command_line : ("*eval(*", "*atob(*", "*require*child_process*")
+  process.command_line : ("*eval(*", "*atob(*", "*require*child_process*")
 )
 ```
 
@@ -17544,7 +17853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1799
+Index: geneve-ut-1834
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17568,7 +17877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1801
+Index: geneve-ut-1836
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17589,7 +17898,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1804
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17604,7 +17913,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1807
+Index: geneve-ut-1842
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17617,7 +17926,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1808
+Index: geneve-ut-1843
 
 ```python
 any where host.os.type == "windows" and
@@ -17632,7 +17941,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1809
+Index: geneve-ut-1844
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17648,7 +17957,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1810
+Index: geneve-ut-1845
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17662,10 +17971,10 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1814
+Index: geneve-ut-1849
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
 process.parent.executable != null and (
   (
     process.executable like ("/bin/perl*", "/usr/bin/perl*", "/usr/local/bin/perl*") and
@@ -17719,7 +18028,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1815
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +18042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1817
+Index: geneve-ut-1852
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -17765,7 +18074,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1819
+Index: geneve-ut-1854
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -17778,7 +18087,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1820
+Index: geneve-ut-1855
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -17797,7 +18106,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1821
+Index: geneve-ut-1856
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -17843,7 +18152,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1823
+Index: geneve-ut-1858
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17864,7 +18173,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1824
+Index: geneve-ut-1859
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -17884,7 +18193,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1825
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17898,7 +18207,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1826
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17930,7 +18239,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1829
+Index: geneve-ut-1864
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -17951,7 +18260,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1831
+Index: geneve-ut-1866
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18052,7 +18361,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1835
+Index: geneve-ut-1870
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18100,7 +18409,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1838
+Index: geneve-ut-1873
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18126,7 +18435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1839
+Index: geneve-ut-1874
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18171,7 +18480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1840
+Index: geneve-ut-1875
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18195,7 +18504,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1841
+Index: geneve-ut-1876
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18211,7 +18520,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1843
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18236,7 +18545,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1844
+Index: geneve-ut-1879
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18251,7 +18560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1847
+Index: geneve-ut-1882
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18265,7 +18574,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1848
+Index: geneve-ut-1883
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18285,7 +18594,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1849
+Index: geneve-ut-1884
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18320,10 +18629,10 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1853
+Index: geneve-ut-1888
 
 ```python
-process where event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where event.type == "start" and event.action == "exec" and (
   process.executable like (
     "/tmp/*", "/dev/shm/*", "/var/tmp/*", "/run/*", "/var/run/*", "/mnt/*", "/media/*", "/boot/*"
   ) or
@@ -18338,7 +18647,7 @@ process where event.type == "start" and event.action == "exec" and process.inter
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1854
+Index: geneve-ut-1889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18351,7 +18660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1857
+Index: geneve-ut-1892
 
 ```python
 any where host.os.type == "windows" and
@@ -18384,7 +18693,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1859
+Index: geneve-ut-1894
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18402,7 +18711,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1860
+Index: geneve-ut-1895
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18424,7 +18733,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1863
+Index: geneve-ut-1898
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18463,7 +18772,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1864
+Index: geneve-ut-1899
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18493,7 +18802,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1865
+Index: geneve-ut-1900
 
 ```python
 any where host.os.type == "windows" and
@@ -18527,7 +18836,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1866
+Index: geneve-ut-1901
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18541,7 +18850,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1869
+Index: geneve-ut-1904
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18572,7 +18881,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1870
+Index: geneve-ut-1905
 
 ```python
 any where host.os.type == "windows" and
@@ -18592,7 +18901,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1871
+Index: geneve-ut-1906
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18633,7 +18942,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1872
+Index: geneve-ut-1907
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18649,7 +18958,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1873
+Index: geneve-ut-1908
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18679,7 +18988,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1877
+Index: geneve-ut-1912
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -18692,7 +19001,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1878
+Index: geneve-ut-1913
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -18716,7 +19025,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1880
+Index: geneve-ut-1916
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18734,7 +19043,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1882
+Index: geneve-ut-1918
 
 ```python
 any where host.os.type == "windows" and
@@ -18749,7 +19058,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1883
+Index: geneve-ut-1919
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -18767,7 +19076,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1884
+Index: geneve-ut-1920
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -18788,7 +19097,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1885
+Index: geneve-ut-1921
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18807,7 +19116,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1888
+Index: geneve-ut-1924
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18832,7 +19141,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1889
+Index: geneve-ut-1925
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18845,7 +19154,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1891
+Index: geneve-ut-1927
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -18858,7 +19167,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1893
+Index: geneve-ut-1929
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18881,7 +19190,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1895
+Index: geneve-ut-1931
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18900,7 +19209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1896
+Index: geneve-ut-1932
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -18922,7 +19231,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1897
+Index: geneve-ut-1933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -18955,7 +19264,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1899
+Index: geneve-ut-1935
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18973,7 +19282,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1900
+Index: geneve-ut-1936
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -18987,7 +19296,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1901
+Index: geneve-ut-1937
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19011,7 +19320,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1902
+Index: geneve-ut-1938
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19034,7 +19343,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1903
+Index: geneve-ut-1939
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19053,10 +19362,10 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1906
+Index: geneve-ut-1942
 
 ```python
-file where host.os.type == "linux" and event.type == "creation" and process.interactive == true and
+file where host.os.type == "linux" and event.type == "creation" and
 file.path like (
   "/etc/*", "/root/*", "/bin/*", "/usr/bin/*", "/usr/local/bin/*", "/entrypoint*"
 ) and (
@@ -19072,7 +19381,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1908
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19107,7 +19416,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1909
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19124,7 +19433,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1910
+Index: geneve-ut-1946
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19144,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1911
+Index: geneve-ut-1947
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19184,7 +19493,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1912
+Index: geneve-ut-1948
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19200,7 +19509,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1913
+Index: geneve-ut-1949
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19214,7 +19523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1914
+Index: geneve-ut-1950
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19252,7 +19561,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1915
+Index: geneve-ut-1951
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19306,7 +19615,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1916
+Index: geneve-ut-1952
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19334,7 +19643,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1918
+Index: geneve-ut-1954
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19348,7 +19657,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1919
+Index: geneve-ut-1955
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19394,7 +19703,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1920
+Index: geneve-ut-1956
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19433,7 +19742,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1921
+Index: geneve-ut-1957
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19446,7 +19755,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1925
+Index: geneve-ut-1961
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19479,7 +19788,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1926
+Index: geneve-ut-1962
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19493,7 +19802,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1927
+Index: geneve-ut-1963
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19507,7 +19816,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1928
+Index: geneve-ut-1964
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19521,7 +19830,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1929
+Index: geneve-ut-1965
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19560,7 +19869,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1936
+Index: geneve-ut-1973
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19602,10 +19911,10 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1938
+Index: geneve-ut-1975
 
 ```python
-process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.interactive == true and (
+process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
   (process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf") and process.args == "install") or
   (process.name == "apk" and process.args == "add") or
   (process.name == "pacman" and process.args like "-*S*") or
@@ -19624,7 +19933,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1940
+Index: geneve-ut-1977
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19637,7 +19946,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1943
+Index: geneve-ut-1980
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19654,7 +19963,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1944
+Index: geneve-ut-1981
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19670,7 +19979,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1945
+Index: geneve-ut-1982
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19683,7 +19992,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1946
+Index: geneve-ut-1983
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -19698,7 +20007,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1947
+Index: geneve-ut-1984
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19721,7 +20030,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1948
+Index: geneve-ut-1985
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19737,7 +20046,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1949
+Index: geneve-ut-1986
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19753,7 +20062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1955
+Index: geneve-ut-1992
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -19765,7 +20074,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1956
+Index: geneve-ut-1993
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19794,7 +20103,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1958
+Index: geneve-ut-1995
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -19808,7 +20117,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1963
+Index: geneve-ut-2000
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -19828,7 +20137,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1964
+Index: geneve-ut-2001
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -19853,7 +20162,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1971
+Index: geneve-ut-2008
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19867,7 +20176,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1972
+Index: geneve-ut-2009
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19890,7 +20199,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1981
+Index: geneve-ut-2018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19924,7 +20233,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1983
+Index: geneve-ut-2020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -19943,7 +20252,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-1990
+Index: geneve-ut-2027
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -19962,7 +20271,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2004
+Index: geneve-ut-2042
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -19979,7 +20288,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2007
+Index: geneve-ut-2045
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -19996,7 +20305,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2023
+Index: geneve-ut-2061
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20015,7 +20324,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2027
+Index: geneve-ut-2065
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20057,7 +20366,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2028
+Index: geneve-ut-2066
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20102,7 +20411,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2031
+Index: geneve-ut-2069
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20144,7 +20453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2033
+Index: geneve-ut-2071
 
 ```python
 host.os.type:"linux" and 
@@ -20172,7 +20481,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2037
+Index: geneve-ut-2075
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20196,7 +20505,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2038
+Index: geneve-ut-2076
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20236,7 +20545,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2039
+Index: geneve-ut-2077
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20283,7 +20592,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2043
+Index: geneve-ut-2081
 
 ```python
 sequence by process.entity_id
@@ -20320,7 +20629,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2075
+Index: geneve-ut-2113
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20334,7 +20643,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2076
+Index: geneve-ut-2114
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20377,7 +20686,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2077
+Index: geneve-ut-2115
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20390,7 +20699,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2080
+Index: geneve-ut-2118
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20404,7 +20713,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2081
+Index: geneve-ut-2119
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20417,7 +20726,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2085
+Index: geneve-ut-2123
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20442,7 +20751,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2086
+Index: geneve-ut-2124
 
 ```python
 process where event.type == "start" and
@@ -20457,7 +20766,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2087
+Index: geneve-ut-2125
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20474,7 +20783,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2088
+Index: geneve-ut-2126
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20488,7 +20797,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2089
+Index: geneve-ut-2127
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20504,7 +20813,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2090
+Index: geneve-ut-2128
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20518,7 +20827,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2091
+Index: geneve-ut-2129
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20545,7 +20854,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2093
+Index: geneve-ut-2131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20557,7 +20866,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2094
+Index: geneve-ut-2132
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20573,7 +20882,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2095
+Index: geneve-ut-2133
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20596,7 +20905,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2096
+Index: geneve-ut-2134
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20609,7 +20918,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2098
+Index: geneve-ut-2136
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20621,7 +20930,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2099
+Index: geneve-ut-2137
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20633,7 +20942,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2100
+Index: geneve-ut-2138
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20645,7 +20954,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2101
+Index: geneve-ut-2139
 
 ```python
 web where (
@@ -20673,7 +20982,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2107
+Index: geneve-ut-2145
 
 ```python
 any where (
@@ -20745,7 +21054,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2109
+Index: geneve-ut-2147
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20766,7 +21075,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2112
+Index: geneve-ut-2150
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -20780,7 +21089,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2113
+Index: geneve-ut-2151
 
 ```python
 file where event.type == "deletion" and
@@ -20797,7 +21106,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2114
+Index: geneve-ut-2152
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20815,7 +21124,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2117
+Index: geneve-ut-2155
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20853,7 +21162,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2119
+Index: geneve-ut-2157
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20890,7 +21199,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2120
+Index: geneve-ut-2158
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20905,7 +21214,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2121
+Index: geneve-ut-2159
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -20918,7 +21227,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2122
+Index: geneve-ut-2160
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20937,10 +21246,10 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2123
+Index: geneve-ut-2161
 
 ```python
-sequence with maxspan=1m
+sequence by host.id with maxspan=1m
   [registry where host.os.type == "windows" and event.type == "change" and process.name : "msiexec.exe" and
    (
     (registry.value : "InstallSource" and
@@ -20962,7 +21271,7 @@ sequence with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2124
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20988,7 +21297,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2125
+Index: geneve-ut-2163
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21010,7 +21319,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2126
+Index: geneve-ut-2164
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21027,7 +21336,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2128
+Index: geneve-ut-2166
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21046,7 +21355,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2129
+Index: geneve-ut-2167
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21086,7 +21395,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2130
+Index: geneve-ut-2168
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21103,7 +21412,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2132
+Index: geneve-ut-2170
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21116,7 +21425,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2133
+Index: geneve-ut-2171
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21130,7 +21439,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2134
+Index: geneve-ut-2172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21158,7 +21467,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2135
+Index: geneve-ut-2173
 
 ```python
 process where event.type == "start" and
@@ -21183,7 +21492,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2136
+Index: geneve-ut-2174
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21197,7 +21506,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2137
+Index: geneve-ut-2175
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21213,7 +21522,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2138
+Index: geneve-ut-2176
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21248,7 +21557,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2139
+Index: geneve-ut-2177
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21266,7 +21575,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2142
+Index: geneve-ut-2180
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/documents_from_rules-8.19.md
+++ b/tests/reports/documents_from_rules-8.19.md
@@ -5,12 +5,12 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.28
+Rules version: 8.19.29
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (223)](#unsupported-rule-type-new_terms-223)
-      1. [Unsupported rule type: esql (179)](#unsupported-rule-type-esql-179)
+      1. [Unsupported rule type: new_terms (236)](#unsupported-rule-type-new_terms-236)
+      1. [Unsupported rule type: esql (187)](#unsupported-rule-type-esql-187)
       1. [Unsupported rule type: machine_learning (95)](#unsupported-rule-type-machine_learning-95)
       1. [Unsupported rule type: threshold (27)](#unsupported-rule-type-threshold-27)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -33,14 +33,14 @@ invalid-syntax
 --processargs-curl-or-bincurl-or-wget
 -------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (374)](#field-type-solver-constant_keyword-374)
+      1. [Field type solver: constant_keyword (384)](#field-type-solver-constant_keyword-384)
       1. [Unsupported function: match (33)](#unsupported-function-match-33)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
       1. [Root with too many branches (limit: 10000) (23)](#root-with-too-many-branches-limit-10000-23)
       1. [Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)](#unsupported-lhs-type-class-eqlastfunctioncall-11)
       1. [Root without branches (9)](#root-without-branches-9)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (8)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-8)
       1. [Unsupported argument type(s): <class 'eql.ast.Field'> (8)](#unsupported-argument-types-class-eqlastfield-8)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-7)
       1. [Unsupported function: startsWith (4)](#unsupported-function-startswith-4)
       1. [<class 'eql.ast.Sample'> (3)](#class-eqlastsample-3)
       1. [Field type solver: match_only_text (3)](#field-type-solver-match_only_text-3)
@@ -141,11 +141,12 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (223)
+### Unsupported rule type: new_terms (236)
 
-223 rules:
+236 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
+* AWS Batch Job Submitted with Container Override by Unusual Identity
 * AWS Bedrock Agent or Action Group Manipulation
 * AWS Bedrock AgentCore Execution Role Used Outside Its Runtime
 * AWS Bedrock Knowledge Base or RAG Data Source Tampering
@@ -157,6 +158,7 @@ invalid-syntax
 * AWS DynamoDB Scan by Unusual User
 * AWS DynamoDB Table Exported to S3
 * AWS EC2 CreateKeyPair by New Principal from Non-Cloud AS Organization
+* AWS EC2 NACL Entry Created or Replaced Allowing All Traffic by New Identity
 * AWS EC2 Role GetCallerIdentity from New Source AS Organization
 * AWS EC2 Route Table Created
 * AWS EC2 Route Table Modified or Deleted
@@ -169,9 +171,11 @@ invalid-syntax
 * AWS IAM Customer-Managed Policy Attached to Role by Rare User
 * AWS IAM Long-Term Access Key First Seen from Source IP
 * AWS IAM OIDC Provider Created by Rare User
+* AWS IAM Permission Boundary or Guardrail Policy Deleted by Unusual Identity
 * AWS IAM User Console Login Without MFA
 * AWS Lambda Function Invoked by an Unusual Principal
 * AWS Lambda Function Invoked from an Unusual Source ASN
+* AWS S3 Bucket ACL Modified to Allow Public Access by New Identity
 * AWS S3 Unauthenticated Bucket Access by Rare Source
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
@@ -212,6 +216,7 @@ invalid-syntax
 * Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
 * Deprecated TLS Version or Weak Cipher Negotiated Externally
+* Direct Process Execution via Background Utility
 * Discovery of Internet Capabilities via Built-in Tools
 * Entra ID Conditional Access MFA Bypass with Unusual User, Client and Source ASN
 * Entra ID Conditional Access Policy (CAP) Modified
@@ -257,14 +262,19 @@ invalid-syntax
 * First Time Seen Account Performing DCSync
 * First Time Seen Driver Loaded
 * First Time Seen Google Workspace OAuth Login from Third-Party Application
+* First Time Seen Memcached Writer
+* First Time Seen NFS AUTH_SYS Root UID Access
 * First Time Seen NewCredentials Logon Process
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
+* First-Time Destructive MongoDB Command from a Client IP
 * FortiGate Administrator Account Creation from Unusual Source
 * GKE Anonymous Request Authorized by Unusual User Agent
 * GKE Forbidden Request from Unusual User Agent
+* GKE Secret Access via Unusual User Agent
 * GKE Secrets List from Unusual Source AS Organization
 * GKE Unusual Sensitive Workload Modification
+* GKE Unusual Service Account Secret Access via New User Agent
 * GKE User Exec into Pod
 * GenAI Process Connection to Unusual Domain
 * GitHub Actions Unusual Bot Push to Repository
@@ -336,11 +346,13 @@ invalid-syntax
 * Suspicious PowerShell Engine ImageLoad
 * Suspicious Sysctl File Event
 * Suspicious System Commands Executed by Previously Unknown Executable
+* Suspicious UID Change to Root via Python
 * Svchost spawning Cmd
 * System Binary Symlink to Suspicious Location
 * System Network Connections Discovery
 * System Owner/User Discovery Linux
 * Systemd Service Started by Unusual Parent Process
+* Thrift RPC Method from an External Client
 * UID Elevation from Previously Unknown Executable
 * Unauthorized Scope for Public App OAuth2 Token Grant with Client Credentials
 * Unknown Execution of Binary with RWX Memory Region
@@ -351,6 +363,7 @@ invalid-syntax
 * Unusual Discovery Signal Alert with Unusual Process Executable
 * Unusual Execution from Kernel Thread (kthreadd) Parent
 * Unusual Exim4 Child Process
+* Unusual File Creation via Web Server
 * Unusual File Operation by dns.exe
 * Unusual Interactive Shell Launched from System User
 * Unusual Kernel Module Enumeration
@@ -369,9 +382,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (179)
+### Unsupported rule type: esql (187)
 
-179 rules:
+187 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -381,6 +394,7 @@ invalid-syntax
 * AWS Bedrock Detected Multiple Validation Exception Errors by a Single User
 * AWS Bedrock Guardrails Detected Multiple Policy Violations Within a Single Blocked Request
 * AWS Bedrock Guardrails Detected Multiple Violations by a Single User Over a Session
+* AWS Bedrock High Risk Filesystem or Execution Tool Invocation
 * AWS Bedrock High-Frequency Single-Model Inference API Probing
 * AWS Bedrock Invocations without Guardrails Detected by a Single User Over a Session
 * AWS Bedrock Model Prompt or Completion Containing Credentials
@@ -393,6 +407,7 @@ invalid-syntax
 * AWS IAM Credentials Added to a Bedrock API Key Phantom User
 * AWS IAM User Console Login from Multiple Geolocations
 * AWS IAM User Created Access Keys For Another User
+* AWS IAM User Self-Created Access Key Subsequently Used
 * AWS Lambda Function High-Frequency Invocation by a Single Principal
 * AWS Lambda Function Invoked Cross-Account
 * AWS Lateral Movement from Kubernetes SA via AssumeRoleWithWebIdentity
@@ -400,6 +415,7 @@ invalid-syntax
 * AWS Rare Source AS Organization Activity
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SageMaker Execution Role Passed by Unusual Principal
 * AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
 * Agent Spoofing - Multiple Hosts Using Same Agent
@@ -439,7 +455,10 @@ invalid-syntax
 * GKE API Request Failure Burst by User
 * GKE Anonymous Endpoint Permission Enumeration
 * GKE Certificate Signing Request Self-Approved
+* GKE Endpoint Permission Enumeration
+* GKE Multi-Resource Discovery
 * GKE Rapid Secret GET Activity Against Multiple Objects
+* GKE Sensitive RBAC Change Followed by Workload Modification
 * GitHub Actions Workflow Modification Blocked
 * GitHub Exfiltration via High Number of Repository Clones by User
 * Google Workspace Device Registration Burst for Single User
@@ -485,6 +504,7 @@ invalid-syntax
 * Multiple Machine Learning Alerts by Influencer Field
 * Multiple Okta User Authentication Events with Same Device Token Hash
 * Multiple Remote Management Tool Vendors on Same Host
+* Multiple SonicWall Login Failures Followed by Successful Login
 * Multiple Vulnerabilities by Asset via Wiz
 * Newly Observed Elastic Defend Behavior Alert
 * Newly Observed FortiGate Alert
@@ -537,6 +557,7 @@ invalid-syntax
 * Rare Connection to WebDAV Target
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
+* Successful AMQP Multi-Queue Purge Burst
 * Suspected Lateral Movement from Compromised Host
 * Suspicious AWS S3 Connection via Script Interpreter
 * Suspicious Python Shell Command Execution
@@ -662,6 +683,7 @@ invalid-syntax
 * AWS S3 Bucket Enumeration or Brute Force
 * AWS Secrets Manager Rapid Secrets Retrieval
 * Attempts to Brute Force an Okta User Account
+* Azure AKS Potential API Enumeration by User
 * Azure Compute Restore Point Collections Deleted
 * Azure Compute Snapshot Deletions by User
 * Azure Storage Account Deletions by User
@@ -672,7 +694,6 @@ invalid-syntax
 * High Number of Process Terminations
 * High Number of Process and/or Service Terminations
 * M365 Identity Login from Impossible Travel Location
-* Multiple Alerts in Different ATT&CK Tactics on a Single Host
 * Multiple Okta Sessions Detected for a Single User
 * Multiple Okta User Auth Events with Same Device Token Hash Behind a Proxy
 * My First Rule
@@ -718,9 +739,9 @@ Invalid syntax
 
 ## Generation errors
 
-### Field type solver: constant_keyword (374)
+### Field type solver: constant_keyword (384)
 
-374 rules:
+384 rules:
 * AWS Account Closed
 * AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
 * AWS Attempt to Leave Organization
@@ -824,7 +845,13 @@ Invalid syntax
 * Attempted Bypass of Okta MFA
 * Azure AKS API Server Proxying Request to Kubelet
 * Azure AKS Attempted User Exec into Pod
+* Azure AKS Certificate Signing Request Created or Approved
+* Azure AKS CoreDNS or Kube-DNS Configuration Modified
+* Azure AKS Ephemeral Container Added to Pod
 * Azure AKS Kubelet Proxy to Command Execution Endpoint
+* Azure AKS Kubernetes Events Deleted
+* Azure AKS Secret get or list with Suspicious User Agent
+* Azure AKS Suspicious Self-Subject Review by Service Account or Node Identity
 * Azure Automation Account Created
 * Azure Automation Runbook Created or Modified
 * Azure Automation Runbook Deleted
@@ -848,6 +875,7 @@ Invalid syntax
 * Azure VNet Full Network Packet Capture Enabled
 * Azure VNet Network Watcher Deleted
 * Azure Virtual Machine Configuration Modified
+* Cassandra JavaScript UDF Creation
 * Command and Scripting Interpreter via Windows Scripts
 * CrowdStrike External Alerts
 * CyberArk Privileged Access Security Error
@@ -960,6 +988,7 @@ Invalid syntax
 * GKE Pod Exec with Curl or Wget to HTTPS
 * GKE Privileged Pod Created
 * GKE RBAC Wildcard Elevation on Existing Role
+* GKE Secret Access from Node or Denied Service Account
 * GKE Secret get or list with Suspicious User Agent
 * GKE Service Account Modified RBAC Objects
 * GKE Service Account Token Created via TokenRequest API
@@ -1048,6 +1077,7 @@ Invalid syntax
 * Microsoft Defender XDR Incident External Alerts
 * Microsoft Sentinel External Alerts
 * Modification or Removal of an Okta Application Sign-On Policy
+* MySQL User-Defined Function Injection
 * New GitHub App Installed
 * New GitHub Owner Added
 * New GitHub Personal Access Token (PAT) Added
@@ -1057,6 +1087,7 @@ Invalid syntax
 * Okta User Assigned Administrator Role
 * Okta User Session Impersonation
 * Possible Okta DoS Attack
+* PostgreSQL COPY PROGRAM Command Execution
 * Potential DLL Side-Loading via Trusted Microsoft Programs
 * Potential File Transfer via Curl for Windows
 * Potential Persistence via File Modification
@@ -1217,6 +1248,18 @@ Invalid syntax
 * Potential Linux Backdoor User Account Creation
 * Suspicious Data Encryption via OpenSSL Utility
 
+### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (8)
+
+8 rules:
+* Execution via MS VisualStudio Pre/Post Build Events
+* Local Scheduled Task Creation
+* Suspicious Execution from VS Code Extension
+* Suspicious Execution from a WebDav Share
+* Suspicious JetBrains TeamCity Child Process
+* Suspicious Microsoft HTML Application Child Process
+* Suspicious Shell Execution via Velociraptor
+* Suspicious Windows Command Shell Arguments
+
 ### Unsupported argument type(s): <class 'eql.ast.Field'> (8)
 
 8 rules:
@@ -1228,17 +1271,6 @@ Invalid syntax
 * Potential Privilege Escalation via SUID/SGID
 * Unusual Network Activity from a Windows System Binary
 * Windows Service Installed via an Unusual Client
-
-### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)
-
-7 rules:
-* Execution via MS VisualStudio Pre/Post Build Events
-* Suspicious Execution from VS Code Extension
-* Suspicious Execution from a WebDav Share
-* Suspicious JetBrains TeamCity Child Process
-* Suspicious Microsoft HTML Application Child Process
-* Suspicious Shell Execution via Velociraptor
-* Suspicious Windows Command Shell Arguments
 
 ### Unsupported function: startsWith (4)
 

--- a/tests/reports/documents_from_rules-9.3.md
+++ b/tests/reports/documents_from_rules-9.3.md
@@ -5,12 +5,12 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.16
+Rules version: 9.3.17
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (226)](#unsupported-rule-type-new_terms-226)
-      1. [Unsupported rule type: esql (193)](#unsupported-rule-type-esql-193)
+      1. [Unsupported rule type: new_terms (239)](#unsupported-rule-type-new_terms-239)
+      1. [Unsupported rule type: esql (201)](#unsupported-rule-type-esql-201)
       1. [Unsupported rule type: machine_learning (105)](#unsupported-rule-type-machine_learning-105)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -33,14 +33,14 @@ invalid-syntax
 --processargs-curl-or-bincurl-or-wget
 -------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (378)](#field-type-solver-constant_keyword-378)
+      1. [Field type solver: constant_keyword (388)](#field-type-solver-constant_keyword-388)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
       1. [Root without branches (11)](#root-without-branches-11)
       1. [Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)](#unsupported-lhs-type-class-eqlastfunctioncall-11)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (8)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-8)
       1. [Unsupported argument type(s): <class 'eql.ast.Field'> (8)](#unsupported-argument-types-class-eqlastfield-8)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-7)
       1. [Unsupported function: startsWith (4)](#unsupported-function-startswith-4)
       1. [<class 'eql.ast.Sample'> (3)](#class-eqlastsample-3)
       1. [Field type solver: match_only_text (3)](#field-type-solver-match_only_text-3)
@@ -142,12 +142,13 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (226)
+### Unsupported rule type: new_terms (239)
 
-226 rules:
+239 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
+* AWS Batch Job Submitted with Container Override by Unusual Identity
 * AWS Bedrock Agent or Action Group Manipulation
 * AWS Bedrock AgentCore Execution Role Used Outside Its Runtime
 * AWS Bedrock Knowledge Base or RAG Data Source Tampering
@@ -159,6 +160,7 @@ invalid-syntax
 * AWS DynamoDB Scan by Unusual User
 * AWS DynamoDB Table Exported to S3
 * AWS EC2 CreateKeyPair by New Principal from Non-Cloud AS Organization
+* AWS EC2 NACL Entry Created or Replaced Allowing All Traffic by New Identity
 * AWS EC2 Role GetCallerIdentity from New Source AS Organization
 * AWS EC2 Route Table Created
 * AWS EC2 Route Table Modified or Deleted
@@ -171,9 +173,11 @@ invalid-syntax
 * AWS IAM Customer-Managed Policy Attached to Role by Rare User
 * AWS IAM Long-Term Access Key First Seen from Source IP
 * AWS IAM OIDC Provider Created by Rare User
+* AWS IAM Permission Boundary or Guardrail Policy Deleted by Unusual Identity
 * AWS IAM User Console Login Without MFA
 * AWS Lambda Function Invoked by an Unusual Principal
 * AWS Lambda Function Invoked from an Unusual Source ASN
+* AWS S3 Bucket ACL Modified to Allow Public Access by New Identity
 * AWS S3 Unauthenticated Bucket Access by Rare Source
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
@@ -214,6 +218,7 @@ invalid-syntax
 * Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
 * Deprecated TLS Version or Weak Cipher Negotiated Externally
+* Direct Process Execution via Background Utility
 * Discovery of Internet Capabilities via Built-in Tools
 * Entra ID Conditional Access MFA Bypass with Unusual User, Client and Source ASN
 * Entra ID Conditional Access Policy (CAP) Modified
@@ -259,14 +264,19 @@ invalid-syntax
 * First Time Seen Account Performing DCSync
 * First Time Seen Driver Loaded
 * First Time Seen Google Workspace OAuth Login from Third-Party Application
+* First Time Seen Memcached Writer
+* First Time Seen NFS AUTH_SYS Root UID Access
 * First Time Seen NewCredentials Logon Process
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
+* First-Time Destructive MongoDB Command from a Client IP
 * FortiGate Administrator Account Creation from Unusual Source
 * GKE Anonymous Request Authorized by Unusual User Agent
 * GKE Forbidden Request from Unusual User Agent
+* GKE Secret Access via Unusual User Agent
 * GKE Secrets List from Unusual Source AS Organization
 * GKE Unusual Sensitive Workload Modification
+* GKE Unusual Service Account Secret Access via New User Agent
 * GKE User Exec into Pod
 * GenAI Process Connection to Unusual Domain
 * GitHub Actions Unusual Bot Push to Repository
@@ -339,11 +349,13 @@ invalid-syntax
 * Suspicious PowerShell Engine ImageLoad
 * Suspicious Sysctl File Event
 * Suspicious System Commands Executed by Previously Unknown Executable
+* Suspicious UID Change to Root via Python
 * Svchost spawning Cmd
 * System Binary Symlink to Suspicious Location
 * System Network Connections Discovery
 * System Owner/User Discovery Linux
 * Systemd Service Started by Unusual Parent Process
+* Thrift RPC Method from an External Client
 * UID Elevation from Previously Unknown Executable
 * Unauthorized Scope for Public App OAuth2 Token Grant with Client Credentials
 * Uncommon DNS Request via Bun or Node.js
@@ -355,6 +367,7 @@ invalid-syntax
 * Unusual Discovery Signal Alert with Unusual Process Executable
 * Unusual Execution from Kernel Thread (kthreadd) Parent
 * Unusual Exim4 Child Process
+* Unusual File Creation via Web Server
 * Unusual File Operation by dns.exe
 * Unusual Interactive Shell Launched from System User
 * Unusual Kernel Module Enumeration
@@ -373,9 +386,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (193)
+### Unsupported rule type: esql (201)
 
-193 rules:
+201 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -385,6 +398,7 @@ invalid-syntax
 * AWS Bedrock Detected Multiple Validation Exception Errors by a Single User
 * AWS Bedrock Guardrails Detected Multiple Policy Violations Within a Single Blocked Request
 * AWS Bedrock Guardrails Detected Multiple Violations by a Single User Over a Session
+* AWS Bedrock High Risk Filesystem or Execution Tool Invocation
 * AWS Bedrock High-Frequency Single-Model Inference API Probing
 * AWS Bedrock Invocations without Guardrails Detected by a Single User Over a Session
 * AWS Bedrock Model Prompt or Completion Containing Credentials
@@ -398,6 +412,7 @@ invalid-syntax
 * AWS IAM Long-Term Access Key Correlated with Elevated Detection Alerts
 * AWS IAM User Console Login from Multiple Geolocations
 * AWS IAM User Created Access Keys For Another User
+* AWS IAM User Self-Created Access Key Subsequently Used
 * AWS Lambda Function High-Frequency Invocation by a Single Principal
 * AWS Lambda Function Invoked Cross-Account
 * AWS Lateral Movement from Kubernetes SA via AssumeRoleWithWebIdentity
@@ -406,6 +421,7 @@ invalid-syntax
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SageMaker Execution Role Passed by Unusual Principal
 * AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
 * Agent Spoofing - Multiple Hosts Using Same Agent
@@ -447,7 +463,10 @@ invalid-syntax
 * GKE API Request Failure Burst by User
 * GKE Anonymous Endpoint Permission Enumeration
 * GKE Certificate Signing Request Self-Approved
+* GKE Endpoint Permission Enumeration
+* GKE Multi-Resource Discovery
 * GKE Rapid Secret GET Activity Against Multiple Objects
+* GKE Sensitive RBAC Change Followed by Workload Modification
 * GitHub Actions Workflow Modification Blocked
 * GitHub Exfiltration via High Number of Repository Clones by User
 * Google Workspace Device Registration Burst for Single User
@@ -499,6 +518,7 @@ invalid-syntax
 * Multiple Okta User Authentication Events with Same Device Token Hash
 * Multiple Rare Elastic Defend Behavior Rules by Host
 * Multiple Remote Management Tool Vendors on Same Host
+* Multiple SonicWall Login Failures Followed by Successful Login
 * Multiple Vulnerabilities by Asset via Wiz
 * Newly Observed Elastic Defend Behavior Alert
 * Newly Observed FortiGate Alert
@@ -553,6 +573,7 @@ invalid-syntax
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
+* Successful AMQP Multi-Queue Purge Burst
 * Suspected Lateral Movement from Compromised Host
 * Suspicious AWS S3 Connection via Script Interpreter
 * Suspicious Python Shell Command Execution
@@ -690,6 +711,7 @@ invalid-syntax
 * AWS S3 Bucket Enumeration or Brute Force
 * AWS Secrets Manager Rapid Secrets Retrieval
 * Attempts to Brute Force an Okta User Account
+* Azure AKS Potential API Enumeration by User
 * Azure Compute Restore Point Collections Deleted
 * Azure Compute Snapshot Deletions by User
 * Azure Storage Account Deletions by User
@@ -701,7 +723,6 @@ invalid-syntax
 * High Number of Process Terminations
 * High Number of Process and/or Service Terminations
 * M365 Identity Login from Impossible Travel Location
-* Multiple Alerts in Different ATT&CK Tactics on a Single Host
 * Multiple Okta Sessions Detected for a Single User
 * Multiple Okta User Auth Events with Same Device Token Hash Behind a Proxy
 * My First Rule
@@ -747,9 +768,9 @@ Invalid syntax
 
 ## Generation errors
 
-### Field type solver: constant_keyword (378)
+### Field type solver: constant_keyword (388)
 
-378 rules:
+388 rules:
 * AWS Account Closed
 * AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
 * AWS Attempt to Leave Organization
@@ -853,7 +874,13 @@ Invalid syntax
 * Attempted Bypass of Okta MFA
 * Azure AKS API Server Proxying Request to Kubelet
 * Azure AKS Attempted User Exec into Pod
+* Azure AKS Certificate Signing Request Created or Approved
+* Azure AKS CoreDNS or Kube-DNS Configuration Modified
+* Azure AKS Ephemeral Container Added to Pod
 * Azure AKS Kubelet Proxy to Command Execution Endpoint
+* Azure AKS Kubernetes Events Deleted
+* Azure AKS Secret get or list with Suspicious User Agent
+* Azure AKS Suspicious Self-Subject Review by Service Account or Node Identity
 * Azure Automation Account Created
 * Azure Automation Runbook Created or Modified
 * Azure Automation Runbook Deleted
@@ -877,6 +904,7 @@ Invalid syntax
 * Azure VNet Full Network Packet Capture Enabled
 * Azure VNet Network Watcher Deleted
 * Azure Virtual Machine Configuration Modified
+* Cassandra JavaScript UDF Creation
 * Command and Scripting Interpreter via Windows Scripts
 * CrowdStrike External Alerts
 * CyberArk Privileged Access Security Error
@@ -992,6 +1020,7 @@ Invalid syntax
 * GKE Pod Exec with Curl or Wget to HTTPS
 * GKE Privileged Pod Created
 * GKE RBAC Wildcard Elevation on Existing Role
+* GKE Secret Access from Node or Denied Service Account
 * GKE Secret get or list with Suspicious User Agent
 * GKE Service Account Modified RBAC Objects
 * GKE Service Account Token Created via TokenRequest API
@@ -1080,6 +1109,7 @@ Invalid syntax
 * Microsoft Defender XDR Incident External Alerts
 * Microsoft Sentinel External Alerts
 * Modification or Removal of an Okta Application Sign-On Policy
+* MySQL User-Defined Function Injection
 * New GitHub App Installed
 * New GitHub Owner Added
 * New GitHub Personal Access Token (PAT) Added
@@ -1089,6 +1119,7 @@ Invalid syntax
 * Okta User Assigned Administrator Role
 * Okta User Session Impersonation
 * Possible Okta DoS Attack
+* PostgreSQL COPY PROGRAM Command Execution
 * Potential DLL Side-Loading via Trusted Microsoft Programs
 * Potential File Transfer via Curl for Windows
 * Potential Persistence via File Modification
@@ -1258,6 +1289,18 @@ Invalid syntax
 * Suspicious Process Access via Direct System Call
 * Uncommon Registry Persistence Change
 
+### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (8)
+
+8 rules:
+* Execution via MS VisualStudio Pre/Post Build Events
+* Local Scheduled Task Creation
+* Suspicious Execution from VS Code Extension
+* Suspicious Execution from a WebDav Share
+* Suspicious JetBrains TeamCity Child Process
+* Suspicious Microsoft HTML Application Child Process
+* Suspicious Shell Execution via Velociraptor
+* Suspicious Windows Command Shell Arguments
+
 ### Unsupported argument type(s): <class 'eql.ast.Field'> (8)
 
 8 rules:
@@ -1269,17 +1312,6 @@ Invalid syntax
 * Potential Privilege Escalation via SUID/SGID
 * Unusual Network Activity from a Windows System Binary
 * Windows Service Installed via an Unusual Client
-
-### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)
-
-7 rules:
-* Execution via MS VisualStudio Pre/Post Build Events
-* Suspicious Execution from VS Code Extension
-* Suspicious Execution from a WebDav Share
-* Suspicious JetBrains TeamCity Child Process
-* Suspicious Microsoft HTML Application Child Process
-* Suspicious Shell Execution via Velociraptor
-* Suspicious Windows Command Shell Arguments
 
 ### Unsupported function: startsWith (4)
 

--- a/tests/reports/documents_from_rules-9.4.md
+++ b/tests/reports/documents_from_rules-9.4.md
@@ -5,13 +5,13 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.8
+Rules version: 9.4.9
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (226)](#unsupported-rule-type-new_terms-226)
-      1. [Unsupported rule type: esql (196)](#unsupported-rule-type-esql-196)
-      1. ['types.SimpleNamespace' object has no attribute 'type' (117)](#typessimplenamespace-object-has-no-attribute-type-117)
+      1. [Unsupported rule type: new_terms (239)](#unsupported-rule-type-new_terms-239)
+      1. [Unsupported rule type: esql (207)](#unsupported-rule-type-esql-207)
+      1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -34,14 +34,14 @@ invalid-syntax
 --processargs-curl-or-bincurl-or-wget
 -------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (378)](#field-type-solver-constant_keyword-378)
+      1. [Field type solver: constant_keyword (388)](#field-type-solver-constant_keyword-388)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
       1. [Root without branches (11)](#root-without-branches-11)
       1. [Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)](#unsupported-lhs-type-class-eqlastfunctioncall-11)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (8)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-8)
       1. [Unsupported argument type(s): <class 'eql.ast.Field'> (8)](#unsupported-argument-types-class-eqlastfield-8)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-7)
       1. [Unsupported function: startsWith (4)](#unsupported-function-startswith-4)
       1. [<class 'eql.ast.Sample'> (3)](#class-eqlastsample-3)
       1. [Field type solver: match_only_text (3)](#field-type-solver-match_only_text-3)
@@ -143,12 +143,13 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (226)
+### Unsupported rule type: new_terms (239)
 
-226 rules:
+239 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
+* AWS Batch Job Submitted with Container Override by Unusual Identity
 * AWS Bedrock Agent or Action Group Manipulation
 * AWS Bedrock AgentCore Execution Role Used Outside Its Runtime
 * AWS Bedrock Knowledge Base or RAG Data Source Tampering
@@ -160,6 +161,7 @@ invalid-syntax
 * AWS DynamoDB Scan by Unusual User
 * AWS DynamoDB Table Exported to S3
 * AWS EC2 CreateKeyPair by New Principal from Non-Cloud AS Organization
+* AWS EC2 NACL Entry Created or Replaced Allowing All Traffic by New Identity
 * AWS EC2 Role GetCallerIdentity from New Source AS Organization
 * AWS EC2 Route Table Created
 * AWS EC2 Route Table Modified or Deleted
@@ -172,9 +174,11 @@ invalid-syntax
 * AWS IAM Customer-Managed Policy Attached to Role by Rare User
 * AWS IAM Long-Term Access Key First Seen from Source IP
 * AWS IAM OIDC Provider Created by Rare User
+* AWS IAM Permission Boundary or Guardrail Policy Deleted by Unusual Identity
 * AWS IAM User Console Login Without MFA
 * AWS Lambda Function Invoked by an Unusual Principal
 * AWS Lambda Function Invoked from an Unusual Source ASN
+* AWS S3 Bucket ACL Modified to Allow Public Access by New Identity
 * AWS S3 Unauthenticated Bucket Access by Rare Source
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
@@ -215,6 +219,7 @@ invalid-syntax
 * Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
 * Deprecated TLS Version or Weak Cipher Negotiated Externally
+* Direct Process Execution via Background Utility
 * Discovery of Internet Capabilities via Built-in Tools
 * Entra ID Conditional Access MFA Bypass with Unusual User, Client and Source ASN
 * Entra ID Conditional Access Policy (CAP) Modified
@@ -260,14 +265,19 @@ invalid-syntax
 * First Time Seen Account Performing DCSync
 * First Time Seen Driver Loaded
 * First Time Seen Google Workspace OAuth Login from Third-Party Application
+* First Time Seen Memcached Writer
+* First Time Seen NFS AUTH_SYS Root UID Access
 * First Time Seen NewCredentials Logon Process
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
+* First-Time Destructive MongoDB Command from a Client IP
 * FortiGate Administrator Account Creation from Unusual Source
 * GKE Anonymous Request Authorized by Unusual User Agent
 * GKE Forbidden Request from Unusual User Agent
+* GKE Secret Access via Unusual User Agent
 * GKE Secrets List from Unusual Source AS Organization
 * GKE Unusual Sensitive Workload Modification
+* GKE Unusual Service Account Secret Access via New User Agent
 * GKE User Exec into Pod
 * GenAI Process Connection to Unusual Domain
 * GitHub Actions Unusual Bot Push to Repository
@@ -340,11 +350,13 @@ invalid-syntax
 * Suspicious PowerShell Engine ImageLoad
 * Suspicious Sysctl File Event
 * Suspicious System Commands Executed by Previously Unknown Executable
+* Suspicious UID Change to Root via Python
 * Svchost spawning Cmd
 * System Binary Symlink to Suspicious Location
 * System Network Connections Discovery
 * System Owner/User Discovery Linux
 * Systemd Service Started by Unusual Parent Process
+* Thrift RPC Method from an External Client
 * UID Elevation from Previously Unknown Executable
 * Unauthorized Scope for Public App OAuth2 Token Grant with Client Credentials
 * Uncommon DNS Request via Bun or Node.js
@@ -356,6 +368,7 @@ invalid-syntax
 * Unusual Discovery Signal Alert with Unusual Process Executable
 * Unusual Execution from Kernel Thread (kthreadd) Parent
 * Unusual Exim4 Child Process
+* Unusual File Creation via Web Server
 * Unusual File Operation by dns.exe
 * Unusual Interactive Shell Launched from System User
 * Unusual Kernel Module Enumeration
@@ -374,9 +387,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (196)
+### Unsupported rule type: esql (207)
 
-196 rules:
+207 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -386,6 +399,7 @@ invalid-syntax
 * AWS Bedrock Detected Multiple Validation Exception Errors by a Single User
 * AWS Bedrock Guardrails Detected Multiple Policy Violations Within a Single Blocked Request
 * AWS Bedrock Guardrails Detected Multiple Violations by a Single User Over a Session
+* AWS Bedrock High Risk Filesystem or Execution Tool Invocation
 * AWS Bedrock High-Frequency Single-Model Inference API Probing
 * AWS Bedrock Invocations without Guardrails Detected by a Single User Over a Session
 * AWS Bedrock Model Prompt or Completion Containing Credentials
@@ -399,6 +413,7 @@ invalid-syntax
 * AWS IAM Long-Term Access Key Correlated with Elevated Detection Alerts
 * AWS IAM User Console Login from Multiple Geolocations
 * AWS IAM User Created Access Keys For Another User
+* AWS IAM User Self-Created Access Key Subsequently Used
 * AWS Lambda Function High-Frequency Invocation by a Single Principal
 * AWS Lambda Function Invoked Cross-Account
 * AWS Lateral Movement from Kubernetes SA via AssumeRoleWithWebIdentity
@@ -407,6 +422,7 @@ invalid-syntax
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SageMaker Execution Role Passed by Unusual Principal
 * AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
 * Agent Spoofing - Multiple Hosts Using Same Agent
@@ -449,7 +465,10 @@ invalid-syntax
 * GKE Anonymous Endpoint Permission Enumeration
 * GKE Certificate Signing Request Self-Approved
 * GKE Certificate Signing Request for Privileged Identity
+* GKE Endpoint Permission Enumeration
+* GKE Multi-Resource Discovery
 * GKE Rapid Secret GET Activity Against Multiple Objects
+* GKE Sensitive RBAC Change Followed by Workload Modification
 * GitHub Actions Workflow Modification Blocked
 * GitHub Exfiltration via High Number of Repository Clones by User
 * Google Workspace Device Registration Burst for Single User
@@ -503,6 +522,7 @@ invalid-syntax
 * Multiple Okta User Authentication Events with Same Device Token Hash
 * Multiple Rare Elastic Defend Behavior Rules by Host
 * Multiple Remote Management Tool Vendors on Same Host
+* Multiple SonicWall Login Failures Followed by Successful Login
 * Multiple Vulnerabilities by Asset via Wiz
 * Newly Observed Elastic Defend Behavior Alert
 * Newly Observed FortiGate Alert
@@ -528,6 +548,7 @@ invalid-syntax
 * Potential Malicious PowerShell Based on Alert Correlation
 * Potential Malware-Driven SSH Brute Force Attempt
 * Potential Masquerading as Svchost
+* Potential NFS Destructive Operation Burst
 * Potential Network Scan Detected
 * Potential Okta Brute Force (Device Token Rotation)
 * Potential Okta Brute Force (Multi-Source)
@@ -547,6 +568,8 @@ invalid-syntax
 * Potential PowerShell Obfuscation via String Concatenation
 * Potential PowerShell Obfuscation via String Reordering
 * Potential Ransomware Behavior - Note Files by System
+* Potential SIP Extension Enumeration
+* Potential SIP REGISTER Brute Force
 * Potential SQL Injection Against Microsoft SQL Server
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
@@ -557,6 +580,7 @@ invalid-syntax
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
+* Successful AMQP Multi-Queue Purge Burst
 * Suspected Lateral Movement from Compromised Host
 * Suspicious AWS S3 Connection via Script Interpreter
 * Suspicious Python Shell Command Execution
@@ -575,9 +599,9 @@ invalid-syntax
 * Web Server Potential Spike in Error Response Codes
 * Web Server Suspicious User Agent Requests
 
-### 'types.SimpleNamespace' object has no attribute 'type' (117)
+### 'types.SimpleNamespace' object has no attribute 'type' (119)
 
-117 rules:
+119 rules:
 
 * AWS RDS Snapshot Export
 * Attempt to Disable IPTables or Firewall
@@ -658,11 +682,13 @@ invalid-syntax
 * Linux Restricted Shell Breakout via the vi command
 * Malicious Remote File Creation
 * Mknod Process Activity
+* Multiple Alerts in Different ATT&CK Tactics on a Single Host
 * Network Connection via Mshta
 * Network Sniffing via Tcpdump
 * Nmap Process Activity
 * PPTP (Point to Point Tunneling Protocol) Activity
 * Persistence via Kernel Module Modification
+* Potential CVE-2025-41244 vmtoolsd LPE Exploitation Attempt
 * Potential Cross Site Scripting (XSS)
 * Potential Linux Reverse Connection through Port Knocking
 * Potential Persistence via Cron Job
@@ -817,6 +843,7 @@ invalid-syntax
 * AWS S3 Bucket Enumeration or Brute Force
 * AWS Secrets Manager Rapid Secrets Retrieval
 * Attempts to Brute Force an Okta User Account
+* Azure AKS Potential API Enumeration by User
 * Azure Compute Restore Point Collections Deleted
 * Azure Compute Snapshot Deletions by User
 * Azure Storage Account Deletions by User
@@ -828,7 +855,6 @@ invalid-syntax
 * High Number of Process Terminations
 * High Number of Process and/or Service Terminations
 * M365 Identity Login from Impossible Travel Location
-* Multiple Alerts in Different ATT&CK Tactics on a Single Host
 * Multiple Okta Sessions Detected for a Single User
 * Multiple Okta User Auth Events with Same Device Token Hash Behind a Proxy
 * My First Rule
@@ -874,9 +900,9 @@ Invalid syntax
 
 ## Generation errors
 
-### Field type solver: constant_keyword (378)
+### Field type solver: constant_keyword (388)
 
-378 rules:
+388 rules:
 * AWS Account Closed
 * AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
 * AWS Attempt to Leave Organization
@@ -980,7 +1006,13 @@ Invalid syntax
 * Attempted Bypass of Okta MFA
 * Azure AKS API Server Proxying Request to Kubelet
 * Azure AKS Attempted User Exec into Pod
+* Azure AKS Certificate Signing Request Created or Approved
+* Azure AKS CoreDNS or Kube-DNS Configuration Modified
+* Azure AKS Ephemeral Container Added to Pod
 * Azure AKS Kubelet Proxy to Command Execution Endpoint
+* Azure AKS Kubernetes Events Deleted
+* Azure AKS Secret get or list with Suspicious User Agent
+* Azure AKS Suspicious Self-Subject Review by Service Account or Node Identity
 * Azure Automation Account Created
 * Azure Automation Runbook Created or Modified
 * Azure Automation Runbook Deleted
@@ -1004,6 +1036,7 @@ Invalid syntax
 * Azure VNet Full Network Packet Capture Enabled
 * Azure VNet Network Watcher Deleted
 * Azure Virtual Machine Configuration Modified
+* Cassandra JavaScript UDF Creation
 * Command and Scripting Interpreter via Windows Scripts
 * CrowdStrike External Alerts
 * CyberArk Privileged Access Security Error
@@ -1119,6 +1152,7 @@ Invalid syntax
 * GKE Pod Exec with Curl or Wget to HTTPS
 * GKE Privileged Pod Created
 * GKE RBAC Wildcard Elevation on Existing Role
+* GKE Secret Access from Node or Denied Service Account
 * GKE Secret get or list with Suspicious User Agent
 * GKE Service Account Modified RBAC Objects
 * GKE Service Account Token Created via TokenRequest API
@@ -1207,6 +1241,7 @@ Invalid syntax
 * Microsoft Defender XDR Incident External Alerts
 * Microsoft Sentinel External Alerts
 * Modification or Removal of an Okta Application Sign-On Policy
+* MySQL User-Defined Function Injection
 * New GitHub App Installed
 * New GitHub Owner Added
 * New GitHub Personal Access Token (PAT) Added
@@ -1216,6 +1251,7 @@ Invalid syntax
 * Okta User Assigned Administrator Role
 * Okta User Session Impersonation
 * Possible Okta DoS Attack
+* PostgreSQL COPY PROGRAM Command Execution
 * Potential DLL Side-Loading via Trusted Microsoft Programs
 * Potential File Transfer via Curl for Windows
 * Potential Persistence via File Modification
@@ -1385,6 +1421,18 @@ Invalid syntax
 * Suspicious Process Access via Direct System Call
 * Uncommon Registry Persistence Change
 
+### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (8)
+
+8 rules:
+* Execution via MS VisualStudio Pre/Post Build Events
+* Local Scheduled Task Creation
+* Suspicious Execution from VS Code Extension
+* Suspicious Execution from a WebDav Share
+* Suspicious JetBrains TeamCity Child Process
+* Suspicious Microsoft HTML Application Child Process
+* Suspicious Shell Execution via Velociraptor
+* Suspicious Windows Command Shell Arguments
+
 ### Unsupported argument type(s): <class 'eql.ast.Field'> (8)
 
 8 rules:
@@ -1396,17 +1444,6 @@ Invalid syntax
 * Potential Privilege Escalation via SUID/SGID
 * Unusual Network Activity from a Windows System Binary
 * Windows Service Installed via an Unusual Client
-
-### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)
-
-7 rules:
-* Execution via MS VisualStudio Pre/Post Build Events
-* Suspicious Execution from VS Code Extension
-* Suspicious Execution from a WebDav Share
-* Suspicious JetBrains TeamCity Child Process
-* Suspicious Microsoft HTML Application Child Process
-* Suspicious Shell Execution via Velociraptor
-* Suspicious Windows Command Shell Arguments
 
 ### Unsupported function: startsWith (4)
 

--- a/tests/reports/documents_from_rules-serverless.md
+++ b/tests/reports/documents_from_rules-serverless.md
@@ -5,13 +5,13 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.8
+Rules version: 9.5.2
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (226)](#unsupported-rule-type-new_terms-226)
-      1. [Unsupported rule type: esql (196)](#unsupported-rule-type-esql-196)
-      1. ['types.SimpleNamespace' object has no attribute 'type' (117)](#typessimplenamespace-object-has-no-attribute-type-117)
+      1. [Unsupported rule type: new_terms (239)](#unsupported-rule-type-new_terms-239)
+      1. [Unsupported rule type: esql (207)](#unsupported-rule-type-esql-207)
+      1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -34,14 +34,14 @@ invalid-syntax
 --processargs-curl-or-bincurl-or-wget
 -------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (378)](#field-type-solver-constant_keyword-378)
+      1. [Field type solver: constant_keyword (388)](#field-type-solver-constant_keyword-388)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
       1. [Root without branches (11)](#root-without-branches-11)
       1. [Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)](#unsupported-lhs-type-class-eqlastfunctioncall-11)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (8)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-8)
       1. [Unsupported argument type(s): <class 'eql.ast.Field'> (8)](#unsupported-argument-types-class-eqlastfield-8)
-      1. [Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)](#unsolvable-constraints-processname-excluded-by-stringscmdexe-cmdexe-7)
       1. [Unsupported function: startsWith (4)](#unsupported-function-startswith-4)
       1. [<class 'eql.ast.Sample'> (3)](#class-eqlastsample-3)
       1. [Field type solver: match_only_text (3)](#field-type-solver-match_only_text-3)
@@ -143,12 +143,13 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (226)
+### Unsupported rule type: new_terms (239)
 
-226 rules:
+239 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
+* AWS Batch Job Submitted with Container Override by Unusual Identity
 * AWS Bedrock Agent or Action Group Manipulation
 * AWS Bedrock AgentCore Execution Role Used Outside Its Runtime
 * AWS Bedrock Knowledge Base or RAG Data Source Tampering
@@ -160,6 +161,7 @@ invalid-syntax
 * AWS DynamoDB Scan by Unusual User
 * AWS DynamoDB Table Exported to S3
 * AWS EC2 CreateKeyPair by New Principal from Non-Cloud AS Organization
+* AWS EC2 NACL Entry Created or Replaced Allowing All Traffic by New Identity
 * AWS EC2 Role GetCallerIdentity from New Source AS Organization
 * AWS EC2 Route Table Created
 * AWS EC2 Route Table Modified or Deleted
@@ -172,9 +174,11 @@ invalid-syntax
 * AWS IAM Customer-Managed Policy Attached to Role by Rare User
 * AWS IAM Long-Term Access Key First Seen from Source IP
 * AWS IAM OIDC Provider Created by Rare User
+* AWS IAM Permission Boundary or Guardrail Policy Deleted by Unusual Identity
 * AWS IAM User Console Login Without MFA
 * AWS Lambda Function Invoked by an Unusual Principal
 * AWS Lambda Function Invoked from an Unusual Source ASN
+* AWS S3 Bucket ACL Modified to Allow Public Access by New Identity
 * AWS S3 Unauthenticated Bucket Access by Rare Source
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
@@ -215,6 +219,7 @@ invalid-syntax
 * Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
 * Deprecated TLS Version or Weak Cipher Negotiated Externally
+* Direct Process Execution via Background Utility
 * Discovery of Internet Capabilities via Built-in Tools
 * Entra ID Conditional Access MFA Bypass with Unusual User, Client and Source ASN
 * Entra ID Conditional Access Policy (CAP) Modified
@@ -260,14 +265,19 @@ invalid-syntax
 * First Time Seen Account Performing DCSync
 * First Time Seen Driver Loaded
 * First Time Seen Google Workspace OAuth Login from Third-Party Application
+* First Time Seen Memcached Writer
+* First Time Seen NFS AUTH_SYS Root UID Access
 * First Time Seen NewCredentials Logon Process
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
+* First-Time Destructive MongoDB Command from a Client IP
 * FortiGate Administrator Account Creation from Unusual Source
 * GKE Anonymous Request Authorized by Unusual User Agent
 * GKE Forbidden Request from Unusual User Agent
+* GKE Secret Access via Unusual User Agent
 * GKE Secrets List from Unusual Source AS Organization
 * GKE Unusual Sensitive Workload Modification
+* GKE Unusual Service Account Secret Access via New User Agent
 * GKE User Exec into Pod
 * GenAI Process Connection to Unusual Domain
 * GitHub Actions Unusual Bot Push to Repository
@@ -340,11 +350,13 @@ invalid-syntax
 * Suspicious PowerShell Engine ImageLoad
 * Suspicious Sysctl File Event
 * Suspicious System Commands Executed by Previously Unknown Executable
+* Suspicious UID Change to Root via Python
 * Svchost spawning Cmd
 * System Binary Symlink to Suspicious Location
 * System Network Connections Discovery
 * System Owner/User Discovery Linux
 * Systemd Service Started by Unusual Parent Process
+* Thrift RPC Method from an External Client
 * UID Elevation from Previously Unknown Executable
 * Unauthorized Scope for Public App OAuth2 Token Grant with Client Credentials
 * Uncommon DNS Request via Bun or Node.js
@@ -356,6 +368,7 @@ invalid-syntax
 * Unusual Discovery Signal Alert with Unusual Process Executable
 * Unusual Execution from Kernel Thread (kthreadd) Parent
 * Unusual Exim4 Child Process
+* Unusual File Creation via Web Server
 * Unusual File Operation by dns.exe
 * Unusual Interactive Shell Launched from System User
 * Unusual Kernel Module Enumeration
@@ -374,9 +387,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (196)
+### Unsupported rule type: esql (207)
 
-196 rules:
+207 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -386,6 +399,7 @@ invalid-syntax
 * AWS Bedrock Detected Multiple Validation Exception Errors by a Single User
 * AWS Bedrock Guardrails Detected Multiple Policy Violations Within a Single Blocked Request
 * AWS Bedrock Guardrails Detected Multiple Violations by a Single User Over a Session
+* AWS Bedrock High Risk Filesystem or Execution Tool Invocation
 * AWS Bedrock High-Frequency Single-Model Inference API Probing
 * AWS Bedrock Invocations without Guardrails Detected by a Single User Over a Session
 * AWS Bedrock Model Prompt or Completion Containing Credentials
@@ -399,6 +413,7 @@ invalid-syntax
 * AWS IAM Long-Term Access Key Correlated with Elevated Detection Alerts
 * AWS IAM User Console Login from Multiple Geolocations
 * AWS IAM User Created Access Keys For Another User
+* AWS IAM User Self-Created Access Key Subsequently Used
 * AWS Lambda Function High-Frequency Invocation by a Single Principal
 * AWS Lambda Function Invoked Cross-Account
 * AWS Lateral Movement from Kubernetes SA via AssumeRoleWithWebIdentity
@@ -407,6 +422,7 @@ invalid-syntax
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SageMaker Execution Role Passed by Unusual Principal
 * AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
 * Agent Spoofing - Multiple Hosts Using Same Agent
@@ -449,7 +465,10 @@ invalid-syntax
 * GKE Anonymous Endpoint Permission Enumeration
 * GKE Certificate Signing Request Self-Approved
 * GKE Certificate Signing Request for Privileged Identity
+* GKE Endpoint Permission Enumeration
+* GKE Multi-Resource Discovery
 * GKE Rapid Secret GET Activity Against Multiple Objects
+* GKE Sensitive RBAC Change Followed by Workload Modification
 * GitHub Actions Workflow Modification Blocked
 * GitHub Exfiltration via High Number of Repository Clones by User
 * Google Workspace Device Registration Burst for Single User
@@ -503,6 +522,7 @@ invalid-syntax
 * Multiple Okta User Authentication Events with Same Device Token Hash
 * Multiple Rare Elastic Defend Behavior Rules by Host
 * Multiple Remote Management Tool Vendors on Same Host
+* Multiple SonicWall Login Failures Followed by Successful Login
 * Multiple Vulnerabilities by Asset via Wiz
 * Newly Observed Elastic Defend Behavior Alert
 * Newly Observed FortiGate Alert
@@ -528,6 +548,7 @@ invalid-syntax
 * Potential Malicious PowerShell Based on Alert Correlation
 * Potential Malware-Driven SSH Brute Force Attempt
 * Potential Masquerading as Svchost
+* Potential NFS Destructive Operation Burst
 * Potential Network Scan Detected
 * Potential Okta Brute Force (Device Token Rotation)
 * Potential Okta Brute Force (Multi-Source)
@@ -547,6 +568,8 @@ invalid-syntax
 * Potential PowerShell Obfuscation via String Concatenation
 * Potential PowerShell Obfuscation via String Reordering
 * Potential Ransomware Behavior - Note Files by System
+* Potential SIP Extension Enumeration
+* Potential SIP REGISTER Brute Force
 * Potential SQL Injection Against Microsoft SQL Server
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
@@ -557,6 +580,7 @@ invalid-syntax
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
+* Successful AMQP Multi-Queue Purge Burst
 * Suspected Lateral Movement from Compromised Host
 * Suspicious AWS S3 Connection via Script Interpreter
 * Suspicious Python Shell Command Execution
@@ -575,9 +599,9 @@ invalid-syntax
 * Web Server Potential Spike in Error Response Codes
 * Web Server Suspicious User Agent Requests
 
-### 'types.SimpleNamespace' object has no attribute 'type' (117)
+### 'types.SimpleNamespace' object has no attribute 'type' (119)
 
-117 rules:
+119 rules:
 
 * AWS RDS Snapshot Export
 * Attempt to Disable IPTables or Firewall
@@ -658,11 +682,13 @@ invalid-syntax
 * Linux Restricted Shell Breakout via the vi command
 * Malicious Remote File Creation
 * Mknod Process Activity
+* Multiple Alerts in Different ATT&CK Tactics on a Single Host
 * Network Connection via Mshta
 * Network Sniffing via Tcpdump
 * Nmap Process Activity
 * PPTP (Point to Point Tunneling Protocol) Activity
 * Persistence via Kernel Module Modification
+* Potential CVE-2025-41244 vmtoolsd LPE Exploitation Attempt
 * Potential Cross Site Scripting (XSS)
 * Potential Linux Reverse Connection through Port Knocking
 * Potential Persistence via Cron Job
@@ -817,6 +843,7 @@ invalid-syntax
 * AWS S3 Bucket Enumeration or Brute Force
 * AWS Secrets Manager Rapid Secrets Retrieval
 * Attempts to Brute Force an Okta User Account
+* Azure AKS Potential API Enumeration by User
 * Azure Compute Restore Point Collections Deleted
 * Azure Compute Snapshot Deletions by User
 * Azure Storage Account Deletions by User
@@ -828,7 +855,6 @@ invalid-syntax
 * High Number of Process Terminations
 * High Number of Process and/or Service Terminations
 * M365 Identity Login from Impossible Travel Location
-* Multiple Alerts in Different ATT&CK Tactics on a Single Host
 * Multiple Okta Sessions Detected for a Single User
 * Multiple Okta User Auth Events with Same Device Token Hash Behind a Proxy
 * My First Rule
@@ -874,9 +900,9 @@ Invalid syntax
 
 ## Generation errors
 
-### Field type solver: constant_keyword (378)
+### Field type solver: constant_keyword (388)
 
-378 rules:
+388 rules:
 * AWS Account Closed
 * AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
 * AWS Attempt to Leave Organization
@@ -980,7 +1006,13 @@ Invalid syntax
 * Attempted Bypass of Okta MFA
 * Azure AKS API Server Proxying Request to Kubelet
 * Azure AKS Attempted User Exec into Pod
+* Azure AKS Certificate Signing Request Created or Approved
+* Azure AKS CoreDNS or Kube-DNS Configuration Modified
+* Azure AKS Ephemeral Container Added to Pod
 * Azure AKS Kubelet Proxy to Command Execution Endpoint
+* Azure AKS Kubernetes Events Deleted
+* Azure AKS Secret get or list with Suspicious User Agent
+* Azure AKS Suspicious Self-Subject Review by Service Account or Node Identity
 * Azure Automation Account Created
 * Azure Automation Runbook Created or Modified
 * Azure Automation Runbook Deleted
@@ -1004,6 +1036,7 @@ Invalid syntax
 * Azure VNet Full Network Packet Capture Enabled
 * Azure VNet Network Watcher Deleted
 * Azure Virtual Machine Configuration Modified
+* Cassandra JavaScript UDF Creation
 * Command and Scripting Interpreter via Windows Scripts
 * CrowdStrike External Alerts
 * CyberArk Privileged Access Security Error
@@ -1119,6 +1152,7 @@ Invalid syntax
 * GKE Pod Exec with Curl or Wget to HTTPS
 * GKE Privileged Pod Created
 * GKE RBAC Wildcard Elevation on Existing Role
+* GKE Secret Access from Node or Denied Service Account
 * GKE Secret get or list with Suspicious User Agent
 * GKE Service Account Modified RBAC Objects
 * GKE Service Account Token Created via TokenRequest API
@@ -1207,6 +1241,7 @@ Invalid syntax
 * Microsoft Defender XDR Incident External Alerts
 * Microsoft Sentinel External Alerts
 * Modification or Removal of an Okta Application Sign-On Policy
+* MySQL User-Defined Function Injection
 * New GitHub App Installed
 * New GitHub Owner Added
 * New GitHub Personal Access Token (PAT) Added
@@ -1216,6 +1251,7 @@ Invalid syntax
 * Okta User Assigned Administrator Role
 * Okta User Session Impersonation
 * Possible Okta DoS Attack
+* PostgreSQL COPY PROGRAM Command Execution
 * Potential DLL Side-Loading via Trusted Microsoft Programs
 * Potential File Transfer via Curl for Windows
 * Potential Persistence via File Modification
@@ -1385,6 +1421,18 @@ Invalid syntax
 * Suspicious Process Access via Direct System Call
 * Uncommon Registry Persistence Change
 
+### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (8)
+
+8 rules:
+* Execution via MS VisualStudio Pre/Post Build Events
+* Local Scheduled Task Creation
+* Suspicious Execution from VS Code Extension
+* Suspicious Execution from a WebDav Share
+* Suspicious JetBrains TeamCity Child Process
+* Suspicious Microsoft HTML Application Child Process
+* Suspicious Shell Execution via Velociraptor
+* Suspicious Windows Command Shell Arguments
+
 ### Unsupported argument type(s): <class 'eql.ast.Field'> (8)
 
 8 rules:
@@ -1396,17 +1444,6 @@ Invalid syntax
 * Potential Privilege Escalation via SUID/SGID
 * Unusual Network Activity from a Windows System Binary
 * Windows Service Installed via an Unusual Client
-
-### Unsolvable constraints: process.name (excluded by Strings({'cmd.exe'}): ('cmd.exe')) (7)
-
-7 rules:
-* Execution via MS VisualStudio Pre/Post Build Events
-* Suspicious Execution from VS Code Extension
-* Suspicious Execution from a WebDav Share
-* Suspicious JetBrains TeamCity Child Process
-* Suspicious Microsoft HTML Application Child Process
-* Suspicious Shell Execution via Velociraptor
-* Suspicious Windows Command Shell Arguments
 
 ### Unsupported function: startsWith (4)
 


### PR DESCRIPTION
Applies pending Renovate updates and addresses closed PR #799 (serverless, which was never merged).

## ECH updates

| Key | Old | New | CI |
|-----|-----|-----|----|
| 8.19 | 8.19.28 | **8.19.29** | PR #806 — [Online tests (8.19.0) failed on report diff](https://github.com/elastic/geneve/actions/runs/30894624424) |
| 9.3 | 9.3.16 | **9.3.17** | PR #807 — [Online tests (9.3.0) failed on report diff](https://github.com/elastic/geneve/actions/runs/30894630402) |
| 9.4 | 9.4.8 | **9.4.9** | PR #809 — [Online tests (9.4.0-SNAPSHOT) failed on report diff](https://github.com/elastic/geneve/actions/runs/30911951629) |

### stack_signals changes

- `8.19`: ack_failed 17→18, ack_unsuccessful_with_signals 17→18, ack_too_few_signals 21→22
- `9.3`: ack_failed 23→24, ack_unsuccessful_with_signals 23→24, ack_too_few_signals 27→28
- `9.4`: ack_failed 23→24, ack_unsuccessful_with_signals 23→24, ack_too_few_signals 27→28

## Serverless update (addresses #799)

PR #799 was closed without merging; the serverless package was still at 9.4.8. Branch was deleted and Renovate had marked 9.5.1 as ignored. Reopened #799, which Renovate then rebased to v9.5.2.

| Key | Old | New | CI |
|-----|-----|-----|----|
| serverless | 9.4.8 | **9.5.2** | PR #799 — [BuildKite build 5435](https://buildkite.com/elastic/geneve-serverless-security-quality-gate/builds/5435) — failed on report diff |

### stack_signals changes

- `serverless`: ack_failed 23→24, ack_unsuccessful_with_signals 23→24, ack_too_few_signals 27→28

Closes #806, #807, #809, #799.