### PR TITLE
Update rules to 9.5.3, 9.4.10, 9.3.18, and 8.19.30

### DIFF
--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -35,7 +35,7 @@ emitter_rules:
     # renovate: datasource=epr package=security_detection_engine-8.18
     "8.18": "8.18.15"
     # renovate: datasource=epr package=security_detection_engine-8.19
-    "8.19": "8.19.29"
+    "8.19": "8.19.30"
     # renovate: datasource=epr package=security_detection_engine-9.0
     "9.0": "9.0.19"
     # renovate: datasource=epr package=security_detection_engine-9.1
@@ -43,15 +43,15 @@ emitter_rules:
     # renovate: datasource=epr package=security_detection_engine-9.2
     "9.2": "9.2.19"
     # renovate: datasource=epr package=security_detection_engine-9.3
-    "9.3": "9.3.17"
+    "9.3": "9.3.18"
     # renovate: datasource=epr package=security_detection_engine-9.4
-    "9.4": "9.4.9"
+    "9.4": "9.4.10"
     # renovate: datasource=epr package=security_detection_engine-9.5
-    "9.5": "9.5.2"
+    "9.5": "9.5.3"
     # renovate: datasource=epr package=security_detection_engine-9.6
-    "9.6": "9.5.2"
+    "9.6": "9.5.3"
     # renovate: datasource=epr package=security_detection_engine
-    "serverless": "9.5.2"
+    "serverless": "9.5.3"
 
   stack_signals:
     "8.2":

--- a/tests/reports/alerts_from_rules-8.19.md
+++ b/tests/reports/alerts_from_rules-8.19.md
@@ -5,7 +5,7 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.29
+Rules version: 8.19.30
 
 ## Table of contents
    1. [Failed rules (18)](#failed-rules-18)
@@ -20,7 +20,7 @@ Rules version: 8.19.29
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0366  
+Index: geneve-ut-0367  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -135,7 +135,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0564  
+Index: geneve-ut-0565  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -161,7 +161,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0567  
+Index: geneve-ut-0568  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -230,7 +230,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0589  
+Index: geneve-ut-0590  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0717  
+Index: geneve-ut-0719  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -290,7 +290,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0895  
+Index: geneve-ut-0897  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -343,7 +343,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1022  
+Index: geneve-ut-1024  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -376,7 +376,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1141  
+Index: geneve-ut-1144  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -402,7 +402,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1159  
+Index: geneve-ut-1162  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -440,7 +440,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1218  
+Index: geneve-ut-1221  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -462,7 +462,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1233  
+Index: geneve-ut-1236  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -501,7 +501,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1315  
+Index: geneve-ut-1318  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -564,7 +564,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1613  
+Index: geneve-ut-1617  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -612,7 +612,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1628  
+Index: geneve-ut-1632  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -647,7 +647,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1649  
+Index: geneve-ut-1653  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -710,7 +710,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1654  
+Index: geneve-ut-1658  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -738,7 +738,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1663  
+Index: geneve-ut-1667  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -770,7 +770,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1754  
+Index: geneve-ut-1758  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -847,7 +847,7 @@ not (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0366
+Index: geneve-ut-0367
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -959,7 +959,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0564
+Index: geneve-ut-0565
 
 ```python
 sequence by host.id, user.id with maxspan=3m
@@ -982,7 +982,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0567
+Index: geneve-ut-0568
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1048,7 +1048,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0589
+Index: geneve-ut-0590
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1074,7 +1074,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0717
+Index: geneve-ut-0719
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1102,7 +1102,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0895
+Index: geneve-ut-0897
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1152,7 +1152,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1022
+Index: geneve-ut-1024
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1182,7 +1182,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1141
+Index: geneve-ut-1144
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1205,7 +1205,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1159
+Index: geneve-ut-1162
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1240,7 +1240,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1218
+Index: geneve-ut-1221
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1259,7 +1259,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1233
+Index: geneve-ut-1236
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1295,7 +1295,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1315
+Index: geneve-ut-1318
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1355,7 +1355,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1613
+Index: geneve-ut-1617
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1400,7 +1400,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1628
+Index: geneve-ut-1632
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1432,7 +1432,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1649
+Index: geneve-ut-1653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1492,7 +1492,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1654
+Index: geneve-ut-1658
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1517,7 +1517,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1663
+Index: geneve-ut-1667
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -1546,7 +1546,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1754
+Index: geneve-ut-1758
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -1634,7 +1634,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0896
+Index: geneve-ut-0898
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1646,7 +1646,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0902
+Index: geneve-ut-0904
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1658,7 +1658,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1266
+Index: geneve-ut-1269
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1676,7 +1676,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1452
+Index: geneve-ut-1455
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -1693,7 +1693,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0366  
+Index: geneve-ut-0367  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -1807,7 +1807,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0564  
+Index: geneve-ut-0565  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -1832,7 +1832,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0567  
+Index: geneve-ut-0568  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -1900,7 +1900,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0589  
+Index: geneve-ut-0590  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -1928,7 +1928,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0717  
+Index: geneve-ut-0719  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -1958,7 +1958,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0874  
+Index: geneve-ut-0876  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -1977,7 +1977,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0895  
+Index: geneve-ut-0897  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2029,7 +2029,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1003  
+Index: geneve-ut-1005  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2049,7 +2049,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1022  
+Index: geneve-ut-1024  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2081,7 +2081,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1141  
+Index: geneve-ut-1144  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2106,7 +2106,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1159  
+Index: geneve-ut-1162  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2143,7 +2143,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1218  
+Index: geneve-ut-1221  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2164,7 +2164,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1233  
+Index: geneve-ut-1236  
 Failure message(s):  
   got 1000 signals, expected 1085  
 
@@ -2202,7 +2202,7 @@ process.command_line like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1307  
+Index: geneve-ut-1310  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2219,7 +2219,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1315  
+Index: geneve-ut-1318  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2281,7 +2281,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1421  
+Index: geneve-ut-1424  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2306,7 +2306,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1613  
+Index: geneve-ut-1617  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -2353,7 +2353,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1628  
+Index: geneve-ut-1632  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -2387,7 +2387,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1649  
+Index: geneve-ut-1653  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -2449,7 +2449,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1654  
+Index: geneve-ut-1658  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -2476,7 +2476,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1663  
+Index: geneve-ut-1667  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -2507,7 +2507,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1754  
+Index: geneve-ut-1758  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3465,7 +3465,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0314
+Index: geneve-ut-0315
 
 ```python
 event.dataset:azure.activitylogs and
@@ -3479,7 +3479,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0317
+Index: geneve-ut-0318
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -3497,7 +3497,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0335
+Index: geneve-ut-0336
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3515,7 +3515,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0336
+Index: geneve-ut-0337
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3533,7 +3533,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0337
+Index: geneve-ut-0338
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3548,7 +3548,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0338
+Index: geneve-ut-0339
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3562,7 +3562,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0339
+Index: geneve-ut-0340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3577,7 +3577,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0341
+Index: geneve-ut-0342
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -3594,7 +3594,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0342
+Index: geneve-ut-0343
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -3606,7 +3606,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0343
+Index: geneve-ut-0344
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -3618,7 +3618,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0344
+Index: geneve-ut-0345
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3633,7 +3633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0345
+Index: geneve-ut-0346
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -3653,7 +3653,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0346
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3675,7 +3675,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0348
+Index: geneve-ut-0349
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -3721,7 +3721,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0349
+Index: geneve-ut-0350
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3755,7 +3755,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0350
+Index: geneve-ut-0351
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3778,7 +3778,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0352
+Index: geneve-ut-0353
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -3800,7 +3800,7 @@ process.executable != null and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0353
+Index: geneve-ut-0354
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -3816,7 +3816,7 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0355
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3841,7 +3841,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0356
+Index: geneve-ut-0357
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -3871,7 +3871,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0358
+Index: geneve-ut-0359
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3885,7 +3885,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0359
+Index: geneve-ut-0360
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3907,7 +3907,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0360
+Index: geneve-ut-0361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -3921,7 +3921,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0361
+Index: geneve-ut-0362
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -3941,7 +3941,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0364
+Index: geneve-ut-0365
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3958,7 +3958,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0367
+Index: geneve-ut-0368
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -3988,7 +3988,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0370
+Index: geneve-ut-0371
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4013,7 +4013,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0372
+Index: geneve-ut-0373
 
 ```python
 sequence by process.entity_id
@@ -4034,7 +4034,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0373
+Index: geneve-ut-0374
 
 ```python
 sequence by process.entity_id
@@ -4055,7 +4055,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0375
+Index: geneve-ut-0376
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4086,7 +4086,7 @@ not process.parent.executable in (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0376
+Index: geneve-ut-0377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4109,7 +4109,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0379
+Index: geneve-ut-0380
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4122,7 +4122,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0380
+Index: geneve-ut-0381
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4135,7 +4135,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0382
+Index: geneve-ut-0383
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4152,7 +4152,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0383
+Index: geneve-ut-0384
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -4165,7 +4165,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0384
+Index: geneve-ut-0385
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -4182,7 +4182,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0385
+Index: geneve-ut-0386
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -4194,7 +4194,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0386
+Index: geneve-ut-0387
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -4262,7 +4262,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0387
+Index: geneve-ut-0388
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -4280,7 +4280,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0388
+Index: geneve-ut-0389
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -4293,7 +4293,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0389
+Index: geneve-ut-0390
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4311,7 +4311,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0390
+Index: geneve-ut-0391
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4323,7 +4323,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0391
+Index: geneve-ut-0392
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4335,7 +4335,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0392
+Index: geneve-ut-0393
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4347,7 +4347,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0393
+Index: geneve-ut-0394
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4359,7 +4359,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0394
+Index: geneve-ut-0395
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -4404,7 +4404,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0396
+Index: geneve-ut-0397
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4424,7 +4424,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0397
+Index: geneve-ut-0398
 
 ```python
 sequence with maxspan=10s
@@ -4444,7 +4444,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0398
+Index: geneve-ut-0399
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4471,7 +4471,7 @@ process.name == "curl" and (
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0401
+Index: geneve-ut-0402
 
 ```python
 process where event.type == "start" and
@@ -4496,7 +4496,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0404
+Index: geneve-ut-0405
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4540,7 +4540,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0405
+Index: geneve-ut-0406
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -4574,7 +4574,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0406
+Index: geneve-ut-0407
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -4590,7 +4590,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0407
+Index: geneve-ut-0408
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -4615,7 +4615,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0409
+Index: geneve-ut-0410
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4633,7 +4633,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0411
+Index: geneve-ut-0412
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -4646,7 +4646,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0416
+Index: geneve-ut-0417
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4660,7 +4660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0417
+Index: geneve-ut-0418
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4681,7 +4681,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0418
+Index: geneve-ut-0419
 
 ```python
 registry where host.os.type == "windows" and
@@ -4695,7 +4695,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0427
+Index: geneve-ut-0428
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -4719,7 +4719,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0437
+Index: geneve-ut-0438
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4735,7 +4735,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0438
+Index: geneve-ut-0439
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4763,7 +4763,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0439
+Index: geneve-ut-0440
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4780,7 +4780,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0440
+Index: geneve-ut-0441
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4797,7 +4797,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0441
+Index: geneve-ut-0442
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4818,7 +4818,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0443
+Index: geneve-ut-0444
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4838,7 +4838,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0444
+Index: geneve-ut-0445
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -4853,7 +4853,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0446
+Index: geneve-ut-0447
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -4866,7 +4866,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0447
+Index: geneve-ut-0448
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4886,7 +4886,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0450
+Index: geneve-ut-0451
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -4899,7 +4899,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0451
+Index: geneve-ut-0452
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4937,7 +4937,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0452
+Index: geneve-ut-0453
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -4957,7 +4957,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0453
+Index: geneve-ut-0454
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -4970,7 +4970,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0454
+Index: geneve-ut-0455
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4993,7 +4993,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0456
+Index: geneve-ut-0457
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5024,7 +5024,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0457
+Index: geneve-ut-0458
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -5043,7 +5043,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0458
+Index: geneve-ut-0459
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -5086,7 +5086,7 @@ not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0460
+Index: geneve-ut-0461
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5101,7 +5101,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0461
+Index: geneve-ut-0462
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5117,7 +5117,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0462
+Index: geneve-ut-0463
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5131,7 +5131,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0463
+Index: geneve-ut-0464
 
 ```python
 sequence by host.id with maxspan=3s
@@ -5157,7 +5157,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0464
+Index: geneve-ut-0465
 
 ```python
 process where event.type == "start" and
@@ -5195,7 +5195,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0469
+Index: geneve-ut-0470
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -5208,7 +5208,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0470
+Index: geneve-ut-0471
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5222,7 +5222,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0471
+Index: geneve-ut-0472
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5257,7 +5257,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0472
+Index: geneve-ut-0473
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -5269,7 +5269,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0519
+Index: geneve-ut-0520
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -5281,7 +5281,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0545
+Index: geneve-ut-0546
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5295,7 +5295,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0548
+Index: geneve-ut-0549
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5322,7 +5322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0551
+Index: geneve-ut-0552
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5343,7 +5343,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0554
+Index: geneve-ut-0555
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -5376,7 +5376,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0556
+Index: geneve-ut-0557
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -5393,7 +5393,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0557
+Index: geneve-ut-0558
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -5421,7 +5421,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0558
+Index: geneve-ut-0559
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -5434,7 +5434,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0560
+Index: geneve-ut-0561
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -5454,7 +5454,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0561
+Index: geneve-ut-0562
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5480,7 +5480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0562
+Index: geneve-ut-0563
 
 ```python
 sequence with maxspan=2h
@@ -5502,7 +5502,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0563
+Index: geneve-ut-0564
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -5531,7 +5531,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0566
+Index: geneve-ut-0567
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5544,7 +5544,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0570
+Index: geneve-ut-0571
 
 ```python
 sequence by user.id with maxspan=5s
@@ -5559,7 +5559,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0571
+Index: geneve-ut-0572
 
 ```python
 process where event.type == "start" and
@@ -5581,7 +5581,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0572
+Index: geneve-ut-0573
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -5593,7 +5593,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0573
+Index: geneve-ut-0574
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5615,7 +5615,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0575
+Index: geneve-ut-0576
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -5632,7 +5632,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0576
+Index: geneve-ut-0577
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5646,7 +5646,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0577
+Index: geneve-ut-0578
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -5659,7 +5659,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0578
+Index: geneve-ut-0579
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5671,7 +5671,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0579
+Index: geneve-ut-0580
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5683,7 +5683,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0580
+Index: geneve-ut-0581
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5697,7 +5697,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0581
+Index: geneve-ut-0582
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -5709,7 +5709,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0582
+Index: geneve-ut-0583
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -5731,7 +5731,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0585
+Index: geneve-ut-0586
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -5780,7 +5780,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0586
+Index: geneve-ut-0587
 
 ```python
 sequence by host.id with maxspan=10s
@@ -5800,7 +5800,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0592
+Index: geneve-ut-0593
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5815,7 +5815,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0593
+Index: geneve-ut-0594
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5829,7 +5829,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0595
+Index: geneve-ut-0596
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5851,7 +5851,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0596
+Index: geneve-ut-0597
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -5872,7 +5872,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0597
+Index: geneve-ut-0598
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5898,7 +5898,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0598
+Index: geneve-ut-0599
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -5926,7 +5926,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0601
+Index: geneve-ut-0602
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -5940,7 +5940,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0638
+Index: geneve-ut-0640
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -5957,7 +5957,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0639
+Index: geneve-ut-0641
 
 ```python
 registry where host.os.type == "windows" and
@@ -5975,7 +5975,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0707
+Index: geneve-ut-0709
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -6014,7 +6014,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0708
+Index: geneve-ut-0710
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6041,7 +6041,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0709
+Index: geneve-ut-0711
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -6056,7 +6056,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0710
+Index: geneve-ut-0712
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -6143,7 +6143,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0718
+Index: geneve-ut-0720
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6161,7 +6161,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0719
+Index: geneve-ut-0721
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -6192,7 +6192,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0720
+Index: geneve-ut-0722
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6219,7 +6219,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0721
+Index: geneve-ut-0723
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -6239,7 +6239,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0725
+Index: geneve-ut-0727
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -6252,7 +6252,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0728
+Index: geneve-ut-0730
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -6264,7 +6264,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0731
+Index: geneve-ut-0733
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -6276,7 +6276,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0735
+Index: geneve-ut-0737
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -6288,7 +6288,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0737
+Index: geneve-ut-0739
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -6305,7 +6305,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0761
+Index: geneve-ut-0763
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6318,7 +6318,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0763
+Index: geneve-ut-0765
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -6342,7 +6342,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0764
+Index: geneve-ut-0766
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -6354,7 +6354,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0777
+Index: geneve-ut-0779
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6372,7 +6372,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0778
+Index: geneve-ut-0780
 
 ```python
 any where process.executable != null and
@@ -6421,7 +6421,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0779
+Index: geneve-ut-0781
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6435,7 +6435,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0783
+Index: geneve-ut-0785
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6450,7 +6450,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0788
+Index: geneve-ut-0790
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6467,7 +6467,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0790
+Index: geneve-ut-0792
 
 ```python
 sequence with maxspan=1m
@@ -6486,7 +6486,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0791
+Index: geneve-ut-0793
 
 ```python
 sequence by host.id with maxspan=1m
@@ -6504,7 +6504,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0792
+Index: geneve-ut-0794
 
 ```python
 sequence by host.id with maxspan=5s
@@ -6523,7 +6523,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0793
+Index: geneve-ut-0795
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -6539,7 +6539,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0794
+Index: geneve-ut-0796
 
 ```python
 sequence by host.id with maxspan=30s
@@ -6555,7 +6555,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0795
+Index: geneve-ut-0797
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6568,7 +6568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0799
+Index: geneve-ut-0801
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6585,7 +6585,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0801
+Index: geneve-ut-0803
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6598,7 +6598,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0802
+Index: geneve-ut-0804
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -6614,7 +6614,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0803
+Index: geneve-ut-0805
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6641,7 +6641,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0804
+Index: geneve-ut-0806
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6665,7 +6665,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0808
+Index: geneve-ut-0810
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6689,7 +6689,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0810
+Index: geneve-ut-0812
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6725,7 +6725,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0811
+Index: geneve-ut-0813
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -6737,7 +6737,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0812
+Index: geneve-ut-0814
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6751,7 +6751,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0813
+Index: geneve-ut-0815
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -6764,7 +6764,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0814
+Index: geneve-ut-0816
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -6823,7 +6823,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0815
+Index: geneve-ut-0817
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6836,7 +6836,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0816
+Index: geneve-ut-0818
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6849,7 +6849,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0817
+Index: geneve-ut-0819
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6870,7 +6870,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0818
+Index: geneve-ut-0820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6888,7 +6888,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0819
+Index: geneve-ut-0821
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6922,7 +6922,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0820
+Index: geneve-ut-0822
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6958,7 +6958,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0821
+Index: geneve-ut-0823
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6980,7 +6980,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0823
+Index: geneve-ut-0825
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7007,7 +7007,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0824
+Index: geneve-ut-0826
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7033,7 +7033,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0825
+Index: geneve-ut-0827
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -7049,7 +7049,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0826
+Index: geneve-ut-0828
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -7065,7 +7065,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0828
+Index: geneve-ut-0830
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -7077,7 +7077,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0829
+Index: geneve-ut-0831
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7105,7 +7105,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0831
+Index: geneve-ut-0833
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7121,7 +7121,7 @@ not process.command_line like ("*download.elastic.co*", "*github.com/kubernetes-
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0833
+Index: geneve-ut-0835
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7144,7 +7144,7 @@ process.name == "kubectl" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0834
+Index: geneve-ut-0836
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7158,7 +7158,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0835
+Index: geneve-ut-0837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7181,7 +7181,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0836
+Index: geneve-ut-0838
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -7214,7 +7214,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0838
+Index: geneve-ut-0840
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -7235,7 +7235,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0839
+Index: geneve-ut-0841
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -7262,7 +7262,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-0849
+Index: geneve-ut-0851
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7284,7 +7284,7 @@ process.name in ("curl", "wget") and process.args like~ (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0875
+Index: geneve-ut-0877
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7303,7 +7303,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0878
+Index: geneve-ut-0880
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7347,7 +7347,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0880
+Index: geneve-ut-0882
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -7372,7 +7372,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0886
+Index: geneve-ut-0888
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -7410,7 +7410,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0891
+Index: geneve-ut-0893
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -7428,7 +7428,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0892
+Index: geneve-ut-0894
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7442,7 +7442,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0897
+Index: geneve-ut-0899
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -7457,7 +7457,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0898
+Index: geneve-ut-0900
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -7471,7 +7471,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0901
+Index: geneve-ut-0903
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7485,7 +7485,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0903
+Index: geneve-ut-0905
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7506,7 +7506,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-0904
+Index: geneve-ut-0906
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7536,7 +7536,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0908
+Index: geneve-ut-0910
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -7583,7 +7583,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0909
+Index: geneve-ut-0911
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7614,7 +7614,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0912
+Index: geneve-ut-0914
 
 ```python
 event.dataset:o365.audit and
@@ -7627,7 +7627,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0914
+Index: geneve-ut-0916
 
 ```python
 event.dataset:o365.audit and
@@ -7640,7 +7640,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0915
+Index: geneve-ut-0917
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -7652,7 +7652,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0951
+Index: geneve-ut-0953
 
 ```python
 event.dataset:o365.audit and
@@ -7665,7 +7665,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0952
+Index: geneve-ut-0954
 
 ```python
 event.dataset:o365.audit and
@@ -7678,7 +7678,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0953
+Index: geneve-ut-0955
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -7690,7 +7690,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0954
+Index: geneve-ut-0956
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -7702,7 +7702,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0955
+Index: geneve-ut-0957
 
 ```python
 event.dataset:o365.audit and
@@ -7715,7 +7715,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0963
+Index: geneve-ut-0965
 
 ```python
 event.dataset: "o365.audit" and
@@ -7728,7 +7728,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0966
+Index: geneve-ut-0968
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7748,7 +7748,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0967
+Index: geneve-ut-0969
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -7760,7 +7760,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0968
+Index: geneve-ut-0970
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -7772,7 +7772,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0972
+Index: geneve-ut-0974
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7784,7 +7784,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0973
+Index: geneve-ut-0975
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -7796,7 +7796,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0974
+Index: geneve-ut-0976
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7808,7 +7808,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0975
+Index: geneve-ut-0977
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7820,7 +7820,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0976
+Index: geneve-ut-0978
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7845,7 +7845,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0977
+Index: geneve-ut-0979
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -7865,7 +7865,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0978
+Index: geneve-ut-0980
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -7878,7 +7878,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-0979
+Index: geneve-ut-0981
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7893,7 +7893,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0980
+Index: geneve-ut-0982
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -7918,7 +7918,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0982
+Index: geneve-ut-0984
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -7930,7 +7930,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0985
+Index: geneve-ut-0987
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7942,7 +7942,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0986
+Index: geneve-ut-0988
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -7954,7 +7954,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0987
+Index: geneve-ut-0989
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -7988,7 +7988,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0990
+Index: geneve-ut-0992
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8002,7 +8002,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0991
+Index: geneve-ut-0993
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8023,7 +8023,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0992
+Index: geneve-ut-0994
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8037,7 +8037,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0996
+Index: geneve-ut-0998
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8072,7 +8072,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0997
+Index: geneve-ut-0999
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -8097,7 +8097,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0998
+Index: geneve-ut-1000
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8114,7 +8114,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1002
+Index: geneve-ut-1004
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8128,7 +8128,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1004
+Index: geneve-ut-1006
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8159,7 +8159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1006
+Index: geneve-ut-1008
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -8213,7 +8213,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1007
+Index: geneve-ut-1009
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -8225,7 +8225,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1008
+Index: geneve-ut-1010
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8243,7 +8243,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1009
+Index: geneve-ut-1011
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8260,7 +8260,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1011
+Index: geneve-ut-1013
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8275,7 +8275,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1013
+Index: geneve-ut-1015
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8291,7 +8291,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1014
+Index: geneve-ut-1016
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -8305,7 +8305,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1016
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8334,7 +8334,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1017
+Index: geneve-ut-1019
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8356,7 +8356,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1018
+Index: geneve-ut-1020
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8375,7 +8375,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1019
+Index: geneve-ut-1021
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -8408,7 +8408,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1020
+Index: geneve-ut-1022
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -8426,7 +8426,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1021
+Index: geneve-ut-1023
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8467,7 +8467,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1033
+Index: geneve-ut-1035
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -8493,7 +8493,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1041
+Index: geneve-ut-1043
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -8517,7 +8517,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1045
+Index: geneve-ut-1047
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8531,7 +8531,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1046
+Index: geneve-ut-1048
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8550,7 +8550,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1047
+Index: geneve-ut-1049
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -8570,7 +8570,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1048
+Index: geneve-ut-1050
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8591,7 +8591,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1049
+Index: geneve-ut-1051
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8606,7 +8606,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1050
+Index: geneve-ut-1052
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8623,7 +8623,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1052
+Index: geneve-ut-1054
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -8647,7 +8647,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1054
+Index: geneve-ut-1056
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -8693,7 +8693,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1055
+Index: geneve-ut-1057
 
 ```python
 sequence by host.id with maxspan=1s
@@ -8735,7 +8735,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1056
+Index: geneve-ut-1058
 
 ```python
 sequence by host.id with maxspan=10s
@@ -8752,7 +8752,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1058
+Index: geneve-ut-1060
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8767,7 +8767,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1059
+Index: geneve-ut-1061
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -8786,7 +8786,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1060
+Index: geneve-ut-1062
 
 ```python
 sequence by process.entity_id
@@ -8806,7 +8806,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1061
+Index: geneve-ut-1063
 
 ```python
 sequence by process.entity_id
@@ -8825,7 +8825,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1062
+Index: geneve-ut-1064
 
 ```python
 sequence by host.id with maxspan=1m
@@ -8854,7 +8854,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1063
+Index: geneve-ut-1065
 
 ```python
 sequence by process.entity_id
@@ -8879,7 +8879,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1064
+Index: geneve-ut-1066
 
 ```python
 sequence by process.entity_id
@@ -8901,7 +8901,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1065
+Index: geneve-ut-1067
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -8934,7 +8934,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1066
+Index: geneve-ut-1068
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8964,7 +8964,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1069
+Index: geneve-ut-1071
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -8981,7 +8981,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1070
+Index: geneve-ut-1072
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -9018,7 +9018,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1071
+Index: geneve-ut-1073
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9031,7 +9031,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1076
+Index: geneve-ut-1078
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -9043,7 +9043,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1078
+Index: geneve-ut-1080
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -9055,7 +9055,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1086
+Index: geneve-ut-1089
 
 ```python
 sequence by host.id with maxspan=10s
@@ -9069,7 +9069,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1087
+Index: geneve-ut-1090
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9083,7 +9083,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1088
+Index: geneve-ut-1091
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -9103,7 +9103,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1090
+Index: geneve-ut-1093
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -9116,7 +9116,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1091
+Index: geneve-ut-1094
 
 ```python
 event.dataset: "okta.system"
@@ -9131,7 +9131,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1093
+Index: geneve-ut-1096
 
 ```python
 sequence by user.name with maxspan=30m
@@ -9153,7 +9153,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1102
+Index: geneve-ut-1105
 
 ```python
 network where event.action == "connection_accepted" and
@@ -9180,7 +9180,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1103
+Index: geneve-ut-1106
 
 ```python
 network where event.action == "lookup_requested" and
@@ -9200,7 +9200,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1104
+Index: geneve-ut-1107
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9215,7 +9215,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1105
+Index: geneve-ut-1108
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -9242,7 +9242,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1106
+Index: geneve-ut-1109
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -9257,7 +9257,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1107
+Index: geneve-ut-1110
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -9273,7 +9273,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1108
+Index: geneve-ut-1111
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -9287,7 +9287,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1109
+Index: geneve-ut-1112
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -9306,7 +9306,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1114
+Index: geneve-ut-1117
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1115
+Index: geneve-ut-1118
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9335,7 +9335,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1116
+Index: geneve-ut-1119
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9354,7 +9354,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1117
+Index: geneve-ut-1120
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9366,7 +9366,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1118
+Index: geneve-ut-1121
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9378,7 +9378,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1119
+Index: geneve-ut-1122
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9396,7 +9396,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1120
+Index: geneve-ut-1123
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9409,7 +9409,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1121
+Index: geneve-ut-1124
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9424,7 +9424,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1122
+Index: geneve-ut-1125
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -9439,7 +9439,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1124
+Index: geneve-ut-1127
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -9459,7 +9459,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1125
+Index: geneve-ut-1128
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9483,7 +9483,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1126
+Index: geneve-ut-1129
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9497,7 +9497,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1127
+Index: geneve-ut-1130
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9516,7 +9516,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1128
+Index: geneve-ut-1131
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9544,7 +9544,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1129
+Index: geneve-ut-1132
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -9573,7 +9573,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1130
+Index: geneve-ut-1133
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9592,7 +9592,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1131
+Index: geneve-ut-1134
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9620,7 +9620,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1132
+Index: geneve-ut-1135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9635,7 +9635,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1133
+Index: geneve-ut-1136
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9698,7 +9698,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1134
+Index: geneve-ut-1137
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -9719,7 +9719,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1135
+Index: geneve-ut-1138
 
 ```python
 any where host.os.type == "windows" and
@@ -9781,7 +9781,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1137
+Index: geneve-ut-1140
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -9810,7 +9810,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1138
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -9824,7 +9824,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1139
+Index: geneve-ut-1142
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9857,7 +9857,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1142
+Index: geneve-ut-1145
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -9904,7 +9904,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1143
+Index: geneve-ut-1146
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9931,7 +9931,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1144
+Index: geneve-ut-1147
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -9944,7 +9944,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1155
+Index: geneve-ut-1158
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9961,7 +9961,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1157
+Index: geneve-ut-1160
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -9986,7 +9986,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1162
+Index: geneve-ut-1165
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10002,7 +10002,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1163
+Index: geneve-ut-1166
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10023,7 +10023,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1164
+Index: geneve-ut-1167
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -10040,7 +10040,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1165
+Index: geneve-ut-1168
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10064,7 +10064,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1167
+Index: geneve-ut-1170
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -10093,7 +10093,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1169
+Index: geneve-ut-1172
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -10117,7 +10117,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1172
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -10135,7 +10135,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1173
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -10158,7 +10158,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1174
+Index: geneve-ut-1177
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -10215,7 +10215,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1175
+Index: geneve-ut-1178
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10232,7 +10232,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1176
+Index: geneve-ut-1179
 
 ```python
 sequence by process.entity_id
@@ -10246,7 +10246,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1190
+Index: geneve-ut-1193
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10261,7 +10261,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1191
+Index: geneve-ut-1194
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10292,7 +10292,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1192
+Index: geneve-ut-1195
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10306,7 +10306,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1193
+Index: geneve-ut-1196
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10319,7 +10319,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1194
+Index: geneve-ut-1197
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -10331,7 +10331,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1195
+Index: geneve-ut-1198
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10344,7 +10344,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1197
+Index: geneve-ut-1200
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -10363,7 +10363,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1198
+Index: geneve-ut-1201
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10384,7 +10384,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1199
+Index: geneve-ut-1202
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10398,7 +10398,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1202
+Index: geneve-ut-1205
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10418,7 +10418,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1203
+Index: geneve-ut-1206
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -10442,7 +10442,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1204
+Index: geneve-ut-1207
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -10458,7 +10458,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1205
+Index: geneve-ut-1208
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -10475,7 +10475,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1206
+Index: geneve-ut-1209
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10496,7 +10496,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1208
+Index: geneve-ut-1211
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -10509,7 +10509,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1210
+Index: geneve-ut-1213
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10537,7 +10537,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1213
+Index: geneve-ut-1216
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10553,7 +10553,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1214
+Index: geneve-ut-1217
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10576,7 +10576,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1215
+Index: geneve-ut-1218
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10589,7 +10589,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1217
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10602,7 +10602,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1222
+Index: geneve-ut-1225
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10616,7 +10616,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1223
+Index: geneve-ut-1226
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10631,7 +10631,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 375  
 Document count: 375  
-Index: geneve-ut-1225
+Index: geneve-ut-1228
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10652,7 +10652,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1228
+Index: geneve-ut-1231
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10695,7 +10695,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1229
+Index: geneve-ut-1232
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10713,7 +10713,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1230
+Index: geneve-ut-1233
 
 ```python
 host.os.type:"windows" and
@@ -10729,7 +10729,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1232
+Index: geneve-ut-1235
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -10741,7 +10741,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1234
+Index: geneve-ut-1237
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -10757,7 +10757,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1235
+Index: geneve-ut-1238
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10775,7 +10775,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1236
+Index: geneve-ut-1239
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -10789,7 +10789,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1238
+Index: geneve-ut-1241
 
 ```python
 sequence by host.id with maxspan=30s
@@ -10812,7 +10812,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1240
+Index: geneve-ut-1243
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -10828,7 +10828,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1241
+Index: geneve-ut-1244
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10841,7 +10841,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1242
+Index: geneve-ut-1245
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10871,7 +10871,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1247
+Index: geneve-ut-1250
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10894,7 +10894,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1248
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10913,7 +10913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1253
+Index: geneve-ut-1256
 
 ```python
 process where host.os.type == "windows" and 
@@ -11055,7 +11055,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1254
+Index: geneve-ut-1257
 
 ```python
 process where host.os.type == "windows" and
@@ -11132,7 +11132,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1257
+Index: geneve-ut-1260
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -11149,7 +11149,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1258
+Index: geneve-ut-1261
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -11183,7 +11183,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1260
+Index: geneve-ut-1263
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -11195,7 +11195,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1261
+Index: geneve-ut-1264
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11234,7 +11234,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1263
+Index: geneve-ut-1266
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -11247,7 +11247,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1268
+Index: geneve-ut-1271
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11261,7 +11261,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1275
+Index: geneve-ut-1278
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -11299,7 +11299,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1276
+Index: geneve-ut-1279
 
 ```python
 network where host.os.type == "windows" and
@@ -11325,7 +11325,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1279
+Index: geneve-ut-1282
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11340,7 +11340,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1281
+Index: geneve-ut-1284
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -11354,7 +11354,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1282
+Index: geneve-ut-1285
 
 ```python
 file where host.os.type == "windows" and
@@ -11368,7 +11368,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1283
+Index: geneve-ut-1286
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11381,7 +11381,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1284
+Index: geneve-ut-1287
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11401,7 +11401,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1285
+Index: geneve-ut-1288
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11421,7 +11421,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1287
+Index: geneve-ut-1290
 
 ```python
 host.os.type:windows and event.category:process and
@@ -11460,7 +11460,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1288
+Index: geneve-ut-1291
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11655,7 +11655,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1301
+Index: geneve-ut-1304
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11671,7 +11671,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1302
+Index: geneve-ut-1305
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -11685,7 +11685,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1303
+Index: geneve-ut-1306
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -11699,7 +11699,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1304
+Index: geneve-ut-1307
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -11716,7 +11716,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -11730,7 +11730,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1306
+Index: geneve-ut-1309
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11746,7 +11746,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1310
+Index: geneve-ut-1313
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -11758,7 +11758,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -11774,7 +11774,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1312
+Index: geneve-ut-1315
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11794,7 +11794,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1314
+Index: geneve-ut-1317
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11834,7 +11834,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1316
+Index: geneve-ut-1319
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -11846,7 +11846,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1317
+Index: geneve-ut-1320
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -11867,7 +11867,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1318
+Index: geneve-ut-1321
 
 ```python
 sequence by host.id with maxspan=15s
@@ -11888,7 +11888,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1319
+Index: geneve-ut-1322
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -11909,7 +11909,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1320
+Index: geneve-ut-1323
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -11935,7 +11935,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1321
+Index: geneve-ut-1324
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -11951,7 +11951,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1322
+Index: geneve-ut-1325
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -11965,7 +11965,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1323
+Index: geneve-ut-1326
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -11988,7 +11988,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1325
+Index: geneve-ut-1328
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -12005,7 +12005,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1326
+Index: geneve-ut-1329
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -12028,7 +12028,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1327
+Index: geneve-ut-1330
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12041,7 +12041,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1328
+Index: geneve-ut-1331
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12055,7 +12055,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1329
+Index: geneve-ut-1332
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12072,7 +12072,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1330
+Index: geneve-ut-1333
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12126,7 +12126,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 any where host.os.type == "windows" and
@@ -12153,7 +12153,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 file where host.os.type == "windows" and
@@ -12168,7 +12168,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1338
+Index: geneve-ut-1341
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -12199,7 +12199,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1339
+Index: geneve-ut-1342
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12213,7 +12213,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 sequence with maxspan=1m
@@ -12255,7 +12255,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1341
+Index: geneve-ut-1344
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12280,7 +12280,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1342
+Index: geneve-ut-1345
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12334,7 +12334,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1343
+Index: geneve-ut-1346
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12354,7 +12354,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1344
+Index: geneve-ut-1347
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -12375,7 +12375,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1345
+Index: geneve-ut-1348
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12390,7 +12390,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1346
+Index: geneve-ut-1349
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -12410,7 +12410,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1347
+Index: geneve-ut-1350
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12452,7 +12452,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1351
+Index: geneve-ut-1354
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -12467,7 +12467,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1352
+Index: geneve-ut-1355
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -12502,7 +12502,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1353
+Index: geneve-ut-1356
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -12519,7 +12519,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 sequence by host.id with maxspan=3s
@@ -12533,7 +12533,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1358
+Index: geneve-ut-1361
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -12546,7 +12546,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1359
+Index: geneve-ut-1362
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -12558,7 +12558,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1360
+Index: geneve-ut-1363
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -12573,7 +12573,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1362
+Index: geneve-ut-1365
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -12601,7 +12601,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 sequence by host.id with maxspan=1s
@@ -12626,7 +12626,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1367
+Index: geneve-ut-1370
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -12663,7 +12663,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1368
+Index: geneve-ut-1371
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12677,7 +12677,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1369
+Index: geneve-ut-1372
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -12693,7 +12693,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -12707,7 +12707,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -12737,7 +12737,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1372
+Index: geneve-ut-1375
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -12766,7 +12766,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12782,7 +12782,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12796,7 +12796,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 file where host.os.type == "windows" and
@@ -12832,7 +12832,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1378
+Index: geneve-ut-1381
 
 ```python
 process where event.type == "start" and
@@ -12846,7 +12846,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1379
+Index: geneve-ut-1382
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12860,7 +12860,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12880,7 +12880,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1382
+Index: geneve-ut-1385
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12897,7 +12897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1383
+Index: geneve-ut-1386
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -12909,7 +12909,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1384
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -12926,7 +12926,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1385
+Index: geneve-ut-1388
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12944,7 +12944,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1392
+Index: geneve-ut-1395
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12971,7 +12971,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1393
+Index: geneve-ut-1396
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -12985,7 +12985,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1395
+Index: geneve-ut-1398
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13002,7 +13002,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1396
+Index: geneve-ut-1399
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13025,7 +13025,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1398
+Index: geneve-ut-1401
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13042,7 +13042,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13055,7 +13055,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1403
+Index: geneve-ut-1406
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13079,7 +13079,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1404
+Index: geneve-ut-1407
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13107,7 +13107,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1419
+Index: geneve-ut-1422
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13128,7 +13128,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1422
+Index: geneve-ut-1425
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13168,7 +13168,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1423
+Index: geneve-ut-1426
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -13185,7 +13185,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13199,7 +13199,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1425
+Index: geneve-ut-1428
 
 ```python
 file where host.os.type == "windows" and
@@ -13218,7 +13218,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1426
+Index: geneve-ut-1429
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -13232,7 +13232,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13250,7 +13250,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1430
+Index: geneve-ut-1433
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -13268,7 +13268,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1433
+Index: geneve-ut-1436
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13282,7 +13282,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1435
+Index: geneve-ut-1438
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13297,7 +13297,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1436
+Index: geneve-ut-1439
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -13320,7 +13320,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1438
+Index: geneve-ut-1441
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13402,7 +13402,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1439
+Index: geneve-ut-1442
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -13423,7 +13423,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1440
+Index: geneve-ut-1443
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and
@@ -13442,7 +13442,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1442
+Index: geneve-ut-1445
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13495,7 +13495,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1443
+Index: geneve-ut-1446
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13507,7 +13507,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1444
+Index: geneve-ut-1447
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13519,7 +13519,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1445
+Index: geneve-ut-1448
 
 ```python
 process where host.os.type == "windows" and
@@ -13534,7 +13534,7 @@ process where host.os.type == "windows" and
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1446
+Index: geneve-ut-1449
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -13594,7 +13594,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1449
+Index: geneve-ut-1452
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -13607,7 +13607,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13639,7 +13639,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1451
+Index: geneve-ut-1454
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -13663,7 +13663,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1453
+Index: geneve-ut-1456
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13696,7 +13696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1454
+Index: geneve-ut-1457
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -13713,7 +13713,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1455
+Index: geneve-ut-1458
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -13742,7 +13742,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1456
+Index: geneve-ut-1459
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13756,7 +13756,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1457
+Index: geneve-ut-1460
 
 ```python
 sequence by process.entity_id
@@ -13781,7 +13781,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1458
+Index: geneve-ut-1461
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -13815,7 +13815,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1459
+Index: geneve-ut-1462
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -13843,7 +13843,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1460
+Index: geneve-ut-1463
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -13862,7 +13862,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1464
+Index: geneve-ut-1467
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13890,7 +13890,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1465
+Index: geneve-ut-1468
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -13909,7 +13909,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1469
+Index: geneve-ut-1472
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -13921,7 +13921,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1470
+Index: geneve-ut-1473
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13933,7 +13933,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1471
+Index: geneve-ut-1474
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -13945,7 +13945,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1472
+Index: geneve-ut-1475
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13957,7 +13957,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1480
+Index: geneve-ut-1483
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13970,7 +13970,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1481
+Index: geneve-ut-1484
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14008,7 +14008,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1483
+Index: geneve-ut-1486
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14023,7 +14023,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1484
+Index: geneve-ut-1487
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14042,7 +14042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1485
+Index: geneve-ut-1488
 
 ```python
 sequence with maxspan=1m
@@ -14090,7 +14090,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1487
+Index: geneve-ut-1490
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -14113,7 +14113,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14127,7 +14127,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1490
+Index: geneve-ut-1493
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14141,7 +14141,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 sequence by host.id, process.entity_id
@@ -14158,7 +14158,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14172,7 +14172,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1494
+Index: geneve-ut-1497
 
 ```python
 sequence by host.id with maxspan=1m
@@ -14192,7 +14192,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1495
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14221,7 +14221,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1496
+Index: geneve-ut-1499
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -14241,7 +14241,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1497
+Index: geneve-ut-1500
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -14254,7 +14254,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1499
+Index: geneve-ut-1502
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -14296,7 +14296,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1500
+Index: geneve-ut-1503
 
 ```python
 sequence with maxspan=1m
@@ -14319,7 +14319,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1501
+Index: geneve-ut-1504
 
 ```python
 sequence with maxspan=1s
@@ -14367,7 +14367,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1502
+Index: geneve-ut-1505
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14384,7 +14384,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1504
+Index: geneve-ut-1507
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -14413,7 +14413,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1505
+Index: geneve-ut-1509
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14441,7 +14441,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1506
+Index: geneve-ut-1510
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -14458,7 +14458,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1508
+Index: geneve-ut-1512
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -14477,7 +14477,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1509
+Index: geneve-ut-1513
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -14498,7 +14498,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1515
+Index: geneve-ut-1519
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -14517,7 +14517,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1516
+Index: geneve-ut-1520
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -14531,7 +14531,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1517
+Index: geneve-ut-1521
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -14551,7 +14551,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1519
+Index: geneve-ut-1523
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14569,7 +14569,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1520
+Index: geneve-ut-1524
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -14590,7 +14590,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1522
+Index: geneve-ut-1526
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14604,7 +14604,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1523
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14619,7 +14619,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1524
+Index: geneve-ut-1528
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14660,7 +14660,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1526
+Index: geneve-ut-1530
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -14685,7 +14685,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1527
+Index: geneve-ut-1531
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -14724,7 +14724,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1528
+Index: geneve-ut-1532
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14738,7 +14738,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1529
+Index: geneve-ut-1533
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14777,7 +14777,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1530
+Index: geneve-ut-1534
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14791,7 +14791,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1531
+Index: geneve-ut-1535
 
 ```python
 process where event.type == "start" and
@@ -14863,7 +14863,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1534
+Index: geneve-ut-1538
 
 ```python
 event.code : "4719" and host.os.type : "windows" and
@@ -14884,7 +14884,7 @@ event.code : "4719" and host.os.type : "windows" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1535
+Index: geneve-ut-1539
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -14905,7 +14905,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1537
+Index: geneve-ut-1541
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14922,7 +14922,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1539
+Index: geneve-ut-1543
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14940,7 +14940,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1540
+Index: geneve-ut-1544
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -14952,7 +14952,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1541
+Index: geneve-ut-1545
 
 ```python
 file where host.os.type == "windows" and
@@ -14985,7 +14985,7 @@ file where host.os.type == "windows" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1544
+Index: geneve-ut-1548
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -15002,7 +15002,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1545
+Index: geneve-ut-1549
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -15022,7 +15022,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1547
+Index: geneve-ut-1551
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15037,7 +15037,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1548
+Index: geneve-ut-1552
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15058,7 +15058,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1549
+Index: geneve-ut-1553
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15081,7 +15081,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1550
+Index: geneve-ut-1554
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -15094,7 +15094,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1551
+Index: geneve-ut-1555
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15111,7 +15111,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1553
+Index: geneve-ut-1557
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -15136,7 +15136,7 @@ not (
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1556
+Index: geneve-ut-1560
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -15185,7 +15185,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1557
+Index: geneve-ut-1561
 
 ```python
 sequence by host.id with maxspan=10s
@@ -15199,7 +15199,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1558
+Index: geneve-ut-1562
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -15214,7 +15214,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1559
+Index: geneve-ut-1563
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15229,7 +15229,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1560
+Index: geneve-ut-1564
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -15251,7 +15251,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1561
+Index: geneve-ut-1565
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15272,7 +15272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1564
+Index: geneve-ut-1568
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15286,7 +15286,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1565
+Index: geneve-ut-1569
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -15309,7 +15309,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1593
+Index: geneve-ut-1597
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -15334,7 +15334,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1594
+Index: geneve-ut-1598
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -15367,7 +15367,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1595
+Index: geneve-ut-1599
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -15426,7 +15426,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1597
+Index: geneve-ut-1601
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -15444,7 +15444,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1598
+Index: geneve-ut-1602
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -15456,7 +15456,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1600
+Index: geneve-ut-1604
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -15481,7 +15481,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1606
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15496,7 +15496,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1607
+Index: geneve-ut-1611
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -15519,7 +15519,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1610
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15533,7 +15533,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1612
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15555,7 +15555,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1614
+Index: geneve-ut-1618
 
 ```python
 sequence by host.id with maxspan=5s
@@ -15582,7 +15582,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1618
+Index: geneve-ut-1622
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -15621,7 +15621,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1619
+Index: geneve-ut-1623
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -15644,7 +15644,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1620
+Index: geneve-ut-1624
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -15658,7 +15658,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1621
+Index: geneve-ut-1625
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15674,7 +15674,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1622
+Index: geneve-ut-1626
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -15690,7 +15690,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1623
+Index: geneve-ut-1627
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15704,7 +15704,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1625
+Index: geneve-ut-1629
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15727,7 +15727,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1626
+Index: geneve-ut-1630
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15755,7 +15755,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1627
+Index: geneve-ut-1631
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15770,7 +15770,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1630
+Index: geneve-ut-1634
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15797,7 +15797,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1632
+Index: geneve-ut-1636
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -15813,7 +15813,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1633
+Index: geneve-ut-1637
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -15826,7 +15826,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1635
+Index: geneve-ut-1639
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15842,7 +15842,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1636
+Index: geneve-ut-1640
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -15858,7 +15858,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1637
+Index: geneve-ut-1641
 
 ```python
 any where host.os.type == "windows" and 
@@ -15925,7 +15925,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1639
+Index: geneve-ut-1643
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -15941,7 +15941,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1640
+Index: geneve-ut-1644
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15977,7 +15977,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1641
+Index: geneve-ut-1645
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16015,7 +16015,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1642
+Index: geneve-ut-1646
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -16050,7 +16050,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1643
+Index: geneve-ut-1647
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16084,7 +16084,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1645
+Index: geneve-ut-1649
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -16105,7 +16105,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1650
+Index: geneve-ut-1654
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -16182,7 +16182,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1651
+Index: geneve-ut-1655
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16204,7 +16204,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1652
+Index: geneve-ut-1656
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16228,7 +16228,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1653
+Index: geneve-ut-1657
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16249,7 +16249,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1656
+Index: geneve-ut-1660
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16264,7 +16264,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1659
+Index: geneve-ut-1663
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16277,7 +16277,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1660
+Index: geneve-ut-1664
 
 ```python
 any where host.os.type == "windows" and
@@ -16292,7 +16292,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1661
+Index: geneve-ut-1665
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16308,7 +16308,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1662
+Index: geneve-ut-1666
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -16322,7 +16322,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1666
+Index: geneve-ut-1670
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16336,7 +16336,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1668
+Index: geneve-ut-1672
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -16368,7 +16368,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1670
+Index: geneve-ut-1674
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -16381,7 +16381,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1671
+Index: geneve-ut-1675
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16400,7 +16400,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1672
+Index: geneve-ut-1676
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16446,7 +16446,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1674
+Index: geneve-ut-1678
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16467,7 +16467,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1675
+Index: geneve-ut-1679
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16487,7 +16487,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1676
+Index: geneve-ut-1680
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16501,7 +16501,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1677
+Index: geneve-ut-1681
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16533,7 +16533,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1680
+Index: geneve-ut-1684
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -16554,7 +16554,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1682
+Index: geneve-ut-1686
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -16655,7 +16655,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1685
+Index: geneve-ut-1689
 
 ```python
 sequence by host.id with maxspan=5s
@@ -16703,7 +16703,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1687
+Index: geneve-ut-1691
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16729,7 +16729,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1688
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16774,7 +16774,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1689
+Index: geneve-ut-1693
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16798,7 +16798,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1690
+Index: geneve-ut-1694
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -16814,7 +16814,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1692
+Index: geneve-ut-1696
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -16839,7 +16839,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1693
+Index: geneve-ut-1697
 
 ```python
 event.category:process and host.os.type:windows and
@@ -16854,7 +16854,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1696
+Index: geneve-ut-1700
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -16868,7 +16868,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1697
+Index: geneve-ut-1701
 
 ```python
 sequence by host.id with maxspan=30s
@@ -16888,7 +16888,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1698
+Index: geneve-ut-1702
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16923,7 +16923,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1702
+Index: geneve-ut-1706
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16936,7 +16936,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1704
+Index: geneve-ut-1708
 
 ```python
 any where host.os.type == "windows" and
@@ -16969,7 +16969,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1706
+Index: geneve-ut-1710
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -16987,7 +16987,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1707
+Index: geneve-ut-1711
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -17009,7 +17009,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1710
+Index: geneve-ut-1714
 
 ```python
 sequence by host.id with maxspan=30s
@@ -17048,7 +17048,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1711
+Index: geneve-ut-1715
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17078,7 +17078,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1712
+Index: geneve-ut-1716
 
 ```python
 any where host.os.type == "windows" and
@@ -17112,7 +17112,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1713
+Index: geneve-ut-1717
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -17126,7 +17126,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1716
+Index: geneve-ut-1720
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17157,7 +17157,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1717
+Index: geneve-ut-1721
 
 ```python
 any where host.os.type == "windows" and
@@ -17177,7 +17177,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1718
+Index: geneve-ut-1722
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17218,7 +17218,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1719
+Index: geneve-ut-1723
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -17234,7 +17234,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1720
+Index: geneve-ut-1724
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17264,7 +17264,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1724
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -17277,7 +17277,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1725
+Index: geneve-ut-1729
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -17301,7 +17301,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1728
+Index: geneve-ut-1732
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17319,7 +17319,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1730
+Index: geneve-ut-1734
 
 ```python
 any where host.os.type == "windows" and
@@ -17334,7 +17334,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1731
+Index: geneve-ut-1735
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -17352,7 +17352,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1732
+Index: geneve-ut-1736
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -17373,7 +17373,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1733
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17392,7 +17392,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1736
+Index: geneve-ut-1740
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17417,7 +17417,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1737
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17430,7 +17430,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1739
+Index: geneve-ut-1743
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -17443,7 +17443,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1741
+Index: geneve-ut-1745
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17466,7 +17466,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1743
+Index: geneve-ut-1747
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17485,7 +17485,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1744
+Index: geneve-ut-1748
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -17507,7 +17507,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1745
+Index: geneve-ut-1749
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -17540,7 +17540,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1747
+Index: geneve-ut-1751
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17558,7 +17558,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1748
+Index: geneve-ut-1752
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -17572,7 +17572,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1749
+Index: geneve-ut-1753
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17596,7 +17596,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1750
+Index: geneve-ut-1754
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -17619,7 +17619,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1751
+Index: geneve-ut-1755
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -17638,7 +17638,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1755
+Index: geneve-ut-1759
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -17673,7 +17673,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1756
+Index: geneve-ut-1760
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17690,7 +17690,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1757
+Index: geneve-ut-1761
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17710,7 +17710,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1758
+Index: geneve-ut-1762
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -17750,7 +17750,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1759
+Index: geneve-ut-1763
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -17766,7 +17766,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1760
+Index: geneve-ut-1764
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17780,7 +17780,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1761
+Index: geneve-ut-1765
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17818,7 +17818,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1762
+Index: geneve-ut-1766
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17872,7 +17872,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1763
+Index: geneve-ut-1767
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -17900,7 +17900,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1765
+Index: geneve-ut-1769
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -17914,7 +17914,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1766
+Index: geneve-ut-1770
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17960,7 +17960,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1767
+Index: geneve-ut-1771
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -17999,7 +17999,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1768
+Index: geneve-ut-1772
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -18012,7 +18012,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1771
+Index: geneve-ut-1775
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -18045,7 +18045,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1772
+Index: geneve-ut-1776
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -18059,7 +18059,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1773
+Index: geneve-ut-1777
 
 ```python
 sequence by host.id with maxspan=1s
@@ -18073,7 +18073,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1774
+Index: geneve-ut-1778
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -18087,7 +18087,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1775
+Index: geneve-ut-1779
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18126,7 +18126,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1782
+Index: geneve-ut-1786
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -18168,7 +18168,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1783
+Index: geneve-ut-1787
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -18181,7 +18181,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1784
+Index: geneve-ut-1788
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18198,7 +18198,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1785
+Index: geneve-ut-1789
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -18214,7 +18214,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1786
+Index: geneve-ut-1790
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18227,7 +18227,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1787
+Index: geneve-ut-1791
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -18242,7 +18242,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1788
+Index: geneve-ut-1792
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18265,7 +18265,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1789
+Index: geneve-ut-1793
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18281,7 +18281,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1790
+Index: geneve-ut-1794
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18297,7 +18297,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1795
+Index: geneve-ut-1799
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -18309,7 +18309,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1796
+Index: geneve-ut-1800
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18338,7 +18338,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1798
+Index: geneve-ut-1802
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -18352,7 +18352,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1803
+Index: geneve-ut-1807
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -18372,7 +18372,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1804
+Index: geneve-ut-1808
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -18397,7 +18397,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1810
+Index: geneve-ut-1814
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18411,7 +18411,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1811
+Index: geneve-ut-1815
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18434,7 +18434,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1816
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -18468,7 +18468,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1818
+Index: geneve-ut-1822
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18487,7 +18487,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-1825
+Index: geneve-ut-1829
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -18506,7 +18506,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1839
+Index: geneve-ut-1843
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -18523,7 +18523,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1842
+Index: geneve-ut-1846
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -18540,7 +18540,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1858
+Index: geneve-ut-1862
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -18559,7 +18559,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1862
+Index: geneve-ut-1866
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18601,7 +18601,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1863
+Index: geneve-ut-1867
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18646,7 +18646,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1866
+Index: geneve-ut-1870
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18688,7 +18688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1868
+Index: geneve-ut-1872
 
 ```python
 host.os.type:"linux" and 
@@ -18716,7 +18716,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1871
+Index: geneve-ut-1875
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18740,7 +18740,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1872
+Index: geneve-ut-1876
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18780,7 +18780,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1873
+Index: geneve-ut-1877
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -18827,7 +18827,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1877
+Index: geneve-ut-1881
 
 ```python
 sequence by process.entity_id
@@ -18864,7 +18864,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1909
+Index: geneve-ut-1913
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18878,7 +18878,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1910
+Index: geneve-ut-1914
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -18921,7 +18921,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1911
+Index: geneve-ut-1915
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -18934,7 +18934,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1913
+Index: geneve-ut-1917
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -18948,7 +18948,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1914
+Index: geneve-ut-1918
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -18961,7 +18961,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1918
+Index: geneve-ut-1922
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -18986,7 +18986,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1919
+Index: geneve-ut-1923
 
 ```python
 process where event.type == "start" and
@@ -19001,7 +19001,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1920
+Index: geneve-ut-1924
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19018,7 +19018,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1921
+Index: geneve-ut-1925
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19032,7 +19032,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1922
+Index: geneve-ut-1926
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19048,7 +19048,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1923
+Index: geneve-ut-1927
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19062,7 +19062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1924
+Index: geneve-ut-1928
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -19089,7 +19089,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1926
+Index: geneve-ut-1930
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -19101,7 +19101,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1927
+Index: geneve-ut-1931
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19117,7 +19117,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1928
+Index: geneve-ut-1932
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -19140,7 +19140,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1929
+Index: geneve-ut-1933
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -19153,7 +19153,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1930
+Index: geneve-ut-1934
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -19165,7 +19165,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1931
+Index: geneve-ut-1935
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -19177,7 +19177,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1932
+Index: geneve-ut-1936
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -19189,7 +19189,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1933
+Index: geneve-ut-1937
 
 ```python
 web where (
@@ -19217,7 +19217,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-1936
+Index: geneve-ut-1940
 
 ```python
 any where (
@@ -19289,7 +19289,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1938
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19310,7 +19310,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1941
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -19324,7 +19324,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1942
+Index: geneve-ut-1946
 
 ```python
 file where event.type == "deletion" and
@@ -19341,7 +19341,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1943
+Index: geneve-ut-1947
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19359,7 +19359,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1945
+Index: geneve-ut-1949
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19397,7 +19397,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1947
+Index: geneve-ut-1951
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19434,7 +19434,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1948
+Index: geneve-ut-1952
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19449,7 +19449,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1949
+Index: geneve-ut-1953
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -19462,7 +19462,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1950
+Index: geneve-ut-1954
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19481,7 +19481,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-1951
+Index: geneve-ut-1955
 
 ```python
 sequence by host.id with maxspan=1m
@@ -19506,7 +19506,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1952
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19532,7 +19532,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1953
+Index: geneve-ut-1957
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -19554,7 +19554,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1954
+Index: geneve-ut-1958
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19571,7 +19571,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-1956
+Index: geneve-ut-1960
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -19590,7 +19590,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-1957
+Index: geneve-ut-1961
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -19630,7 +19630,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1958
+Index: geneve-ut-1962
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19647,7 +19647,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1960
+Index: geneve-ut-1964
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -19660,7 +19660,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1961
+Index: geneve-ut-1965
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -19674,7 +19674,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1962
+Index: geneve-ut-1966
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19702,7 +19702,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1963
+Index: geneve-ut-1967
 
 ```python
 process where event.type == "start" and
@@ -19727,7 +19727,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1964
+Index: geneve-ut-1968
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19741,7 +19741,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1965
+Index: geneve-ut-1969
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19757,7 +19757,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1966
+Index: geneve-ut-1970
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19792,7 +19792,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1967
+Index: geneve-ut-1971
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19810,7 +19810,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1970
+Index: geneve-ut-1974
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.3.md
+++ b/tests/reports/alerts_from_rules-9.3.md
@@ -5,7 +5,7 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.17
+Rules version: 9.3.18
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
@@ -20,7 +20,7 @@ Rules version: 9.3.17
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0360  
+Index: geneve-ut-0361  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0371  
+Index: geneve-ut-0372  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -190,7 +190,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0590  
+Index: geneve-ut-0591  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0613  
+Index: geneve-ut-0614  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0744  
+Index: geneve-ut-0746  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0933  
+Index: geneve-ut-0935  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1061  
+Index: geneve-ut-1063  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1090  
+Index: geneve-ut-1092  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1158  
+Index: geneve-ut-1161  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1186  
+Index: geneve-ut-1189  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1204  
+Index: geneve-ut-1207  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1266  
+Index: geneve-ut-1269  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1281  
+Index: geneve-ut-1284  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1365  
+Index: geneve-ut-1368  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1593  
+Index: geneve-ut-1597  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1597  
+Index: geneve-ut-1601  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1678  
+Index: geneve-ut-1682  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1693  
+Index: geneve-ut-1697  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1706  
+Index: geneve-ut-1710  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1716  
+Index: geneve-ut-1720  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1721  
+Index: geneve-ut-1725  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1730  
+Index: geneve-ut-1734  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1825  
+Index: geneve-ut-1829  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1854  
+Index: geneve-ut-1858  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1123,7 +1123,7 @@ container.id like "*"
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0360
+Index: geneve-ut-0361
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1175,7 +1175,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0371
+Index: geneve-ut-0372
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -1287,7 +1287,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0590
+Index: geneve-ut-0591
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1353,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0613
+Index: geneve-ut-0614
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0744
+Index: geneve-ut-0746
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0933
+Index: geneve-ut-0935
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1061
+Index: geneve-ut-1063
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1090
+Index: geneve-ut-1092
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1158
+Index: geneve-ut-1161
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1186
+Index: geneve-ut-1189
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1204
+Index: geneve-ut-1207
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1266
+Index: geneve-ut-1269
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1281
+Index: geneve-ut-1284
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1365
+Index: geneve-ut-1368
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1593
+Index: geneve-ut-1597
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1597
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1678
+Index: geneve-ut-1682
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1693
+Index: geneve-ut-1697
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1706
+Index: geneve-ut-1710
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1716
+Index: geneve-ut-1720
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1721
+Index: geneve-ut-1725
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1730
+Index: geneve-ut-1734
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1825
+Index: geneve-ut-1829
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1854
+Index: geneve-ut-1858
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0934
+Index: geneve-ut-0936
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0940
+Index: geneve-ut-0942
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1316
+Index: geneve-ut-1319
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1506
+Index: geneve-ut-1509
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2227,7 +2227,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0360  
+Index: geneve-ut-0361  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2281,7 +2281,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0371  
+Index: geneve-ut-0372  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -2395,7 +2395,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0590  
+Index: geneve-ut-0591  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2463,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0613  
+Index: geneve-ut-0614  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0744  
+Index: geneve-ut-0746  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0906  
+Index: geneve-ut-0908  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0933  
+Index: geneve-ut-0935  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1040  
+Index: geneve-ut-1042  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1061  
+Index: geneve-ut-1063  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1090  
+Index: geneve-ut-1092  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1158  
+Index: geneve-ut-1161  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1186  
+Index: geneve-ut-1189  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1204  
+Index: geneve-ut-1207  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1266  
+Index: geneve-ut-1269  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1281  
+Index: geneve-ut-1284  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1357  
+Index: geneve-ut-1360  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1365  
+Index: geneve-ut-1368  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1474  
+Index: geneve-ut-1477  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1593  
+Index: geneve-ut-1597  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1597  
+Index: geneve-ut-1601  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1678  
+Index: geneve-ut-1682  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1693  
+Index: geneve-ut-1697  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1706  
+Index: geneve-ut-1710  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1716  
+Index: geneve-ut-1720  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1721  
+Index: geneve-ut-1725  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1730  
+Index: geneve-ut-1734  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1825  
+Index: geneve-ut-1829  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1854  
+Index: geneve-ut-1858  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -4269,7 +4269,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0317
+Index: geneve-ut-0318
 
 ```python
 event.dataset:azure.activitylogs and
@@ -4283,7 +4283,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0320
+Index: geneve-ut-0321
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -4301,7 +4301,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0338
+Index: geneve-ut-0339
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4319,7 +4319,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0339
+Index: geneve-ut-0340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4337,7 +4337,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0340
+Index: geneve-ut-0341
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4352,7 +4352,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0341
+Index: geneve-ut-0342
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4366,7 +4366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0342
+Index: geneve-ut-0343
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4381,7 +4381,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0344
+Index: geneve-ut-0345
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4398,7 +4398,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0345
+Index: geneve-ut-0346
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4410,7 +4410,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0346
+Index: geneve-ut-0347
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4422,7 +4422,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0347
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4437,7 +4437,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0348
+Index: geneve-ut-0349
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4457,7 +4457,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0349
+Index: geneve-ut-0350
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4479,7 +4479,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0351
+Index: geneve-ut-0352
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4525,7 +4525,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0352
+Index: geneve-ut-0353
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4559,7 +4559,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0353
+Index: geneve-ut-0354
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4582,7 +4582,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0355
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4604,7 +4604,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0356
+Index: geneve-ut-0357
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4632,7 +4632,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0357
+Index: geneve-ut-0358
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4648,7 +4648,7 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0359
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4673,7 +4673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0361
+Index: geneve-ut-0362
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4703,7 +4703,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0363
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4717,7 +4717,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0364
+Index: geneve-ut-0365
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4739,7 +4739,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0365
+Index: geneve-ut-0366
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4753,7 +4753,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0366
+Index: geneve-ut-0367
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4773,7 +4773,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0369
+Index: geneve-ut-0370
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4790,7 +4790,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0372
+Index: geneve-ut-0373
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4820,7 +4820,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0375
+Index: geneve-ut-0376
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4845,7 +4845,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0377
+Index: geneve-ut-0378
 
 ```python
 sequence by process.entity_id
@@ -4866,7 +4866,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0378
+Index: geneve-ut-0379
 
 ```python
 sequence by process.entity_id
@@ -4887,7 +4887,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0381
+Index: geneve-ut-0382
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4918,7 +4918,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0382
+Index: geneve-ut-0383
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4930,7 +4930,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0383
+Index: geneve-ut-0384
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4953,7 +4953,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0386
+Index: geneve-ut-0387
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4966,7 +4966,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0387
+Index: geneve-ut-0388
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4979,7 +4979,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0389
+Index: geneve-ut-0390
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4996,7 +4996,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0390
+Index: geneve-ut-0391
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -5009,7 +5009,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0391
+Index: geneve-ut-0392
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -5026,7 +5026,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0392
+Index: geneve-ut-0393
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -5038,7 +5038,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0393
+Index: geneve-ut-0394
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -5106,7 +5106,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0394
+Index: geneve-ut-0395
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -5124,7 +5124,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0395
+Index: geneve-ut-0396
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -5137,7 +5137,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0396
+Index: geneve-ut-0397
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5155,7 +5155,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0397
+Index: geneve-ut-0398
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5167,7 +5167,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0398
+Index: geneve-ut-0399
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5179,7 +5179,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0399
+Index: geneve-ut-0400
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5191,7 +5191,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0400
+Index: geneve-ut-0401
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5203,7 +5203,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0401
+Index: geneve-ut-0402
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -5248,7 +5248,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0403
+Index: geneve-ut-0404
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5268,7 +5268,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0404
+Index: geneve-ut-0405
 
 ```python
 sequence with maxspan=10s
@@ -5288,7 +5288,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0405
+Index: geneve-ut-0406
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5315,7 +5315,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0406
+Index: geneve-ut-0407
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5329,7 +5329,7 @@ container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0409
+Index: geneve-ut-0410
 
 ```python
 process where event.type == "start" and
@@ -5354,7 +5354,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0412
+Index: geneve-ut-0413
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5398,7 +5398,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0413
+Index: geneve-ut-0414
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5432,7 +5432,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0414
+Index: geneve-ut-0415
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5477,7 +5477,7 @@ container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0415
+Index: geneve-ut-0416
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5493,7 +5493,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0416
+Index: geneve-ut-0417
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5518,7 +5518,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0417
+Index: geneve-ut-0418
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5537,7 +5537,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0419
+Index: geneve-ut-0420
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5664,7 +5664,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0420
+Index: geneve-ut-0421
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5682,7 +5682,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0422
+Index: geneve-ut-0423
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5695,7 +5695,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0423
+Index: geneve-ut-0424
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5725,7 +5725,7 @@ container.security_context.privileged == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0429
+Index: geneve-ut-0430
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5739,7 +5739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0430
+Index: geneve-ut-0431
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5760,7 +5760,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0431
+Index: geneve-ut-0432
 
 ```python
 registry where host.os.type == "windows" and
@@ -5774,7 +5774,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0440
+Index: geneve-ut-0441
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5798,7 +5798,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0451
+Index: geneve-ut-0452
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5852,7 +5852,7 @@ container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0453
+Index: geneve-ut-0454
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5868,7 +5868,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0454
+Index: geneve-ut-0455
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5896,7 +5896,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0455
+Index: geneve-ut-0456
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5913,7 +5913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0456
+Index: geneve-ut-0457
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5930,7 +5930,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0457
+Index: geneve-ut-0458
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5951,7 +5951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0459
+Index: geneve-ut-0460
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5971,7 +5971,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0460
+Index: geneve-ut-0461
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5986,7 +5986,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0462
+Index: geneve-ut-0463
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5999,7 +5999,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0463
+Index: geneve-ut-0464
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6019,7 +6019,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0466
+Index: geneve-ut-0467
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -6032,7 +6032,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0467
+Index: geneve-ut-0468
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6070,7 +6070,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0468
+Index: geneve-ut-0469
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -6090,7 +6090,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0469
+Index: geneve-ut-0470
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6103,7 +6103,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0470
+Index: geneve-ut-0471
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -6126,7 +6126,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0472
+Index: geneve-ut-0473
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6157,7 +6157,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0473
+Index: geneve-ut-0474
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -6176,7 +6176,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0474
+Index: geneve-ut-0475
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6219,7 +6219,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0475
+Index: geneve-ut-0476
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -6233,7 +6233,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0477
+Index: geneve-ut-0478
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6248,7 +6248,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0478
+Index: geneve-ut-0479
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6264,7 +6264,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0479
+Index: geneve-ut-0480
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6278,7 +6278,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0480
+Index: geneve-ut-0481
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6304,7 +6304,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0481
+Index: geneve-ut-0482
 
 ```python
 process where event.type == "start" and
@@ -6342,7 +6342,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0488
+Index: geneve-ut-0489
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -6355,7 +6355,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0489
+Index: geneve-ut-0490
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6369,7 +6369,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0490
+Index: geneve-ut-0491
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6391,7 +6391,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0491
+Index: geneve-ut-0492
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6426,7 +6426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0492
+Index: geneve-ut-0493
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6438,7 +6438,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0540
+Index: geneve-ut-0541
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6450,7 +6450,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0566
+Index: geneve-ut-0567
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6464,7 +6464,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0569
+Index: geneve-ut-0570
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6491,7 +6491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0572
+Index: geneve-ut-0573
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6512,7 +6512,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0573
+Index: geneve-ut-0574
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6542,7 +6542,7 @@ container.id like "*"
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0576
+Index: geneve-ut-0577
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6560,7 +6560,7 @@ container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0577
+Index: geneve-ut-0578
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6593,7 +6593,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0579
+Index: geneve-ut-0580
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6610,7 +6610,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0580
+Index: geneve-ut-0581
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6638,7 +6638,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0581
+Index: geneve-ut-0582
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6651,7 +6651,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0583
+Index: geneve-ut-0584
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6671,7 +6671,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0584
+Index: geneve-ut-0585
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6697,7 +6697,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0585
+Index: geneve-ut-0586
 
 ```python
 sequence with maxspan=2h
@@ -6719,7 +6719,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0586
+Index: geneve-ut-0587
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6748,7 +6748,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0589
+Index: geneve-ut-0590
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6761,7 +6761,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0593
+Index: geneve-ut-0594
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6776,7 +6776,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0594
+Index: geneve-ut-0595
 
 ```python
 process where event.type == "start" and
@@ -6798,7 +6798,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0595
+Index: geneve-ut-0596
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6810,7 +6810,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0596
+Index: geneve-ut-0597
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6832,7 +6832,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0598
+Index: geneve-ut-0599
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6849,7 +6849,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0599
+Index: geneve-ut-0600
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6863,7 +6863,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0600
+Index: geneve-ut-0601
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6876,7 +6876,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0601
+Index: geneve-ut-0602
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6888,7 +6888,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0602
+Index: geneve-ut-0603
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6900,7 +6900,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0603
+Index: geneve-ut-0604
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6914,7 +6914,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0604
+Index: geneve-ut-0605
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6926,7 +6926,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0605
+Index: geneve-ut-0606
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -6948,7 +6948,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0608
+Index: geneve-ut-0609
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6997,7 +6997,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0609
+Index: geneve-ut-0610
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -7014,7 +7014,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0610
+Index: geneve-ut-0611
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7034,7 +7034,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0615
+Index: geneve-ut-0616
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7056,7 +7056,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0618
+Index: geneve-ut-0619
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7071,7 +7071,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0619
+Index: geneve-ut-0620
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7085,7 +7085,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0621
+Index: geneve-ut-0622
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7107,7 +7107,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0622
+Index: geneve-ut-0623
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -7128,7 +7128,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0623
+Index: geneve-ut-0624
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7154,7 +7154,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0624
+Index: geneve-ut-0625
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -7182,7 +7182,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0627
+Index: geneve-ut-0628
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -7196,7 +7196,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0665
+Index: geneve-ut-0667
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -7213,7 +7213,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0666
+Index: geneve-ut-0668
 
 ```python
 registry where host.os.type == "windows" and
@@ -7231,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0734
+Index: geneve-ut-0736
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0735
+Index: geneve-ut-0737
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0736
+Index: geneve-ut-0738
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0737
+Index: geneve-ut-0739
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0745
+Index: geneve-ut-0747
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0746
+Index: geneve-ut-0748
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0747
+Index: geneve-ut-0749
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0748
+Index: geneve-ut-0750
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0752
+Index: geneve-ut-0754
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0755
+Index: geneve-ut-0757
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0758
+Index: geneve-ut-0760
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0762
+Index: geneve-ut-0764
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0764
+Index: geneve-ut-0766
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0788
+Index: geneve-ut-0790
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0790
+Index: geneve-ut-0792
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0791
+Index: geneve-ut-0793
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0804
+Index: geneve-ut-0806
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0805
+Index: geneve-ut-0807
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0806
+Index: geneve-ut-0808
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0810
+Index: geneve-ut-0812
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0815
+Index: geneve-ut-0817
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0817
+Index: geneve-ut-0819
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0818
+Index: geneve-ut-0820
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0819
+Index: geneve-ut-0821
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0820
+Index: geneve-ut-0822
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0821
+Index: geneve-ut-0823
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0822
+Index: geneve-ut-0824
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0827
+Index: geneve-ut-0829
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0829
+Index: geneve-ut-0831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0830
+Index: geneve-ut-0832
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0831
+Index: geneve-ut-0833
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7897,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0832
+Index: geneve-ut-0834
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7921,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0837
+Index: geneve-ut-0839
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0839
+Index: geneve-ut-0841
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0840
+Index: geneve-ut-0842
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0841
+Index: geneve-ut-0843
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0842
+Index: geneve-ut-0844
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0843
+Index: geneve-ut-0845
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0844
+Index: geneve-ut-0846
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0845
+Index: geneve-ut-0847
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0846
+Index: geneve-ut-0848
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0847
+Index: geneve-ut-0849
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0848
+Index: geneve-ut-0850
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0850
+Index: geneve-ut-0852
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0852
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0853
+Index: geneve-ut-0855
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0854
+Index: geneve-ut-0856
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0855
+Index: geneve-ut-0857
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0857
+Index: geneve-ut-0859
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0858
+Index: geneve-ut-0860
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0860
+Index: geneve-ut-0862
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0862
+Index: geneve-ut-0864
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0863
+Index: geneve-ut-0865
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0865
+Index: geneve-ut-0867
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0866
+Index: geneve-ut-0868
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8436,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0867
+Index: geneve-ut-0869
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8463,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0870
+Index: geneve-ut-0872
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0871
+Index: geneve-ut-0873
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0881
+Index: geneve-ut-0883
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0907
+Index: geneve-ut-0909
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0910
+Index: geneve-ut-0912
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0912
+Index: geneve-ut-0914
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0924
+Index: geneve-ut-0926
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0929
+Index: geneve-ut-0931
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0930
+Index: geneve-ut-0932
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0935
+Index: geneve-ut-0937
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0936
+Index: geneve-ut-0938
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0939
+Index: geneve-ut-0941
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0941
+Index: geneve-ut-0943
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-0942
+Index: geneve-ut-0944
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0946
+Index: geneve-ut-0948
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0947
+Index: geneve-ut-0949
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8863,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0950
+Index: geneve-ut-0952
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0952
+Index: geneve-ut-0954
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0953
+Index: geneve-ut-0955
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0989
+Index: geneve-ut-0991
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0990
+Index: geneve-ut-0992
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0991
+Index: geneve-ut-0993
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0992
+Index: geneve-ut-0994
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0993
+Index: geneve-ut-0995
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1001
+Index: geneve-ut-1003
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1004
+Index: geneve-ut-1006
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1005
+Index: geneve-ut-1007
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1006
+Index: geneve-ut-1008
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1010
+Index: geneve-ut-1012
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1011
+Index: geneve-ut-1013
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1012
+Index: geneve-ut-1014
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1013
+Index: geneve-ut-1015
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1014
+Index: geneve-ut-1016
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1015
+Index: geneve-ut-1017
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1016
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1017
+Index: geneve-ut-1019
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9142,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1018
+Index: geneve-ut-1020
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9167,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1020
+Index: geneve-ut-1022
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1023
+Index: geneve-ut-1025
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1024
+Index: geneve-ut-1026
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1025
+Index: geneve-ut-1027
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1028
+Index: geneve-ut-1030
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1029
+Index: geneve-ut-1031
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1030
+Index: geneve-ut-1032
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1033
+Index: geneve-ut-1035
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1034
+Index: geneve-ut-1036
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1035
+Index: geneve-ut-1037
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1039
+Index: geneve-ut-1041
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1041
+Index: geneve-ut-1043
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1043
+Index: geneve-ut-1045
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1044
+Index: geneve-ut-1046
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1045
+Index: geneve-ut-1047
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1046
+Index: geneve-ut-1048
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1048
+Index: geneve-ut-1050
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1049
+Index: geneve-ut-1051
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1051
+Index: geneve-ut-1053
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1052
+Index: geneve-ut-1054
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9604,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1054
+Index: geneve-ut-1056
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1055
+Index: geneve-ut-1057
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1056
+Index: geneve-ut-1058
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1057
+Index: geneve-ut-1059
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1058
+Index: geneve-ut-1060
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1059
+Index: geneve-ut-1061
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1060
+Index: geneve-ut-1062
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1072
+Index: geneve-ut-1074
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1081
+Index: geneve-ut-1083
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1085
+Index: geneve-ut-1087
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1086
+Index: geneve-ut-1088
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1087
+Index: geneve-ut-1089
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1088
+Index: geneve-ut-1090
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1089
+Index: geneve-ut-1091
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1091
+Index: geneve-ut-1093
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1092
+Index: geneve-ut-1094
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1094
+Index: geneve-ut-1096
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1096
+Index: geneve-ut-1098
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1097
+Index: geneve-ut-1099
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1098
+Index: geneve-ut-1100
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1100
+Index: geneve-ut-1102
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1101
+Index: geneve-ut-1103
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1102
+Index: geneve-ut-1104
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1103
+Index: geneve-ut-1105
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1104
+Index: geneve-ut-1106
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1105
+Index: geneve-ut-1107
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1106
+Index: geneve-ut-1108
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1107
+Index: geneve-ut-1109
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1108
+Index: geneve-ut-1110
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1111
+Index: geneve-ut-1113
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1112
+Index: geneve-ut-1114
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1113
+Index: geneve-ut-1115
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1118
+Index: geneve-ut-1120
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1121
+Index: geneve-ut-1123
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1129
+Index: geneve-ut-1132
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1130
+Index: geneve-ut-1133
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1131
+Index: geneve-ut-1134
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1132
+Index: geneve-ut-1135
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1134
+Index: geneve-ut-1137
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1135
+Index: geneve-ut-1138
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1137
+Index: geneve-ut-1140
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1146
+Index: geneve-ut-1149
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1147
+Index: geneve-ut-1150
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1148
+Index: geneve-ut-1151
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1149
+Index: geneve-ut-1152
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1150
+Index: geneve-ut-1153
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1151
+Index: geneve-ut-1154
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1152
+Index: geneve-ut-1155
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1153
+Index: geneve-ut-1156
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10670,7 +10670,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1159
+Index: geneve-ut-1162
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10685,7 +10685,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1160
+Index: geneve-ut-1163
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10699,7 +10699,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1161
+Index: geneve-ut-1164
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10718,7 +10718,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1162
+Index: geneve-ut-1165
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10730,7 +10730,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1163
+Index: geneve-ut-1166
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10742,7 +10742,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1164
+Index: geneve-ut-1167
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10760,7 +10760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1165
+Index: geneve-ut-1168
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10773,7 +10773,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1166
+Index: geneve-ut-1169
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10788,7 +10788,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1167
+Index: geneve-ut-1170
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10803,7 +10803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1169
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10823,7 +10823,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1170
+Index: geneve-ut-1173
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10847,7 +10847,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1171
+Index: geneve-ut-1174
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10861,7 +10861,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1172
+Index: geneve-ut-1175
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10880,7 +10880,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1173
+Index: geneve-ut-1176
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10908,7 +10908,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1174
+Index: geneve-ut-1177
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10937,7 +10937,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1175
+Index: geneve-ut-1178
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10956,7 +10956,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1176
+Index: geneve-ut-1179
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10984,7 +10984,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1177
+Index: geneve-ut-1180
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10999,7 +10999,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1178
+Index: geneve-ut-1181
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11062,7 +11062,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1179
+Index: geneve-ut-1182
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11083,7 +11083,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1180
+Index: geneve-ut-1183
 
 ```python
 any where host.os.type == "windows" and
@@ -11145,7 +11145,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1182
+Index: geneve-ut-1185
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11174,7 +11174,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1183
+Index: geneve-ut-1186
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11188,7 +11188,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1184
+Index: geneve-ut-1187
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11221,7 +11221,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1187
+Index: geneve-ut-1190
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11268,7 +11268,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1188
+Index: geneve-ut-1191
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11295,7 +11295,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1189
+Index: geneve-ut-1192
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11308,7 +11308,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1200
+Index: geneve-ut-1203
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11325,7 +11325,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1202
+Index: geneve-ut-1205
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11350,7 +11350,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1207
+Index: geneve-ut-1210
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11366,7 +11366,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1208
+Index: geneve-ut-1211
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11387,7 +11387,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1209
+Index: geneve-ut-1212
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11404,7 +11404,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1210
+Index: geneve-ut-1213
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11417,7 +11417,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1211
+Index: geneve-ut-1214
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11441,7 +11441,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1213
+Index: geneve-ut-1216
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11470,7 +11470,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1215
+Index: geneve-ut-1218
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11497,7 +11497,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1216
+Index: geneve-ut-1219
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11521,7 +11521,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1219
+Index: geneve-ut-1222
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11539,7 +11539,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1220
+Index: geneve-ut-1223
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11562,7 +11562,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1221
+Index: geneve-ut-1224
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11619,7 +11619,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1222
+Index: geneve-ut-1225
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11636,7 +11636,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1223
+Index: geneve-ut-1226
 
 ```python
 sequence by process.entity_id
@@ -11650,7 +11650,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1237
+Index: geneve-ut-1240
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11665,7 +11665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1238
+Index: geneve-ut-1241
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11696,7 +11696,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1239
+Index: geneve-ut-1242
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11710,7 +11710,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1240
+Index: geneve-ut-1243
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11723,7 +11723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1241
+Index: geneve-ut-1244
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11735,7 +11735,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1242
+Index: geneve-ut-1245
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11748,7 +11748,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1244
+Index: geneve-ut-1247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11767,7 +11767,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1245
+Index: geneve-ut-1248
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11780,7 +11780,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1246
+Index: geneve-ut-1249
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11801,7 +11801,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1247
+Index: geneve-ut-1250
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11815,7 +11815,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1250
+Index: geneve-ut-1253
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11835,7 +11835,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1251
+Index: geneve-ut-1254
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11859,7 +11859,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1252
+Index: geneve-ut-1255
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11875,7 +11875,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1253
+Index: geneve-ut-1256
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11892,7 +11892,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1254
+Index: geneve-ut-1257
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11913,7 +11913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1256
+Index: geneve-ut-1259
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11926,7 +11926,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1258
+Index: geneve-ut-1261
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11954,7 +11954,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1261
+Index: geneve-ut-1264
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11970,7 +11970,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1262
+Index: geneve-ut-1265
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11993,7 +11993,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1263
+Index: geneve-ut-1266
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12006,7 +12006,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1265
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12019,7 +12019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1270
+Index: geneve-ut-1273
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12033,7 +12033,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1271
+Index: geneve-ut-1274
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +12048,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1273
+Index: geneve-ut-1276
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12071,7 +12071,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1276
+Index: geneve-ut-1279
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12114,7 +12114,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1277
+Index: geneve-ut-1280
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12132,7 +12132,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1278
+Index: geneve-ut-1281
 
 ```python
 host.os.type:"windows" and
@@ -12148,7 +12148,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1280
+Index: geneve-ut-1283
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12160,7 +12160,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1282
+Index: geneve-ut-1285
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12176,7 +12176,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1283
+Index: geneve-ut-1286
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12192,7 +12192,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1284
+Index: geneve-ut-1287
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12210,7 +12210,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1285
+Index: geneve-ut-1288
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12224,7 +12224,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1287
+Index: geneve-ut-1290
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12247,7 +12247,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1289
+Index: geneve-ut-1292
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12263,7 +12263,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1290
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12276,7 +12276,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1291
+Index: geneve-ut-1294
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12306,7 +12306,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1296
+Index: geneve-ut-1299
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12329,7 +12329,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1297
+Index: geneve-ut-1300
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12348,7 +12348,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1302
+Index: geneve-ut-1305
 
 ```python
 process where host.os.type == "windows" and 
@@ -12490,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1303
+Index: geneve-ut-1306
 
 ```python
 process where host.os.type == "windows" and
@@ -12567,7 +12567,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1307
+Index: geneve-ut-1310
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12584,7 +12584,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1308
+Index: geneve-ut-1311
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12618,7 +12618,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1310
+Index: geneve-ut-1313
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12630,7 +12630,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12669,7 +12669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1313
+Index: geneve-ut-1316
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12682,7 +12682,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1318
+Index: geneve-ut-1321
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12696,7 +12696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1325
+Index: geneve-ut-1328
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12734,7 +12734,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1326
+Index: geneve-ut-1329
 
 ```python
 network where host.os.type == "windows" and
@@ -12760,7 +12760,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1329
+Index: geneve-ut-1332
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12775,7 +12775,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12789,7 +12789,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 file where host.os.type == "windows" and
@@ -12803,7 +12803,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1333
+Index: geneve-ut-1336
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12816,7 +12816,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12836,7 +12836,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1335
+Index: geneve-ut-1338
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12895,7 +12895,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1338
+Index: geneve-ut-1341
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13090,7 +13090,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1351
+Index: geneve-ut-1354
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13106,7 +13106,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1352
+Index: geneve-ut-1355
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13120,7 +13120,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1353
+Index: geneve-ut-1356
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13134,7 +13134,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1354
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13151,7 +13151,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13165,7 +13165,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13181,7 +13181,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1360
+Index: geneve-ut-1363
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13193,7 +13193,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1361
+Index: geneve-ut-1364
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13209,7 +13209,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1362
+Index: geneve-ut-1365
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13229,7 +13229,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1364
+Index: geneve-ut-1367
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13269,7 +13269,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1366
+Index: geneve-ut-1369
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13281,7 +13281,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1367
+Index: geneve-ut-1370
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13302,7 +13302,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1368
+Index: geneve-ut-1371
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13323,7 +13323,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1369
+Index: geneve-ut-1372
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13344,7 +13344,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13370,7 +13370,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13386,7 +13386,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1372
+Index: geneve-ut-1375
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13400,7 +13400,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13423,7 +13423,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13440,7 +13440,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1376
+Index: geneve-ut-1379
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13463,7 +13463,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1377
+Index: geneve-ut-1380
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13476,7 +13476,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1378
+Index: geneve-ut-1381
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13490,7 +13490,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1379
+Index: geneve-ut-1382
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13507,7 +13507,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13561,7 +13561,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1381
+Index: geneve-ut-1384
 
 ```python
 any where host.os.type == "windows" and
@@ -13588,7 +13588,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1387
+Index: geneve-ut-1390
 
 ```python
 file where host.os.type == "windows" and
@@ -13603,7 +13603,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1388
+Index: geneve-ut-1391
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13634,7 +13634,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1389
+Index: geneve-ut-1392
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +13648,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1390
+Index: geneve-ut-1393
 
 ```python
 sequence with maxspan=1m
@@ -13690,7 +13690,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1391
+Index: geneve-ut-1394
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13715,7 +13715,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1392
+Index: geneve-ut-1395
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13769,7 +13769,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1393
+Index: geneve-ut-1396
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13789,7 +13789,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1394
+Index: geneve-ut-1397
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13810,7 +13810,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1395
+Index: geneve-ut-1398
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13825,7 +13825,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1396
+Index: geneve-ut-1399
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13845,7 +13845,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1397
+Index: geneve-ut-1400
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13887,7 +13887,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13902,7 +13902,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1402
+Index: geneve-ut-1405
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13937,7 +13937,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1403
+Index: geneve-ut-1406
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13954,7 +13954,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1405
+Index: geneve-ut-1408
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13968,7 +13968,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1408
+Index: geneve-ut-1411
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13981,7 +13981,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1409
+Index: geneve-ut-1412
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13993,7 +13993,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1410
+Index: geneve-ut-1413
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14008,7 +14008,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1412
+Index: geneve-ut-1415
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14036,7 +14036,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1413
+Index: geneve-ut-1416
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14061,7 +14061,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1417
+Index: geneve-ut-1420
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14098,7 +14098,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1418
+Index: geneve-ut-1421
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14112,7 +14112,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1419
+Index: geneve-ut-1422
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14128,7 +14128,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1420
+Index: geneve-ut-1423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14142,7 +14142,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1421
+Index: geneve-ut-1424
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14172,7 +14172,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1422
+Index: geneve-ut-1425
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14201,7 +14201,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1423
+Index: geneve-ut-1426
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14217,7 +14217,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14231,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1425
+Index: geneve-ut-1428
 
 ```python
 file where host.os.type == "windows" and
@@ -14267,7 +14267,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 process where event.type == "start" and
@@ -14281,7 +14281,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1429
+Index: geneve-ut-1432
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14295,7 +14295,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1430
+Index: geneve-ut-1433
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14315,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1432
+Index: geneve-ut-1435
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14332,7 +14332,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1433
+Index: geneve-ut-1436
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14344,7 +14344,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1434
+Index: geneve-ut-1437
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14361,7 +14361,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1435
+Index: geneve-ut-1438
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14379,7 +14379,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1442
+Index: geneve-ut-1445
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14392,7 +14392,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1443
+Index: geneve-ut-1446
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14419,7 +14419,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1444
+Index: geneve-ut-1447
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14432,7 +14432,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1445
+Index: geneve-ut-1448
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14446,7 +14446,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1447
+Index: geneve-ut-1450
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14463,7 +14463,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1448
+Index: geneve-ut-1451
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14486,7 +14486,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14503,7 +14503,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1453
+Index: geneve-ut-1456
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14516,7 +14516,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1455
+Index: geneve-ut-1458
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14540,7 +14540,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1456
+Index: geneve-ut-1459
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14568,7 +14568,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1471
+Index: geneve-ut-1474
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14589,7 +14589,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1473
+Index: geneve-ut-1476
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14617,7 +14617,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1475
+Index: geneve-ut-1478
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14657,7 +14657,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1476
+Index: geneve-ut-1479
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14674,7 +14674,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1477
+Index: geneve-ut-1480
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14688,7 +14688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1478
+Index: geneve-ut-1481
 
 ```python
 file where host.os.type == "windows" and
@@ -14707,7 +14707,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1479
+Index: geneve-ut-1482
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14721,7 +14721,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1481
+Index: geneve-ut-1484
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14739,7 +14739,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1483
+Index: geneve-ut-1486
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14757,7 +14757,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1486
+Index: geneve-ut-1489
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14771,7 +14771,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1488
+Index: geneve-ut-1491
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14786,7 +14786,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14809,7 +14809,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1491
+Index: geneve-ut-1494
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14891,7 +14891,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14912,7 +14912,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14938,7 +14938,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1495
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14991,7 +14991,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1496
+Index: geneve-ut-1499
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15003,7 +15003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1497
+Index: geneve-ut-1500
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15015,7 +15015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1498
+Index: geneve-ut-1501
 
 ```python
 process where host.os.type == "windows" and
@@ -15030,7 +15030,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1499
+Index: geneve-ut-1502
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15060,7 +15060,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1500
+Index: geneve-ut-1503
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15120,7 +15120,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1503
+Index: geneve-ut-1506
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15133,7 +15133,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1504
+Index: geneve-ut-1507
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15165,7 +15165,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1505
+Index: geneve-ut-1508
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15189,7 +15189,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1507
+Index: geneve-ut-1510
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15222,7 +15222,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1508
+Index: geneve-ut-1511
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15239,7 +15239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1509
+Index: geneve-ut-1512
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15268,7 +15268,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1510
+Index: geneve-ut-1513
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15282,7 +15282,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1511
+Index: geneve-ut-1514
 
 ```python
 sequence by process.entity_id
@@ -15307,7 +15307,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15341,7 +15341,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1513
+Index: geneve-ut-1516
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15369,7 +15369,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1514
+Index: geneve-ut-1517
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15388,7 +15388,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1518
+Index: geneve-ut-1521
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15416,7 +15416,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1519
+Index: geneve-ut-1522
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15435,7 +15435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1523
+Index: geneve-ut-1526
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15447,7 +15447,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1524
+Index: geneve-ut-1527
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15459,7 +15459,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1525
+Index: geneve-ut-1528
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15471,7 +15471,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15483,7 +15483,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1536
+Index: geneve-ut-1539
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15496,7 +15496,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1537
+Index: geneve-ut-1540
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15534,7 +15534,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1539
+Index: geneve-ut-1542
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15549,7 +15549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1540
+Index: geneve-ut-1543
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15568,7 +15568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1541
+Index: geneve-ut-1544
 
 ```python
 sequence with maxspan=1m
@@ -15616,7 +15616,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1543
+Index: geneve-ut-1546
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15639,7 +15639,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1545
+Index: geneve-ut-1548
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15653,7 +15653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1546
+Index: geneve-ut-1549
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15667,7 +15667,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 sequence by host.id, process.entity_id
@@ -15684,7 +15684,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15698,7 +15698,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1550
+Index: geneve-ut-1553
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15718,7 +15718,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15747,7 +15747,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1552
+Index: geneve-ut-1555
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15767,7 +15767,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1553
+Index: geneve-ut-1556
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15780,7 +15780,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1555
+Index: geneve-ut-1558
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15822,7 +15822,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1556
+Index: geneve-ut-1559
 
 ```python
 sequence with maxspan=1m
@@ -15845,7 +15845,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1557
+Index: geneve-ut-1560
 
 ```python
 sequence with maxspan=1s
@@ -15893,7 +15893,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1558
+Index: geneve-ut-1561
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15910,7 +15910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1560
+Index: geneve-ut-1563
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15939,7 +15939,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1561
+Index: geneve-ut-1565
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15967,7 +15967,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1562
+Index: geneve-ut-1566
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15984,7 +15984,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1564
+Index: geneve-ut-1568
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16003,7 +16003,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1565
+Index: geneve-ut-1569
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16024,7 +16024,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1570
+Index: geneve-ut-1574
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16038,7 +16038,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1572
+Index: geneve-ut-1576
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16057,7 +16057,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1573
+Index: geneve-ut-1577
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16071,7 +16071,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1574
+Index: geneve-ut-1578
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16091,7 +16091,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1576
+Index: geneve-ut-1580
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16109,7 +16109,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1577
+Index: geneve-ut-1581
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16130,7 +16130,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1579
+Index: geneve-ut-1583
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16144,7 +16144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1580
+Index: geneve-ut-1584
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16159,7 +16159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1581
+Index: geneve-ut-1585
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16200,7 +16200,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1583
+Index: geneve-ut-1587
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16225,7 +16225,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1584
+Index: geneve-ut-1588
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16264,7 +16264,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1585
+Index: geneve-ut-1589
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16278,7 +16278,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1586
+Index: geneve-ut-1590
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16317,7 +16317,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1587
+Index: geneve-ut-1591
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16331,7 +16331,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1588
+Index: geneve-ut-1592
 
 ```python
 process where event.type == "start" and
@@ -16403,7 +16403,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1592
+Index: geneve-ut-1596
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16424,7 +16424,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1595
+Index: geneve-ut-1599
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16441,7 +16441,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1598
+Index: geneve-ut-1602
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16459,7 +16459,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1599
+Index: geneve-ut-1603
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16471,7 +16471,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1600
+Index: geneve-ut-1604
 
 ```python
 file where host.os.type == "windows" and
@@ -16504,7 +16504,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1603
+Index: geneve-ut-1607
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16536,7 +16536,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1605
+Index: geneve-ut-1609
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16572,7 +16572,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1606
+Index: geneve-ut-1610
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16589,7 +16589,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1607
+Index: geneve-ut-1611
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16609,7 +16609,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1609
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16624,7 +16624,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1610
+Index: geneve-ut-1614
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16645,7 +16645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1611
+Index: geneve-ut-1615
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16668,7 +16668,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1612
+Index: geneve-ut-1616
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16681,7 +16681,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1613
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16698,7 +16698,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1615
+Index: geneve-ut-1619
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16723,7 +16723,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1618
+Index: geneve-ut-1622
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16754,7 +16754,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1619
+Index: geneve-ut-1623
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16803,7 +16803,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1620
+Index: geneve-ut-1624
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16817,7 +16817,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1621
+Index: geneve-ut-1625
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16832,7 +16832,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1622
+Index: geneve-ut-1626
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16847,7 +16847,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1623
+Index: geneve-ut-1627
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16869,7 +16869,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1624
+Index: geneve-ut-1628
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16890,7 +16890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1627
+Index: geneve-ut-1631
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16904,7 +16904,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1628
+Index: geneve-ut-1632
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16927,7 +16927,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1658
+Index: geneve-ut-1662
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16952,7 +16952,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1659
+Index: geneve-ut-1663
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16985,7 +16985,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1660
+Index: geneve-ut-1664
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17044,7 +17044,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1662
+Index: geneve-ut-1666
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17062,7 +17062,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1663
+Index: geneve-ut-1667
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17074,7 +17074,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1665
+Index: geneve-ut-1669
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17099,7 +17099,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1671
+Index: geneve-ut-1675
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17114,7 +17114,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1672
+Index: geneve-ut-1676
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17137,7 +17137,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1675
+Index: geneve-ut-1679
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17151,7 +17151,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1677
+Index: geneve-ut-1681
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17173,7 +17173,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1679
+Index: geneve-ut-1683
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17200,7 +17200,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1683
+Index: geneve-ut-1687
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17239,7 +17239,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1684
+Index: geneve-ut-1688
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17262,7 +17262,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1685
+Index: geneve-ut-1689
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17276,7 +17276,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1686
+Index: geneve-ut-1690
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17292,7 +17292,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1687
+Index: geneve-ut-1691
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17308,7 +17308,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1688
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17322,7 +17322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1690
+Index: geneve-ut-1694
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17345,7 +17345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1691
+Index: geneve-ut-1695
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17373,7 +17373,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1692
+Index: geneve-ut-1696
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +17388,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1695
+Index: geneve-ut-1699
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17415,7 +17415,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1697
+Index: geneve-ut-1701
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17446,7 +17446,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1698
+Index: geneve-ut-1702
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17462,7 +17462,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1699
+Index: geneve-ut-1703
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17475,7 +17475,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1701
+Index: geneve-ut-1705
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17491,7 +17491,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1702
+Index: geneve-ut-1706
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17507,7 +17507,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1703
+Index: geneve-ut-1707
 
 ```python
 any where host.os.type == "windows" and 
@@ -17574,7 +17574,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1705
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17590,7 +17590,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1707
+Index: geneve-ut-1711
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17626,7 +17626,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1708
+Index: geneve-ut-1712
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +17664,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1709
+Index: geneve-ut-1713
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17699,7 +17699,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1710
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +17733,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1712
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17754,7 +17754,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1717
+Index: geneve-ut-1721
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17831,7 +17831,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1718
+Index: geneve-ut-1722
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17853,7 +17853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1719
+Index: geneve-ut-1723
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17877,7 +17877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1720
+Index: geneve-ut-1724
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17898,7 +17898,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1723
+Index: geneve-ut-1727
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17913,7 +17913,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1726
+Index: geneve-ut-1730
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17926,7 +17926,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1727
+Index: geneve-ut-1731
 
 ```python
 any where host.os.type == "windows" and
@@ -17941,7 +17941,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1728
+Index: geneve-ut-1732
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17957,7 +17957,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1729
+Index: geneve-ut-1733
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17971,7 +17971,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1733
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18028,7 +18028,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1734
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18042,7 +18042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1736
+Index: geneve-ut-1740
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18074,7 +18074,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1738
+Index: geneve-ut-1742
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18087,7 +18087,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1739
+Index: geneve-ut-1743
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18106,7 +18106,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1740
+Index: geneve-ut-1744
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18152,7 +18152,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1742
+Index: geneve-ut-1746
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18173,7 +18173,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1743
+Index: geneve-ut-1747
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18193,7 +18193,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1744
+Index: geneve-ut-1748
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18207,7 +18207,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1745
+Index: geneve-ut-1749
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18239,7 +18239,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1748
+Index: geneve-ut-1752
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18260,7 +18260,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1750
+Index: geneve-ut-1754
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18361,7 +18361,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1753
+Index: geneve-ut-1757
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18409,7 +18409,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1756
+Index: geneve-ut-1760
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18435,7 +18435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1757
+Index: geneve-ut-1761
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18480,7 +18480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1758
+Index: geneve-ut-1762
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18504,7 +18504,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1759
+Index: geneve-ut-1763
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18520,7 +18520,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1761
+Index: geneve-ut-1765
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18545,7 +18545,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1762
+Index: geneve-ut-1766
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18560,7 +18560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1765
+Index: geneve-ut-1769
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18574,7 +18574,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1766
+Index: geneve-ut-1770
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18594,7 +18594,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1767
+Index: geneve-ut-1771
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18629,7 +18629,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1771
+Index: geneve-ut-1775
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18647,7 +18647,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1772
+Index: geneve-ut-1776
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18660,7 +18660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1774
+Index: geneve-ut-1778
 
 ```python
 any where host.os.type == "windows" and
@@ -18693,7 +18693,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1776
+Index: geneve-ut-1780
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18711,7 +18711,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1777
+Index: geneve-ut-1781
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18733,7 +18733,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1780
+Index: geneve-ut-1784
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18772,7 +18772,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1781
+Index: geneve-ut-1785
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18802,7 +18802,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1782
+Index: geneve-ut-1786
 
 ```python
 any where host.os.type == "windows" and
@@ -18836,7 +18836,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1783
+Index: geneve-ut-1787
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18850,7 +18850,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1786
+Index: geneve-ut-1790
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18881,7 +18881,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1787
+Index: geneve-ut-1791
 
 ```python
 any where host.os.type == "windows" and
@@ -18901,7 +18901,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1788
+Index: geneve-ut-1792
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18942,7 +18942,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1789
+Index: geneve-ut-1793
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18958,7 +18958,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1790
+Index: geneve-ut-1794
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18988,7 +18988,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1794
+Index: geneve-ut-1798
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19001,7 +19001,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1795
+Index: geneve-ut-1799
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19025,7 +19025,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1798
+Index: geneve-ut-1802
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19043,7 +19043,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1800
+Index: geneve-ut-1804
 
 ```python
 any where host.os.type == "windows" and
@@ -19058,7 +19058,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1801
+Index: geneve-ut-1805
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19076,7 +19076,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1802
+Index: geneve-ut-1806
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19097,7 +19097,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1803
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19116,7 +19116,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1806
+Index: geneve-ut-1810
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19141,7 +19141,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1807
+Index: geneve-ut-1811
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19154,7 +19154,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1809
+Index: geneve-ut-1813
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19167,7 +19167,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1811
+Index: geneve-ut-1815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19190,7 +19190,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1813
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19209,7 +19209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1814
+Index: geneve-ut-1818
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19231,7 +19231,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1815
+Index: geneve-ut-1819
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19264,7 +19264,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1817
+Index: geneve-ut-1821
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19282,7 +19282,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1818
+Index: geneve-ut-1822
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19296,7 +19296,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1819
+Index: geneve-ut-1823
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19320,7 +19320,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1820
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19343,7 +19343,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1821
+Index: geneve-ut-1825
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19362,7 +19362,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1824
+Index: geneve-ut-1828
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19381,7 +19381,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1826
+Index: geneve-ut-1830
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19416,7 +19416,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1827
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19433,7 +19433,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1828
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1829
+Index: geneve-ut-1833
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19493,7 +19493,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1830
+Index: geneve-ut-1834
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19509,7 +19509,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1831
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19523,7 +19523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1832
+Index: geneve-ut-1836
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19561,7 +19561,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1833
+Index: geneve-ut-1837
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19615,7 +19615,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1834
+Index: geneve-ut-1838
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19643,7 +19643,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1836
+Index: geneve-ut-1840
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19657,7 +19657,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1837
+Index: geneve-ut-1841
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19703,7 +19703,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1838
+Index: geneve-ut-1842
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19742,7 +19742,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1839
+Index: geneve-ut-1843
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19755,7 +19755,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1842
+Index: geneve-ut-1846
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19788,7 +19788,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1843
+Index: geneve-ut-1847
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19802,7 +19802,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1844
+Index: geneve-ut-1848
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19816,7 +19816,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1845
+Index: geneve-ut-1849
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19830,7 +19830,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1846
+Index: geneve-ut-1850
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19869,7 +19869,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1853
+Index: geneve-ut-1857
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19911,7 +19911,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1855
+Index: geneve-ut-1859
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19933,7 +19933,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1856
+Index: geneve-ut-1860
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19946,7 +19946,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1858
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19963,7 +19963,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1859
+Index: geneve-ut-1863
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19979,7 +19979,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1860
+Index: geneve-ut-1864
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19992,7 +19992,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1861
+Index: geneve-ut-1865
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20007,7 +20007,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1862
+Index: geneve-ut-1866
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20030,7 +20030,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1863
+Index: geneve-ut-1867
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20046,7 +20046,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1864
+Index: geneve-ut-1868
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20062,7 +20062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1870
+Index: geneve-ut-1874
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20074,7 +20074,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1871
+Index: geneve-ut-1875
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20103,7 +20103,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1873
+Index: geneve-ut-1877
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20117,7 +20117,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1878
+Index: geneve-ut-1882
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20137,7 +20137,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1879
+Index: geneve-ut-1883
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20162,7 +20162,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1886
+Index: geneve-ut-1890
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20176,7 +20176,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1887
+Index: geneve-ut-1891
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20199,7 +20199,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1896
+Index: geneve-ut-1900
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20233,7 +20233,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1898
+Index: geneve-ut-1902
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20252,7 +20252,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-1905
+Index: geneve-ut-1909
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20271,7 +20271,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1920
+Index: geneve-ut-1924
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20288,7 +20288,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1923
+Index: geneve-ut-1927
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20305,7 +20305,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1939
+Index: geneve-ut-1943
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20324,7 +20324,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1943
+Index: geneve-ut-1947
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20366,7 +20366,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1944
+Index: geneve-ut-1948
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20411,7 +20411,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1947
+Index: geneve-ut-1951
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20453,7 +20453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1949
+Index: geneve-ut-1953
 
 ```python
 host.os.type:"linux" and 
@@ -20481,7 +20481,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1952
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20505,7 +20505,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1953
+Index: geneve-ut-1957
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20545,7 +20545,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1954
+Index: geneve-ut-1958
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20592,7 +20592,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1958
+Index: geneve-ut-1962
 
 ```python
 sequence by process.entity_id
@@ -20629,7 +20629,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1990
+Index: geneve-ut-1994
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20643,7 +20643,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1991
+Index: geneve-ut-1995
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20686,7 +20686,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1992
+Index: geneve-ut-1996
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20699,7 +20699,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1994
+Index: geneve-ut-1998
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20713,7 +20713,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1995
+Index: geneve-ut-1999
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20726,7 +20726,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1999
+Index: geneve-ut-2003
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20751,7 +20751,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2000
+Index: geneve-ut-2004
 
 ```python
 process where event.type == "start" and
@@ -20766,7 +20766,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2001
+Index: geneve-ut-2005
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20783,7 +20783,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2002
+Index: geneve-ut-2006
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20797,7 +20797,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2003
+Index: geneve-ut-2007
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20813,7 +20813,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2004
+Index: geneve-ut-2008
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20827,7 +20827,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2005
+Index: geneve-ut-2009
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20854,7 +20854,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2007
+Index: geneve-ut-2011
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20866,7 +20866,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2008
+Index: geneve-ut-2012
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20882,7 +20882,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2009
+Index: geneve-ut-2013
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20905,7 +20905,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2010
+Index: geneve-ut-2014
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20918,7 +20918,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2011
+Index: geneve-ut-2015
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20930,7 +20930,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2012
+Index: geneve-ut-2016
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20942,7 +20942,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2013
+Index: geneve-ut-2017
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20954,7 +20954,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2014
+Index: geneve-ut-2018
 
 ```python
 web where (
@@ -20982,7 +20982,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2020
+Index: geneve-ut-2024
 
 ```python
 any where (
@@ -21054,7 +21054,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2022
+Index: geneve-ut-2026
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21075,7 +21075,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2025
+Index: geneve-ut-2029
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21089,7 +21089,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2026
+Index: geneve-ut-2030
 
 ```python
 file where event.type == "deletion" and
@@ -21106,7 +21106,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2027
+Index: geneve-ut-2031
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21124,7 +21124,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2029
+Index: geneve-ut-2033
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21162,7 +21162,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2031
+Index: geneve-ut-2035
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21199,7 +21199,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2032
+Index: geneve-ut-2036
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21214,7 +21214,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2033
+Index: geneve-ut-2037
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21227,7 +21227,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2034
+Index: geneve-ut-2038
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21246,7 +21246,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2035
+Index: geneve-ut-2039
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21271,7 +21271,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2036
+Index: geneve-ut-2040
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21297,7 +21297,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2037
+Index: geneve-ut-2041
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21319,7 +21319,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2038
+Index: geneve-ut-2042
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21336,7 +21336,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2040
+Index: geneve-ut-2044
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21355,7 +21355,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2041
+Index: geneve-ut-2045
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21395,7 +21395,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2042
+Index: geneve-ut-2046
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21412,7 +21412,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2044
+Index: geneve-ut-2048
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21425,7 +21425,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2045
+Index: geneve-ut-2049
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21439,7 +21439,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2046
+Index: geneve-ut-2050
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21467,7 +21467,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2047
+Index: geneve-ut-2051
 
 ```python
 process where event.type == "start" and
@@ -21492,7 +21492,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2048
+Index: geneve-ut-2052
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21506,7 +21506,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2049
+Index: geneve-ut-2053
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21522,7 +21522,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2050
+Index: geneve-ut-2054
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21557,7 +21557,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2051
+Index: geneve-ut-2055
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21575,7 +21575,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2054
+Index: geneve-ut-2058
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.4.md
+++ b/tests/reports/alerts_from_rules-9.4.md
@@ -5,7 +5,7 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.9
+Rules version: 9.4.10
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
@@ -20,7 +20,7 @@ Rules version: 9.4.9
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367  
+Index: geneve-ut-0368  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378  
+Index: geneve-ut-0379  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -190,7 +190,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646  
+Index: geneve-ut-0647  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671  
+Index: geneve-ut-0672  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805  
+Index: geneve-ut-0807  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998  
+Index: geneve-ut-1000  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143  
+Index: geneve-ut-1145  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173  
+Index: geneve-ut-1175  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245  
+Index: geneve-ut-1248  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274  
+Index: geneve-ut-1277  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292  
+Index: geneve-ut-1295  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356  
+Index: geneve-ut-1359  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371  
+Index: geneve-ut-1374  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461  
+Index: geneve-ut-1464  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705  
+Index: geneve-ut-1709  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709  
+Index: geneve-ut-1713  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793  
+Index: geneve-ut-1797  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808  
+Index: geneve-ut-1812  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821  
+Index: geneve-ut-1825  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831  
+Index: geneve-ut-1835  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837  
+Index: geneve-ut-1841  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846  
+Index: geneve-ut-1850  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943  
+Index: geneve-ut-1947  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974  
+Index: geneve-ut-1978  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1123,7 +1123,7 @@ container.id like "*"
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367
+Index: geneve-ut-0368
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1175,7 +1175,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378
+Index: geneve-ut-0379
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -1287,7 +1287,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646
+Index: geneve-ut-0647
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1353,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671
+Index: geneve-ut-0672
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805
+Index: geneve-ut-0807
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998
+Index: geneve-ut-1000
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143
+Index: geneve-ut-1145
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245
+Index: geneve-ut-1248
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292
+Index: geneve-ut-1295
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461
+Index: geneve-ut-1464
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709
+Index: geneve-ut-1713
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793
+Index: geneve-ut-1797
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808
+Index: geneve-ut-1812
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821
+Index: geneve-ut-1825
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837
+Index: geneve-ut-1841
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943
+Index: geneve-ut-1947
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974
+Index: geneve-ut-1978
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0999
+Index: geneve-ut-1001
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1019
+Index: geneve-ut-1021
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1408
+Index: geneve-ut-1411
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1609
+Index: geneve-ut-1612
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2227,7 +2227,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367  
+Index: geneve-ut-0368  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2281,7 +2281,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378  
+Index: geneve-ut-0379  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -2395,7 +2395,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646  
+Index: geneve-ut-0647  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2463,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671  
+Index: geneve-ut-0672  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805  
+Index: geneve-ut-0807  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0971  
+Index: geneve-ut-0973  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998  
+Index: geneve-ut-1000  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1121  
+Index: geneve-ut-1123  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143  
+Index: geneve-ut-1145  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173  
+Index: geneve-ut-1175  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245  
+Index: geneve-ut-1248  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274  
+Index: geneve-ut-1277  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292  
+Index: geneve-ut-1295  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356  
+Index: geneve-ut-1359  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371  
+Index: geneve-ut-1374  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1452  
+Index: geneve-ut-1455  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461  
+Index: geneve-ut-1464  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1576  
+Index: geneve-ut-1579  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705  
+Index: geneve-ut-1709  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709  
+Index: geneve-ut-1713  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793  
+Index: geneve-ut-1797  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808  
+Index: geneve-ut-1812  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821  
+Index: geneve-ut-1825  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831  
+Index: geneve-ut-1835  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837  
+Index: geneve-ut-1841  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846  
+Index: geneve-ut-1850  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943  
+Index: geneve-ut-1947  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974  
+Index: geneve-ut-1978  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -4269,7 +4269,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0323
+Index: geneve-ut-0324
 
 ```python
 event.dataset:azure.activitylogs and
@@ -4283,7 +4283,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0326
+Index: geneve-ut-0327
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -4301,7 +4301,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0344
+Index: geneve-ut-0345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4319,7 +4319,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0345
+Index: geneve-ut-0346
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4337,7 +4337,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0346
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4352,7 +4352,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0347
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4366,7 +4366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0348
+Index: geneve-ut-0349
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4381,7 +4381,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0351
+Index: geneve-ut-0352
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4398,7 +4398,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0352
+Index: geneve-ut-0353
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4410,7 +4410,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0353
+Index: geneve-ut-0354
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4422,7 +4422,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0354
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4437,7 +4437,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0355
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4457,7 +4457,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0356
+Index: geneve-ut-0357
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4479,7 +4479,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0358
+Index: geneve-ut-0359
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4525,7 +4525,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0359
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4559,7 +4559,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0360
+Index: geneve-ut-0361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4582,7 +4582,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0362
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4604,7 +4604,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0363
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4632,7 +4632,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0364
+Index: geneve-ut-0365
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4648,7 +4648,7 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0366
+Index: geneve-ut-0367
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4673,7 +4673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0368
+Index: geneve-ut-0369
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4703,7 +4703,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0370
+Index: geneve-ut-0371
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4717,7 +4717,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0371
+Index: geneve-ut-0372
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4739,7 +4739,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0372
+Index: geneve-ut-0373
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4753,7 +4753,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0373
+Index: geneve-ut-0374
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4773,7 +4773,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0376
+Index: geneve-ut-0377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4790,7 +4790,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0379
+Index: geneve-ut-0380
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4820,7 +4820,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0382
+Index: geneve-ut-0383
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4845,7 +4845,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0384
+Index: geneve-ut-0385
 
 ```python
 sequence by process.entity_id
@@ -4866,7 +4866,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0385
+Index: geneve-ut-0386
 
 ```python
 sequence by process.entity_id
@@ -4887,7 +4887,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0388
+Index: geneve-ut-0389
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4918,7 +4918,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0389
+Index: geneve-ut-0390
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4930,7 +4930,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0390
+Index: geneve-ut-0391
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4953,7 +4953,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0393
+Index: geneve-ut-0394
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4966,7 +4966,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0394
+Index: geneve-ut-0395
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4979,7 +4979,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0396
+Index: geneve-ut-0397
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4996,7 +4996,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0397
+Index: geneve-ut-0398
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -5009,7 +5009,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0398
+Index: geneve-ut-0399
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -5026,7 +5026,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0399
+Index: geneve-ut-0400
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -5038,7 +5038,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0400
+Index: geneve-ut-0401
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -5106,7 +5106,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0401
+Index: geneve-ut-0402
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -5124,7 +5124,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0402
+Index: geneve-ut-0403
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -5137,7 +5137,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0403
+Index: geneve-ut-0404
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5155,7 +5155,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0404
+Index: geneve-ut-0405
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5167,7 +5167,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0405
+Index: geneve-ut-0406
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5179,7 +5179,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0406
+Index: geneve-ut-0407
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5191,7 +5191,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0407
+Index: geneve-ut-0408
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5203,7 +5203,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0408
+Index: geneve-ut-0409
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -5248,7 +5248,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0410
+Index: geneve-ut-0411
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5268,7 +5268,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0411
+Index: geneve-ut-0412
 
 ```python
 sequence with maxspan=10s
@@ -5288,7 +5288,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0412
+Index: geneve-ut-0413
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5315,7 +5315,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0413
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5329,7 +5329,7 @@ container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0416
+Index: geneve-ut-0417
 
 ```python
 process where event.type == "start" and
@@ -5354,7 +5354,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0419
+Index: geneve-ut-0420
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5398,7 +5398,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0420
+Index: geneve-ut-0421
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5432,7 +5432,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0422
+Index: geneve-ut-0423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5477,7 +5477,7 @@ container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0423
+Index: geneve-ut-0424
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5493,7 +5493,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0424
+Index: geneve-ut-0425
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5518,7 +5518,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0425
+Index: geneve-ut-0426
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5537,7 +5537,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0427
+Index: geneve-ut-0428
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5664,7 +5664,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0428
+Index: geneve-ut-0429
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5682,7 +5682,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0430
+Index: geneve-ut-0431
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5695,7 +5695,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0431
+Index: geneve-ut-0432
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5725,7 +5725,7 @@ container.security_context.privileged == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0437
+Index: geneve-ut-0438
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5739,7 +5739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0449
+Index: geneve-ut-0450
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5760,7 +5760,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0456
+Index: geneve-ut-0457
 
 ```python
 registry where host.os.type == "windows" and
@@ -5774,7 +5774,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0468
+Index: geneve-ut-0469
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5798,7 +5798,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0507
+Index: geneve-ut-0508
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5852,7 +5852,7 @@ container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0509
+Index: geneve-ut-0510
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5868,7 +5868,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0510
+Index: geneve-ut-0511
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5896,7 +5896,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0511
+Index: geneve-ut-0512
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5913,7 +5913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0512
+Index: geneve-ut-0513
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5930,7 +5930,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0513
+Index: geneve-ut-0514
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5951,7 +5951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0515
+Index: geneve-ut-0516
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5971,7 +5971,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0516
+Index: geneve-ut-0517
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5986,7 +5986,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0518
+Index: geneve-ut-0519
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5999,7 +5999,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0519
+Index: geneve-ut-0520
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6019,7 +6019,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0522
+Index: geneve-ut-0523
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -6032,7 +6032,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0523
+Index: geneve-ut-0524
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6070,7 +6070,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0524
+Index: geneve-ut-0525
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -6090,7 +6090,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0525
+Index: geneve-ut-0526
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6103,7 +6103,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0526
+Index: geneve-ut-0527
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -6126,7 +6126,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0528
+Index: geneve-ut-0529
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6157,7 +6157,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0529
+Index: geneve-ut-0530
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -6176,7 +6176,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0530
+Index: geneve-ut-0531
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6219,7 +6219,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0531
+Index: geneve-ut-0532
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -6233,7 +6233,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0533
+Index: geneve-ut-0534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6248,7 +6248,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0534
+Index: geneve-ut-0535
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6264,7 +6264,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0535
+Index: geneve-ut-0536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6278,7 +6278,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0536
+Index: geneve-ut-0537
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6304,7 +6304,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0537
+Index: geneve-ut-0538
 
 ```python
 process where event.type == "start" and
@@ -6342,7 +6342,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0544
+Index: geneve-ut-0545
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -6355,7 +6355,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0545
+Index: geneve-ut-0546
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6369,7 +6369,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0546
+Index: geneve-ut-0547
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6391,7 +6391,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0547
+Index: geneve-ut-0548
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6426,7 +6426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0548
+Index: geneve-ut-0549
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6438,7 +6438,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0596
+Index: geneve-ut-0597
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6450,7 +6450,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0622
+Index: geneve-ut-0623
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6464,7 +6464,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0625
+Index: geneve-ut-0626
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6491,7 +6491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0628
+Index: geneve-ut-0629
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6512,7 +6512,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0629
+Index: geneve-ut-0630
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6542,7 +6542,7 @@ container.id like "*"
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0632
+Index: geneve-ut-0633
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6560,7 +6560,7 @@ container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0633
+Index: geneve-ut-0634
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6593,7 +6593,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0635
+Index: geneve-ut-0636
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6610,7 +6610,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0636
+Index: geneve-ut-0637
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6638,7 +6638,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0637
+Index: geneve-ut-0638
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6651,7 +6651,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0639
+Index: geneve-ut-0640
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6671,7 +6671,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0640
+Index: geneve-ut-0641
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6697,7 +6697,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0641
+Index: geneve-ut-0642
 
 ```python
 sequence with maxspan=2h
@@ -6719,7 +6719,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0642
+Index: geneve-ut-0643
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6748,7 +6748,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0645
+Index: geneve-ut-0646
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6761,7 +6761,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0649
+Index: geneve-ut-0650
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6776,7 +6776,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0650
+Index: geneve-ut-0651
 
 ```python
 process where event.type == "start" and
@@ -6798,7 +6798,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0652
+Index: geneve-ut-0653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6810,7 +6810,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0653
+Index: geneve-ut-0654
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6832,7 +6832,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0655
+Index: geneve-ut-0656
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6849,7 +6849,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0656
+Index: geneve-ut-0657
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6863,7 +6863,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0657
+Index: geneve-ut-0658
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6876,7 +6876,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0658
+Index: geneve-ut-0659
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6888,7 +6888,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0659
+Index: geneve-ut-0660
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6900,7 +6900,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0660
+Index: geneve-ut-0661
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6914,7 +6914,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0661
+Index: geneve-ut-0662
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6926,7 +6926,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0662
+Index: geneve-ut-0663
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -6948,7 +6948,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0666
+Index: geneve-ut-0667
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6997,7 +6997,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0667
+Index: geneve-ut-0668
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -7014,7 +7014,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0668
+Index: geneve-ut-0669
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7034,7 +7034,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0673
+Index: geneve-ut-0674
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7056,7 +7056,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0676
+Index: geneve-ut-0677
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7071,7 +7071,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0677
+Index: geneve-ut-0678
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7085,7 +7085,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0679
+Index: geneve-ut-0680
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7107,7 +7107,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0681
+Index: geneve-ut-0682
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -7128,7 +7128,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0682
+Index: geneve-ut-0683
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7154,7 +7154,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0683
+Index: geneve-ut-0684
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -7182,7 +7182,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0686
+Index: geneve-ut-0687
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -7196,7 +7196,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0724
+Index: geneve-ut-0726
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -7213,7 +7213,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0725
+Index: geneve-ut-0727
 
 ```python
 registry where host.os.type == "windows" and
@@ -7231,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0795
+Index: geneve-ut-0797
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0796
+Index: geneve-ut-0798
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0797
+Index: geneve-ut-0799
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0798
+Index: geneve-ut-0800
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0806
+Index: geneve-ut-0808
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0807
+Index: geneve-ut-0809
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0808
+Index: geneve-ut-0810
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0809
+Index: geneve-ut-0811
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0813
+Index: geneve-ut-0815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0816
+Index: geneve-ut-0818
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0819
+Index: geneve-ut-0821
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0823
+Index: geneve-ut-0825
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0825
+Index: geneve-ut-0827
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0851
+Index: geneve-ut-0853
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0854
+Index: geneve-ut-0856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0855
+Index: geneve-ut-0857
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0868
+Index: geneve-ut-0870
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0869
+Index: geneve-ut-0871
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0870
+Index: geneve-ut-0872
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0874
+Index: geneve-ut-0876
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0880
+Index: geneve-ut-0882
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0882
+Index: geneve-ut-0884
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0883
+Index: geneve-ut-0885
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0884
+Index: geneve-ut-0886
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0885
+Index: geneve-ut-0887
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0886
+Index: geneve-ut-0888
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0887
+Index: geneve-ut-0889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0892
+Index: geneve-ut-0894
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0894
+Index: geneve-ut-0896
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0895
+Index: geneve-ut-0897
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0896
+Index: geneve-ut-0898
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7897,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0897
+Index: geneve-ut-0899
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7921,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0902
+Index: geneve-ut-0904
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0904
+Index: geneve-ut-0906
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0905
+Index: geneve-ut-0907
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0906
+Index: geneve-ut-0908
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0907
+Index: geneve-ut-0909
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0908
+Index: geneve-ut-0910
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0909
+Index: geneve-ut-0911
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0910
+Index: geneve-ut-0912
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0911
+Index: geneve-ut-0913
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0912
+Index: geneve-ut-0914
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0913
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0915
+Index: geneve-ut-0917
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0917
+Index: geneve-ut-0919
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0918
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0919
+Index: geneve-ut-0921
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0920
+Index: geneve-ut-0922
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0922
+Index: geneve-ut-0924
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0923
+Index: geneve-ut-0925
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0925
+Index: geneve-ut-0927
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0927
+Index: geneve-ut-0929
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0928
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0930
+Index: geneve-ut-0932
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0931
+Index: geneve-ut-0933
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8436,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0932
+Index: geneve-ut-0934
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8463,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0935
+Index: geneve-ut-0937
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0936
+Index: geneve-ut-0938
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0946
+Index: geneve-ut-0948
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0972
+Index: geneve-ut-0974
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0975
+Index: geneve-ut-0977
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0977
+Index: geneve-ut-0979
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0989
+Index: geneve-ut-0991
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0994
+Index: geneve-ut-0996
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0995
+Index: geneve-ut-0997
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1000
+Index: geneve-ut-1002
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1015
+Index: geneve-ut-1017
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1018
+Index: geneve-ut-1020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1020
+Index: geneve-ut-1022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1021
+Index: geneve-ut-1023
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1025
+Index: geneve-ut-1027
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1026
+Index: geneve-ut-1028
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8863,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1029
+Index: geneve-ut-1031
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1031
+Index: geneve-ut-1033
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1032
+Index: geneve-ut-1034
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1068
+Index: geneve-ut-1070
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1069
+Index: geneve-ut-1071
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1070
+Index: geneve-ut-1072
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1071
+Index: geneve-ut-1073
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1072
+Index: geneve-ut-1074
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1080
+Index: geneve-ut-1082
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1083
+Index: geneve-ut-1085
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1084
+Index: geneve-ut-1086
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1085
+Index: geneve-ut-1087
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1089
+Index: geneve-ut-1091
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1090
+Index: geneve-ut-1092
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1092
+Index: geneve-ut-1094
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1093
+Index: geneve-ut-1095
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1094
+Index: geneve-ut-1096
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1095
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1096
+Index: geneve-ut-1098
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1097
+Index: geneve-ut-1099
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9142,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1098
+Index: geneve-ut-1100
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9167,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1100
+Index: geneve-ut-1102
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1103
+Index: geneve-ut-1105
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1104
+Index: geneve-ut-1106
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1105
+Index: geneve-ut-1107
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1108
+Index: geneve-ut-1110
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1109
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1110
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1114
+Index: geneve-ut-1116
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1115
+Index: geneve-ut-1117
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1116
+Index: geneve-ut-1118
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1120
+Index: geneve-ut-1122
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1122
+Index: geneve-ut-1124
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1124
+Index: geneve-ut-1126
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1125
+Index: geneve-ut-1127
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1127
+Index: geneve-ut-1129
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1128
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1132
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1131
+Index: geneve-ut-1133
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1133
+Index: geneve-ut-1135
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1134
+Index: geneve-ut-1136
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9604,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1136
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1137
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1138
+Index: geneve-ut-1140
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1139
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1140
+Index: geneve-ut-1142
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1141
+Index: geneve-ut-1143
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1142
+Index: geneve-ut-1144
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1155
+Index: geneve-ut-1157
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1164
+Index: geneve-ut-1166
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1168
+Index: geneve-ut-1170
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1169
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1170
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1171
+Index: geneve-ut-1173
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1172
+Index: geneve-ut-1174
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1174
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1175
+Index: geneve-ut-1177
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1177
+Index: geneve-ut-1179
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1179
+Index: geneve-ut-1181
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1180
+Index: geneve-ut-1182
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1181
+Index: geneve-ut-1183
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1183
+Index: geneve-ut-1185
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1184
+Index: geneve-ut-1186
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1185
+Index: geneve-ut-1187
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1186
+Index: geneve-ut-1188
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1188
+Index: geneve-ut-1190
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1189
+Index: geneve-ut-1191
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1190
+Index: geneve-ut-1192
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1191
+Index: geneve-ut-1193
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1192
+Index: geneve-ut-1194
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1196
+Index: geneve-ut-1198
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1197
+Index: geneve-ut-1199
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1198
+Index: geneve-ut-1200
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1203
+Index: geneve-ut-1205
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1206
+Index: geneve-ut-1208
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1215
+Index: geneve-ut-1218
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1216
+Index: geneve-ut-1219
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1217
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1218
+Index: geneve-ut-1221
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1220
+Index: geneve-ut-1223
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1221
+Index: geneve-ut-1224
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1223
+Index: geneve-ut-1226
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1232
+Index: geneve-ut-1235
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1233
+Index: geneve-ut-1236
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1234
+Index: geneve-ut-1237
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1235
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1236
+Index: geneve-ut-1239
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1237
+Index: geneve-ut-1240
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1238
+Index: geneve-ut-1241
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1239
+Index: geneve-ut-1242
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10670,7 +10670,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1246
+Index: geneve-ut-1249
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10685,7 +10685,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1247
+Index: geneve-ut-1250
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10699,7 +10699,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1248
+Index: geneve-ut-1251
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10718,7 +10718,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1249
+Index: geneve-ut-1252
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10730,7 +10730,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1250
+Index: geneve-ut-1253
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10742,7 +10742,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1251
+Index: geneve-ut-1254
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10760,7 +10760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1252
+Index: geneve-ut-1255
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10773,7 +10773,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1253
+Index: geneve-ut-1256
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10788,7 +10788,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1254
+Index: geneve-ut-1257
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10803,7 +10803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1257
+Index: geneve-ut-1260
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10823,7 +10823,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1258
+Index: geneve-ut-1261
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10847,7 +10847,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1259
+Index: geneve-ut-1262
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10861,7 +10861,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1260
+Index: geneve-ut-1263
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10880,7 +10880,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1261
+Index: geneve-ut-1264
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10908,7 +10908,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1262
+Index: geneve-ut-1265
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10937,7 +10937,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1263
+Index: geneve-ut-1266
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10956,7 +10956,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1264
+Index: geneve-ut-1267
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10984,7 +10984,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1265
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10999,7 +10999,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1266
+Index: geneve-ut-1269
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11062,7 +11062,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1267
+Index: geneve-ut-1270
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11083,7 +11083,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1268
+Index: geneve-ut-1271
 
 ```python
 any where host.os.type == "windows" and
@@ -11145,7 +11145,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1270
+Index: geneve-ut-1273
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11174,7 +11174,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1271
+Index: geneve-ut-1274
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11188,7 +11188,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1272
+Index: geneve-ut-1275
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11221,7 +11221,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1275
+Index: geneve-ut-1278
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11268,7 +11268,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1276
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11295,7 +11295,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1277
+Index: geneve-ut-1280
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11308,7 +11308,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1288
+Index: geneve-ut-1291
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11325,7 +11325,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1290
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11350,7 +11350,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1295
+Index: geneve-ut-1298
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11366,7 +11366,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1296
+Index: geneve-ut-1299
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11387,7 +11387,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1298
+Index: geneve-ut-1301
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11404,7 +11404,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1299
+Index: geneve-ut-1302
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11417,7 +11417,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1300
+Index: geneve-ut-1303
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11441,7 +11441,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1302
+Index: geneve-ut-1305
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11470,7 +11470,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1304
+Index: geneve-ut-1307
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11497,7 +11497,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11521,7 +11521,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1308
+Index: geneve-ut-1311
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11539,7 +11539,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1309
+Index: geneve-ut-1312
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11562,7 +11562,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1310
+Index: geneve-ut-1313
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11619,7 +11619,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11636,7 +11636,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1312
+Index: geneve-ut-1315
 
 ```python
 sequence by process.entity_id
@@ -11650,7 +11650,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1327
+Index: geneve-ut-1330
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11665,7 +11665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1328
+Index: geneve-ut-1331
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11696,7 +11696,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1329
+Index: geneve-ut-1332
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11710,7 +11710,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1330
+Index: geneve-ut-1333
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11723,7 +11723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11735,7 +11735,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11748,7 +11748,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11767,7 +11767,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1335
+Index: geneve-ut-1338
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11780,7 +11780,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1336
+Index: geneve-ut-1339
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11801,7 +11801,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11815,7 +11815,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11835,7 +11835,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1341
+Index: geneve-ut-1344
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11859,7 +11859,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1342
+Index: geneve-ut-1345
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11875,7 +11875,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1343
+Index: geneve-ut-1346
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11892,7 +11892,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1344
+Index: geneve-ut-1347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11913,7 +11913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1346
+Index: geneve-ut-1349
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11926,7 +11926,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1348
+Index: geneve-ut-1351
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11954,7 +11954,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1351
+Index: geneve-ut-1354
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11970,7 +11970,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1352
+Index: geneve-ut-1355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11993,7 +11993,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1353
+Index: geneve-ut-1356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12006,7 +12006,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12019,7 +12019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1360
+Index: geneve-ut-1363
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12033,7 +12033,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1361
+Index: geneve-ut-1364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +12048,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12071,7 +12071,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1366
+Index: geneve-ut-1369
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12114,7 +12114,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1367
+Index: geneve-ut-1370
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12132,7 +12132,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1368
+Index: geneve-ut-1371
 
 ```python
 host.os.type:"windows" and
@@ -12148,7 +12148,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12160,7 +12160,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1372
+Index: geneve-ut-1375
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12176,7 +12176,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12192,7 +12192,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12210,7 +12210,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12224,7 +12224,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1377
+Index: geneve-ut-1380
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12247,7 +12247,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1379
+Index: geneve-ut-1382
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12263,7 +12263,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12276,7 +12276,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1381
+Index: geneve-ut-1384
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12306,7 +12306,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1387
+Index: geneve-ut-1390
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12329,7 +12329,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1388
+Index: geneve-ut-1391
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12348,7 +12348,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1393
+Index: geneve-ut-1396
 
 ```python
 process where host.os.type == "windows" and 
@@ -12490,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1394
+Index: geneve-ut-1397
 
 ```python
 process where host.os.type == "windows" and
@@ -12567,7 +12567,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1398
+Index: geneve-ut-1401
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12584,7 +12584,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1399
+Index: geneve-ut-1402
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12618,7 +12618,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12630,7 +12630,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1402
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12669,7 +12669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1405
+Index: geneve-ut-1408
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12682,7 +12682,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1410
+Index: geneve-ut-1413
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12696,7 +12696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1417
+Index: geneve-ut-1420
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12734,7 +12734,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1418
+Index: geneve-ut-1421
 
 ```python
 network where host.os.type == "windows" and
@@ -12760,7 +12760,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1421
+Index: geneve-ut-1424
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12775,7 +12775,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12789,7 +12789,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1425
+Index: geneve-ut-1428
 
 ```python
 file where host.os.type == "windows" and
@@ -12803,7 +12803,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1426
+Index: geneve-ut-1429
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12816,7 +12816,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1427
+Index: geneve-ut-1430
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12836,7 +12836,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1430
+Index: geneve-ut-1433
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12895,7 +12895,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1431
+Index: geneve-ut-1434
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13090,7 +13090,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1446
+Index: geneve-ut-1449
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13106,7 +13106,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1447
+Index: geneve-ut-1450
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13120,7 +13120,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1448
+Index: geneve-ut-1451
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13134,7 +13134,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1449
+Index: geneve-ut-1452
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13151,7 +13151,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13165,7 +13165,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1451
+Index: geneve-ut-1454
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13181,7 +13181,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1456
+Index: geneve-ut-1459
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13193,7 +13193,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1457
+Index: geneve-ut-1460
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13209,7 +13209,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1458
+Index: geneve-ut-1461
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13229,7 +13229,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1460
+Index: geneve-ut-1463
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13269,7 +13269,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1462
+Index: geneve-ut-1465
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13281,7 +13281,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1463
+Index: geneve-ut-1466
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13302,7 +13302,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1464
+Index: geneve-ut-1467
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13323,7 +13323,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1465
+Index: geneve-ut-1468
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13344,7 +13344,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1466
+Index: geneve-ut-1469
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13370,7 +13370,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1467
+Index: geneve-ut-1470
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13386,7 +13386,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1468
+Index: geneve-ut-1471
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13400,7 +13400,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1470
+Index: geneve-ut-1473
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13423,7 +13423,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1472
+Index: geneve-ut-1475
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13440,7 +13440,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1473
+Index: geneve-ut-1476
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13463,7 +13463,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1474
+Index: geneve-ut-1477
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13476,7 +13476,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1475
+Index: geneve-ut-1478
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13490,7 +13490,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1476
+Index: geneve-ut-1479
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13507,7 +13507,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1477
+Index: geneve-ut-1480
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13561,7 +13561,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1478
+Index: geneve-ut-1481
 
 ```python
 any where host.os.type == "windows" and
@@ -13588,7 +13588,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1484
+Index: geneve-ut-1487
 
 ```python
 file where host.os.type == "windows" and
@@ -13603,7 +13603,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1485
+Index: geneve-ut-1488
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13634,7 +13634,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1486
+Index: geneve-ut-1489
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +13648,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1487
+Index: geneve-ut-1490
 
 ```python
 sequence with maxspan=1m
@@ -13690,7 +13690,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1488
+Index: geneve-ut-1491
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13715,7 +13715,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13769,7 +13769,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1490
+Index: geneve-ut-1493
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13789,7 +13789,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1491
+Index: geneve-ut-1494
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13810,7 +13810,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13825,7 +13825,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13845,7 +13845,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1494
+Index: geneve-ut-1497
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13887,7 +13887,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1498
+Index: geneve-ut-1501
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13902,7 +13902,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1499
+Index: geneve-ut-1502
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13937,7 +13937,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1500
+Index: geneve-ut-1503
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13954,7 +13954,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1505
+Index: geneve-ut-1508
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13968,7 +13968,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1508
+Index: geneve-ut-1511
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13981,7 +13981,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1509
+Index: geneve-ut-1512
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13993,7 +13993,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1510
+Index: geneve-ut-1513
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14008,7 +14008,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14036,7 +14036,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1514
+Index: geneve-ut-1517
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14061,7 +14061,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1518
+Index: geneve-ut-1521
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14098,7 +14098,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1519
+Index: geneve-ut-1522
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14112,7 +14112,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1520
+Index: geneve-ut-1523
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14128,7 +14128,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1521
+Index: geneve-ut-1524
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14142,7 +14142,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1522
+Index: geneve-ut-1525
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14172,7 +14172,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1523
+Index: geneve-ut-1526
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14201,7 +14201,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1524
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14217,7 +14217,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1525
+Index: geneve-ut-1528
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14231,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 file where host.os.type == "windows" and
@@ -14267,7 +14267,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1529
+Index: geneve-ut-1532
 
 ```python
 process where event.type == "start" and
@@ -14281,7 +14281,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1530
+Index: geneve-ut-1533
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14295,7 +14295,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1531
+Index: geneve-ut-1534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14315,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1533
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14332,7 +14332,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1534
+Index: geneve-ut-1537
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14344,7 +14344,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1535
+Index: geneve-ut-1538
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14361,7 +14361,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1536
+Index: geneve-ut-1539
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14379,7 +14379,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1543
+Index: geneve-ut-1546
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14392,7 +14392,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1544
+Index: geneve-ut-1547
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14419,7 +14419,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1545
+Index: geneve-ut-1548
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14432,7 +14432,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1546
+Index: geneve-ut-1549
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14446,7 +14446,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14463,7 +14463,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14486,7 +14486,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14503,7 +14503,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1554
+Index: geneve-ut-1557
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14516,7 +14516,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1556
+Index: geneve-ut-1559
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14540,7 +14540,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1557
+Index: geneve-ut-1560
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14568,7 +14568,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1573
+Index: geneve-ut-1576
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14589,7 +14589,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1575
+Index: geneve-ut-1578
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14617,7 +14617,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1577
+Index: geneve-ut-1580
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14657,7 +14657,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1578
+Index: geneve-ut-1581
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14674,7 +14674,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1579
+Index: geneve-ut-1582
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14688,7 +14688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1580
+Index: geneve-ut-1583
 
 ```python
 file where host.os.type == "windows" and
@@ -14707,7 +14707,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1581
+Index: geneve-ut-1584
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14721,7 +14721,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1583
+Index: geneve-ut-1586
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14739,7 +14739,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1585
+Index: geneve-ut-1588
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14757,7 +14757,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1588
+Index: geneve-ut-1591
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14771,7 +14771,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1590
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14786,7 +14786,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1591
+Index: geneve-ut-1594
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14809,7 +14809,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1593
+Index: geneve-ut-1596
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14891,7 +14891,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1594
+Index: geneve-ut-1597
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14912,7 +14912,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1595
+Index: geneve-ut-1598
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14938,7 +14938,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1598
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14991,7 +14991,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1599
+Index: geneve-ut-1602
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15003,7 +15003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1600
+Index: geneve-ut-1603
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15015,7 +15015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1601
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and
@@ -15030,7 +15030,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1602
+Index: geneve-ut-1605
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15060,7 +15060,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1603
+Index: geneve-ut-1606
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15120,7 +15120,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1606
+Index: geneve-ut-1609
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15133,7 +15133,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1607
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15165,7 +15165,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1608
+Index: geneve-ut-1611
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15189,7 +15189,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1610
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15222,7 +15222,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1611
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15239,7 +15239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1613
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15268,7 +15268,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1614
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15282,7 +15282,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1615
+Index: geneve-ut-1618
 
 ```python
 sequence by process.entity_id
@@ -15307,7 +15307,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1616
+Index: geneve-ut-1619
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15341,7 +15341,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1617
+Index: geneve-ut-1620
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15369,7 +15369,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1618
+Index: geneve-ut-1621
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15388,7 +15388,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1624
+Index: geneve-ut-1627
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15416,7 +15416,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1625
+Index: geneve-ut-1628
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15435,7 +15435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1629
+Index: geneve-ut-1632
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15447,7 +15447,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1630
+Index: geneve-ut-1633
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15459,7 +15459,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1631
+Index: geneve-ut-1634
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15471,7 +15471,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1632
+Index: geneve-ut-1635
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15483,7 +15483,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1643
+Index: geneve-ut-1646
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15496,7 +15496,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1644
+Index: geneve-ut-1647
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15534,7 +15534,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1646
+Index: geneve-ut-1649
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15549,7 +15549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1647
+Index: geneve-ut-1650
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15568,7 +15568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1648
+Index: geneve-ut-1651
 
 ```python
 sequence with maxspan=1m
@@ -15616,7 +15616,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1650
+Index: geneve-ut-1653
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15639,7 +15639,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1652
+Index: geneve-ut-1655
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15653,7 +15653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1653
+Index: geneve-ut-1656
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15667,7 +15667,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1655
+Index: geneve-ut-1658
 
 ```python
 sequence by host.id, process.entity_id
@@ -15684,7 +15684,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1656
+Index: geneve-ut-1659
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15698,7 +15698,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1657
+Index: geneve-ut-1660
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15718,7 +15718,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1658
+Index: geneve-ut-1661
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15747,7 +15747,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1659
+Index: geneve-ut-1662
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15767,7 +15767,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1660
+Index: geneve-ut-1663
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15780,7 +15780,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1662
+Index: geneve-ut-1665
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15822,7 +15822,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1663
+Index: geneve-ut-1666
 
 ```python
 sequence with maxspan=1m
@@ -15845,7 +15845,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1664
+Index: geneve-ut-1667
 
 ```python
 sequence with maxspan=1s
@@ -15893,7 +15893,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1665
+Index: geneve-ut-1668
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15910,7 +15910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1667
+Index: geneve-ut-1670
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15939,7 +15939,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1669
+Index: geneve-ut-1673
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15967,7 +15967,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1670
+Index: geneve-ut-1674
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15984,7 +15984,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1672
+Index: geneve-ut-1676
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16003,7 +16003,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1673
+Index: geneve-ut-1677
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16024,7 +16024,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1682
+Index: geneve-ut-1686
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16038,7 +16038,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1684
+Index: geneve-ut-1688
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16057,7 +16057,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1685
+Index: geneve-ut-1689
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16071,7 +16071,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1686
+Index: geneve-ut-1690
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16091,7 +16091,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1688
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16109,7 +16109,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1689
+Index: geneve-ut-1693
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16130,7 +16130,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1691
+Index: geneve-ut-1695
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16144,7 +16144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1692
+Index: geneve-ut-1696
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16159,7 +16159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1693
+Index: geneve-ut-1697
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16200,7 +16200,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1695
+Index: geneve-ut-1699
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16225,7 +16225,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1696
+Index: geneve-ut-1700
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16264,7 +16264,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1697
+Index: geneve-ut-1701
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16278,7 +16278,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1698
+Index: geneve-ut-1702
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16317,7 +16317,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1699
+Index: geneve-ut-1703
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16331,7 +16331,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1700
+Index: geneve-ut-1704
 
 ```python
 process where event.type == "start" and
@@ -16403,7 +16403,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1704
+Index: geneve-ut-1708
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16424,7 +16424,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1707
+Index: geneve-ut-1711
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16441,7 +16441,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1710
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16459,7 +16459,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1711
+Index: geneve-ut-1715
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16471,7 +16471,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1712
+Index: geneve-ut-1716
 
 ```python
 file where host.os.type == "windows" and
@@ -16504,7 +16504,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1715
+Index: geneve-ut-1719
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16536,7 +16536,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1717
+Index: geneve-ut-1721
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16572,7 +16572,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1718
+Index: geneve-ut-1722
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16589,7 +16589,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1719
+Index: geneve-ut-1723
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16609,7 +16609,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1721
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16624,7 +16624,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1722
+Index: geneve-ut-1726
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16645,7 +16645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1723
+Index: geneve-ut-1727
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16668,7 +16668,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1724
+Index: geneve-ut-1728
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16681,7 +16681,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1725
+Index: geneve-ut-1729
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16698,7 +16698,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1728
+Index: geneve-ut-1732
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16723,7 +16723,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1731
+Index: geneve-ut-1735
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16754,7 +16754,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1732
+Index: geneve-ut-1736
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16803,7 +16803,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1733
+Index: geneve-ut-1737
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16817,7 +16817,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1734
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16832,7 +16832,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1735
+Index: geneve-ut-1739
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16847,7 +16847,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1736
+Index: geneve-ut-1740
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16869,7 +16869,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1737
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16890,7 +16890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1741
+Index: geneve-ut-1745
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16904,7 +16904,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1742
+Index: geneve-ut-1746
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16927,7 +16927,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1772
+Index: geneve-ut-1776
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16952,7 +16952,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1773
+Index: geneve-ut-1777
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16985,7 +16985,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1774
+Index: geneve-ut-1778
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17044,7 +17044,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1776
+Index: geneve-ut-1780
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17062,7 +17062,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1777
+Index: geneve-ut-1781
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17074,7 +17074,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1780
+Index: geneve-ut-1784
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17099,7 +17099,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1786
+Index: geneve-ut-1790
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17114,7 +17114,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1787
+Index: geneve-ut-1791
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17137,7 +17137,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1790
+Index: geneve-ut-1794
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17151,7 +17151,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1792
+Index: geneve-ut-1796
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17173,7 +17173,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1794
+Index: geneve-ut-1798
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17200,7 +17200,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1798
+Index: geneve-ut-1802
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17239,7 +17239,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1799
+Index: geneve-ut-1803
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17262,7 +17262,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1800
+Index: geneve-ut-1804
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17276,7 +17276,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1801
+Index: geneve-ut-1805
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17292,7 +17292,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1802
+Index: geneve-ut-1806
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17308,7 +17308,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1803
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17322,7 +17322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1805
+Index: geneve-ut-1809
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17345,7 +17345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1806
+Index: geneve-ut-1810
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17373,7 +17373,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1807
+Index: geneve-ut-1811
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +17388,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1810
+Index: geneve-ut-1814
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17415,7 +17415,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1812
+Index: geneve-ut-1816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17446,7 +17446,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1813
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17462,7 +17462,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1814
+Index: geneve-ut-1818
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17475,7 +17475,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1816
+Index: geneve-ut-1820
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17491,7 +17491,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1817
+Index: geneve-ut-1821
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17507,7 +17507,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1818
+Index: geneve-ut-1822
 
 ```python
 any where host.os.type == "windows" and 
@@ -17574,7 +17574,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1820
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17590,7 +17590,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1822
+Index: geneve-ut-1826
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17626,7 +17626,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1823
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +17664,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1824
+Index: geneve-ut-1828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17699,7 +17699,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1825
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +17733,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1827
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17754,7 +17754,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1832
+Index: geneve-ut-1836
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17831,7 +17831,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1833
+Index: geneve-ut-1837
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17853,7 +17853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1834
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17877,7 +17877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1836
+Index: geneve-ut-1840
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17898,7 +17898,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1839
+Index: geneve-ut-1843
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17913,7 +17913,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1842
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17926,7 +17926,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1843
+Index: geneve-ut-1847
 
 ```python
 any where host.os.type == "windows" and
@@ -17941,7 +17941,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1844
+Index: geneve-ut-1848
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17957,7 +17957,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1845
+Index: geneve-ut-1849
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17971,7 +17971,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1849
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18028,7 +18028,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1850
+Index: geneve-ut-1854
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18042,7 +18042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1852
+Index: geneve-ut-1856
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18074,7 +18074,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1854
+Index: geneve-ut-1858
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18087,7 +18087,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1855
+Index: geneve-ut-1859
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18106,7 +18106,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1856
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18152,7 +18152,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1858
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18173,7 +18173,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1859
+Index: geneve-ut-1863
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18193,7 +18193,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1860
+Index: geneve-ut-1864
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18207,7 +18207,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1861
+Index: geneve-ut-1865
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18239,7 +18239,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1864
+Index: geneve-ut-1868
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18260,7 +18260,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1866
+Index: geneve-ut-1870
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18361,7 +18361,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1870
+Index: geneve-ut-1874
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18409,7 +18409,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1873
+Index: geneve-ut-1877
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18435,7 +18435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1874
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18480,7 +18480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1875
+Index: geneve-ut-1879
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18504,7 +18504,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1876
+Index: geneve-ut-1880
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18520,7 +18520,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1878
+Index: geneve-ut-1882
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18545,7 +18545,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1879
+Index: geneve-ut-1883
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18560,7 +18560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1882
+Index: geneve-ut-1886
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18574,7 +18574,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1883
+Index: geneve-ut-1887
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18594,7 +18594,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1884
+Index: geneve-ut-1888
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18629,7 +18629,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1888
+Index: geneve-ut-1892
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18647,7 +18647,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1889
+Index: geneve-ut-1893
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18660,7 +18660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1892
+Index: geneve-ut-1896
 
 ```python
 any where host.os.type == "windows" and
@@ -18693,7 +18693,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1894
+Index: geneve-ut-1898
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18711,7 +18711,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1895
+Index: geneve-ut-1899
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18733,7 +18733,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1898
+Index: geneve-ut-1902
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18772,7 +18772,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1899
+Index: geneve-ut-1903
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18802,7 +18802,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1900
+Index: geneve-ut-1904
 
 ```python
 any where host.os.type == "windows" and
@@ -18836,7 +18836,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1901
+Index: geneve-ut-1905
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18850,7 +18850,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1904
+Index: geneve-ut-1908
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18881,7 +18881,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1905
+Index: geneve-ut-1909
 
 ```python
 any where host.os.type == "windows" and
@@ -18901,7 +18901,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1906
+Index: geneve-ut-1910
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18942,7 +18942,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1907
+Index: geneve-ut-1911
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18958,7 +18958,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1908
+Index: geneve-ut-1912
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18988,7 +18988,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1912
+Index: geneve-ut-1916
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19001,7 +19001,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1913
+Index: geneve-ut-1917
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19025,7 +19025,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1916
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19043,7 +19043,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1918
+Index: geneve-ut-1922
 
 ```python
 any where host.os.type == "windows" and
@@ -19058,7 +19058,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1919
+Index: geneve-ut-1923
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19076,7 +19076,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1920
+Index: geneve-ut-1924
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19097,7 +19097,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1921
+Index: geneve-ut-1925
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19116,7 +19116,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1924
+Index: geneve-ut-1928
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19141,7 +19141,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1925
+Index: geneve-ut-1929
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19154,7 +19154,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1927
+Index: geneve-ut-1931
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19167,7 +19167,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1929
+Index: geneve-ut-1933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19190,7 +19190,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1931
+Index: geneve-ut-1935
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19209,7 +19209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1932
+Index: geneve-ut-1936
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19231,7 +19231,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1933
+Index: geneve-ut-1937
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19264,7 +19264,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1935
+Index: geneve-ut-1939
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19282,7 +19282,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1936
+Index: geneve-ut-1940
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19296,7 +19296,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1937
+Index: geneve-ut-1941
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19320,7 +19320,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1938
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19343,7 +19343,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1939
+Index: geneve-ut-1943
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19362,7 +19362,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1942
+Index: geneve-ut-1946
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19381,7 +19381,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1944
+Index: geneve-ut-1948
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19416,7 +19416,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1945
+Index: geneve-ut-1949
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19433,7 +19433,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1946
+Index: geneve-ut-1950
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1947
+Index: geneve-ut-1951
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19493,7 +19493,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1948
+Index: geneve-ut-1952
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19509,7 +19509,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1949
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19523,7 +19523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1950
+Index: geneve-ut-1954
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19561,7 +19561,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1951
+Index: geneve-ut-1955
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19615,7 +19615,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1952
+Index: geneve-ut-1956
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19643,7 +19643,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1954
+Index: geneve-ut-1958
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19657,7 +19657,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1955
+Index: geneve-ut-1959
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19703,7 +19703,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1956
+Index: geneve-ut-1960
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19742,7 +19742,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1957
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19755,7 +19755,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1961
+Index: geneve-ut-1965
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19788,7 +19788,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1962
+Index: geneve-ut-1966
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19802,7 +19802,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1963
+Index: geneve-ut-1967
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19816,7 +19816,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1964
+Index: geneve-ut-1968
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19830,7 +19830,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1965
+Index: geneve-ut-1969
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19869,7 +19869,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1973
+Index: geneve-ut-1977
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19911,7 +19911,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1975
+Index: geneve-ut-1979
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19933,7 +19933,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1977
+Index: geneve-ut-1981
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19946,7 +19946,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1980
+Index: geneve-ut-1984
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19963,7 +19963,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1981
+Index: geneve-ut-1985
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19979,7 +19979,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1982
+Index: geneve-ut-1986
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19992,7 +19992,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1983
+Index: geneve-ut-1987
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20007,7 +20007,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1984
+Index: geneve-ut-1988
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20030,7 +20030,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1985
+Index: geneve-ut-1989
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20046,7 +20046,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1986
+Index: geneve-ut-1990
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20062,7 +20062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1992
+Index: geneve-ut-1996
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20074,7 +20074,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1993
+Index: geneve-ut-1997
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20103,7 +20103,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1995
+Index: geneve-ut-1999
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20117,7 +20117,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2000
+Index: geneve-ut-2004
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20137,7 +20137,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2001
+Index: geneve-ut-2005
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20162,7 +20162,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2008
+Index: geneve-ut-2012
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20176,7 +20176,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2009
+Index: geneve-ut-2013
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20199,7 +20199,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2018
+Index: geneve-ut-2022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20233,7 +20233,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2020
+Index: geneve-ut-2024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20252,7 +20252,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2027
+Index: geneve-ut-2031
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20271,7 +20271,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2042
+Index: geneve-ut-2046
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20288,7 +20288,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2045
+Index: geneve-ut-2049
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20305,7 +20305,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2061
+Index: geneve-ut-2065
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20324,7 +20324,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2065
+Index: geneve-ut-2069
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20366,7 +20366,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2066
+Index: geneve-ut-2070
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20411,7 +20411,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2069
+Index: geneve-ut-2073
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20453,7 +20453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2071
+Index: geneve-ut-2075
 
 ```python
 host.os.type:"linux" and 
@@ -20481,7 +20481,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2075
+Index: geneve-ut-2079
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20505,7 +20505,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2076
+Index: geneve-ut-2080
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20545,7 +20545,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2077
+Index: geneve-ut-2081
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20592,7 +20592,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2081
+Index: geneve-ut-2085
 
 ```python
 sequence by process.entity_id
@@ -20629,7 +20629,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2113
+Index: geneve-ut-2117
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20643,7 +20643,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2114
+Index: geneve-ut-2118
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20686,7 +20686,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2115
+Index: geneve-ut-2119
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20699,7 +20699,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2118
+Index: geneve-ut-2122
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20713,7 +20713,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2119
+Index: geneve-ut-2123
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20726,7 +20726,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2123
+Index: geneve-ut-2127
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20751,7 +20751,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2124
+Index: geneve-ut-2128
 
 ```python
 process where event.type == "start" and
@@ -20766,7 +20766,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2125
+Index: geneve-ut-2129
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20783,7 +20783,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2126
+Index: geneve-ut-2130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20797,7 +20797,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2127
+Index: geneve-ut-2131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20813,7 +20813,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2128
+Index: geneve-ut-2132
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20827,7 +20827,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2129
+Index: geneve-ut-2133
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20854,7 +20854,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2131
+Index: geneve-ut-2135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20866,7 +20866,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2132
+Index: geneve-ut-2136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20882,7 +20882,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2133
+Index: geneve-ut-2137
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20905,7 +20905,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2134
+Index: geneve-ut-2138
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20918,7 +20918,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2136
+Index: geneve-ut-2140
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20930,7 +20930,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2137
+Index: geneve-ut-2141
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20942,7 +20942,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2138
+Index: geneve-ut-2142
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20954,7 +20954,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2139
+Index: geneve-ut-2143
 
 ```python
 web where (
@@ -20982,7 +20982,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2145
+Index: geneve-ut-2149
 
 ```python
 any where (
@@ -21054,7 +21054,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2147
+Index: geneve-ut-2151
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21075,7 +21075,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2150
+Index: geneve-ut-2154
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21089,7 +21089,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2151
+Index: geneve-ut-2155
 
 ```python
 file where event.type == "deletion" and
@@ -21106,7 +21106,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2152
+Index: geneve-ut-2156
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21124,7 +21124,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2155
+Index: geneve-ut-2159
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21162,7 +21162,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2157
+Index: geneve-ut-2161
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21199,7 +21199,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2158
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21214,7 +21214,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2159
+Index: geneve-ut-2163
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21227,7 +21227,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2160
+Index: geneve-ut-2164
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21246,7 +21246,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2161
+Index: geneve-ut-2165
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21271,7 +21271,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2162
+Index: geneve-ut-2166
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21297,7 +21297,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2163
+Index: geneve-ut-2167
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21319,7 +21319,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2164
+Index: geneve-ut-2168
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21336,7 +21336,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2166
+Index: geneve-ut-2170
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21355,7 +21355,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2167
+Index: geneve-ut-2171
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21395,7 +21395,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2168
+Index: geneve-ut-2172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21412,7 +21412,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2170
+Index: geneve-ut-2174
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21425,7 +21425,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2171
+Index: geneve-ut-2175
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21439,7 +21439,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2172
+Index: geneve-ut-2176
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21467,7 +21467,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2173
+Index: geneve-ut-2177
 
 ```python
 process where event.type == "start" and
@@ -21492,7 +21492,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2174
+Index: geneve-ut-2178
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21506,7 +21506,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2175
+Index: geneve-ut-2179
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21522,7 +21522,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2176
+Index: geneve-ut-2180
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21557,7 +21557,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2177
+Index: geneve-ut-2181
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21575,7 +21575,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2180
+Index: geneve-ut-2184
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.5.md
+++ b/tests/reports/alerts_from_rules-9.5.md
@@ -5,7 +5,7 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.2
+Rules version: 9.5.3
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
@@ -20,7 +20,7 @@ Rules version: 9.5.2
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367  
+Index: geneve-ut-0368  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378  
+Index: geneve-ut-0379  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -190,7 +190,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646  
+Index: geneve-ut-0647  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671  
+Index: geneve-ut-0672  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805  
+Index: geneve-ut-0807  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998  
+Index: geneve-ut-1000  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143  
+Index: geneve-ut-1145  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173  
+Index: geneve-ut-1175  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245  
+Index: geneve-ut-1248  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274  
+Index: geneve-ut-1277  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292  
+Index: geneve-ut-1295  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356  
+Index: geneve-ut-1359  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371  
+Index: geneve-ut-1374  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461  
+Index: geneve-ut-1464  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705  
+Index: geneve-ut-1709  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709  
+Index: geneve-ut-1713  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793  
+Index: geneve-ut-1797  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808  
+Index: geneve-ut-1812  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821  
+Index: geneve-ut-1825  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831  
+Index: geneve-ut-1835  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837  
+Index: geneve-ut-1841  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846  
+Index: geneve-ut-1850  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943  
+Index: geneve-ut-1947  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974  
+Index: geneve-ut-1978  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1123,7 +1123,7 @@ container.id like "*"
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367
+Index: geneve-ut-0368
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1175,7 +1175,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378
+Index: geneve-ut-0379
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -1287,7 +1287,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646
+Index: geneve-ut-0647
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1353,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671
+Index: geneve-ut-0672
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805
+Index: geneve-ut-0807
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998
+Index: geneve-ut-1000
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143
+Index: geneve-ut-1145
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245
+Index: geneve-ut-1248
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292
+Index: geneve-ut-1295
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461
+Index: geneve-ut-1464
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709
+Index: geneve-ut-1713
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793
+Index: geneve-ut-1797
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808
+Index: geneve-ut-1812
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821
+Index: geneve-ut-1825
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837
+Index: geneve-ut-1841
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943
+Index: geneve-ut-1947
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974
+Index: geneve-ut-1978
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0999
+Index: geneve-ut-1001
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1019
+Index: geneve-ut-1021
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1408
+Index: geneve-ut-1411
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1609
+Index: geneve-ut-1612
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2227,7 +2227,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367  
+Index: geneve-ut-0368  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2281,7 +2281,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378  
+Index: geneve-ut-0379  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -2395,7 +2395,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646  
+Index: geneve-ut-0647  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2463,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671  
+Index: geneve-ut-0672  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805  
+Index: geneve-ut-0807  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0971  
+Index: geneve-ut-0973  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998  
+Index: geneve-ut-1000  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1121  
+Index: geneve-ut-1123  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143  
+Index: geneve-ut-1145  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173  
+Index: geneve-ut-1175  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245  
+Index: geneve-ut-1248  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274  
+Index: geneve-ut-1277  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292  
+Index: geneve-ut-1295  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356  
+Index: geneve-ut-1359  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371  
+Index: geneve-ut-1374  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1452  
+Index: geneve-ut-1455  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461  
+Index: geneve-ut-1464  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1576  
+Index: geneve-ut-1579  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705  
+Index: geneve-ut-1709  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709  
+Index: geneve-ut-1713  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793  
+Index: geneve-ut-1797  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808  
+Index: geneve-ut-1812  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821  
+Index: geneve-ut-1825  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831  
+Index: geneve-ut-1835  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837  
+Index: geneve-ut-1841  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846  
+Index: geneve-ut-1850  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943  
+Index: geneve-ut-1947  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974  
+Index: geneve-ut-1978  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -4269,7 +4269,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0323
+Index: geneve-ut-0324
 
 ```python
 event.dataset:azure.activitylogs and
@@ -4283,7 +4283,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0326
+Index: geneve-ut-0327
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -4301,7 +4301,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0344
+Index: geneve-ut-0345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4319,7 +4319,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0345
+Index: geneve-ut-0346
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4337,7 +4337,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0346
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4352,7 +4352,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0347
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4366,7 +4366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0348
+Index: geneve-ut-0349
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4381,7 +4381,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0351
+Index: geneve-ut-0352
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4398,7 +4398,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0352
+Index: geneve-ut-0353
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4410,7 +4410,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0353
+Index: geneve-ut-0354
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4422,7 +4422,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0354
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4437,7 +4437,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0355
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4457,7 +4457,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0356
+Index: geneve-ut-0357
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4479,7 +4479,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0358
+Index: geneve-ut-0359
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4525,7 +4525,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0359
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4559,7 +4559,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0360
+Index: geneve-ut-0361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4582,7 +4582,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0362
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4604,7 +4604,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0363
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4632,7 +4632,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0364
+Index: geneve-ut-0365
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4648,7 +4648,7 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0366
+Index: geneve-ut-0367
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4673,7 +4673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0368
+Index: geneve-ut-0369
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4703,7 +4703,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0370
+Index: geneve-ut-0371
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4717,7 +4717,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0371
+Index: geneve-ut-0372
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4739,7 +4739,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0372
+Index: geneve-ut-0373
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4753,7 +4753,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0373
+Index: geneve-ut-0374
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4773,7 +4773,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0376
+Index: geneve-ut-0377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4790,7 +4790,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0379
+Index: geneve-ut-0380
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4820,7 +4820,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0382
+Index: geneve-ut-0383
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4845,7 +4845,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0384
+Index: geneve-ut-0385
 
 ```python
 sequence by process.entity_id
@@ -4866,7 +4866,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0385
+Index: geneve-ut-0386
 
 ```python
 sequence by process.entity_id
@@ -4887,7 +4887,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0388
+Index: geneve-ut-0389
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4918,7 +4918,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0389
+Index: geneve-ut-0390
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4930,7 +4930,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0390
+Index: geneve-ut-0391
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4953,7 +4953,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0393
+Index: geneve-ut-0394
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4966,7 +4966,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0394
+Index: geneve-ut-0395
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4979,7 +4979,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0396
+Index: geneve-ut-0397
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4996,7 +4996,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0397
+Index: geneve-ut-0398
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -5009,7 +5009,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0398
+Index: geneve-ut-0399
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -5026,7 +5026,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0399
+Index: geneve-ut-0400
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -5038,7 +5038,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0400
+Index: geneve-ut-0401
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -5106,7 +5106,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0401
+Index: geneve-ut-0402
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -5124,7 +5124,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0402
+Index: geneve-ut-0403
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -5137,7 +5137,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0403
+Index: geneve-ut-0404
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5155,7 +5155,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0404
+Index: geneve-ut-0405
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5167,7 +5167,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0405
+Index: geneve-ut-0406
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5179,7 +5179,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0406
+Index: geneve-ut-0407
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5191,7 +5191,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0407
+Index: geneve-ut-0408
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5203,7 +5203,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0408
+Index: geneve-ut-0409
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -5248,7 +5248,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0410
+Index: geneve-ut-0411
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5268,7 +5268,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0411
+Index: geneve-ut-0412
 
 ```python
 sequence with maxspan=10s
@@ -5288,7 +5288,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0412
+Index: geneve-ut-0413
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5315,7 +5315,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0413
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5329,7 +5329,7 @@ container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0416
+Index: geneve-ut-0417
 
 ```python
 process where event.type == "start" and
@@ -5354,7 +5354,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0419
+Index: geneve-ut-0420
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5398,7 +5398,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0420
+Index: geneve-ut-0421
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5432,7 +5432,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0422
+Index: geneve-ut-0423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5477,7 +5477,7 @@ container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0423
+Index: geneve-ut-0424
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5493,7 +5493,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0424
+Index: geneve-ut-0425
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5518,7 +5518,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0425
+Index: geneve-ut-0426
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5537,7 +5537,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0427
+Index: geneve-ut-0428
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5664,7 +5664,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0428
+Index: geneve-ut-0429
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5682,7 +5682,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0430
+Index: geneve-ut-0431
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5695,7 +5695,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0431
+Index: geneve-ut-0432
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5725,7 +5725,7 @@ container.security_context.privileged == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0437
+Index: geneve-ut-0438
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5739,7 +5739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0449
+Index: geneve-ut-0450
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5760,7 +5760,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0456
+Index: geneve-ut-0457
 
 ```python
 registry where host.os.type == "windows" and
@@ -5774,7 +5774,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0468
+Index: geneve-ut-0469
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5798,7 +5798,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0507
+Index: geneve-ut-0508
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5852,7 +5852,7 @@ container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0509
+Index: geneve-ut-0510
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5868,7 +5868,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0510
+Index: geneve-ut-0511
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5896,7 +5896,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0511
+Index: geneve-ut-0512
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5913,7 +5913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0512
+Index: geneve-ut-0513
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5930,7 +5930,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0513
+Index: geneve-ut-0514
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5951,7 +5951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0515
+Index: geneve-ut-0516
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5971,7 +5971,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0516
+Index: geneve-ut-0517
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5986,7 +5986,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0518
+Index: geneve-ut-0519
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5999,7 +5999,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0519
+Index: geneve-ut-0520
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6019,7 +6019,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0522
+Index: geneve-ut-0523
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -6032,7 +6032,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0523
+Index: geneve-ut-0524
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6070,7 +6070,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0524
+Index: geneve-ut-0525
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -6090,7 +6090,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0525
+Index: geneve-ut-0526
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6103,7 +6103,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0526
+Index: geneve-ut-0527
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -6126,7 +6126,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0528
+Index: geneve-ut-0529
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6157,7 +6157,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0529
+Index: geneve-ut-0530
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -6176,7 +6176,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0530
+Index: geneve-ut-0531
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6219,7 +6219,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0531
+Index: geneve-ut-0532
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -6233,7 +6233,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0533
+Index: geneve-ut-0534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6248,7 +6248,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0534
+Index: geneve-ut-0535
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6264,7 +6264,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0535
+Index: geneve-ut-0536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6278,7 +6278,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0536
+Index: geneve-ut-0537
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6304,7 +6304,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0537
+Index: geneve-ut-0538
 
 ```python
 process where event.type == "start" and
@@ -6342,7 +6342,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0544
+Index: geneve-ut-0545
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -6355,7 +6355,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0545
+Index: geneve-ut-0546
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6369,7 +6369,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0546
+Index: geneve-ut-0547
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6391,7 +6391,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0547
+Index: geneve-ut-0548
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6426,7 +6426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0548
+Index: geneve-ut-0549
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6438,7 +6438,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0596
+Index: geneve-ut-0597
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6450,7 +6450,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0622
+Index: geneve-ut-0623
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6464,7 +6464,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0625
+Index: geneve-ut-0626
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6491,7 +6491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0628
+Index: geneve-ut-0629
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6512,7 +6512,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0629
+Index: geneve-ut-0630
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6542,7 +6542,7 @@ container.id like "*"
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0632
+Index: geneve-ut-0633
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6560,7 +6560,7 @@ container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0633
+Index: geneve-ut-0634
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6593,7 +6593,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0635
+Index: geneve-ut-0636
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6610,7 +6610,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0636
+Index: geneve-ut-0637
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6638,7 +6638,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0637
+Index: geneve-ut-0638
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6651,7 +6651,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0639
+Index: geneve-ut-0640
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6671,7 +6671,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0640
+Index: geneve-ut-0641
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6697,7 +6697,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0641
+Index: geneve-ut-0642
 
 ```python
 sequence with maxspan=2h
@@ -6719,7 +6719,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0642
+Index: geneve-ut-0643
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6748,7 +6748,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0645
+Index: geneve-ut-0646
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6761,7 +6761,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0649
+Index: geneve-ut-0650
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6776,7 +6776,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0650
+Index: geneve-ut-0651
 
 ```python
 process where event.type == "start" and
@@ -6798,7 +6798,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0652
+Index: geneve-ut-0653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6810,7 +6810,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0653
+Index: geneve-ut-0654
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6832,7 +6832,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0655
+Index: geneve-ut-0656
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6849,7 +6849,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0656
+Index: geneve-ut-0657
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6863,7 +6863,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0657
+Index: geneve-ut-0658
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6876,7 +6876,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0658
+Index: geneve-ut-0659
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6888,7 +6888,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0659
+Index: geneve-ut-0660
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6900,7 +6900,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0660
+Index: geneve-ut-0661
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6914,7 +6914,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0661
+Index: geneve-ut-0662
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6926,7 +6926,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0662
+Index: geneve-ut-0663
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -6948,7 +6948,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0666
+Index: geneve-ut-0667
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6997,7 +6997,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0667
+Index: geneve-ut-0668
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -7014,7 +7014,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0668
+Index: geneve-ut-0669
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7034,7 +7034,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0673
+Index: geneve-ut-0674
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7056,7 +7056,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0676
+Index: geneve-ut-0677
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7071,7 +7071,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0677
+Index: geneve-ut-0678
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7085,7 +7085,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0679
+Index: geneve-ut-0680
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7107,7 +7107,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0681
+Index: geneve-ut-0682
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -7128,7 +7128,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0682
+Index: geneve-ut-0683
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7154,7 +7154,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0683
+Index: geneve-ut-0684
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -7182,7 +7182,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0686
+Index: geneve-ut-0687
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -7196,7 +7196,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0724
+Index: geneve-ut-0726
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -7213,7 +7213,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0725
+Index: geneve-ut-0727
 
 ```python
 registry where host.os.type == "windows" and
@@ -7231,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0795
+Index: geneve-ut-0797
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0796
+Index: geneve-ut-0798
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0797
+Index: geneve-ut-0799
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0798
+Index: geneve-ut-0800
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0806
+Index: geneve-ut-0808
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0807
+Index: geneve-ut-0809
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0808
+Index: geneve-ut-0810
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0809
+Index: geneve-ut-0811
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0813
+Index: geneve-ut-0815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0816
+Index: geneve-ut-0818
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0819
+Index: geneve-ut-0821
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0823
+Index: geneve-ut-0825
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0825
+Index: geneve-ut-0827
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0851
+Index: geneve-ut-0853
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0854
+Index: geneve-ut-0856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0855
+Index: geneve-ut-0857
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0868
+Index: geneve-ut-0870
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0869
+Index: geneve-ut-0871
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0870
+Index: geneve-ut-0872
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0874
+Index: geneve-ut-0876
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0880
+Index: geneve-ut-0882
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0882
+Index: geneve-ut-0884
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0883
+Index: geneve-ut-0885
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0884
+Index: geneve-ut-0886
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0885
+Index: geneve-ut-0887
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0886
+Index: geneve-ut-0888
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0887
+Index: geneve-ut-0889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0892
+Index: geneve-ut-0894
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0894
+Index: geneve-ut-0896
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0895
+Index: geneve-ut-0897
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0896
+Index: geneve-ut-0898
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7897,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0897
+Index: geneve-ut-0899
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7921,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0902
+Index: geneve-ut-0904
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0904
+Index: geneve-ut-0906
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0905
+Index: geneve-ut-0907
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0906
+Index: geneve-ut-0908
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0907
+Index: geneve-ut-0909
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0908
+Index: geneve-ut-0910
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0909
+Index: geneve-ut-0911
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0910
+Index: geneve-ut-0912
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0911
+Index: geneve-ut-0913
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0912
+Index: geneve-ut-0914
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0913
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0915
+Index: geneve-ut-0917
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0917
+Index: geneve-ut-0919
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0918
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0919
+Index: geneve-ut-0921
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0920
+Index: geneve-ut-0922
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0922
+Index: geneve-ut-0924
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0923
+Index: geneve-ut-0925
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0925
+Index: geneve-ut-0927
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0927
+Index: geneve-ut-0929
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0928
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0930
+Index: geneve-ut-0932
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0931
+Index: geneve-ut-0933
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8436,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0932
+Index: geneve-ut-0934
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8463,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0935
+Index: geneve-ut-0937
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0936
+Index: geneve-ut-0938
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0946
+Index: geneve-ut-0948
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0972
+Index: geneve-ut-0974
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0975
+Index: geneve-ut-0977
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0977
+Index: geneve-ut-0979
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0989
+Index: geneve-ut-0991
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0994
+Index: geneve-ut-0996
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0995
+Index: geneve-ut-0997
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1000
+Index: geneve-ut-1002
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1015
+Index: geneve-ut-1017
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1018
+Index: geneve-ut-1020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1020
+Index: geneve-ut-1022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1021
+Index: geneve-ut-1023
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1025
+Index: geneve-ut-1027
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1026
+Index: geneve-ut-1028
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8863,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1029
+Index: geneve-ut-1031
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1031
+Index: geneve-ut-1033
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1032
+Index: geneve-ut-1034
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1068
+Index: geneve-ut-1070
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1069
+Index: geneve-ut-1071
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1070
+Index: geneve-ut-1072
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1071
+Index: geneve-ut-1073
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1072
+Index: geneve-ut-1074
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1080
+Index: geneve-ut-1082
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1083
+Index: geneve-ut-1085
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1084
+Index: geneve-ut-1086
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1085
+Index: geneve-ut-1087
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1089
+Index: geneve-ut-1091
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1090
+Index: geneve-ut-1092
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1092
+Index: geneve-ut-1094
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1093
+Index: geneve-ut-1095
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1094
+Index: geneve-ut-1096
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1095
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1096
+Index: geneve-ut-1098
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1097
+Index: geneve-ut-1099
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9142,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1098
+Index: geneve-ut-1100
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9167,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1100
+Index: geneve-ut-1102
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1103
+Index: geneve-ut-1105
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1104
+Index: geneve-ut-1106
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1105
+Index: geneve-ut-1107
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1108
+Index: geneve-ut-1110
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1109
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1110
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1114
+Index: geneve-ut-1116
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1115
+Index: geneve-ut-1117
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1116
+Index: geneve-ut-1118
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1120
+Index: geneve-ut-1122
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1122
+Index: geneve-ut-1124
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1124
+Index: geneve-ut-1126
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1125
+Index: geneve-ut-1127
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1127
+Index: geneve-ut-1129
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1128
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1132
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1131
+Index: geneve-ut-1133
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1133
+Index: geneve-ut-1135
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1134
+Index: geneve-ut-1136
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9604,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1136
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1137
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1138
+Index: geneve-ut-1140
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1139
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1140
+Index: geneve-ut-1142
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1141
+Index: geneve-ut-1143
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1142
+Index: geneve-ut-1144
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1155
+Index: geneve-ut-1157
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1164
+Index: geneve-ut-1166
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1168
+Index: geneve-ut-1170
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1169
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1170
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1171
+Index: geneve-ut-1173
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1172
+Index: geneve-ut-1174
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1174
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1175
+Index: geneve-ut-1177
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1177
+Index: geneve-ut-1179
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1179
+Index: geneve-ut-1181
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1180
+Index: geneve-ut-1182
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1181
+Index: geneve-ut-1183
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1183
+Index: geneve-ut-1185
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1184
+Index: geneve-ut-1186
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1185
+Index: geneve-ut-1187
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1186
+Index: geneve-ut-1188
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1188
+Index: geneve-ut-1190
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1189
+Index: geneve-ut-1191
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1190
+Index: geneve-ut-1192
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1191
+Index: geneve-ut-1193
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1192
+Index: geneve-ut-1194
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1196
+Index: geneve-ut-1198
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1197
+Index: geneve-ut-1199
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1198
+Index: geneve-ut-1200
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1203
+Index: geneve-ut-1205
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1206
+Index: geneve-ut-1208
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1215
+Index: geneve-ut-1218
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1216
+Index: geneve-ut-1219
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1217
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1218
+Index: geneve-ut-1221
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1220
+Index: geneve-ut-1223
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1221
+Index: geneve-ut-1224
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1223
+Index: geneve-ut-1226
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1232
+Index: geneve-ut-1235
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1233
+Index: geneve-ut-1236
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1234
+Index: geneve-ut-1237
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1235
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1236
+Index: geneve-ut-1239
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1237
+Index: geneve-ut-1240
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1238
+Index: geneve-ut-1241
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1239
+Index: geneve-ut-1242
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10670,7 +10670,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1246
+Index: geneve-ut-1249
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10685,7 +10685,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1247
+Index: geneve-ut-1250
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10699,7 +10699,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1248
+Index: geneve-ut-1251
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10718,7 +10718,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1249
+Index: geneve-ut-1252
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10730,7 +10730,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1250
+Index: geneve-ut-1253
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10742,7 +10742,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1251
+Index: geneve-ut-1254
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10760,7 +10760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1252
+Index: geneve-ut-1255
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10773,7 +10773,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1253
+Index: geneve-ut-1256
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10788,7 +10788,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1254
+Index: geneve-ut-1257
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10803,7 +10803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1257
+Index: geneve-ut-1260
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10823,7 +10823,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1258
+Index: geneve-ut-1261
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10847,7 +10847,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1259
+Index: geneve-ut-1262
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10861,7 +10861,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1260
+Index: geneve-ut-1263
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10880,7 +10880,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1261
+Index: geneve-ut-1264
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10908,7 +10908,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1262
+Index: geneve-ut-1265
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10937,7 +10937,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1263
+Index: geneve-ut-1266
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10956,7 +10956,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1264
+Index: geneve-ut-1267
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10984,7 +10984,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1265
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10999,7 +10999,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1266
+Index: geneve-ut-1269
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11062,7 +11062,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1267
+Index: geneve-ut-1270
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11083,7 +11083,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1268
+Index: geneve-ut-1271
 
 ```python
 any where host.os.type == "windows" and
@@ -11145,7 +11145,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1270
+Index: geneve-ut-1273
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11174,7 +11174,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1271
+Index: geneve-ut-1274
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11188,7 +11188,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1272
+Index: geneve-ut-1275
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11221,7 +11221,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1275
+Index: geneve-ut-1278
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11268,7 +11268,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1276
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11295,7 +11295,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1277
+Index: geneve-ut-1280
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11308,7 +11308,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1288
+Index: geneve-ut-1291
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11325,7 +11325,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1290
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11350,7 +11350,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1295
+Index: geneve-ut-1298
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11366,7 +11366,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1296
+Index: geneve-ut-1299
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11387,7 +11387,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1298
+Index: geneve-ut-1301
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11404,7 +11404,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1299
+Index: geneve-ut-1302
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11417,7 +11417,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1300
+Index: geneve-ut-1303
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11441,7 +11441,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1302
+Index: geneve-ut-1305
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11470,7 +11470,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1304
+Index: geneve-ut-1307
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11497,7 +11497,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11521,7 +11521,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1308
+Index: geneve-ut-1311
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11539,7 +11539,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1309
+Index: geneve-ut-1312
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11562,7 +11562,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1310
+Index: geneve-ut-1313
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11619,7 +11619,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11636,7 +11636,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1312
+Index: geneve-ut-1315
 
 ```python
 sequence by process.entity_id
@@ -11650,7 +11650,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1327
+Index: geneve-ut-1330
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11665,7 +11665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1328
+Index: geneve-ut-1331
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11696,7 +11696,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1329
+Index: geneve-ut-1332
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11710,7 +11710,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1330
+Index: geneve-ut-1333
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11723,7 +11723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11735,7 +11735,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11748,7 +11748,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11767,7 +11767,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1335
+Index: geneve-ut-1338
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11780,7 +11780,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1336
+Index: geneve-ut-1339
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11801,7 +11801,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11815,7 +11815,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11835,7 +11835,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1341
+Index: geneve-ut-1344
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11859,7 +11859,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1342
+Index: geneve-ut-1345
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11875,7 +11875,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1343
+Index: geneve-ut-1346
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11892,7 +11892,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1344
+Index: geneve-ut-1347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11913,7 +11913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1346
+Index: geneve-ut-1349
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11926,7 +11926,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1348
+Index: geneve-ut-1351
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11954,7 +11954,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1351
+Index: geneve-ut-1354
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11970,7 +11970,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1352
+Index: geneve-ut-1355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11993,7 +11993,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1353
+Index: geneve-ut-1356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12006,7 +12006,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12019,7 +12019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1360
+Index: geneve-ut-1363
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12033,7 +12033,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1361
+Index: geneve-ut-1364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +12048,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12071,7 +12071,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1366
+Index: geneve-ut-1369
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12114,7 +12114,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1367
+Index: geneve-ut-1370
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12132,7 +12132,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1368
+Index: geneve-ut-1371
 
 ```python
 host.os.type:"windows" and
@@ -12148,7 +12148,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12160,7 +12160,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1372
+Index: geneve-ut-1375
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12176,7 +12176,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12192,7 +12192,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12210,7 +12210,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12224,7 +12224,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1377
+Index: geneve-ut-1380
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12247,7 +12247,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1379
+Index: geneve-ut-1382
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12263,7 +12263,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12276,7 +12276,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1381
+Index: geneve-ut-1384
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12306,7 +12306,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1387
+Index: geneve-ut-1390
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12329,7 +12329,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1388
+Index: geneve-ut-1391
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12348,7 +12348,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1393
+Index: geneve-ut-1396
 
 ```python
 process where host.os.type == "windows" and 
@@ -12490,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1394
+Index: geneve-ut-1397
 
 ```python
 process where host.os.type == "windows" and
@@ -12567,7 +12567,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1398
+Index: geneve-ut-1401
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12584,7 +12584,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1399
+Index: geneve-ut-1402
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12618,7 +12618,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12630,7 +12630,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1402
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12669,7 +12669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1405
+Index: geneve-ut-1408
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12682,7 +12682,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1410
+Index: geneve-ut-1413
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12696,7 +12696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1417
+Index: geneve-ut-1420
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12734,7 +12734,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1418
+Index: geneve-ut-1421
 
 ```python
 network where host.os.type == "windows" and
@@ -12760,7 +12760,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1421
+Index: geneve-ut-1424
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12775,7 +12775,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12789,7 +12789,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1425
+Index: geneve-ut-1428
 
 ```python
 file where host.os.type == "windows" and
@@ -12803,7 +12803,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1426
+Index: geneve-ut-1429
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12816,7 +12816,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1427
+Index: geneve-ut-1430
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12836,7 +12836,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1430
+Index: geneve-ut-1433
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12895,7 +12895,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1431
+Index: geneve-ut-1434
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13090,7 +13090,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1446
+Index: geneve-ut-1449
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13106,7 +13106,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1447
+Index: geneve-ut-1450
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13120,7 +13120,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1448
+Index: geneve-ut-1451
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13134,7 +13134,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1449
+Index: geneve-ut-1452
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13151,7 +13151,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13165,7 +13165,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1451
+Index: geneve-ut-1454
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13181,7 +13181,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1456
+Index: geneve-ut-1459
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13193,7 +13193,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1457
+Index: geneve-ut-1460
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13209,7 +13209,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1458
+Index: geneve-ut-1461
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13229,7 +13229,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1460
+Index: geneve-ut-1463
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13269,7 +13269,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1462
+Index: geneve-ut-1465
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13281,7 +13281,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1463
+Index: geneve-ut-1466
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13302,7 +13302,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1464
+Index: geneve-ut-1467
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13323,7 +13323,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1465
+Index: geneve-ut-1468
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13344,7 +13344,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1466
+Index: geneve-ut-1469
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13370,7 +13370,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1467
+Index: geneve-ut-1470
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13386,7 +13386,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1468
+Index: geneve-ut-1471
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13400,7 +13400,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1470
+Index: geneve-ut-1473
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13423,7 +13423,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1472
+Index: geneve-ut-1475
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13440,7 +13440,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1473
+Index: geneve-ut-1476
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13463,7 +13463,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1474
+Index: geneve-ut-1477
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13476,7 +13476,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1475
+Index: geneve-ut-1478
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13490,7 +13490,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1476
+Index: geneve-ut-1479
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13507,7 +13507,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1477
+Index: geneve-ut-1480
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13561,7 +13561,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1478
+Index: geneve-ut-1481
 
 ```python
 any where host.os.type == "windows" and
@@ -13588,7 +13588,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1484
+Index: geneve-ut-1487
 
 ```python
 file where host.os.type == "windows" and
@@ -13603,7 +13603,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1485
+Index: geneve-ut-1488
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13634,7 +13634,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1486
+Index: geneve-ut-1489
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +13648,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1487
+Index: geneve-ut-1490
 
 ```python
 sequence with maxspan=1m
@@ -13690,7 +13690,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1488
+Index: geneve-ut-1491
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13715,7 +13715,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13769,7 +13769,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1490
+Index: geneve-ut-1493
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13789,7 +13789,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1491
+Index: geneve-ut-1494
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13810,7 +13810,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13825,7 +13825,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13845,7 +13845,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1494
+Index: geneve-ut-1497
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13887,7 +13887,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1498
+Index: geneve-ut-1501
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13902,7 +13902,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1499
+Index: geneve-ut-1502
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13937,7 +13937,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1500
+Index: geneve-ut-1503
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13954,7 +13954,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1505
+Index: geneve-ut-1508
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13968,7 +13968,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1508
+Index: geneve-ut-1511
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13981,7 +13981,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1509
+Index: geneve-ut-1512
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13993,7 +13993,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1510
+Index: geneve-ut-1513
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14008,7 +14008,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14036,7 +14036,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1514
+Index: geneve-ut-1517
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14061,7 +14061,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1518
+Index: geneve-ut-1521
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14098,7 +14098,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1519
+Index: geneve-ut-1522
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14112,7 +14112,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1520
+Index: geneve-ut-1523
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14128,7 +14128,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1521
+Index: geneve-ut-1524
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14142,7 +14142,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1522
+Index: geneve-ut-1525
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14172,7 +14172,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1523
+Index: geneve-ut-1526
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14201,7 +14201,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1524
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14217,7 +14217,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1525
+Index: geneve-ut-1528
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14231,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 file where host.os.type == "windows" and
@@ -14267,7 +14267,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1529
+Index: geneve-ut-1532
 
 ```python
 process where event.type == "start" and
@@ -14281,7 +14281,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1530
+Index: geneve-ut-1533
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14295,7 +14295,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1531
+Index: geneve-ut-1534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14315,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1533
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14332,7 +14332,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1534
+Index: geneve-ut-1537
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14344,7 +14344,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1535
+Index: geneve-ut-1538
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14361,7 +14361,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1536
+Index: geneve-ut-1539
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14379,7 +14379,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1543
+Index: geneve-ut-1546
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14392,7 +14392,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1544
+Index: geneve-ut-1547
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14419,7 +14419,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1545
+Index: geneve-ut-1548
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14432,7 +14432,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1546
+Index: geneve-ut-1549
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14446,7 +14446,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14463,7 +14463,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14486,7 +14486,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14503,7 +14503,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1554
+Index: geneve-ut-1557
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14516,7 +14516,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1556
+Index: geneve-ut-1559
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14540,7 +14540,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1557
+Index: geneve-ut-1560
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14568,7 +14568,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1573
+Index: geneve-ut-1576
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14589,7 +14589,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1575
+Index: geneve-ut-1578
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14617,7 +14617,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1577
+Index: geneve-ut-1580
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14657,7 +14657,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1578
+Index: geneve-ut-1581
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14674,7 +14674,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1579
+Index: geneve-ut-1582
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14688,7 +14688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1580
+Index: geneve-ut-1583
 
 ```python
 file where host.os.type == "windows" and
@@ -14707,7 +14707,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1581
+Index: geneve-ut-1584
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14721,7 +14721,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1583
+Index: geneve-ut-1586
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14739,7 +14739,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1585
+Index: geneve-ut-1588
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14757,7 +14757,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1588
+Index: geneve-ut-1591
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14771,7 +14771,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1590
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14786,7 +14786,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1591
+Index: geneve-ut-1594
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14809,7 +14809,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1593
+Index: geneve-ut-1596
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14891,7 +14891,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1594
+Index: geneve-ut-1597
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14912,7 +14912,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1595
+Index: geneve-ut-1598
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14938,7 +14938,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1598
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14991,7 +14991,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1599
+Index: geneve-ut-1602
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15003,7 +15003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1600
+Index: geneve-ut-1603
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15015,7 +15015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1601
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and
@@ -15030,7 +15030,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1602
+Index: geneve-ut-1605
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15060,7 +15060,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1603
+Index: geneve-ut-1606
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15120,7 +15120,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1606
+Index: geneve-ut-1609
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15133,7 +15133,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1607
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15165,7 +15165,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1608
+Index: geneve-ut-1611
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15189,7 +15189,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1610
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15222,7 +15222,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1611
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15239,7 +15239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1613
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15268,7 +15268,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1614
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15282,7 +15282,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1615
+Index: geneve-ut-1618
 
 ```python
 sequence by process.entity_id
@@ -15307,7 +15307,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1616
+Index: geneve-ut-1619
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15341,7 +15341,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1617
+Index: geneve-ut-1620
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15369,7 +15369,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1618
+Index: geneve-ut-1621
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15388,7 +15388,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1624
+Index: geneve-ut-1627
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15416,7 +15416,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1625
+Index: geneve-ut-1628
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15435,7 +15435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1629
+Index: geneve-ut-1632
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15447,7 +15447,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1630
+Index: geneve-ut-1633
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15459,7 +15459,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1631
+Index: geneve-ut-1634
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15471,7 +15471,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1632
+Index: geneve-ut-1635
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15483,7 +15483,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1643
+Index: geneve-ut-1646
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15496,7 +15496,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1644
+Index: geneve-ut-1647
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15534,7 +15534,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1646
+Index: geneve-ut-1649
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15549,7 +15549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1647
+Index: geneve-ut-1650
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15568,7 +15568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1648
+Index: geneve-ut-1651
 
 ```python
 sequence with maxspan=1m
@@ -15616,7 +15616,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1650
+Index: geneve-ut-1653
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15639,7 +15639,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1652
+Index: geneve-ut-1655
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15653,7 +15653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1653
+Index: geneve-ut-1656
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15667,7 +15667,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1655
+Index: geneve-ut-1658
 
 ```python
 sequence by host.id, process.entity_id
@@ -15684,7 +15684,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1656
+Index: geneve-ut-1659
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15698,7 +15698,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1657
+Index: geneve-ut-1660
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15718,7 +15718,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1658
+Index: geneve-ut-1661
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15747,7 +15747,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1659
+Index: geneve-ut-1662
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15767,7 +15767,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1660
+Index: geneve-ut-1663
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15780,7 +15780,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1662
+Index: geneve-ut-1665
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15822,7 +15822,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1663
+Index: geneve-ut-1666
 
 ```python
 sequence with maxspan=1m
@@ -15845,7 +15845,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1664
+Index: geneve-ut-1667
 
 ```python
 sequence with maxspan=1s
@@ -15893,7 +15893,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1665
+Index: geneve-ut-1668
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15910,7 +15910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1667
+Index: geneve-ut-1670
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15939,7 +15939,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1669
+Index: geneve-ut-1673
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15967,7 +15967,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1670
+Index: geneve-ut-1674
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15984,7 +15984,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1672
+Index: geneve-ut-1676
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16003,7 +16003,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1673
+Index: geneve-ut-1677
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16024,7 +16024,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1682
+Index: geneve-ut-1686
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16038,7 +16038,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1684
+Index: geneve-ut-1688
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16057,7 +16057,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1685
+Index: geneve-ut-1689
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16071,7 +16071,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1686
+Index: geneve-ut-1690
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16091,7 +16091,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1688
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16109,7 +16109,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1689
+Index: geneve-ut-1693
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16130,7 +16130,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1691
+Index: geneve-ut-1695
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16144,7 +16144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1692
+Index: geneve-ut-1696
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16159,7 +16159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1693
+Index: geneve-ut-1697
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16200,7 +16200,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1695
+Index: geneve-ut-1699
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16225,7 +16225,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1696
+Index: geneve-ut-1700
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16264,7 +16264,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1697
+Index: geneve-ut-1701
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16278,7 +16278,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1698
+Index: geneve-ut-1702
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16317,7 +16317,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1699
+Index: geneve-ut-1703
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16331,7 +16331,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1700
+Index: geneve-ut-1704
 
 ```python
 process where event.type == "start" and
@@ -16403,7 +16403,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1704
+Index: geneve-ut-1708
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16424,7 +16424,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1707
+Index: geneve-ut-1711
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16441,7 +16441,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1710
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16459,7 +16459,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1711
+Index: geneve-ut-1715
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16471,7 +16471,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1712
+Index: geneve-ut-1716
 
 ```python
 file where host.os.type == "windows" and
@@ -16504,7 +16504,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1715
+Index: geneve-ut-1719
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16536,7 +16536,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1717
+Index: geneve-ut-1721
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16572,7 +16572,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1718
+Index: geneve-ut-1722
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16589,7 +16589,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1719
+Index: geneve-ut-1723
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16609,7 +16609,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1721
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16624,7 +16624,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1722
+Index: geneve-ut-1726
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16645,7 +16645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1723
+Index: geneve-ut-1727
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16668,7 +16668,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1724
+Index: geneve-ut-1728
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16681,7 +16681,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1725
+Index: geneve-ut-1729
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16698,7 +16698,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1728
+Index: geneve-ut-1732
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16723,7 +16723,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1731
+Index: geneve-ut-1735
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16754,7 +16754,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1732
+Index: geneve-ut-1736
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16803,7 +16803,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1733
+Index: geneve-ut-1737
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16817,7 +16817,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1734
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16832,7 +16832,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1735
+Index: geneve-ut-1739
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16847,7 +16847,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1736
+Index: geneve-ut-1740
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16869,7 +16869,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1737
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16890,7 +16890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1741
+Index: geneve-ut-1745
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16904,7 +16904,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1742
+Index: geneve-ut-1746
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16927,7 +16927,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1772
+Index: geneve-ut-1776
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16952,7 +16952,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1773
+Index: geneve-ut-1777
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16985,7 +16985,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1774
+Index: geneve-ut-1778
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17044,7 +17044,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1776
+Index: geneve-ut-1780
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17062,7 +17062,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1777
+Index: geneve-ut-1781
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17074,7 +17074,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1780
+Index: geneve-ut-1784
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17099,7 +17099,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1786
+Index: geneve-ut-1790
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17114,7 +17114,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1787
+Index: geneve-ut-1791
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17137,7 +17137,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1790
+Index: geneve-ut-1794
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17151,7 +17151,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1792
+Index: geneve-ut-1796
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17173,7 +17173,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1794
+Index: geneve-ut-1798
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17200,7 +17200,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1798
+Index: geneve-ut-1802
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17239,7 +17239,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1799
+Index: geneve-ut-1803
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17262,7 +17262,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1800
+Index: geneve-ut-1804
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17276,7 +17276,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1801
+Index: geneve-ut-1805
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17292,7 +17292,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1802
+Index: geneve-ut-1806
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17308,7 +17308,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1803
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17322,7 +17322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1805
+Index: geneve-ut-1809
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17345,7 +17345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1806
+Index: geneve-ut-1810
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17373,7 +17373,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1807
+Index: geneve-ut-1811
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +17388,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1810
+Index: geneve-ut-1814
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17415,7 +17415,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1812
+Index: geneve-ut-1816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17446,7 +17446,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1813
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17462,7 +17462,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1814
+Index: geneve-ut-1818
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17475,7 +17475,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1816
+Index: geneve-ut-1820
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17491,7 +17491,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1817
+Index: geneve-ut-1821
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17507,7 +17507,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1818
+Index: geneve-ut-1822
 
 ```python
 any where host.os.type == "windows" and 
@@ -17574,7 +17574,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1820
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17590,7 +17590,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1822
+Index: geneve-ut-1826
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17626,7 +17626,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1823
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +17664,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1824
+Index: geneve-ut-1828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17699,7 +17699,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1825
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +17733,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1827
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17754,7 +17754,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1832
+Index: geneve-ut-1836
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17831,7 +17831,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1833
+Index: geneve-ut-1837
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17853,7 +17853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1834
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17877,7 +17877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1836
+Index: geneve-ut-1840
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17898,7 +17898,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1839
+Index: geneve-ut-1843
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17913,7 +17913,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1842
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17926,7 +17926,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1843
+Index: geneve-ut-1847
 
 ```python
 any where host.os.type == "windows" and
@@ -17941,7 +17941,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1844
+Index: geneve-ut-1848
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17957,7 +17957,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1845
+Index: geneve-ut-1849
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17971,7 +17971,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1849
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18028,7 +18028,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1850
+Index: geneve-ut-1854
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18042,7 +18042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1852
+Index: geneve-ut-1856
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18074,7 +18074,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1854
+Index: geneve-ut-1858
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18087,7 +18087,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1855
+Index: geneve-ut-1859
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18106,7 +18106,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1856
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18152,7 +18152,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1858
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18173,7 +18173,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1859
+Index: geneve-ut-1863
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18193,7 +18193,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1860
+Index: geneve-ut-1864
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18207,7 +18207,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1861
+Index: geneve-ut-1865
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18239,7 +18239,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1864
+Index: geneve-ut-1868
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18260,7 +18260,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1866
+Index: geneve-ut-1870
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18361,7 +18361,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1870
+Index: geneve-ut-1874
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18409,7 +18409,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1873
+Index: geneve-ut-1877
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18435,7 +18435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1874
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18480,7 +18480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1875
+Index: geneve-ut-1879
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18504,7 +18504,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1876
+Index: geneve-ut-1880
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18520,7 +18520,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1878
+Index: geneve-ut-1882
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18545,7 +18545,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1879
+Index: geneve-ut-1883
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18560,7 +18560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1882
+Index: geneve-ut-1886
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18574,7 +18574,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1883
+Index: geneve-ut-1887
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18594,7 +18594,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1884
+Index: geneve-ut-1888
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18629,7 +18629,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1888
+Index: geneve-ut-1892
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18647,7 +18647,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1889
+Index: geneve-ut-1893
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18660,7 +18660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1892
+Index: geneve-ut-1896
 
 ```python
 any where host.os.type == "windows" and
@@ -18693,7 +18693,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1894
+Index: geneve-ut-1898
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18711,7 +18711,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1895
+Index: geneve-ut-1899
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18733,7 +18733,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1898
+Index: geneve-ut-1902
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18772,7 +18772,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1899
+Index: geneve-ut-1903
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18802,7 +18802,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1900
+Index: geneve-ut-1904
 
 ```python
 any where host.os.type == "windows" and
@@ -18836,7 +18836,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1901
+Index: geneve-ut-1905
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18850,7 +18850,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1904
+Index: geneve-ut-1908
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18881,7 +18881,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1905
+Index: geneve-ut-1909
 
 ```python
 any where host.os.type == "windows" and
@@ -18901,7 +18901,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1906
+Index: geneve-ut-1910
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18942,7 +18942,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1907
+Index: geneve-ut-1911
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18958,7 +18958,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1908
+Index: geneve-ut-1912
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18988,7 +18988,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1912
+Index: geneve-ut-1916
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19001,7 +19001,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1913
+Index: geneve-ut-1917
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19025,7 +19025,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1916
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19043,7 +19043,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1918
+Index: geneve-ut-1922
 
 ```python
 any where host.os.type == "windows" and
@@ -19058,7 +19058,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1919
+Index: geneve-ut-1923
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19076,7 +19076,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1920
+Index: geneve-ut-1924
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19097,7 +19097,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1921
+Index: geneve-ut-1925
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19116,7 +19116,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1924
+Index: geneve-ut-1928
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19141,7 +19141,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1925
+Index: geneve-ut-1929
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19154,7 +19154,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1927
+Index: geneve-ut-1931
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19167,7 +19167,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1929
+Index: geneve-ut-1933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19190,7 +19190,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1931
+Index: geneve-ut-1935
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19209,7 +19209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1932
+Index: geneve-ut-1936
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19231,7 +19231,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1933
+Index: geneve-ut-1937
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19264,7 +19264,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1935
+Index: geneve-ut-1939
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19282,7 +19282,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1936
+Index: geneve-ut-1940
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19296,7 +19296,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1937
+Index: geneve-ut-1941
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19320,7 +19320,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1938
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19343,7 +19343,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1939
+Index: geneve-ut-1943
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19362,7 +19362,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1942
+Index: geneve-ut-1946
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19381,7 +19381,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1944
+Index: geneve-ut-1948
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19416,7 +19416,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1945
+Index: geneve-ut-1949
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19433,7 +19433,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1946
+Index: geneve-ut-1950
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1947
+Index: geneve-ut-1951
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19493,7 +19493,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1948
+Index: geneve-ut-1952
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19509,7 +19509,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1949
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19523,7 +19523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1950
+Index: geneve-ut-1954
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19561,7 +19561,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1951
+Index: geneve-ut-1955
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19615,7 +19615,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1952
+Index: geneve-ut-1956
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19643,7 +19643,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1954
+Index: geneve-ut-1958
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19657,7 +19657,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1955
+Index: geneve-ut-1959
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19703,7 +19703,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1956
+Index: geneve-ut-1960
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19742,7 +19742,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1957
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19755,7 +19755,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1961
+Index: geneve-ut-1965
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19788,7 +19788,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1962
+Index: geneve-ut-1966
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19802,7 +19802,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1963
+Index: geneve-ut-1967
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19816,7 +19816,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1964
+Index: geneve-ut-1968
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19830,7 +19830,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1965
+Index: geneve-ut-1969
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19869,7 +19869,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1973
+Index: geneve-ut-1977
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19911,7 +19911,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1975
+Index: geneve-ut-1979
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19933,7 +19933,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1977
+Index: geneve-ut-1981
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19946,7 +19946,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1980
+Index: geneve-ut-1984
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19963,7 +19963,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1981
+Index: geneve-ut-1985
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19979,7 +19979,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1982
+Index: geneve-ut-1986
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19992,7 +19992,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1983
+Index: geneve-ut-1987
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20007,7 +20007,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1984
+Index: geneve-ut-1988
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20030,7 +20030,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1985
+Index: geneve-ut-1989
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20046,7 +20046,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1986
+Index: geneve-ut-1990
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20062,7 +20062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1992
+Index: geneve-ut-1996
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20074,7 +20074,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1993
+Index: geneve-ut-1997
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20103,7 +20103,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1995
+Index: geneve-ut-1999
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20117,7 +20117,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2000
+Index: geneve-ut-2004
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20137,7 +20137,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2001
+Index: geneve-ut-2005
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20162,7 +20162,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2008
+Index: geneve-ut-2012
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20176,7 +20176,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2009
+Index: geneve-ut-2013
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20199,7 +20199,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2018
+Index: geneve-ut-2022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20233,7 +20233,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2020
+Index: geneve-ut-2024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20252,7 +20252,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2027
+Index: geneve-ut-2031
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20271,7 +20271,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2042
+Index: geneve-ut-2046
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20288,7 +20288,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2045
+Index: geneve-ut-2049
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20305,7 +20305,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2061
+Index: geneve-ut-2065
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20324,7 +20324,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2065
+Index: geneve-ut-2069
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20366,7 +20366,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2066
+Index: geneve-ut-2070
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20411,7 +20411,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2069
+Index: geneve-ut-2073
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20453,7 +20453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2071
+Index: geneve-ut-2075
 
 ```python
 host.os.type:"linux" and 
@@ -20481,7 +20481,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2075
+Index: geneve-ut-2079
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20505,7 +20505,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2076
+Index: geneve-ut-2080
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20545,7 +20545,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2077
+Index: geneve-ut-2081
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20592,7 +20592,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2081
+Index: geneve-ut-2085
 
 ```python
 sequence by process.entity_id
@@ -20629,7 +20629,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2113
+Index: geneve-ut-2117
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20643,7 +20643,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2114
+Index: geneve-ut-2118
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20686,7 +20686,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2115
+Index: geneve-ut-2119
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20699,7 +20699,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2118
+Index: geneve-ut-2122
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20713,7 +20713,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2119
+Index: geneve-ut-2123
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20726,7 +20726,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2123
+Index: geneve-ut-2127
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20751,7 +20751,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2124
+Index: geneve-ut-2128
 
 ```python
 process where event.type == "start" and
@@ -20766,7 +20766,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2125
+Index: geneve-ut-2129
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20783,7 +20783,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2126
+Index: geneve-ut-2130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20797,7 +20797,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2127
+Index: geneve-ut-2131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20813,7 +20813,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2128
+Index: geneve-ut-2132
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20827,7 +20827,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2129
+Index: geneve-ut-2133
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20854,7 +20854,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2131
+Index: geneve-ut-2135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20866,7 +20866,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2132
+Index: geneve-ut-2136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20882,7 +20882,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2133
+Index: geneve-ut-2137
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20905,7 +20905,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2134
+Index: geneve-ut-2138
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20918,7 +20918,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2136
+Index: geneve-ut-2140
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20930,7 +20930,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2137
+Index: geneve-ut-2141
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20942,7 +20942,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2138
+Index: geneve-ut-2142
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20954,7 +20954,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2139
+Index: geneve-ut-2143
 
 ```python
 web where (
@@ -20982,7 +20982,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2145
+Index: geneve-ut-2149
 
 ```python
 any where (
@@ -21054,7 +21054,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2147
+Index: geneve-ut-2151
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21075,7 +21075,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2150
+Index: geneve-ut-2154
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21089,7 +21089,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2151
+Index: geneve-ut-2155
 
 ```python
 file where event.type == "deletion" and
@@ -21106,7 +21106,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2152
+Index: geneve-ut-2156
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21124,7 +21124,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2155
+Index: geneve-ut-2159
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21162,7 +21162,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2157
+Index: geneve-ut-2161
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21199,7 +21199,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2158
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21214,7 +21214,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2159
+Index: geneve-ut-2163
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21227,7 +21227,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2160
+Index: geneve-ut-2164
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21246,7 +21246,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2161
+Index: geneve-ut-2165
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21271,7 +21271,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2162
+Index: geneve-ut-2166
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21297,7 +21297,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2163
+Index: geneve-ut-2167
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21319,7 +21319,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2164
+Index: geneve-ut-2168
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21336,7 +21336,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2166
+Index: geneve-ut-2170
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21355,7 +21355,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2167
+Index: geneve-ut-2171
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21395,7 +21395,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2168
+Index: geneve-ut-2172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21412,7 +21412,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2170
+Index: geneve-ut-2174
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21425,7 +21425,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2171
+Index: geneve-ut-2175
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21439,7 +21439,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2172
+Index: geneve-ut-2176
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21467,7 +21467,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2173
+Index: geneve-ut-2177
 
 ```python
 process where event.type == "start" and
@@ -21492,7 +21492,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2174
+Index: geneve-ut-2178
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21506,7 +21506,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2175
+Index: geneve-ut-2179
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21522,7 +21522,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2176
+Index: geneve-ut-2180
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21557,7 +21557,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2177
+Index: geneve-ut-2181
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21575,7 +21575,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2180
+Index: geneve-ut-2184
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.6.md
+++ b/tests/reports/alerts_from_rules-9.6.md
@@ -5,7 +5,7 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.2
+Rules version: 9.5.3
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
@@ -20,7 +20,7 @@ Rules version: 9.5.2
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367  
+Index: geneve-ut-0368  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378  
+Index: geneve-ut-0379  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -190,7 +190,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646  
+Index: geneve-ut-0647  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671  
+Index: geneve-ut-0672  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805  
+Index: geneve-ut-0807  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998  
+Index: geneve-ut-1000  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143  
+Index: geneve-ut-1145  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173  
+Index: geneve-ut-1175  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245  
+Index: geneve-ut-1248  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274  
+Index: geneve-ut-1277  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292  
+Index: geneve-ut-1295  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356  
+Index: geneve-ut-1359  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371  
+Index: geneve-ut-1374  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461  
+Index: geneve-ut-1464  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705  
+Index: geneve-ut-1709  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709  
+Index: geneve-ut-1713  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793  
+Index: geneve-ut-1797  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808  
+Index: geneve-ut-1812  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821  
+Index: geneve-ut-1825  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831  
+Index: geneve-ut-1835  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837  
+Index: geneve-ut-1841  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846  
+Index: geneve-ut-1850  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943  
+Index: geneve-ut-1947  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974  
+Index: geneve-ut-1978  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1123,7 +1123,7 @@ container.id like "*"
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367
+Index: geneve-ut-0368
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1175,7 +1175,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378
+Index: geneve-ut-0379
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -1287,7 +1287,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646
+Index: geneve-ut-0647
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1353,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671
+Index: geneve-ut-0672
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805
+Index: geneve-ut-0807
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998
+Index: geneve-ut-1000
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143
+Index: geneve-ut-1145
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245
+Index: geneve-ut-1248
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292
+Index: geneve-ut-1295
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461
+Index: geneve-ut-1464
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709
+Index: geneve-ut-1713
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793
+Index: geneve-ut-1797
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808
+Index: geneve-ut-1812
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821
+Index: geneve-ut-1825
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837
+Index: geneve-ut-1841
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943
+Index: geneve-ut-1947
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974
+Index: geneve-ut-1978
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0999
+Index: geneve-ut-1001
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1019
+Index: geneve-ut-1021
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1408
+Index: geneve-ut-1411
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1609
+Index: geneve-ut-1612
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2227,7 +2227,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367  
+Index: geneve-ut-0368  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2281,7 +2281,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378  
+Index: geneve-ut-0379  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -2395,7 +2395,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646  
+Index: geneve-ut-0647  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2463,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671  
+Index: geneve-ut-0672  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805  
+Index: geneve-ut-0807  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0971  
+Index: geneve-ut-0973  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998  
+Index: geneve-ut-1000  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1121  
+Index: geneve-ut-1123  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143  
+Index: geneve-ut-1145  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173  
+Index: geneve-ut-1175  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245  
+Index: geneve-ut-1248  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274  
+Index: geneve-ut-1277  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292  
+Index: geneve-ut-1295  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356  
+Index: geneve-ut-1359  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371  
+Index: geneve-ut-1374  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1452  
+Index: geneve-ut-1455  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461  
+Index: geneve-ut-1464  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1576  
+Index: geneve-ut-1579  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705  
+Index: geneve-ut-1709  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709  
+Index: geneve-ut-1713  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793  
+Index: geneve-ut-1797  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808  
+Index: geneve-ut-1812  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821  
+Index: geneve-ut-1825  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831  
+Index: geneve-ut-1835  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837  
+Index: geneve-ut-1841  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846  
+Index: geneve-ut-1850  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943  
+Index: geneve-ut-1947  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974  
+Index: geneve-ut-1978  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -4269,7 +4269,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0323
+Index: geneve-ut-0324
 
 ```python
 event.dataset:azure.activitylogs and
@@ -4283,7 +4283,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0326
+Index: geneve-ut-0327
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -4301,7 +4301,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0344
+Index: geneve-ut-0345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4319,7 +4319,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0345
+Index: geneve-ut-0346
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4337,7 +4337,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0346
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4352,7 +4352,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0347
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4366,7 +4366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0348
+Index: geneve-ut-0349
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4381,7 +4381,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0351
+Index: geneve-ut-0352
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4398,7 +4398,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0352
+Index: geneve-ut-0353
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4410,7 +4410,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0353
+Index: geneve-ut-0354
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4422,7 +4422,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0354
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4437,7 +4437,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0355
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4457,7 +4457,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0356
+Index: geneve-ut-0357
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4479,7 +4479,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0358
+Index: geneve-ut-0359
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4525,7 +4525,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0359
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4559,7 +4559,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0360
+Index: geneve-ut-0361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4582,7 +4582,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0362
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4604,7 +4604,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0363
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4632,7 +4632,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0364
+Index: geneve-ut-0365
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4648,7 +4648,7 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0366
+Index: geneve-ut-0367
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4673,7 +4673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0368
+Index: geneve-ut-0369
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4703,7 +4703,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0370
+Index: geneve-ut-0371
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4717,7 +4717,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0371
+Index: geneve-ut-0372
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4739,7 +4739,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0372
+Index: geneve-ut-0373
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4753,7 +4753,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0373
+Index: geneve-ut-0374
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4773,7 +4773,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0376
+Index: geneve-ut-0377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4790,7 +4790,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0379
+Index: geneve-ut-0380
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4820,7 +4820,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0382
+Index: geneve-ut-0383
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4845,7 +4845,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0384
+Index: geneve-ut-0385
 
 ```python
 sequence by process.entity_id
@@ -4866,7 +4866,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0385
+Index: geneve-ut-0386
 
 ```python
 sequence by process.entity_id
@@ -4887,7 +4887,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0388
+Index: geneve-ut-0389
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4918,7 +4918,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0389
+Index: geneve-ut-0390
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4930,7 +4930,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0390
+Index: geneve-ut-0391
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4953,7 +4953,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0393
+Index: geneve-ut-0394
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4966,7 +4966,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0394
+Index: geneve-ut-0395
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4979,7 +4979,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0396
+Index: geneve-ut-0397
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4996,7 +4996,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0397
+Index: geneve-ut-0398
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -5009,7 +5009,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0398
+Index: geneve-ut-0399
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -5026,7 +5026,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0399
+Index: geneve-ut-0400
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -5038,7 +5038,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0400
+Index: geneve-ut-0401
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -5106,7 +5106,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0401
+Index: geneve-ut-0402
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -5124,7 +5124,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0402
+Index: geneve-ut-0403
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -5137,7 +5137,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0403
+Index: geneve-ut-0404
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5155,7 +5155,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0404
+Index: geneve-ut-0405
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5167,7 +5167,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0405
+Index: geneve-ut-0406
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5179,7 +5179,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0406
+Index: geneve-ut-0407
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5191,7 +5191,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0407
+Index: geneve-ut-0408
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5203,7 +5203,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0408
+Index: geneve-ut-0409
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -5248,7 +5248,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0410
+Index: geneve-ut-0411
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5268,7 +5268,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0411
+Index: geneve-ut-0412
 
 ```python
 sequence with maxspan=10s
@@ -5288,7 +5288,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0412
+Index: geneve-ut-0413
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5315,7 +5315,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0413
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5329,7 +5329,7 @@ container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0416
+Index: geneve-ut-0417
 
 ```python
 process where event.type == "start" and
@@ -5354,7 +5354,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0419
+Index: geneve-ut-0420
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5398,7 +5398,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0420
+Index: geneve-ut-0421
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5432,7 +5432,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0422
+Index: geneve-ut-0423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5477,7 +5477,7 @@ container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0423
+Index: geneve-ut-0424
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5493,7 +5493,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0424
+Index: geneve-ut-0425
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5518,7 +5518,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0425
+Index: geneve-ut-0426
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5537,7 +5537,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0427
+Index: geneve-ut-0428
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5664,7 +5664,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0428
+Index: geneve-ut-0429
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5682,7 +5682,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0430
+Index: geneve-ut-0431
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5695,7 +5695,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0431
+Index: geneve-ut-0432
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5725,7 +5725,7 @@ container.security_context.privileged == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0437
+Index: geneve-ut-0438
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5739,7 +5739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0449
+Index: geneve-ut-0450
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5760,7 +5760,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0456
+Index: geneve-ut-0457
 
 ```python
 registry where host.os.type == "windows" and
@@ -5774,7 +5774,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0468
+Index: geneve-ut-0469
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5798,7 +5798,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0507
+Index: geneve-ut-0508
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5852,7 +5852,7 @@ container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0509
+Index: geneve-ut-0510
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5868,7 +5868,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0510
+Index: geneve-ut-0511
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5896,7 +5896,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0511
+Index: geneve-ut-0512
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5913,7 +5913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0512
+Index: geneve-ut-0513
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5930,7 +5930,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0513
+Index: geneve-ut-0514
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5951,7 +5951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0515
+Index: geneve-ut-0516
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5971,7 +5971,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0516
+Index: geneve-ut-0517
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5986,7 +5986,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0518
+Index: geneve-ut-0519
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5999,7 +5999,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0519
+Index: geneve-ut-0520
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6019,7 +6019,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0522
+Index: geneve-ut-0523
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -6032,7 +6032,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0523
+Index: geneve-ut-0524
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6070,7 +6070,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0524
+Index: geneve-ut-0525
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -6090,7 +6090,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0525
+Index: geneve-ut-0526
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6103,7 +6103,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0526
+Index: geneve-ut-0527
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -6126,7 +6126,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0528
+Index: geneve-ut-0529
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6157,7 +6157,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0529
+Index: geneve-ut-0530
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -6176,7 +6176,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0530
+Index: geneve-ut-0531
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6219,7 +6219,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0531
+Index: geneve-ut-0532
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -6233,7 +6233,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0533
+Index: geneve-ut-0534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6248,7 +6248,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0534
+Index: geneve-ut-0535
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6264,7 +6264,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0535
+Index: geneve-ut-0536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6278,7 +6278,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0536
+Index: geneve-ut-0537
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6304,7 +6304,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0537
+Index: geneve-ut-0538
 
 ```python
 process where event.type == "start" and
@@ -6342,7 +6342,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0544
+Index: geneve-ut-0545
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -6355,7 +6355,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0545
+Index: geneve-ut-0546
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6369,7 +6369,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0546
+Index: geneve-ut-0547
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6391,7 +6391,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0547
+Index: geneve-ut-0548
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6426,7 +6426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0548
+Index: geneve-ut-0549
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6438,7 +6438,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0596
+Index: geneve-ut-0597
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6450,7 +6450,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0622
+Index: geneve-ut-0623
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6464,7 +6464,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0625
+Index: geneve-ut-0626
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6491,7 +6491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0628
+Index: geneve-ut-0629
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6512,7 +6512,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0629
+Index: geneve-ut-0630
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6542,7 +6542,7 @@ container.id like "*"
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0632
+Index: geneve-ut-0633
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6560,7 +6560,7 @@ container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0633
+Index: geneve-ut-0634
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6593,7 +6593,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0635
+Index: geneve-ut-0636
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6610,7 +6610,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0636
+Index: geneve-ut-0637
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6638,7 +6638,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0637
+Index: geneve-ut-0638
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6651,7 +6651,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0639
+Index: geneve-ut-0640
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6671,7 +6671,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0640
+Index: geneve-ut-0641
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6697,7 +6697,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0641
+Index: geneve-ut-0642
 
 ```python
 sequence with maxspan=2h
@@ -6719,7 +6719,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0642
+Index: geneve-ut-0643
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6748,7 +6748,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0645
+Index: geneve-ut-0646
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6761,7 +6761,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0649
+Index: geneve-ut-0650
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6776,7 +6776,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0650
+Index: geneve-ut-0651
 
 ```python
 process where event.type == "start" and
@@ -6798,7 +6798,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0652
+Index: geneve-ut-0653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6810,7 +6810,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0653
+Index: geneve-ut-0654
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6832,7 +6832,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0655
+Index: geneve-ut-0656
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6849,7 +6849,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0656
+Index: geneve-ut-0657
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6863,7 +6863,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0657
+Index: geneve-ut-0658
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6876,7 +6876,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0658
+Index: geneve-ut-0659
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6888,7 +6888,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0659
+Index: geneve-ut-0660
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6900,7 +6900,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0660
+Index: geneve-ut-0661
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6914,7 +6914,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0661
+Index: geneve-ut-0662
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6926,7 +6926,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0662
+Index: geneve-ut-0663
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -6948,7 +6948,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0666
+Index: geneve-ut-0667
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6997,7 +6997,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0667
+Index: geneve-ut-0668
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -7014,7 +7014,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0668
+Index: geneve-ut-0669
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7034,7 +7034,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0673
+Index: geneve-ut-0674
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7056,7 +7056,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0676
+Index: geneve-ut-0677
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7071,7 +7071,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0677
+Index: geneve-ut-0678
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7085,7 +7085,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0679
+Index: geneve-ut-0680
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7107,7 +7107,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0681
+Index: geneve-ut-0682
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -7128,7 +7128,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0682
+Index: geneve-ut-0683
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7154,7 +7154,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0683
+Index: geneve-ut-0684
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -7182,7 +7182,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0686
+Index: geneve-ut-0687
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -7196,7 +7196,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0724
+Index: geneve-ut-0726
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -7213,7 +7213,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0725
+Index: geneve-ut-0727
 
 ```python
 registry where host.os.type == "windows" and
@@ -7231,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0795
+Index: geneve-ut-0797
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0796
+Index: geneve-ut-0798
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0797
+Index: geneve-ut-0799
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0798
+Index: geneve-ut-0800
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0806
+Index: geneve-ut-0808
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0807
+Index: geneve-ut-0809
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0808
+Index: geneve-ut-0810
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0809
+Index: geneve-ut-0811
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0813
+Index: geneve-ut-0815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0816
+Index: geneve-ut-0818
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0819
+Index: geneve-ut-0821
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0823
+Index: geneve-ut-0825
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0825
+Index: geneve-ut-0827
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0851
+Index: geneve-ut-0853
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0854
+Index: geneve-ut-0856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0855
+Index: geneve-ut-0857
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0868
+Index: geneve-ut-0870
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0869
+Index: geneve-ut-0871
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0870
+Index: geneve-ut-0872
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0874
+Index: geneve-ut-0876
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0880
+Index: geneve-ut-0882
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0882
+Index: geneve-ut-0884
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0883
+Index: geneve-ut-0885
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0884
+Index: geneve-ut-0886
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0885
+Index: geneve-ut-0887
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0886
+Index: geneve-ut-0888
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0887
+Index: geneve-ut-0889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0892
+Index: geneve-ut-0894
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0894
+Index: geneve-ut-0896
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0895
+Index: geneve-ut-0897
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0896
+Index: geneve-ut-0898
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7897,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0897
+Index: geneve-ut-0899
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7921,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0902
+Index: geneve-ut-0904
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0904
+Index: geneve-ut-0906
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0905
+Index: geneve-ut-0907
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0906
+Index: geneve-ut-0908
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0907
+Index: geneve-ut-0909
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0908
+Index: geneve-ut-0910
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0909
+Index: geneve-ut-0911
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0910
+Index: geneve-ut-0912
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0911
+Index: geneve-ut-0913
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0912
+Index: geneve-ut-0914
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0913
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0915
+Index: geneve-ut-0917
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0917
+Index: geneve-ut-0919
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0918
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0919
+Index: geneve-ut-0921
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0920
+Index: geneve-ut-0922
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0922
+Index: geneve-ut-0924
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0923
+Index: geneve-ut-0925
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0925
+Index: geneve-ut-0927
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0927
+Index: geneve-ut-0929
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0928
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0930
+Index: geneve-ut-0932
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0931
+Index: geneve-ut-0933
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8436,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0932
+Index: geneve-ut-0934
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8463,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0935
+Index: geneve-ut-0937
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0936
+Index: geneve-ut-0938
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0946
+Index: geneve-ut-0948
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0972
+Index: geneve-ut-0974
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0975
+Index: geneve-ut-0977
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0977
+Index: geneve-ut-0979
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0989
+Index: geneve-ut-0991
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0994
+Index: geneve-ut-0996
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0995
+Index: geneve-ut-0997
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1000
+Index: geneve-ut-1002
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1015
+Index: geneve-ut-1017
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1018
+Index: geneve-ut-1020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1020
+Index: geneve-ut-1022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1021
+Index: geneve-ut-1023
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1025
+Index: geneve-ut-1027
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1026
+Index: geneve-ut-1028
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8863,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1029
+Index: geneve-ut-1031
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1031
+Index: geneve-ut-1033
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1032
+Index: geneve-ut-1034
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1068
+Index: geneve-ut-1070
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1069
+Index: geneve-ut-1071
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1070
+Index: geneve-ut-1072
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1071
+Index: geneve-ut-1073
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1072
+Index: geneve-ut-1074
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1080
+Index: geneve-ut-1082
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1083
+Index: geneve-ut-1085
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1084
+Index: geneve-ut-1086
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1085
+Index: geneve-ut-1087
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1089
+Index: geneve-ut-1091
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1090
+Index: geneve-ut-1092
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1092
+Index: geneve-ut-1094
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1093
+Index: geneve-ut-1095
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1094
+Index: geneve-ut-1096
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1095
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1096
+Index: geneve-ut-1098
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1097
+Index: geneve-ut-1099
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9142,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1098
+Index: geneve-ut-1100
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9167,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1100
+Index: geneve-ut-1102
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1103
+Index: geneve-ut-1105
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1104
+Index: geneve-ut-1106
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1105
+Index: geneve-ut-1107
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1108
+Index: geneve-ut-1110
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1109
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1110
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1114
+Index: geneve-ut-1116
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1115
+Index: geneve-ut-1117
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1116
+Index: geneve-ut-1118
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1120
+Index: geneve-ut-1122
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1122
+Index: geneve-ut-1124
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1124
+Index: geneve-ut-1126
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1125
+Index: geneve-ut-1127
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1127
+Index: geneve-ut-1129
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1128
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1132
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1131
+Index: geneve-ut-1133
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1133
+Index: geneve-ut-1135
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1134
+Index: geneve-ut-1136
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9604,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1136
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1137
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1138
+Index: geneve-ut-1140
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1139
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1140
+Index: geneve-ut-1142
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1141
+Index: geneve-ut-1143
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1142
+Index: geneve-ut-1144
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1155
+Index: geneve-ut-1157
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1164
+Index: geneve-ut-1166
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1168
+Index: geneve-ut-1170
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1169
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1170
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1171
+Index: geneve-ut-1173
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1172
+Index: geneve-ut-1174
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1174
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1175
+Index: geneve-ut-1177
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1177
+Index: geneve-ut-1179
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1179
+Index: geneve-ut-1181
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1180
+Index: geneve-ut-1182
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1181
+Index: geneve-ut-1183
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1183
+Index: geneve-ut-1185
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1184
+Index: geneve-ut-1186
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1185
+Index: geneve-ut-1187
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1186
+Index: geneve-ut-1188
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1188
+Index: geneve-ut-1190
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1189
+Index: geneve-ut-1191
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1190
+Index: geneve-ut-1192
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1191
+Index: geneve-ut-1193
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1192
+Index: geneve-ut-1194
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1196
+Index: geneve-ut-1198
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1197
+Index: geneve-ut-1199
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1198
+Index: geneve-ut-1200
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1203
+Index: geneve-ut-1205
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1206
+Index: geneve-ut-1208
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1215
+Index: geneve-ut-1218
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1216
+Index: geneve-ut-1219
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1217
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1218
+Index: geneve-ut-1221
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1220
+Index: geneve-ut-1223
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1221
+Index: geneve-ut-1224
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1223
+Index: geneve-ut-1226
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1232
+Index: geneve-ut-1235
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1233
+Index: geneve-ut-1236
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1234
+Index: geneve-ut-1237
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1235
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1236
+Index: geneve-ut-1239
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1237
+Index: geneve-ut-1240
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1238
+Index: geneve-ut-1241
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1239
+Index: geneve-ut-1242
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10670,7 +10670,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1246
+Index: geneve-ut-1249
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10685,7 +10685,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1247
+Index: geneve-ut-1250
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10699,7 +10699,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1248
+Index: geneve-ut-1251
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10718,7 +10718,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1249
+Index: geneve-ut-1252
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10730,7 +10730,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1250
+Index: geneve-ut-1253
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10742,7 +10742,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1251
+Index: geneve-ut-1254
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10760,7 +10760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1252
+Index: geneve-ut-1255
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10773,7 +10773,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1253
+Index: geneve-ut-1256
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10788,7 +10788,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1254
+Index: geneve-ut-1257
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10803,7 +10803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1257
+Index: geneve-ut-1260
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10823,7 +10823,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1258
+Index: geneve-ut-1261
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10847,7 +10847,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1259
+Index: geneve-ut-1262
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10861,7 +10861,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1260
+Index: geneve-ut-1263
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10880,7 +10880,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1261
+Index: geneve-ut-1264
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10908,7 +10908,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1262
+Index: geneve-ut-1265
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10937,7 +10937,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1263
+Index: geneve-ut-1266
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10956,7 +10956,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1264
+Index: geneve-ut-1267
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10984,7 +10984,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1265
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10999,7 +10999,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1266
+Index: geneve-ut-1269
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11062,7 +11062,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1267
+Index: geneve-ut-1270
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11083,7 +11083,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1268
+Index: geneve-ut-1271
 
 ```python
 any where host.os.type == "windows" and
@@ -11145,7 +11145,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1270
+Index: geneve-ut-1273
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11174,7 +11174,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1271
+Index: geneve-ut-1274
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11188,7 +11188,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1272
+Index: geneve-ut-1275
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11221,7 +11221,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1275
+Index: geneve-ut-1278
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11268,7 +11268,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1276
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11295,7 +11295,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1277
+Index: geneve-ut-1280
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11308,7 +11308,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1288
+Index: geneve-ut-1291
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11325,7 +11325,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1290
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11350,7 +11350,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1295
+Index: geneve-ut-1298
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11366,7 +11366,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1296
+Index: geneve-ut-1299
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11387,7 +11387,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1298
+Index: geneve-ut-1301
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11404,7 +11404,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1299
+Index: geneve-ut-1302
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11417,7 +11417,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1300
+Index: geneve-ut-1303
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11441,7 +11441,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1302
+Index: geneve-ut-1305
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11470,7 +11470,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1304
+Index: geneve-ut-1307
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11497,7 +11497,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11521,7 +11521,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1308
+Index: geneve-ut-1311
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11539,7 +11539,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1309
+Index: geneve-ut-1312
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11562,7 +11562,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1310
+Index: geneve-ut-1313
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11619,7 +11619,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11636,7 +11636,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1312
+Index: geneve-ut-1315
 
 ```python
 sequence by process.entity_id
@@ -11650,7 +11650,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1327
+Index: geneve-ut-1330
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11665,7 +11665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1328
+Index: geneve-ut-1331
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11696,7 +11696,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1329
+Index: geneve-ut-1332
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11710,7 +11710,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1330
+Index: geneve-ut-1333
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11723,7 +11723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11735,7 +11735,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11748,7 +11748,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11767,7 +11767,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1335
+Index: geneve-ut-1338
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11780,7 +11780,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1336
+Index: geneve-ut-1339
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11801,7 +11801,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11815,7 +11815,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11835,7 +11835,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1341
+Index: geneve-ut-1344
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11859,7 +11859,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1342
+Index: geneve-ut-1345
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11875,7 +11875,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1343
+Index: geneve-ut-1346
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11892,7 +11892,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1344
+Index: geneve-ut-1347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11913,7 +11913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1346
+Index: geneve-ut-1349
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11926,7 +11926,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1348
+Index: geneve-ut-1351
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11954,7 +11954,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1351
+Index: geneve-ut-1354
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11970,7 +11970,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1352
+Index: geneve-ut-1355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11993,7 +11993,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1353
+Index: geneve-ut-1356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12006,7 +12006,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12019,7 +12019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1360
+Index: geneve-ut-1363
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12033,7 +12033,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1361
+Index: geneve-ut-1364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +12048,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12071,7 +12071,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1366
+Index: geneve-ut-1369
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12114,7 +12114,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1367
+Index: geneve-ut-1370
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12132,7 +12132,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1368
+Index: geneve-ut-1371
 
 ```python
 host.os.type:"windows" and
@@ -12148,7 +12148,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12160,7 +12160,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1372
+Index: geneve-ut-1375
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12176,7 +12176,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12192,7 +12192,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12210,7 +12210,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12224,7 +12224,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1377
+Index: geneve-ut-1380
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12247,7 +12247,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1379
+Index: geneve-ut-1382
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12263,7 +12263,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12276,7 +12276,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1381
+Index: geneve-ut-1384
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12306,7 +12306,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1387
+Index: geneve-ut-1390
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12329,7 +12329,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1388
+Index: geneve-ut-1391
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12348,7 +12348,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1393
+Index: geneve-ut-1396
 
 ```python
 process where host.os.type == "windows" and 
@@ -12490,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1394
+Index: geneve-ut-1397
 
 ```python
 process where host.os.type == "windows" and
@@ -12567,7 +12567,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1398
+Index: geneve-ut-1401
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12584,7 +12584,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1399
+Index: geneve-ut-1402
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12618,7 +12618,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12630,7 +12630,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1402
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12669,7 +12669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1405
+Index: geneve-ut-1408
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12682,7 +12682,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1410
+Index: geneve-ut-1413
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12696,7 +12696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1417
+Index: geneve-ut-1420
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12734,7 +12734,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1418
+Index: geneve-ut-1421
 
 ```python
 network where host.os.type == "windows" and
@@ -12760,7 +12760,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1421
+Index: geneve-ut-1424
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12775,7 +12775,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12789,7 +12789,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1425
+Index: geneve-ut-1428
 
 ```python
 file where host.os.type == "windows" and
@@ -12803,7 +12803,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1426
+Index: geneve-ut-1429
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12816,7 +12816,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1427
+Index: geneve-ut-1430
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12836,7 +12836,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1430
+Index: geneve-ut-1433
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12895,7 +12895,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1431
+Index: geneve-ut-1434
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13090,7 +13090,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1446
+Index: geneve-ut-1449
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13106,7 +13106,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1447
+Index: geneve-ut-1450
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13120,7 +13120,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1448
+Index: geneve-ut-1451
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13134,7 +13134,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1449
+Index: geneve-ut-1452
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13151,7 +13151,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13165,7 +13165,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1451
+Index: geneve-ut-1454
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13181,7 +13181,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1456
+Index: geneve-ut-1459
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13193,7 +13193,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1457
+Index: geneve-ut-1460
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13209,7 +13209,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1458
+Index: geneve-ut-1461
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13229,7 +13229,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1460
+Index: geneve-ut-1463
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13269,7 +13269,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1462
+Index: geneve-ut-1465
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13281,7 +13281,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1463
+Index: geneve-ut-1466
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13302,7 +13302,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1464
+Index: geneve-ut-1467
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13323,7 +13323,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1465
+Index: geneve-ut-1468
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13344,7 +13344,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1466
+Index: geneve-ut-1469
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13370,7 +13370,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1467
+Index: geneve-ut-1470
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13386,7 +13386,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1468
+Index: geneve-ut-1471
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13400,7 +13400,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1470
+Index: geneve-ut-1473
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13423,7 +13423,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1472
+Index: geneve-ut-1475
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13440,7 +13440,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1473
+Index: geneve-ut-1476
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13463,7 +13463,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1474
+Index: geneve-ut-1477
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13476,7 +13476,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1475
+Index: geneve-ut-1478
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13490,7 +13490,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1476
+Index: geneve-ut-1479
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13507,7 +13507,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1477
+Index: geneve-ut-1480
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13561,7 +13561,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1478
+Index: geneve-ut-1481
 
 ```python
 any where host.os.type == "windows" and
@@ -13588,7 +13588,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1484
+Index: geneve-ut-1487
 
 ```python
 file where host.os.type == "windows" and
@@ -13603,7 +13603,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1485
+Index: geneve-ut-1488
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13634,7 +13634,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1486
+Index: geneve-ut-1489
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +13648,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1487
+Index: geneve-ut-1490
 
 ```python
 sequence with maxspan=1m
@@ -13690,7 +13690,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1488
+Index: geneve-ut-1491
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13715,7 +13715,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13769,7 +13769,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1490
+Index: geneve-ut-1493
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13789,7 +13789,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1491
+Index: geneve-ut-1494
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13810,7 +13810,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13825,7 +13825,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13845,7 +13845,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1494
+Index: geneve-ut-1497
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13887,7 +13887,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1498
+Index: geneve-ut-1501
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13902,7 +13902,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1499
+Index: geneve-ut-1502
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13937,7 +13937,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1500
+Index: geneve-ut-1503
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13954,7 +13954,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1505
+Index: geneve-ut-1508
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13968,7 +13968,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1508
+Index: geneve-ut-1511
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13981,7 +13981,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1509
+Index: geneve-ut-1512
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13993,7 +13993,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1510
+Index: geneve-ut-1513
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14008,7 +14008,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14036,7 +14036,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1514
+Index: geneve-ut-1517
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14061,7 +14061,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1518
+Index: geneve-ut-1521
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14098,7 +14098,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1519
+Index: geneve-ut-1522
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14112,7 +14112,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1520
+Index: geneve-ut-1523
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14128,7 +14128,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1521
+Index: geneve-ut-1524
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14142,7 +14142,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1522
+Index: geneve-ut-1525
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14172,7 +14172,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1523
+Index: geneve-ut-1526
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14201,7 +14201,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1524
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14217,7 +14217,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1525
+Index: geneve-ut-1528
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14231,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 file where host.os.type == "windows" and
@@ -14267,7 +14267,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1529
+Index: geneve-ut-1532
 
 ```python
 process where event.type == "start" and
@@ -14281,7 +14281,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1530
+Index: geneve-ut-1533
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14295,7 +14295,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1531
+Index: geneve-ut-1534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14315,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1533
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14332,7 +14332,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1534
+Index: geneve-ut-1537
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14344,7 +14344,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1535
+Index: geneve-ut-1538
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14361,7 +14361,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1536
+Index: geneve-ut-1539
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14379,7 +14379,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1543
+Index: geneve-ut-1546
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14392,7 +14392,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1544
+Index: geneve-ut-1547
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14419,7 +14419,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1545
+Index: geneve-ut-1548
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14432,7 +14432,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1546
+Index: geneve-ut-1549
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14446,7 +14446,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14463,7 +14463,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14486,7 +14486,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14503,7 +14503,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1554
+Index: geneve-ut-1557
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14516,7 +14516,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1556
+Index: geneve-ut-1559
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14540,7 +14540,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1557
+Index: geneve-ut-1560
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14568,7 +14568,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1573
+Index: geneve-ut-1576
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14589,7 +14589,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1575
+Index: geneve-ut-1578
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14617,7 +14617,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1577
+Index: geneve-ut-1580
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14657,7 +14657,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1578
+Index: geneve-ut-1581
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14674,7 +14674,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1579
+Index: geneve-ut-1582
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14688,7 +14688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1580
+Index: geneve-ut-1583
 
 ```python
 file where host.os.type == "windows" and
@@ -14707,7 +14707,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1581
+Index: geneve-ut-1584
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14721,7 +14721,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1583
+Index: geneve-ut-1586
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14739,7 +14739,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1585
+Index: geneve-ut-1588
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14757,7 +14757,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1588
+Index: geneve-ut-1591
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14771,7 +14771,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1590
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14786,7 +14786,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1591
+Index: geneve-ut-1594
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14809,7 +14809,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1593
+Index: geneve-ut-1596
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14891,7 +14891,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1594
+Index: geneve-ut-1597
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14912,7 +14912,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1595
+Index: geneve-ut-1598
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14938,7 +14938,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1598
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14991,7 +14991,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1599
+Index: geneve-ut-1602
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15003,7 +15003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1600
+Index: geneve-ut-1603
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15015,7 +15015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1601
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and
@@ -15030,7 +15030,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1602
+Index: geneve-ut-1605
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15060,7 +15060,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1603
+Index: geneve-ut-1606
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15120,7 +15120,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1606
+Index: geneve-ut-1609
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15133,7 +15133,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1607
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15165,7 +15165,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1608
+Index: geneve-ut-1611
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15189,7 +15189,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1610
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15222,7 +15222,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1611
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15239,7 +15239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1613
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15268,7 +15268,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1614
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15282,7 +15282,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1615
+Index: geneve-ut-1618
 
 ```python
 sequence by process.entity_id
@@ -15307,7 +15307,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1616
+Index: geneve-ut-1619
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15341,7 +15341,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1617
+Index: geneve-ut-1620
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15369,7 +15369,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1618
+Index: geneve-ut-1621
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15388,7 +15388,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1624
+Index: geneve-ut-1627
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15416,7 +15416,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1625
+Index: geneve-ut-1628
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15435,7 +15435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1629
+Index: geneve-ut-1632
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15447,7 +15447,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1630
+Index: geneve-ut-1633
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15459,7 +15459,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1631
+Index: geneve-ut-1634
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15471,7 +15471,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1632
+Index: geneve-ut-1635
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15483,7 +15483,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1643
+Index: geneve-ut-1646
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15496,7 +15496,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1644
+Index: geneve-ut-1647
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15534,7 +15534,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1646
+Index: geneve-ut-1649
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15549,7 +15549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1647
+Index: geneve-ut-1650
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15568,7 +15568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1648
+Index: geneve-ut-1651
 
 ```python
 sequence with maxspan=1m
@@ -15616,7 +15616,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1650
+Index: geneve-ut-1653
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15639,7 +15639,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1652
+Index: geneve-ut-1655
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15653,7 +15653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1653
+Index: geneve-ut-1656
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15667,7 +15667,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1655
+Index: geneve-ut-1658
 
 ```python
 sequence by host.id, process.entity_id
@@ -15684,7 +15684,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1656
+Index: geneve-ut-1659
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15698,7 +15698,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1657
+Index: geneve-ut-1660
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15718,7 +15718,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1658
+Index: geneve-ut-1661
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15747,7 +15747,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1659
+Index: geneve-ut-1662
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15767,7 +15767,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1660
+Index: geneve-ut-1663
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15780,7 +15780,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1662
+Index: geneve-ut-1665
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15822,7 +15822,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1663
+Index: geneve-ut-1666
 
 ```python
 sequence with maxspan=1m
@@ -15845,7 +15845,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1664
+Index: geneve-ut-1667
 
 ```python
 sequence with maxspan=1s
@@ -15893,7 +15893,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1665
+Index: geneve-ut-1668
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15910,7 +15910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1667
+Index: geneve-ut-1670
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15939,7 +15939,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1669
+Index: geneve-ut-1673
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15967,7 +15967,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1670
+Index: geneve-ut-1674
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15984,7 +15984,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1672
+Index: geneve-ut-1676
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16003,7 +16003,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1673
+Index: geneve-ut-1677
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16024,7 +16024,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1682
+Index: geneve-ut-1686
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16038,7 +16038,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1684
+Index: geneve-ut-1688
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16057,7 +16057,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1685
+Index: geneve-ut-1689
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16071,7 +16071,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1686
+Index: geneve-ut-1690
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16091,7 +16091,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1688
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16109,7 +16109,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1689
+Index: geneve-ut-1693
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16130,7 +16130,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1691
+Index: geneve-ut-1695
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16144,7 +16144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1692
+Index: geneve-ut-1696
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16159,7 +16159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1693
+Index: geneve-ut-1697
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16200,7 +16200,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1695
+Index: geneve-ut-1699
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16225,7 +16225,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1696
+Index: geneve-ut-1700
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16264,7 +16264,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1697
+Index: geneve-ut-1701
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16278,7 +16278,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1698
+Index: geneve-ut-1702
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16317,7 +16317,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1699
+Index: geneve-ut-1703
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16331,7 +16331,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1700
+Index: geneve-ut-1704
 
 ```python
 process where event.type == "start" and
@@ -16403,7 +16403,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1704
+Index: geneve-ut-1708
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16424,7 +16424,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1707
+Index: geneve-ut-1711
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16441,7 +16441,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1710
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16459,7 +16459,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1711
+Index: geneve-ut-1715
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16471,7 +16471,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1712
+Index: geneve-ut-1716
 
 ```python
 file where host.os.type == "windows" and
@@ -16504,7 +16504,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1715
+Index: geneve-ut-1719
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16536,7 +16536,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1717
+Index: geneve-ut-1721
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16572,7 +16572,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1718
+Index: geneve-ut-1722
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16589,7 +16589,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1719
+Index: geneve-ut-1723
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16609,7 +16609,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1721
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16624,7 +16624,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1722
+Index: geneve-ut-1726
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16645,7 +16645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1723
+Index: geneve-ut-1727
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16668,7 +16668,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1724
+Index: geneve-ut-1728
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16681,7 +16681,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1725
+Index: geneve-ut-1729
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16698,7 +16698,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1728
+Index: geneve-ut-1732
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16723,7 +16723,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1731
+Index: geneve-ut-1735
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16754,7 +16754,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1732
+Index: geneve-ut-1736
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16803,7 +16803,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1733
+Index: geneve-ut-1737
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16817,7 +16817,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1734
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16832,7 +16832,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1735
+Index: geneve-ut-1739
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16847,7 +16847,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1736
+Index: geneve-ut-1740
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16869,7 +16869,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1737
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16890,7 +16890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1741
+Index: geneve-ut-1745
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16904,7 +16904,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1742
+Index: geneve-ut-1746
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16927,7 +16927,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1772
+Index: geneve-ut-1776
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16952,7 +16952,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1773
+Index: geneve-ut-1777
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16985,7 +16985,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1774
+Index: geneve-ut-1778
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17044,7 +17044,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1776
+Index: geneve-ut-1780
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17062,7 +17062,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1777
+Index: geneve-ut-1781
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17074,7 +17074,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1780
+Index: geneve-ut-1784
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17099,7 +17099,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1786
+Index: geneve-ut-1790
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17114,7 +17114,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1787
+Index: geneve-ut-1791
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17137,7 +17137,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1790
+Index: geneve-ut-1794
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17151,7 +17151,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1792
+Index: geneve-ut-1796
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17173,7 +17173,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1794
+Index: geneve-ut-1798
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17200,7 +17200,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1798
+Index: geneve-ut-1802
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17239,7 +17239,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1799
+Index: geneve-ut-1803
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17262,7 +17262,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1800
+Index: geneve-ut-1804
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17276,7 +17276,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1801
+Index: geneve-ut-1805
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17292,7 +17292,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1802
+Index: geneve-ut-1806
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17308,7 +17308,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1803
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17322,7 +17322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1805
+Index: geneve-ut-1809
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17345,7 +17345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1806
+Index: geneve-ut-1810
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17373,7 +17373,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1807
+Index: geneve-ut-1811
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +17388,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1810
+Index: geneve-ut-1814
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17415,7 +17415,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1812
+Index: geneve-ut-1816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17446,7 +17446,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1813
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17462,7 +17462,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1814
+Index: geneve-ut-1818
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17475,7 +17475,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1816
+Index: geneve-ut-1820
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17491,7 +17491,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1817
+Index: geneve-ut-1821
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17507,7 +17507,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1818
+Index: geneve-ut-1822
 
 ```python
 any where host.os.type == "windows" and 
@@ -17574,7 +17574,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1820
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17590,7 +17590,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1822
+Index: geneve-ut-1826
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17626,7 +17626,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1823
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +17664,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1824
+Index: geneve-ut-1828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17699,7 +17699,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1825
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +17733,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1827
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17754,7 +17754,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1832
+Index: geneve-ut-1836
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17831,7 +17831,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1833
+Index: geneve-ut-1837
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17853,7 +17853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1834
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17877,7 +17877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1836
+Index: geneve-ut-1840
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17898,7 +17898,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1839
+Index: geneve-ut-1843
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17913,7 +17913,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1842
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17926,7 +17926,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1843
+Index: geneve-ut-1847
 
 ```python
 any where host.os.type == "windows" and
@@ -17941,7 +17941,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1844
+Index: geneve-ut-1848
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17957,7 +17957,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1845
+Index: geneve-ut-1849
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17971,7 +17971,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1849
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18028,7 +18028,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1850
+Index: geneve-ut-1854
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18042,7 +18042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1852
+Index: geneve-ut-1856
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18074,7 +18074,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1854
+Index: geneve-ut-1858
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18087,7 +18087,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1855
+Index: geneve-ut-1859
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18106,7 +18106,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1856
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18152,7 +18152,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1858
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18173,7 +18173,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1859
+Index: geneve-ut-1863
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18193,7 +18193,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1860
+Index: geneve-ut-1864
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18207,7 +18207,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1861
+Index: geneve-ut-1865
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18239,7 +18239,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1864
+Index: geneve-ut-1868
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18260,7 +18260,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1866
+Index: geneve-ut-1870
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18361,7 +18361,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1870
+Index: geneve-ut-1874
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18409,7 +18409,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1873
+Index: geneve-ut-1877
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18435,7 +18435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1874
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18480,7 +18480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1875
+Index: geneve-ut-1879
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18504,7 +18504,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1876
+Index: geneve-ut-1880
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18520,7 +18520,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1878
+Index: geneve-ut-1882
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18545,7 +18545,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1879
+Index: geneve-ut-1883
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18560,7 +18560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1882
+Index: geneve-ut-1886
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18574,7 +18574,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1883
+Index: geneve-ut-1887
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18594,7 +18594,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1884
+Index: geneve-ut-1888
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18629,7 +18629,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1888
+Index: geneve-ut-1892
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18647,7 +18647,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1889
+Index: geneve-ut-1893
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18660,7 +18660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1892
+Index: geneve-ut-1896
 
 ```python
 any where host.os.type == "windows" and
@@ -18693,7 +18693,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1894
+Index: geneve-ut-1898
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18711,7 +18711,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1895
+Index: geneve-ut-1899
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18733,7 +18733,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1898
+Index: geneve-ut-1902
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18772,7 +18772,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1899
+Index: geneve-ut-1903
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18802,7 +18802,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1900
+Index: geneve-ut-1904
 
 ```python
 any where host.os.type == "windows" and
@@ -18836,7 +18836,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1901
+Index: geneve-ut-1905
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18850,7 +18850,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1904
+Index: geneve-ut-1908
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18881,7 +18881,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1905
+Index: geneve-ut-1909
 
 ```python
 any where host.os.type == "windows" and
@@ -18901,7 +18901,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1906
+Index: geneve-ut-1910
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18942,7 +18942,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1907
+Index: geneve-ut-1911
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18958,7 +18958,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1908
+Index: geneve-ut-1912
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18988,7 +18988,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1912
+Index: geneve-ut-1916
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19001,7 +19001,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1913
+Index: geneve-ut-1917
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19025,7 +19025,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1916
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19043,7 +19043,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1918
+Index: geneve-ut-1922
 
 ```python
 any where host.os.type == "windows" and
@@ -19058,7 +19058,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1919
+Index: geneve-ut-1923
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19076,7 +19076,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1920
+Index: geneve-ut-1924
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19097,7 +19097,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1921
+Index: geneve-ut-1925
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19116,7 +19116,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1924
+Index: geneve-ut-1928
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19141,7 +19141,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1925
+Index: geneve-ut-1929
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19154,7 +19154,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1927
+Index: geneve-ut-1931
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19167,7 +19167,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1929
+Index: geneve-ut-1933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19190,7 +19190,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1931
+Index: geneve-ut-1935
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19209,7 +19209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1932
+Index: geneve-ut-1936
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19231,7 +19231,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1933
+Index: geneve-ut-1937
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19264,7 +19264,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1935
+Index: geneve-ut-1939
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19282,7 +19282,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1936
+Index: geneve-ut-1940
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19296,7 +19296,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1937
+Index: geneve-ut-1941
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19320,7 +19320,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1938
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19343,7 +19343,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1939
+Index: geneve-ut-1943
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19362,7 +19362,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1942
+Index: geneve-ut-1946
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19381,7 +19381,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1944
+Index: geneve-ut-1948
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19416,7 +19416,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1945
+Index: geneve-ut-1949
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19433,7 +19433,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1946
+Index: geneve-ut-1950
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1947
+Index: geneve-ut-1951
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19493,7 +19493,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1948
+Index: geneve-ut-1952
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19509,7 +19509,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1949
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19523,7 +19523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1950
+Index: geneve-ut-1954
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19561,7 +19561,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1951
+Index: geneve-ut-1955
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19615,7 +19615,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1952
+Index: geneve-ut-1956
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19643,7 +19643,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1954
+Index: geneve-ut-1958
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19657,7 +19657,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1955
+Index: geneve-ut-1959
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19703,7 +19703,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1956
+Index: geneve-ut-1960
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19742,7 +19742,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1957
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19755,7 +19755,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1961
+Index: geneve-ut-1965
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19788,7 +19788,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1962
+Index: geneve-ut-1966
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19802,7 +19802,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1963
+Index: geneve-ut-1967
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19816,7 +19816,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1964
+Index: geneve-ut-1968
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19830,7 +19830,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1965
+Index: geneve-ut-1969
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19869,7 +19869,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1973
+Index: geneve-ut-1977
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19911,7 +19911,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1975
+Index: geneve-ut-1979
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19933,7 +19933,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1977
+Index: geneve-ut-1981
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19946,7 +19946,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1980
+Index: geneve-ut-1984
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19963,7 +19963,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1981
+Index: geneve-ut-1985
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19979,7 +19979,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1982
+Index: geneve-ut-1986
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19992,7 +19992,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1983
+Index: geneve-ut-1987
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20007,7 +20007,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1984
+Index: geneve-ut-1988
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20030,7 +20030,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1985
+Index: geneve-ut-1989
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20046,7 +20046,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1986
+Index: geneve-ut-1990
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20062,7 +20062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1992
+Index: geneve-ut-1996
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20074,7 +20074,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1993
+Index: geneve-ut-1997
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20103,7 +20103,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1995
+Index: geneve-ut-1999
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20117,7 +20117,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2000
+Index: geneve-ut-2004
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20137,7 +20137,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2001
+Index: geneve-ut-2005
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20162,7 +20162,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2008
+Index: geneve-ut-2012
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20176,7 +20176,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2009
+Index: geneve-ut-2013
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20199,7 +20199,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2018
+Index: geneve-ut-2022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20233,7 +20233,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2020
+Index: geneve-ut-2024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20252,7 +20252,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2027
+Index: geneve-ut-2031
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20271,7 +20271,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2042
+Index: geneve-ut-2046
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20288,7 +20288,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2045
+Index: geneve-ut-2049
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20305,7 +20305,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2061
+Index: geneve-ut-2065
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20324,7 +20324,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2065
+Index: geneve-ut-2069
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20366,7 +20366,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2066
+Index: geneve-ut-2070
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20411,7 +20411,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2069
+Index: geneve-ut-2073
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20453,7 +20453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2071
+Index: geneve-ut-2075
 
 ```python
 host.os.type:"linux" and 
@@ -20481,7 +20481,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2075
+Index: geneve-ut-2079
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20505,7 +20505,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2076
+Index: geneve-ut-2080
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20545,7 +20545,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2077
+Index: geneve-ut-2081
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20592,7 +20592,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2081
+Index: geneve-ut-2085
 
 ```python
 sequence by process.entity_id
@@ -20629,7 +20629,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2113
+Index: geneve-ut-2117
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20643,7 +20643,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2114
+Index: geneve-ut-2118
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20686,7 +20686,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2115
+Index: geneve-ut-2119
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20699,7 +20699,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2118
+Index: geneve-ut-2122
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20713,7 +20713,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2119
+Index: geneve-ut-2123
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20726,7 +20726,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2123
+Index: geneve-ut-2127
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20751,7 +20751,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2124
+Index: geneve-ut-2128
 
 ```python
 process where event.type == "start" and
@@ -20766,7 +20766,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2125
+Index: geneve-ut-2129
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20783,7 +20783,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2126
+Index: geneve-ut-2130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20797,7 +20797,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2127
+Index: geneve-ut-2131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20813,7 +20813,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2128
+Index: geneve-ut-2132
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20827,7 +20827,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2129
+Index: geneve-ut-2133
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20854,7 +20854,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2131
+Index: geneve-ut-2135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20866,7 +20866,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2132
+Index: geneve-ut-2136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20882,7 +20882,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2133
+Index: geneve-ut-2137
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20905,7 +20905,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2134
+Index: geneve-ut-2138
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20918,7 +20918,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2136
+Index: geneve-ut-2140
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20930,7 +20930,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2137
+Index: geneve-ut-2141
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20942,7 +20942,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2138
+Index: geneve-ut-2142
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20954,7 +20954,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2139
+Index: geneve-ut-2143
 
 ```python
 web where (
@@ -20982,7 +20982,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2145
+Index: geneve-ut-2149
 
 ```python
 any where (
@@ -21054,7 +21054,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2147
+Index: geneve-ut-2151
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21075,7 +21075,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2150
+Index: geneve-ut-2154
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21089,7 +21089,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2151
+Index: geneve-ut-2155
 
 ```python
 file where event.type == "deletion" and
@@ -21106,7 +21106,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2152
+Index: geneve-ut-2156
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21124,7 +21124,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2155
+Index: geneve-ut-2159
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21162,7 +21162,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2157
+Index: geneve-ut-2161
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21199,7 +21199,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2158
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21214,7 +21214,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2159
+Index: geneve-ut-2163
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21227,7 +21227,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2160
+Index: geneve-ut-2164
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21246,7 +21246,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2161
+Index: geneve-ut-2165
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21271,7 +21271,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2162
+Index: geneve-ut-2166
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21297,7 +21297,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2163
+Index: geneve-ut-2167
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21319,7 +21319,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2164
+Index: geneve-ut-2168
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21336,7 +21336,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2166
+Index: geneve-ut-2170
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21355,7 +21355,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2167
+Index: geneve-ut-2171
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21395,7 +21395,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2168
+Index: geneve-ut-2172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21412,7 +21412,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2170
+Index: geneve-ut-2174
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21425,7 +21425,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2171
+Index: geneve-ut-2175
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21439,7 +21439,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2172
+Index: geneve-ut-2176
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21467,7 +21467,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2173
+Index: geneve-ut-2177
 
 ```python
 process where event.type == "start" and
@@ -21492,7 +21492,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2174
+Index: geneve-ut-2178
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21506,7 +21506,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2175
+Index: geneve-ut-2179
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21522,7 +21522,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2176
+Index: geneve-ut-2180
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21557,7 +21557,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2177
+Index: geneve-ut-2181
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21575,7 +21575,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2180
+Index: geneve-ut-2184
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-serverless.md
+++ b/tests/reports/alerts_from_rules-serverless.md
@@ -5,7 +5,7 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.2
+Rules version: 9.5.3
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
@@ -20,7 +20,7 @@ Rules version: 9.5.2
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367  
+Index: geneve-ut-0368  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378  
+Index: geneve-ut-0379  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -190,7 +190,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646  
+Index: geneve-ut-0647  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671  
+Index: geneve-ut-0672  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805  
+Index: geneve-ut-0807  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998  
+Index: geneve-ut-1000  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143  
+Index: geneve-ut-1145  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173  
+Index: geneve-ut-1175  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245  
+Index: geneve-ut-1248  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274  
+Index: geneve-ut-1277  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292  
+Index: geneve-ut-1295  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356  
+Index: geneve-ut-1359  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371  
+Index: geneve-ut-1374  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461  
+Index: geneve-ut-1464  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705  
+Index: geneve-ut-1709  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709  
+Index: geneve-ut-1713  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793  
+Index: geneve-ut-1797  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808  
+Index: geneve-ut-1812  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821  
+Index: geneve-ut-1825  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831  
+Index: geneve-ut-1835  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837  
+Index: geneve-ut-1841  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846  
+Index: geneve-ut-1850  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943  
+Index: geneve-ut-1947  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974  
+Index: geneve-ut-1978  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1123,7 +1123,7 @@ container.id like "*"
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367
+Index: geneve-ut-0368
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1175,7 +1175,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378
+Index: geneve-ut-0379
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -1287,7 +1287,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646
+Index: geneve-ut-0647
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1353,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671
+Index: geneve-ut-0672
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805
+Index: geneve-ut-0807
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998
+Index: geneve-ut-1000
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143
+Index: geneve-ut-1145
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245
+Index: geneve-ut-1248
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292
+Index: geneve-ut-1295
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461
+Index: geneve-ut-1464
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709
+Index: geneve-ut-1713
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793
+Index: geneve-ut-1797
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808
+Index: geneve-ut-1812
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821
+Index: geneve-ut-1825
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837
+Index: geneve-ut-1841
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943
+Index: geneve-ut-1947
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974
+Index: geneve-ut-1978
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0999
+Index: geneve-ut-1001
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1019
+Index: geneve-ut-1021
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1408
+Index: geneve-ut-1411
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1609
+Index: geneve-ut-1612
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2227,7 +2227,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0367  
+Index: geneve-ut-0368  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2281,7 +2281,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0378  
+Index: geneve-ut-0379  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -2395,7 +2395,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0646  
+Index: geneve-ut-0647  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2463,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0671  
+Index: geneve-ut-0672  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0805  
+Index: geneve-ut-0807  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0971  
+Index: geneve-ut-0973  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0998  
+Index: geneve-ut-1000  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1121  
+Index: geneve-ut-1123  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1143  
+Index: geneve-ut-1145  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1173  
+Index: geneve-ut-1175  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1245  
+Index: geneve-ut-1248  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1274  
+Index: geneve-ut-1277  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1292  
+Index: geneve-ut-1295  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1356  
+Index: geneve-ut-1359  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1371  
+Index: geneve-ut-1374  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1452  
+Index: geneve-ut-1455  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1461  
+Index: geneve-ut-1464  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1576  
+Index: geneve-ut-1579  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1705  
+Index: geneve-ut-1709  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1709  
+Index: geneve-ut-1713  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1793  
+Index: geneve-ut-1797  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1808  
+Index: geneve-ut-1812  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1821  
+Index: geneve-ut-1825  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1831  
+Index: geneve-ut-1835  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1837  
+Index: geneve-ut-1841  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1846  
+Index: geneve-ut-1850  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1943  
+Index: geneve-ut-1947  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1974  
+Index: geneve-ut-1978  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -4269,7 +4269,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0323
+Index: geneve-ut-0324
 
 ```python
 event.dataset:azure.activitylogs and
@@ -4283,7 +4283,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0326
+Index: geneve-ut-0327
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -4301,7 +4301,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0344
+Index: geneve-ut-0345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4319,7 +4319,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0345
+Index: geneve-ut-0346
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4337,7 +4337,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0346
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4352,7 +4352,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0347
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4366,7 +4366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0348
+Index: geneve-ut-0349
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4381,7 +4381,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0351
+Index: geneve-ut-0352
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4398,7 +4398,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0352
+Index: geneve-ut-0353
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4410,7 +4410,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0353
+Index: geneve-ut-0354
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4422,7 +4422,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0354
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4437,7 +4437,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0355
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4457,7 +4457,7 @@ not (
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0356
+Index: geneve-ut-0357
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4479,7 +4479,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0358
+Index: geneve-ut-0359
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4525,7 +4525,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0359
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4559,7 +4559,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0360
+Index: geneve-ut-0361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4582,7 +4582,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0362
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4604,7 +4604,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0363
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4632,7 +4632,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0364
+Index: geneve-ut-0365
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4648,7 +4648,7 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0366
+Index: geneve-ut-0367
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4673,7 +4673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0368
+Index: geneve-ut-0369
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4703,7 +4703,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0370
+Index: geneve-ut-0371
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4717,7 +4717,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0371
+Index: geneve-ut-0372
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4739,7 +4739,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0372
+Index: geneve-ut-0373
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4753,7 +4753,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0373
+Index: geneve-ut-0374
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4773,7 +4773,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0376
+Index: geneve-ut-0377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4790,7 +4790,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0379
+Index: geneve-ut-0380
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4820,7 +4820,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0382
+Index: geneve-ut-0383
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4845,7 +4845,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0384
+Index: geneve-ut-0385
 
 ```python
 sequence by process.entity_id
@@ -4866,7 +4866,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0385
+Index: geneve-ut-0386
 
 ```python
 sequence by process.entity_id
@@ -4887,7 +4887,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0388
+Index: geneve-ut-0389
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4918,7 +4918,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0389
+Index: geneve-ut-0390
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4930,7 +4930,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0390
+Index: geneve-ut-0391
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4953,7 +4953,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0393
+Index: geneve-ut-0394
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4966,7 +4966,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0394
+Index: geneve-ut-0395
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4979,7 +4979,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0396
+Index: geneve-ut-0397
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4996,7 +4996,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0397
+Index: geneve-ut-0398
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -5009,7 +5009,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0398
+Index: geneve-ut-0399
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -5026,7 +5026,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0399
+Index: geneve-ut-0400
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -5038,7 +5038,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0400
+Index: geneve-ut-0401
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -5106,7 +5106,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0401
+Index: geneve-ut-0402
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -5124,7 +5124,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0402
+Index: geneve-ut-0403
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -5137,7 +5137,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0403
+Index: geneve-ut-0404
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5155,7 +5155,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0404
+Index: geneve-ut-0405
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5167,7 +5167,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0405
+Index: geneve-ut-0406
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5179,7 +5179,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0406
+Index: geneve-ut-0407
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5191,7 +5191,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0407
+Index: geneve-ut-0408
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5203,7 +5203,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0408
+Index: geneve-ut-0409
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -5248,7 +5248,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0410
+Index: geneve-ut-0411
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5268,7 +5268,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0411
+Index: geneve-ut-0412
 
 ```python
 sequence with maxspan=10s
@@ -5288,7 +5288,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0412
+Index: geneve-ut-0413
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5315,7 +5315,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0413
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5329,7 +5329,7 @@ container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0416
+Index: geneve-ut-0417
 
 ```python
 process where event.type == "start" and
@@ -5354,7 +5354,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0419
+Index: geneve-ut-0420
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5398,7 +5398,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0420
+Index: geneve-ut-0421
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5432,7 +5432,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0422
+Index: geneve-ut-0423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5477,7 +5477,7 @@ container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0423
+Index: geneve-ut-0424
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5493,7 +5493,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0424
+Index: geneve-ut-0425
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5518,7 +5518,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0425
+Index: geneve-ut-0426
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5537,7 +5537,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0427
+Index: geneve-ut-0428
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5664,7 +5664,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0428
+Index: geneve-ut-0429
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5682,7 +5682,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0430
+Index: geneve-ut-0431
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5695,7 +5695,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0431
+Index: geneve-ut-0432
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5725,7 +5725,7 @@ container.security_context.privileged == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0437
+Index: geneve-ut-0438
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5739,7 +5739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0449
+Index: geneve-ut-0450
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5760,7 +5760,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0456
+Index: geneve-ut-0457
 
 ```python
 registry where host.os.type == "windows" and
@@ -5774,7 +5774,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0468
+Index: geneve-ut-0469
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5798,7 +5798,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0507
+Index: geneve-ut-0508
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5852,7 +5852,7 @@ container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0509
+Index: geneve-ut-0510
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5868,7 +5868,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0510
+Index: geneve-ut-0511
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5896,7 +5896,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0511
+Index: geneve-ut-0512
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5913,7 +5913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0512
+Index: geneve-ut-0513
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5930,7 +5930,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0513
+Index: geneve-ut-0514
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5951,7 +5951,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0515
+Index: geneve-ut-0516
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5971,7 +5971,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0516
+Index: geneve-ut-0517
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5986,7 +5986,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0518
+Index: geneve-ut-0519
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5999,7 +5999,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0519
+Index: geneve-ut-0520
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6019,7 +6019,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0522
+Index: geneve-ut-0523
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -6032,7 +6032,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0523
+Index: geneve-ut-0524
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6070,7 +6070,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0524
+Index: geneve-ut-0525
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -6090,7 +6090,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0525
+Index: geneve-ut-0526
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6103,7 +6103,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0526
+Index: geneve-ut-0527
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -6126,7 +6126,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0528
+Index: geneve-ut-0529
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6157,7 +6157,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0529
+Index: geneve-ut-0530
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -6176,7 +6176,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0530
+Index: geneve-ut-0531
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6219,7 +6219,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0531
+Index: geneve-ut-0532
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -6233,7 +6233,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0533
+Index: geneve-ut-0534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6248,7 +6248,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0534
+Index: geneve-ut-0535
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6264,7 +6264,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0535
+Index: geneve-ut-0536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6278,7 +6278,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0536
+Index: geneve-ut-0537
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6304,7 +6304,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 419  
 Document count: 419  
-Index: geneve-ut-0537
+Index: geneve-ut-0538
 
 ```python
 process where event.type == "start" and
@@ -6342,7 +6342,7 @@ process where event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0544
+Index: geneve-ut-0545
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -6355,7 +6355,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0545
+Index: geneve-ut-0546
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6369,7 +6369,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0546
+Index: geneve-ut-0547
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6391,7 +6391,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0547
+Index: geneve-ut-0548
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6426,7 +6426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0548
+Index: geneve-ut-0549
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6438,7 +6438,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0596
+Index: geneve-ut-0597
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6450,7 +6450,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0622
+Index: geneve-ut-0623
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6464,7 +6464,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0625
+Index: geneve-ut-0626
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6491,7 +6491,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0628
+Index: geneve-ut-0629
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6512,7 +6512,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0629
+Index: geneve-ut-0630
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6542,7 +6542,7 @@ container.id like "*"
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0632
+Index: geneve-ut-0633
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6560,7 +6560,7 @@ container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0633
+Index: geneve-ut-0634
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6593,7 +6593,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0635
+Index: geneve-ut-0636
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6610,7 +6610,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0636
+Index: geneve-ut-0637
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6638,7 +6638,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0637
+Index: geneve-ut-0638
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6651,7 +6651,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0639
+Index: geneve-ut-0640
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6671,7 +6671,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0640
+Index: geneve-ut-0641
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6697,7 +6697,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0641
+Index: geneve-ut-0642
 
 ```python
 sequence with maxspan=2h
@@ -6719,7 +6719,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0642
+Index: geneve-ut-0643
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6748,7 +6748,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0645
+Index: geneve-ut-0646
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6761,7 +6761,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0649
+Index: geneve-ut-0650
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6776,7 +6776,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0650
+Index: geneve-ut-0651
 
 ```python
 process where event.type == "start" and
@@ -6798,7 +6798,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0652
+Index: geneve-ut-0653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6810,7 +6810,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0653
+Index: geneve-ut-0654
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6832,7 +6832,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0655
+Index: geneve-ut-0656
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6849,7 +6849,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0656
+Index: geneve-ut-0657
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6863,7 +6863,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0657
+Index: geneve-ut-0658
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6876,7 +6876,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0658
+Index: geneve-ut-0659
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6888,7 +6888,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0659
+Index: geneve-ut-0660
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6900,7 +6900,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0660
+Index: geneve-ut-0661
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6914,7 +6914,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0661
+Index: geneve-ut-0662
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6926,7 +6926,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0662
+Index: geneve-ut-0663
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -6948,7 +6948,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0666
+Index: geneve-ut-0667
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6997,7 +6997,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0667
+Index: geneve-ut-0668
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -7014,7 +7014,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0668
+Index: geneve-ut-0669
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7034,7 +7034,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0673
+Index: geneve-ut-0674
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7056,7 +7056,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0676
+Index: geneve-ut-0677
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7071,7 +7071,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0677
+Index: geneve-ut-0678
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7085,7 +7085,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0679
+Index: geneve-ut-0680
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7107,7 +7107,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0681
+Index: geneve-ut-0682
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -7128,7 +7128,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0682
+Index: geneve-ut-0683
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7154,7 +7154,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0683
+Index: geneve-ut-0684
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -7182,7 +7182,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0686
+Index: geneve-ut-0687
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -7196,7 +7196,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0724
+Index: geneve-ut-0726
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -7213,7 +7213,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0725
+Index: geneve-ut-0727
 
 ```python
 registry where host.os.type == "windows" and
@@ -7231,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0795
+Index: geneve-ut-0797
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0796
+Index: geneve-ut-0798
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0797
+Index: geneve-ut-0799
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0798
+Index: geneve-ut-0800
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0806
+Index: geneve-ut-0808
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0807
+Index: geneve-ut-0809
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0808
+Index: geneve-ut-0810
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0809
+Index: geneve-ut-0811
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0813
+Index: geneve-ut-0815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0816
+Index: geneve-ut-0818
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0819
+Index: geneve-ut-0821
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0823
+Index: geneve-ut-0825
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0825
+Index: geneve-ut-0827
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0851
+Index: geneve-ut-0853
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0854
+Index: geneve-ut-0856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0855
+Index: geneve-ut-0857
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0868
+Index: geneve-ut-0870
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0869
+Index: geneve-ut-0871
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0870
+Index: geneve-ut-0872
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0874
+Index: geneve-ut-0876
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0880
+Index: geneve-ut-0882
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0882
+Index: geneve-ut-0884
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0883
+Index: geneve-ut-0885
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0884
+Index: geneve-ut-0886
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0885
+Index: geneve-ut-0887
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0886
+Index: geneve-ut-0888
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0887
+Index: geneve-ut-0889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0892
+Index: geneve-ut-0894
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0894
+Index: geneve-ut-0896
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0895
+Index: geneve-ut-0897
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0896
+Index: geneve-ut-0898
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7897,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0897
+Index: geneve-ut-0899
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7921,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0902
+Index: geneve-ut-0904
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0904
+Index: geneve-ut-0906
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0905
+Index: geneve-ut-0907
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0906
+Index: geneve-ut-0908
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0907
+Index: geneve-ut-0909
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0908
+Index: geneve-ut-0910
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0909
+Index: geneve-ut-0911
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0910
+Index: geneve-ut-0912
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0911
+Index: geneve-ut-0913
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0912
+Index: geneve-ut-0914
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0913
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0915
+Index: geneve-ut-0917
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0917
+Index: geneve-ut-0919
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0918
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0919
+Index: geneve-ut-0921
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0920
+Index: geneve-ut-0922
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0922
+Index: geneve-ut-0924
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0923
+Index: geneve-ut-0925
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0925
+Index: geneve-ut-0927
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0927
+Index: geneve-ut-0929
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0928
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0930
+Index: geneve-ut-0932
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0931
+Index: geneve-ut-0933
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8436,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0932
+Index: geneve-ut-0934
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8463,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0935
+Index: geneve-ut-0937
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0936
+Index: geneve-ut-0938
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0946
+Index: geneve-ut-0948
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0972
+Index: geneve-ut-0974
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0975
+Index: geneve-ut-0977
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0977
+Index: geneve-ut-0979
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0989
+Index: geneve-ut-0991
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0994
+Index: geneve-ut-0996
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0995
+Index: geneve-ut-0997
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1000
+Index: geneve-ut-1002
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1015
+Index: geneve-ut-1017
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1018
+Index: geneve-ut-1020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1020
+Index: geneve-ut-1022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1021
+Index: geneve-ut-1023
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1025
+Index: geneve-ut-1027
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1026
+Index: geneve-ut-1028
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8863,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1029
+Index: geneve-ut-1031
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1031
+Index: geneve-ut-1033
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1032
+Index: geneve-ut-1034
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1068
+Index: geneve-ut-1070
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1069
+Index: geneve-ut-1071
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1070
+Index: geneve-ut-1072
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1071
+Index: geneve-ut-1073
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1072
+Index: geneve-ut-1074
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1080
+Index: geneve-ut-1082
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1083
+Index: geneve-ut-1085
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1084
+Index: geneve-ut-1086
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1085
+Index: geneve-ut-1087
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1089
+Index: geneve-ut-1091
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1090
+Index: geneve-ut-1092
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1092
+Index: geneve-ut-1094
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1093
+Index: geneve-ut-1095
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1094
+Index: geneve-ut-1096
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1095
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1096
+Index: geneve-ut-1098
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1097
+Index: geneve-ut-1099
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9142,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1098
+Index: geneve-ut-1100
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9167,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1100
+Index: geneve-ut-1102
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1103
+Index: geneve-ut-1105
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1104
+Index: geneve-ut-1106
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1105
+Index: geneve-ut-1107
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1108
+Index: geneve-ut-1110
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1109
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1110
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1114
+Index: geneve-ut-1116
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1115
+Index: geneve-ut-1117
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1116
+Index: geneve-ut-1118
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1120
+Index: geneve-ut-1122
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1122
+Index: geneve-ut-1124
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1124
+Index: geneve-ut-1126
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1125
+Index: geneve-ut-1127
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1127
+Index: geneve-ut-1129
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1128
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1132
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1131
+Index: geneve-ut-1133
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1133
+Index: geneve-ut-1135
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1134
+Index: geneve-ut-1136
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9604,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1136
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1137
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1138
+Index: geneve-ut-1140
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1139
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1140
+Index: geneve-ut-1142
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1141
+Index: geneve-ut-1143
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1142
+Index: geneve-ut-1144
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1155
+Index: geneve-ut-1157
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1164
+Index: geneve-ut-1166
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1168
+Index: geneve-ut-1170
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1169
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1170
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1171
+Index: geneve-ut-1173
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1172
+Index: geneve-ut-1174
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1174
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1175
+Index: geneve-ut-1177
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1177
+Index: geneve-ut-1179
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1179
+Index: geneve-ut-1181
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1180
+Index: geneve-ut-1182
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1181
+Index: geneve-ut-1183
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1183
+Index: geneve-ut-1185
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1184
+Index: geneve-ut-1186
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1185
+Index: geneve-ut-1187
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1186
+Index: geneve-ut-1188
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1188
+Index: geneve-ut-1190
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1189
+Index: geneve-ut-1191
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1190
+Index: geneve-ut-1192
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1191
+Index: geneve-ut-1193
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1192
+Index: geneve-ut-1194
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1196
+Index: geneve-ut-1198
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1197
+Index: geneve-ut-1199
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1198
+Index: geneve-ut-1200
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1203
+Index: geneve-ut-1205
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1206
+Index: geneve-ut-1208
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1215
+Index: geneve-ut-1218
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1216
+Index: geneve-ut-1219
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1217
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1218
+Index: geneve-ut-1221
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1220
+Index: geneve-ut-1223
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1221
+Index: geneve-ut-1224
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1223
+Index: geneve-ut-1226
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1232
+Index: geneve-ut-1235
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1233
+Index: geneve-ut-1236
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1234
+Index: geneve-ut-1237
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1235
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1236
+Index: geneve-ut-1239
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1237
+Index: geneve-ut-1240
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1238
+Index: geneve-ut-1241
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1239
+Index: geneve-ut-1242
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10670,7 +10670,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1246
+Index: geneve-ut-1249
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10685,7 +10685,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1247
+Index: geneve-ut-1250
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10699,7 +10699,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1248
+Index: geneve-ut-1251
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10718,7 +10718,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1249
+Index: geneve-ut-1252
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10730,7 +10730,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1250
+Index: geneve-ut-1253
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10742,7 +10742,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1251
+Index: geneve-ut-1254
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10760,7 +10760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1252
+Index: geneve-ut-1255
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10773,7 +10773,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1253
+Index: geneve-ut-1256
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10788,7 +10788,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1254
+Index: geneve-ut-1257
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10803,7 +10803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1257
+Index: geneve-ut-1260
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10823,7 +10823,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1258
+Index: geneve-ut-1261
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10847,7 +10847,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1259
+Index: geneve-ut-1262
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10861,7 +10861,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1260
+Index: geneve-ut-1263
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10880,7 +10880,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1261
+Index: geneve-ut-1264
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10908,7 +10908,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1262
+Index: geneve-ut-1265
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10937,7 +10937,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1263
+Index: geneve-ut-1266
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10956,7 +10956,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1264
+Index: geneve-ut-1267
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10984,7 +10984,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1265
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10999,7 +10999,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1266
+Index: geneve-ut-1269
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11062,7 +11062,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1267
+Index: geneve-ut-1270
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11083,7 +11083,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1268
+Index: geneve-ut-1271
 
 ```python
 any where host.os.type == "windows" and
@@ -11145,7 +11145,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1270
+Index: geneve-ut-1273
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11174,7 +11174,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1271
+Index: geneve-ut-1274
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11188,7 +11188,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1272
+Index: geneve-ut-1275
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11221,7 +11221,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1275
+Index: geneve-ut-1278
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11268,7 +11268,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1276
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11295,7 +11295,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1277
+Index: geneve-ut-1280
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11308,7 +11308,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1288
+Index: geneve-ut-1291
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11325,7 +11325,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1290
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11350,7 +11350,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1295
+Index: geneve-ut-1298
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11366,7 +11366,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1296
+Index: geneve-ut-1299
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11387,7 +11387,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1298
+Index: geneve-ut-1301
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11404,7 +11404,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1299
+Index: geneve-ut-1302
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11417,7 +11417,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1300
+Index: geneve-ut-1303
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11441,7 +11441,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1302
+Index: geneve-ut-1305
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11470,7 +11470,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1304
+Index: geneve-ut-1307
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11497,7 +11497,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11521,7 +11521,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1308
+Index: geneve-ut-1311
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11539,7 +11539,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1309
+Index: geneve-ut-1312
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11562,7 +11562,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1310
+Index: geneve-ut-1313
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11619,7 +11619,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11636,7 +11636,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1312
+Index: geneve-ut-1315
 
 ```python
 sequence by process.entity_id
@@ -11650,7 +11650,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1327
+Index: geneve-ut-1330
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11665,7 +11665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1328
+Index: geneve-ut-1331
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11696,7 +11696,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1329
+Index: geneve-ut-1332
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11710,7 +11710,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1330
+Index: geneve-ut-1333
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11723,7 +11723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11735,7 +11735,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11748,7 +11748,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11767,7 +11767,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1335
+Index: geneve-ut-1338
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11780,7 +11780,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1336
+Index: geneve-ut-1339
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11801,7 +11801,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11815,7 +11815,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11835,7 +11835,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1341
+Index: geneve-ut-1344
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11859,7 +11859,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1342
+Index: geneve-ut-1345
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11875,7 +11875,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1343
+Index: geneve-ut-1346
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11892,7 +11892,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1344
+Index: geneve-ut-1347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11913,7 +11913,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1346
+Index: geneve-ut-1349
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11926,7 +11926,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1348
+Index: geneve-ut-1351
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11954,7 +11954,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1351
+Index: geneve-ut-1354
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11970,7 +11970,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1352
+Index: geneve-ut-1355
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11993,7 +11993,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1353
+Index: geneve-ut-1356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12006,7 +12006,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12019,7 +12019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1360
+Index: geneve-ut-1363
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12033,7 +12033,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1361
+Index: geneve-ut-1364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +12048,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12071,7 +12071,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1366
+Index: geneve-ut-1369
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12114,7 +12114,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1367
+Index: geneve-ut-1370
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12132,7 +12132,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1368
+Index: geneve-ut-1371
 
 ```python
 host.os.type:"windows" and
@@ -12148,7 +12148,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12160,7 +12160,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1372
+Index: geneve-ut-1375
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12176,7 +12176,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12192,7 +12192,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12210,7 +12210,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12224,7 +12224,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1377
+Index: geneve-ut-1380
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12247,7 +12247,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1379
+Index: geneve-ut-1382
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12263,7 +12263,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12276,7 +12276,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1381
+Index: geneve-ut-1384
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12306,7 +12306,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1387
+Index: geneve-ut-1390
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12329,7 +12329,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1388
+Index: geneve-ut-1391
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12348,7 +12348,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1393
+Index: geneve-ut-1396
 
 ```python
 process where host.os.type == "windows" and 
@@ -12490,7 +12490,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1394
+Index: geneve-ut-1397
 
 ```python
 process where host.os.type == "windows" and
@@ -12567,7 +12567,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1398
+Index: geneve-ut-1401
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12584,7 +12584,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1399
+Index: geneve-ut-1402
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12618,7 +12618,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12630,7 +12630,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1402
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12669,7 +12669,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1405
+Index: geneve-ut-1408
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12682,7 +12682,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1410
+Index: geneve-ut-1413
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12696,7 +12696,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1417
+Index: geneve-ut-1420
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12734,7 +12734,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1418
+Index: geneve-ut-1421
 
 ```python
 network where host.os.type == "windows" and
@@ -12760,7 +12760,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1421
+Index: geneve-ut-1424
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12775,7 +12775,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12789,7 +12789,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1425
+Index: geneve-ut-1428
 
 ```python
 file where host.os.type == "windows" and
@@ -12803,7 +12803,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1426
+Index: geneve-ut-1429
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12816,7 +12816,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1427
+Index: geneve-ut-1430
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12836,7 +12836,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1430
+Index: geneve-ut-1433
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12895,7 +12895,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1431
+Index: geneve-ut-1434
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13090,7 +13090,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1446
+Index: geneve-ut-1449
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13106,7 +13106,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1447
+Index: geneve-ut-1450
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13120,7 +13120,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1448
+Index: geneve-ut-1451
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13134,7 +13134,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1449
+Index: geneve-ut-1452
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13151,7 +13151,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13165,7 +13165,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1451
+Index: geneve-ut-1454
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13181,7 +13181,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1456
+Index: geneve-ut-1459
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13193,7 +13193,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1457
+Index: geneve-ut-1460
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13209,7 +13209,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1458
+Index: geneve-ut-1461
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13229,7 +13229,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1460
+Index: geneve-ut-1463
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13269,7 +13269,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1462
+Index: geneve-ut-1465
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13281,7 +13281,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1463
+Index: geneve-ut-1466
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13302,7 +13302,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1464
+Index: geneve-ut-1467
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13323,7 +13323,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1465
+Index: geneve-ut-1468
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13344,7 +13344,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1466
+Index: geneve-ut-1469
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13370,7 +13370,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1467
+Index: geneve-ut-1470
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13386,7 +13386,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1468
+Index: geneve-ut-1471
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13400,7 +13400,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1470
+Index: geneve-ut-1473
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13423,7 +13423,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1472
+Index: geneve-ut-1475
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13440,7 +13440,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1473
+Index: geneve-ut-1476
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13463,7 +13463,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1474
+Index: geneve-ut-1477
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13476,7 +13476,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1475
+Index: geneve-ut-1478
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13490,7 +13490,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1476
+Index: geneve-ut-1479
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13507,7 +13507,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1477
+Index: geneve-ut-1480
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13561,7 +13561,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1478
+Index: geneve-ut-1481
 
 ```python
 any where host.os.type == "windows" and
@@ -13588,7 +13588,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1484
+Index: geneve-ut-1487
 
 ```python
 file where host.os.type == "windows" and
@@ -13603,7 +13603,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1485
+Index: geneve-ut-1488
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13634,7 +13634,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1486
+Index: geneve-ut-1489
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +13648,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1487
+Index: geneve-ut-1490
 
 ```python
 sequence with maxspan=1m
@@ -13690,7 +13690,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1488
+Index: geneve-ut-1491
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13715,7 +13715,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13769,7 +13769,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1490
+Index: geneve-ut-1493
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13789,7 +13789,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1491
+Index: geneve-ut-1494
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13810,7 +13810,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13825,7 +13825,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13845,7 +13845,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1494
+Index: geneve-ut-1497
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13887,7 +13887,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1498
+Index: geneve-ut-1501
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13902,7 +13902,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1499
+Index: geneve-ut-1502
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13937,7 +13937,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1500
+Index: geneve-ut-1503
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13954,7 +13954,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1505
+Index: geneve-ut-1508
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13968,7 +13968,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1508
+Index: geneve-ut-1511
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13981,7 +13981,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1509
+Index: geneve-ut-1512
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13993,7 +13993,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1510
+Index: geneve-ut-1513
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14008,7 +14008,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14036,7 +14036,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1514
+Index: geneve-ut-1517
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14061,7 +14061,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1518
+Index: geneve-ut-1521
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14098,7 +14098,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1519
+Index: geneve-ut-1522
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14112,7 +14112,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1520
+Index: geneve-ut-1523
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14128,7 +14128,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1521
+Index: geneve-ut-1524
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14142,7 +14142,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1522
+Index: geneve-ut-1525
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14172,7 +14172,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1523
+Index: geneve-ut-1526
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14201,7 +14201,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1524
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14217,7 +14217,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1525
+Index: geneve-ut-1528
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14231,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 file where host.os.type == "windows" and
@@ -14267,7 +14267,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1529
+Index: geneve-ut-1532
 
 ```python
 process where event.type == "start" and
@@ -14281,7 +14281,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1530
+Index: geneve-ut-1533
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14295,7 +14295,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1531
+Index: geneve-ut-1534
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14315,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1533
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14332,7 +14332,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1534
+Index: geneve-ut-1537
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14344,7 +14344,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1535
+Index: geneve-ut-1538
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14361,7 +14361,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1536
+Index: geneve-ut-1539
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14379,7 +14379,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1543
+Index: geneve-ut-1546
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14392,7 +14392,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1544
+Index: geneve-ut-1547
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14419,7 +14419,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1545
+Index: geneve-ut-1548
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14432,7 +14432,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1546
+Index: geneve-ut-1549
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14446,7 +14446,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14463,7 +14463,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14486,7 +14486,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14503,7 +14503,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1554
+Index: geneve-ut-1557
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14516,7 +14516,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1556
+Index: geneve-ut-1559
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14540,7 +14540,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1557
+Index: geneve-ut-1560
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14568,7 +14568,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1573
+Index: geneve-ut-1576
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14589,7 +14589,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1575
+Index: geneve-ut-1578
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14617,7 +14617,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1577
+Index: geneve-ut-1580
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14657,7 +14657,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1578
+Index: geneve-ut-1581
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14674,7 +14674,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1579
+Index: geneve-ut-1582
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14688,7 +14688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1580
+Index: geneve-ut-1583
 
 ```python
 file where host.os.type == "windows" and
@@ -14707,7 +14707,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1581
+Index: geneve-ut-1584
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14721,7 +14721,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1583
+Index: geneve-ut-1586
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14739,7 +14739,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1585
+Index: geneve-ut-1588
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14757,7 +14757,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1588
+Index: geneve-ut-1591
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14771,7 +14771,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1590
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14786,7 +14786,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1591
+Index: geneve-ut-1594
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14809,7 +14809,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1593
+Index: geneve-ut-1596
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14891,7 +14891,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1594
+Index: geneve-ut-1597
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14912,7 +14912,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1595
+Index: geneve-ut-1598
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14938,7 +14938,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1598
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14991,7 +14991,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1599
+Index: geneve-ut-1602
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15003,7 +15003,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1600
+Index: geneve-ut-1603
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15015,7 +15015,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1601
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and
@@ -15030,7 +15030,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1602
+Index: geneve-ut-1605
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15060,7 +15060,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1603
+Index: geneve-ut-1606
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15120,7 +15120,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1606
+Index: geneve-ut-1609
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15133,7 +15133,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1607
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15165,7 +15165,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1608
+Index: geneve-ut-1611
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15189,7 +15189,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1610
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15222,7 +15222,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1611
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15239,7 +15239,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1613
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15268,7 +15268,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1614
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15282,7 +15282,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1615
+Index: geneve-ut-1618
 
 ```python
 sequence by process.entity_id
@@ -15307,7 +15307,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1616
+Index: geneve-ut-1619
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15341,7 +15341,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1617
+Index: geneve-ut-1620
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15369,7 +15369,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1618
+Index: geneve-ut-1621
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15388,7 +15388,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1624
+Index: geneve-ut-1627
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15416,7 +15416,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1625
+Index: geneve-ut-1628
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15435,7 +15435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1629
+Index: geneve-ut-1632
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15447,7 +15447,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1630
+Index: geneve-ut-1633
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15459,7 +15459,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1631
+Index: geneve-ut-1634
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15471,7 +15471,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1632
+Index: geneve-ut-1635
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15483,7 +15483,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1643
+Index: geneve-ut-1646
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15496,7 +15496,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1644
+Index: geneve-ut-1647
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15534,7 +15534,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1646
+Index: geneve-ut-1649
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15549,7 +15549,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1647
+Index: geneve-ut-1650
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15568,7 +15568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1648
+Index: geneve-ut-1651
 
 ```python
 sequence with maxspan=1m
@@ -15616,7 +15616,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1650
+Index: geneve-ut-1653
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15639,7 +15639,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1652
+Index: geneve-ut-1655
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15653,7 +15653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1653
+Index: geneve-ut-1656
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15667,7 +15667,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1655
+Index: geneve-ut-1658
 
 ```python
 sequence by host.id, process.entity_id
@@ -15684,7 +15684,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1656
+Index: geneve-ut-1659
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15698,7 +15698,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1657
+Index: geneve-ut-1660
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15718,7 +15718,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1658
+Index: geneve-ut-1661
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15747,7 +15747,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1659
+Index: geneve-ut-1662
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15767,7 +15767,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1660
+Index: geneve-ut-1663
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15780,7 +15780,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1662
+Index: geneve-ut-1665
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15822,7 +15822,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1663
+Index: geneve-ut-1666
 
 ```python
 sequence with maxspan=1m
@@ -15845,7 +15845,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1664
+Index: geneve-ut-1667
 
 ```python
 sequence with maxspan=1s
@@ -15893,7 +15893,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1665
+Index: geneve-ut-1668
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15910,7 +15910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1667
+Index: geneve-ut-1670
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15939,7 +15939,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1669
+Index: geneve-ut-1673
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15967,7 +15967,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1670
+Index: geneve-ut-1674
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15984,7 +15984,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1672
+Index: geneve-ut-1676
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16003,7 +16003,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1673
+Index: geneve-ut-1677
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16024,7 +16024,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1682
+Index: geneve-ut-1686
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16038,7 +16038,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1684
+Index: geneve-ut-1688
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16057,7 +16057,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1685
+Index: geneve-ut-1689
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16071,7 +16071,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1686
+Index: geneve-ut-1690
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16091,7 +16091,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1688
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16109,7 +16109,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1689
+Index: geneve-ut-1693
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16130,7 +16130,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1691
+Index: geneve-ut-1695
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16144,7 +16144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1692
+Index: geneve-ut-1696
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16159,7 +16159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1693
+Index: geneve-ut-1697
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16200,7 +16200,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1695
+Index: geneve-ut-1699
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16225,7 +16225,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1696
+Index: geneve-ut-1700
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16264,7 +16264,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1697
+Index: geneve-ut-1701
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16278,7 +16278,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1698
+Index: geneve-ut-1702
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16317,7 +16317,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1699
+Index: geneve-ut-1703
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16331,7 +16331,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1700
+Index: geneve-ut-1704
 
 ```python
 process where event.type == "start" and
@@ -16403,7 +16403,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1704
+Index: geneve-ut-1708
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16424,7 +16424,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1707
+Index: geneve-ut-1711
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16441,7 +16441,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1710
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16459,7 +16459,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1711
+Index: geneve-ut-1715
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16471,7 +16471,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1712
+Index: geneve-ut-1716
 
 ```python
 file where host.os.type == "windows" and
@@ -16504,7 +16504,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1715
+Index: geneve-ut-1719
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16536,7 +16536,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1717
+Index: geneve-ut-1721
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16572,7 +16572,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1718
+Index: geneve-ut-1722
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16589,7 +16589,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1719
+Index: geneve-ut-1723
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16609,7 +16609,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1721
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16624,7 +16624,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1722
+Index: geneve-ut-1726
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16645,7 +16645,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1723
+Index: geneve-ut-1727
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16668,7 +16668,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1724
+Index: geneve-ut-1728
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16681,7 +16681,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1725
+Index: geneve-ut-1729
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16698,7 +16698,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1728
+Index: geneve-ut-1732
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16723,7 +16723,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1731
+Index: geneve-ut-1735
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16754,7 +16754,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1732
+Index: geneve-ut-1736
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16803,7 +16803,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1733
+Index: geneve-ut-1737
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16817,7 +16817,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1734
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16832,7 +16832,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1735
+Index: geneve-ut-1739
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16847,7 +16847,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1736
+Index: geneve-ut-1740
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16869,7 +16869,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1737
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16890,7 +16890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1741
+Index: geneve-ut-1745
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16904,7 +16904,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1742
+Index: geneve-ut-1746
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16927,7 +16927,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1772
+Index: geneve-ut-1776
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16952,7 +16952,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1773
+Index: geneve-ut-1777
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16985,7 +16985,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1774
+Index: geneve-ut-1778
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17044,7 +17044,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1776
+Index: geneve-ut-1780
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17062,7 +17062,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1777
+Index: geneve-ut-1781
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17074,7 +17074,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1780
+Index: geneve-ut-1784
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17099,7 +17099,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1786
+Index: geneve-ut-1790
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17114,7 +17114,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1787
+Index: geneve-ut-1791
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17137,7 +17137,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1790
+Index: geneve-ut-1794
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17151,7 +17151,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1792
+Index: geneve-ut-1796
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17173,7 +17173,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1794
+Index: geneve-ut-1798
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17200,7 +17200,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1798
+Index: geneve-ut-1802
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17239,7 +17239,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1799
+Index: geneve-ut-1803
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17262,7 +17262,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1800
+Index: geneve-ut-1804
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17276,7 +17276,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1801
+Index: geneve-ut-1805
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17292,7 +17292,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1802
+Index: geneve-ut-1806
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17308,7 +17308,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1803
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17322,7 +17322,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1805
+Index: geneve-ut-1809
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17345,7 +17345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1806
+Index: geneve-ut-1810
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17373,7 +17373,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1807
+Index: geneve-ut-1811
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +17388,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1810
+Index: geneve-ut-1814
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17415,7 +17415,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1812
+Index: geneve-ut-1816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17446,7 +17446,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1813
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17462,7 +17462,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1814
+Index: geneve-ut-1818
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17475,7 +17475,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1816
+Index: geneve-ut-1820
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17491,7 +17491,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1817
+Index: geneve-ut-1821
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17507,7 +17507,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1818
+Index: geneve-ut-1822
 
 ```python
 any where host.os.type == "windows" and 
@@ -17574,7 +17574,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1820
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17590,7 +17590,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1822
+Index: geneve-ut-1826
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17626,7 +17626,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1823
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +17664,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1824
+Index: geneve-ut-1828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17699,7 +17699,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1825
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +17733,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1827
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17754,7 +17754,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1832
+Index: geneve-ut-1836
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17831,7 +17831,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1833
+Index: geneve-ut-1837
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17853,7 +17853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1834
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17877,7 +17877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1836
+Index: geneve-ut-1840
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17898,7 +17898,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1839
+Index: geneve-ut-1843
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17913,7 +17913,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1842
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17926,7 +17926,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1843
+Index: geneve-ut-1847
 
 ```python
 any where host.os.type == "windows" and
@@ -17941,7 +17941,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1844
+Index: geneve-ut-1848
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17957,7 +17957,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1845
+Index: geneve-ut-1849
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17971,7 +17971,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1849
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18028,7 +18028,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1850
+Index: geneve-ut-1854
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18042,7 +18042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1852
+Index: geneve-ut-1856
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18074,7 +18074,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1854
+Index: geneve-ut-1858
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18087,7 +18087,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1855
+Index: geneve-ut-1859
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18106,7 +18106,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1856
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18152,7 +18152,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1858
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18173,7 +18173,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1859
+Index: geneve-ut-1863
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18193,7 +18193,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1860
+Index: geneve-ut-1864
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18207,7 +18207,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1861
+Index: geneve-ut-1865
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18239,7 +18239,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1864
+Index: geneve-ut-1868
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18260,7 +18260,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1866
+Index: geneve-ut-1870
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18361,7 +18361,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1870
+Index: geneve-ut-1874
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18409,7 +18409,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1873
+Index: geneve-ut-1877
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18435,7 +18435,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1874
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18480,7 +18480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1875
+Index: geneve-ut-1879
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18504,7 +18504,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1876
+Index: geneve-ut-1880
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18520,7 +18520,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1878
+Index: geneve-ut-1882
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18545,7 +18545,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1879
+Index: geneve-ut-1883
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18560,7 +18560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1882
+Index: geneve-ut-1886
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18574,7 +18574,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1883
+Index: geneve-ut-1887
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18594,7 +18594,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1884
+Index: geneve-ut-1888
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18629,7 +18629,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1888
+Index: geneve-ut-1892
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18647,7 +18647,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1889
+Index: geneve-ut-1893
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18660,7 +18660,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1892
+Index: geneve-ut-1896
 
 ```python
 any where host.os.type == "windows" and
@@ -18693,7 +18693,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1894
+Index: geneve-ut-1898
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18711,7 +18711,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1895
+Index: geneve-ut-1899
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18733,7 +18733,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1898
+Index: geneve-ut-1902
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18772,7 +18772,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1899
+Index: geneve-ut-1903
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18802,7 +18802,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1900
+Index: geneve-ut-1904
 
 ```python
 any where host.os.type == "windows" and
@@ -18836,7 +18836,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1901
+Index: geneve-ut-1905
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18850,7 +18850,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1904
+Index: geneve-ut-1908
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18881,7 +18881,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1905
+Index: geneve-ut-1909
 
 ```python
 any where host.os.type == "windows" and
@@ -18901,7 +18901,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1906
+Index: geneve-ut-1910
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18942,7 +18942,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1907
+Index: geneve-ut-1911
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18958,7 +18958,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1908
+Index: geneve-ut-1912
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18988,7 +18988,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1912
+Index: geneve-ut-1916
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19001,7 +19001,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1913
+Index: geneve-ut-1917
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19025,7 +19025,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1916
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19043,7 +19043,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1918
+Index: geneve-ut-1922
 
 ```python
 any where host.os.type == "windows" and
@@ -19058,7 +19058,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1919
+Index: geneve-ut-1923
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19076,7 +19076,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1920
+Index: geneve-ut-1924
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19097,7 +19097,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1921
+Index: geneve-ut-1925
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19116,7 +19116,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1924
+Index: geneve-ut-1928
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19141,7 +19141,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1925
+Index: geneve-ut-1929
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19154,7 +19154,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1927
+Index: geneve-ut-1931
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19167,7 +19167,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1929
+Index: geneve-ut-1933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19190,7 +19190,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1931
+Index: geneve-ut-1935
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19209,7 +19209,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1932
+Index: geneve-ut-1936
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19231,7 +19231,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1933
+Index: geneve-ut-1937
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19264,7 +19264,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1935
+Index: geneve-ut-1939
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19282,7 +19282,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1936
+Index: geneve-ut-1940
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19296,7 +19296,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1937
+Index: geneve-ut-1941
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19320,7 +19320,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1938
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19343,7 +19343,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1939
+Index: geneve-ut-1943
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19362,7 +19362,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1942
+Index: geneve-ut-1946
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19381,7 +19381,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1944
+Index: geneve-ut-1948
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19416,7 +19416,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1945
+Index: geneve-ut-1949
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19433,7 +19433,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1946
+Index: geneve-ut-1950
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1947
+Index: geneve-ut-1951
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19493,7 +19493,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1948
+Index: geneve-ut-1952
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19509,7 +19509,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1949
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19523,7 +19523,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1950
+Index: geneve-ut-1954
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19561,7 +19561,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1951
+Index: geneve-ut-1955
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19615,7 +19615,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1952
+Index: geneve-ut-1956
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19643,7 +19643,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1954
+Index: geneve-ut-1958
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19657,7 +19657,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1955
+Index: geneve-ut-1959
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19703,7 +19703,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1956
+Index: geneve-ut-1960
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19742,7 +19742,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1957
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19755,7 +19755,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1961
+Index: geneve-ut-1965
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19788,7 +19788,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1962
+Index: geneve-ut-1966
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19802,7 +19802,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1963
+Index: geneve-ut-1967
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19816,7 +19816,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1964
+Index: geneve-ut-1968
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19830,7 +19830,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1965
+Index: geneve-ut-1969
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19869,7 +19869,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1973
+Index: geneve-ut-1977
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19911,7 +19911,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1975
+Index: geneve-ut-1979
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19933,7 +19933,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1977
+Index: geneve-ut-1981
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19946,7 +19946,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1980
+Index: geneve-ut-1984
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19963,7 +19963,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1981
+Index: geneve-ut-1985
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19979,7 +19979,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1982
+Index: geneve-ut-1986
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19992,7 +19992,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1983
+Index: geneve-ut-1987
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20007,7 +20007,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1984
+Index: geneve-ut-1988
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20030,7 +20030,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1985
+Index: geneve-ut-1989
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20046,7 +20046,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1986
+Index: geneve-ut-1990
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20062,7 +20062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1992
+Index: geneve-ut-1996
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20074,7 +20074,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1993
+Index: geneve-ut-1997
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20103,7 +20103,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1995
+Index: geneve-ut-1999
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20117,7 +20117,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2000
+Index: geneve-ut-2004
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20137,7 +20137,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2001
+Index: geneve-ut-2005
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20162,7 +20162,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2008
+Index: geneve-ut-2012
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20176,7 +20176,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2009
+Index: geneve-ut-2013
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20199,7 +20199,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2018
+Index: geneve-ut-2022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20233,7 +20233,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2020
+Index: geneve-ut-2024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20252,7 +20252,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2027
+Index: geneve-ut-2031
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20271,7 +20271,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2042
+Index: geneve-ut-2046
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20288,7 +20288,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2045
+Index: geneve-ut-2049
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20305,7 +20305,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2061
+Index: geneve-ut-2065
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20324,7 +20324,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2065
+Index: geneve-ut-2069
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20366,7 +20366,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2066
+Index: geneve-ut-2070
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20411,7 +20411,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2069
+Index: geneve-ut-2073
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20453,7 +20453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2071
+Index: geneve-ut-2075
 
 ```python
 host.os.type:"linux" and 
@@ -20481,7 +20481,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2075
+Index: geneve-ut-2079
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20505,7 +20505,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2076
+Index: geneve-ut-2080
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20545,7 +20545,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2077
+Index: geneve-ut-2081
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20592,7 +20592,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2081
+Index: geneve-ut-2085
 
 ```python
 sequence by process.entity_id
@@ -20629,7 +20629,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2113
+Index: geneve-ut-2117
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20643,7 +20643,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2114
+Index: geneve-ut-2118
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20686,7 +20686,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2115
+Index: geneve-ut-2119
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20699,7 +20699,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2118
+Index: geneve-ut-2122
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20713,7 +20713,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2119
+Index: geneve-ut-2123
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20726,7 +20726,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2123
+Index: geneve-ut-2127
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20751,7 +20751,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2124
+Index: geneve-ut-2128
 
 ```python
 process where event.type == "start" and
@@ -20766,7 +20766,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2125
+Index: geneve-ut-2129
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20783,7 +20783,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2126
+Index: geneve-ut-2130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20797,7 +20797,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2127
+Index: geneve-ut-2131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20813,7 +20813,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2128
+Index: geneve-ut-2132
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20827,7 +20827,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2129
+Index: geneve-ut-2133
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20854,7 +20854,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2131
+Index: geneve-ut-2135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20866,7 +20866,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2132
+Index: geneve-ut-2136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20882,7 +20882,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2133
+Index: geneve-ut-2137
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20905,7 +20905,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2134
+Index: geneve-ut-2138
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20918,7 +20918,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2136
+Index: geneve-ut-2140
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20930,7 +20930,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2137
+Index: geneve-ut-2141
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20942,7 +20942,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2138
+Index: geneve-ut-2142
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20954,7 +20954,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2139
+Index: geneve-ut-2143
 
 ```python
 web where (
@@ -20982,7 +20982,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2145
+Index: geneve-ut-2149
 
 ```python
 any where (
@@ -21054,7 +21054,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2147
+Index: geneve-ut-2151
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21075,7 +21075,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2150
+Index: geneve-ut-2154
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21089,7 +21089,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2151
+Index: geneve-ut-2155
 
 ```python
 file where event.type == "deletion" and
@@ -21106,7 +21106,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2152
+Index: geneve-ut-2156
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21124,7 +21124,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2155
+Index: geneve-ut-2159
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21162,7 +21162,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2157
+Index: geneve-ut-2161
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21199,7 +21199,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2158
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21214,7 +21214,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2159
+Index: geneve-ut-2163
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21227,7 +21227,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2160
+Index: geneve-ut-2164
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21246,7 +21246,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2161
+Index: geneve-ut-2165
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21271,7 +21271,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2162
+Index: geneve-ut-2166
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21297,7 +21297,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2163
+Index: geneve-ut-2167
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21319,7 +21319,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2164
+Index: geneve-ut-2168
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21336,7 +21336,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2166
+Index: geneve-ut-2170
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21355,7 +21355,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2167
+Index: geneve-ut-2171
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21395,7 +21395,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2168
+Index: geneve-ut-2172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21412,7 +21412,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2170
+Index: geneve-ut-2174
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21425,7 +21425,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2171
+Index: geneve-ut-2175
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21439,7 +21439,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2172
+Index: geneve-ut-2176
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21467,7 +21467,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2173
+Index: geneve-ut-2177
 
 ```python
 process where event.type == "start" and
@@ -21492,7 +21492,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2174
+Index: geneve-ut-2178
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21506,7 +21506,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2175
+Index: geneve-ut-2179
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21522,7 +21522,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2176
+Index: geneve-ut-2180
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21557,7 +21557,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2177
+Index: geneve-ut-2181
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21575,7 +21575,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2180
+Index: geneve-ut-2184
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/documents_from_rules-8.19.md
+++ b/tests/reports/documents_from_rules-8.19.md
@@ -5,32 +5,15 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.29
+Rules version: 8.19.30
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (236)](#unsupported-rule-type-new_terms-236)
-      1. [Unsupported rule type: esql (187)](#unsupported-rule-type-esql-187)
+      1. [Unsupported rule type: new_terms (238)](#unsupported-rule-type-new_terms-238)
+      1. [Unsupported rule type: esql (188)](#unsupported-rule-type-esql-188)
       1. [Unsupported rule type: machine_learning (95)](#unsupported-rule-type-machine_learning-95)
       1. [Unsupported rule type: threshold (27)](#unsupported-rule-type-threshold-27)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)](#error-at-line10column3
-comparisons-against-fields-are-not-currently-supported-offender-lengthusername---1-in-
-
---verify-the-machine-account-matches-the-full-hostname-not-just-a-prefix-substring-
--lengthhostname--lengthusername---1-or-substringhostname-lengthusername---1-lengthusername---and
---
-
---verify-if-the-source-ip-belongs-to-the-host-
--not-endswithstringsourceip-stringhostip-and-1)
       1. [Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -50,7 +33,7 @@ invalid-syntax
 --processargs-curl-or-bincurl-or-wget
 -------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (384)](#field-type-solver-constant_keyword-384)
+      1. [Field type solver: constant_keyword (385)](#field-type-solver-constant_keyword-385)
       1. [Unsupported function: match (33)](#unsupported-function-match-33)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
       1. [Root with too many branches (limit: 10000) (23)](#root-with-too-many-branches-limit-10000-23)
@@ -64,6 +47,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
+      1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
       1. [Unsolvable constraints: event.category & event.type (empty intersection) (2)](#unsolvable-constraints-eventcategory--eventtype-empty-intersection-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'python*'}): ('python*')) (2)](#unsolvable-constraints-processname-excluded-by-stringspython-python-2)
@@ -71,7 +55,6 @@ invalid-syntax
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
       1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
-      1. [Unsupported function: endswith (2)](#unsupported-function-endswith-2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
@@ -158,9 +141,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (236)
+### Unsupported rule type: new_terms (238)
 
-236 rules:
+238 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Batch Job Submitted with Container Override by Unusual Identity
@@ -282,6 +265,7 @@ invalid-syntax
 * First Time Seen Memcached Writer
 * First Time Seen NFS AUTH_SYS Root UID Access
 * First Time Seen NewCredentials Logon Process
+* First Time Seen RMM Signer Across the Environment
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
@@ -332,6 +316,7 @@ invalid-syntax
 * Network Activity Detected via Kworker
 * Network Traffic Capture via CAP_NET_RAW
 * New GitHub Self Hosted Action Runner
+* Newly Observed RC4 Kerberos Service Ticket Request
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
@@ -399,9 +384,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (187)
+### Unsupported rule type: esql (188)
 
-187 rules:
+188 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -572,6 +557,7 @@ invalid-syntax
 * PowerShell Obfuscation via Negative Index String Reversal
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
+* Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
 * Successful AMQP Multi-Queue Purge Burst
@@ -734,20 +720,6 @@ invalid-syntax
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)
-
-1 rules:
-
-* Potential Computer Account NTLM Relay Activity
-
 ### Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -770,9 +742,9 @@ Invalid syntax
 
 ## Generation errors
 
-### Field type solver: constant_keyword (384)
+### Field type solver: constant_keyword (385)
 
-384 rules:
+385 rules:
 * AWS Account Closed
 * AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
 * AWS Attempt to Leave Organization
@@ -882,6 +854,7 @@ Invalid syntax
 * Azure AKS Kubelet Proxy to Command Execution Endpoint
 * Azure AKS Kubernetes Events Deleted
 * Azure AKS Secret get or list with Suspicious User Agent
+* Azure AKS Service Account Token Created via TokenRequest API
 * Azure AKS Suspicious Self-Subject Review by Service Account or Node Identity
 * Azure Automation Account Created
 * Azure Automation Runbook Created or Modified
@@ -1346,6 +1319,13 @@ Invalid syntax
 * Unsigned DLL Loaded by a Trusted Process
 * Unsigned DLL Side-Loading from a Suspicious Folder
 
+### Unsupported function: endswith (3)
+
+3 rules:
+* Potential Computer Account NTLM Relay Activity
+* Potential Machine Account Relay Attack via SMB
+* Unusual Execution via Microsoft Common Console File
+
 ### Unsolvable constraints: event.category & event.type (empty intersection) (2)
 
 2 rules:
@@ -1387,12 +1367,6 @@ Invalid syntax
 2 rules:
 * Parent Process PID Spoofing
 * Privileges Elevation via Parent Process PID Spoofing
-
-### Unsupported function: endswith (2)
-
-2 rules:
-* Potential Machine Account Relay Attack via SMB
-* Unusual Execution via Microsoft Common Console File
 
 ### Unsupported is_negated: {'is_negated': True} (2)
 

--- a/tests/reports/documents_from_rules-9.3.md
+++ b/tests/reports/documents_from_rules-9.3.md
@@ -5,32 +5,15 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.17
+Rules version: 9.3.18
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (239)](#unsupported-rule-type-new_terms-239)
-      1. [Unsupported rule type: esql (201)](#unsupported-rule-type-esql-201)
+      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
+      1. [Unsupported rule type: esql (202)](#unsupported-rule-type-esql-202)
       1. [Unsupported rule type: machine_learning (105)](#unsupported-rule-type-machine_learning-105)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)](#error-at-line10column3
-comparisons-against-fields-are-not-currently-supported-offender-lengthusername---1-in-
-
---verify-the-machine-account-matches-the-full-hostname-not-just-a-prefix-substring-
--lengthhostname--lengthusername---1-or-substringhostname-lengthusername---1-lengthusername---and
---
-
---verify-if-the-source-ip-belongs-to-the-host-
--not-endswithstringsourceip-stringhostip-and-1)
       1. [Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -50,7 +33,7 @@ invalid-syntax
 --processargs-curl-or-bincurl-or-wget
 -------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (388)](#field-type-solver-constant_keyword-388)
+      1. [Field type solver: constant_keyword (389)](#field-type-solver-constant_keyword-389)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
@@ -65,6 +48,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
+      1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
       1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nc.traditional'}): ('nc.traditional')) (2)](#unsolvable-constraints-processname-excluded-by-stringsnctraditional-nctraditional-2)
@@ -73,7 +57,6 @@ invalid-syntax
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
       1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
-      1. [Unsupported function: endswith (2)](#unsupported-function-endswith-2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
@@ -159,9 +142,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (239)
+### Unsupported rule type: new_terms (241)
 
-239 rules:
+241 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -284,6 +267,7 @@ invalid-syntax
 * First Time Seen Memcached Writer
 * First Time Seen NFS AUTH_SYS Root UID Access
 * First Time Seen NewCredentials Logon Process
+* First Time Seen RMM Signer Across the Environment
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
@@ -335,6 +319,7 @@ invalid-syntax
 * Network Traffic Capture via CAP_NET_RAW
 * New GitHub Self Hosted Action Runner
 * New USB Storage Device Mounted
+* Newly Observed RC4 Kerberos Service Ticket Request
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
@@ -403,9 +388,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (201)
+### Unsupported rule type: esql (202)
 
-201 rules:
+202 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -587,6 +572,7 @@ invalid-syntax
 * PowerShell Obfuscation via Negative Index String Reversal
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
+* Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
@@ -763,20 +749,6 @@ invalid-syntax
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)
-
-1 rules:
-
-* Potential Computer Account NTLM Relay Activity
-
 ### Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -799,9 +771,9 @@ Invalid syntax
 
 ## Generation errors
 
-### Field type solver: constant_keyword (388)
+### Field type solver: constant_keyword (389)
 
-388 rules:
+389 rules:
 * AWS Account Closed
 * AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
 * AWS Attempt to Leave Organization
@@ -911,6 +883,7 @@ Invalid syntax
 * Azure AKS Kubelet Proxy to Command Execution Endpoint
 * Azure AKS Kubernetes Events Deleted
 * Azure AKS Secret get or list with Suspicious User Agent
+* Azure AKS Service Account Token Created via TokenRequest API
 * Azure AKS Suspicious Self-Subject Review by Service Account or Node Identity
 * Azure Automation Account Created
 * Azure Automation Runbook Created or Modified
@@ -1394,6 +1367,13 @@ Invalid syntax
 * Unsigned DLL Loaded by a Trusted Process
 * Unsigned DLL Side-Loading from a Suspicious Folder
 
+### Unsupported function: endswith (3)
+
+3 rules:
+* Potential Computer Account NTLM Relay Activity
+* Potential Machine Account Relay Attack via SMB
+* Unusual Execution via Microsoft Common Console File
+
 ### Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)
 
 2 rules:
@@ -1441,12 +1421,6 @@ Invalid syntax
 2 rules:
 * Parent Process PID Spoofing
 * Privileges Elevation via Parent Process PID Spoofing
-
-### Unsupported function: endswith (2)
-
-2 rules:
-* Potential Machine Account Relay Attack via SMB
-* Unusual Execution via Microsoft Common Console File
 
 ### Unsupported is_negated: {'is_negated': True} (2)
 

--- a/tests/reports/documents_from_rules-9.4.md
+++ b/tests/reports/documents_from_rules-9.4.md
@@ -5,33 +5,16 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.9
+Rules version: 9.4.10
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (239)](#unsupported-rule-type-new_terms-239)
-      1. [Unsupported rule type: esql (207)](#unsupported-rule-type-esql-207)
+      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
+      1. [Unsupported rule type: esql (208)](#unsupported-rule-type-esql-208)
       1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)](#error-at-line10column3
-comparisons-against-fields-are-not-currently-supported-offender-lengthusername---1-in-
-
---verify-the-machine-account-matches-the-full-hostname-not-just-a-prefix-substring-
--lengthhostname--lengthusername---1-or-substringhostname-lengthusername---1-lengthusername---and
---
-
---verify-if-the-source-ip-belongs-to-the-host-
--not-endswithstringsourceip-stringhostip-and-1)
       1. [Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -51,7 +34,7 @@ invalid-syntax
 --processargs-curl-or-bincurl-or-wget
 -------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (388)](#field-type-solver-constant_keyword-388)
+      1. [Field type solver: constant_keyword (389)](#field-type-solver-constant_keyword-389)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
@@ -66,6 +49,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
+      1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
       1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nc.traditional'}): ('nc.traditional')) (2)](#unsolvable-constraints-processname-excluded-by-stringsnctraditional-nctraditional-2)
@@ -74,7 +58,6 @@ invalid-syntax
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
       1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
-      1. [Unsupported function: endswith (2)](#unsupported-function-endswith-2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
@@ -160,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (239)
+### Unsupported rule type: new_terms (241)
 
-239 rules:
+241 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -285,6 +268,7 @@ invalid-syntax
 * First Time Seen Memcached Writer
 * First Time Seen NFS AUTH_SYS Root UID Access
 * First Time Seen NewCredentials Logon Process
+* First Time Seen RMM Signer Across the Environment
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
@@ -336,6 +320,7 @@ invalid-syntax
 * Network Traffic Capture via CAP_NET_RAW
 * New GitHub Self Hosted Action Runner
 * New USB Storage Device Mounted
+* Newly Observed RC4 Kerberos Service Ticket Request
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
@@ -404,9 +389,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (207)
+### Unsupported rule type: esql (208)
 
-207 rules:
+208 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -594,6 +579,7 @@ invalid-syntax
 * PowerShell Obfuscation via Negative Index String Reversal
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
+* Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
@@ -895,20 +881,6 @@ invalid-syntax
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)
-
-1 rules:
-
-* Potential Computer Account NTLM Relay Activity
-
 ### Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -931,9 +903,9 @@ Invalid syntax
 
 ## Generation errors
 
-### Field type solver: constant_keyword (388)
+### Field type solver: constant_keyword (389)
 
-388 rules:
+389 rules:
 * AWS Account Closed
 * AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
 * AWS Attempt to Leave Organization
@@ -1043,6 +1015,7 @@ Invalid syntax
 * Azure AKS Kubelet Proxy to Command Execution Endpoint
 * Azure AKS Kubernetes Events Deleted
 * Azure AKS Secret get or list with Suspicious User Agent
+* Azure AKS Service Account Token Created via TokenRequest API
 * Azure AKS Suspicious Self-Subject Review by Service Account or Node Identity
 * Azure Automation Account Created
 * Azure Automation Runbook Created or Modified
@@ -1526,6 +1499,13 @@ Invalid syntax
 * Unsigned DLL Loaded by a Trusted Process
 * Unsigned DLL Side-Loading from a Suspicious Folder
 
+### Unsupported function: endswith (3)
+
+3 rules:
+* Potential Computer Account NTLM Relay Activity
+* Potential Machine Account Relay Attack via SMB
+* Unusual Execution via Microsoft Common Console File
+
 ### Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)
 
 2 rules:
@@ -1573,12 +1553,6 @@ Invalid syntax
 2 rules:
 * Parent Process PID Spoofing
 * Privileges Elevation via Parent Process PID Spoofing
-
-### Unsupported function: endswith (2)
-
-2 rules:
-* Potential Machine Account Relay Attack via SMB
-* Unusual Execution via Microsoft Common Console File
 
 ### Unsupported is_negated: {'is_negated': True} (2)
 

--- a/tests/reports/documents_from_rules-9.5.md
+++ b/tests/reports/documents_from_rules-9.5.md
@@ -5,33 +5,16 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.2
+Rules version: 9.5.3
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (239)](#unsupported-rule-type-new_terms-239)
-      1. [Unsupported rule type: esql (207)](#unsupported-rule-type-esql-207)
+      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
+      1. [Unsupported rule type: esql (208)](#unsupported-rule-type-esql-208)
       1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)](#error-at-line10column3
-comparisons-against-fields-are-not-currently-supported-offender-lengthusername---1-in-
-
---verify-the-machine-account-matches-the-full-hostname-not-just-a-prefix-substring-
--lengthhostname--lengthusername---1-or-substringhostname-lengthusername---1-lengthusername---and
---
-
---verify-if-the-source-ip-belongs-to-the-host-
--not-endswithstringsourceip-stringhostip-and-1)
       1. [Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -51,7 +34,7 @@ invalid-syntax
 --processargs-curl-or-bincurl-or-wget
 -------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (388)](#field-type-solver-constant_keyword-388)
+      1. [Field type solver: constant_keyword (389)](#field-type-solver-constant_keyword-389)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
@@ -66,6 +49,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
+      1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
       1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nc.traditional'}): ('nc.traditional')) (2)](#unsolvable-constraints-processname-excluded-by-stringsnctraditional-nctraditional-2)
@@ -74,7 +58,6 @@ invalid-syntax
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
       1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
-      1. [Unsupported function: endswith (2)](#unsupported-function-endswith-2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
@@ -160,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (239)
+### Unsupported rule type: new_terms (241)
 
-239 rules:
+241 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -285,6 +268,7 @@ invalid-syntax
 * First Time Seen Memcached Writer
 * First Time Seen NFS AUTH_SYS Root UID Access
 * First Time Seen NewCredentials Logon Process
+* First Time Seen RMM Signer Across the Environment
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
@@ -336,6 +320,7 @@ invalid-syntax
 * Network Traffic Capture via CAP_NET_RAW
 * New GitHub Self Hosted Action Runner
 * New USB Storage Device Mounted
+* Newly Observed RC4 Kerberos Service Ticket Request
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
@@ -404,9 +389,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (207)
+### Unsupported rule type: esql (208)
 
-207 rules:
+208 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -594,6 +579,7 @@ invalid-syntax
 * PowerShell Obfuscation via Negative Index String Reversal
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
+* Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
@@ -895,20 +881,6 @@ invalid-syntax
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)
-
-1 rules:
-
-* Potential Computer Account NTLM Relay Activity
-
 ### Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -931,9 +903,9 @@ Invalid syntax
 
 ## Generation errors
 
-### Field type solver: constant_keyword (388)
+### Field type solver: constant_keyword (389)
 
-388 rules:
+389 rules:
 * AWS Account Closed
 * AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
 * AWS Attempt to Leave Organization
@@ -1043,6 +1015,7 @@ Invalid syntax
 * Azure AKS Kubelet Proxy to Command Execution Endpoint
 * Azure AKS Kubernetes Events Deleted
 * Azure AKS Secret get or list with Suspicious User Agent
+* Azure AKS Service Account Token Created via TokenRequest API
 * Azure AKS Suspicious Self-Subject Review by Service Account or Node Identity
 * Azure Automation Account Created
 * Azure Automation Runbook Created or Modified
@@ -1526,6 +1499,13 @@ Invalid syntax
 * Unsigned DLL Loaded by a Trusted Process
 * Unsigned DLL Side-Loading from a Suspicious Folder
 
+### Unsupported function: endswith (3)
+
+3 rules:
+* Potential Computer Account NTLM Relay Activity
+* Potential Machine Account Relay Attack via SMB
+* Unusual Execution via Microsoft Common Console File
+
 ### Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)
 
 2 rules:
@@ -1573,12 +1553,6 @@ Invalid syntax
 2 rules:
 * Parent Process PID Spoofing
 * Privileges Elevation via Parent Process PID Spoofing
-
-### Unsupported function: endswith (2)
-
-2 rules:
-* Potential Machine Account Relay Attack via SMB
-* Unusual Execution via Microsoft Common Console File
 
 ### Unsupported is_negated: {'is_negated': True} (2)
 

--- a/tests/reports/documents_from_rules-9.6.md
+++ b/tests/reports/documents_from_rules-9.6.md
@@ -5,33 +5,16 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.2
+Rules version: 9.5.3
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (239)](#unsupported-rule-type-new_terms-239)
-      1. [Unsupported rule type: esql (207)](#unsupported-rule-type-esql-207)
+      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
+      1. [Unsupported rule type: esql (208)](#unsupported-rule-type-esql-208)
       1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)](#error-at-line10column3
-comparisons-against-fields-are-not-currently-supported-offender-lengthusername---1-in-
-
---verify-the-machine-account-matches-the-full-hostname-not-just-a-prefix-substring-
--lengthhostname--lengthusername---1-or-substringhostname-lengthusername---1-lengthusername---and
---
-
---verify-if-the-source-ip-belongs-to-the-host-
--not-endswithstringsourceip-stringhostip-and-1)
       1. [Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -51,7 +34,7 @@ invalid-syntax
 --processargs-curl-or-bincurl-or-wget
 -------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (388)](#field-type-solver-constant_keyword-388)
+      1. [Field type solver: constant_keyword (389)](#field-type-solver-constant_keyword-389)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
@@ -66,6 +49,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
+      1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
       1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nc.traditional'}): ('nc.traditional')) (2)](#unsolvable-constraints-processname-excluded-by-stringsnctraditional-nctraditional-2)
@@ -74,7 +58,6 @@ invalid-syntax
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
       1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
-      1. [Unsupported function: endswith (2)](#unsupported-function-endswith-2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
@@ -160,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (239)
+### Unsupported rule type: new_terms (241)
 
-239 rules:
+241 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -285,6 +268,7 @@ invalid-syntax
 * First Time Seen Memcached Writer
 * First Time Seen NFS AUTH_SYS Root UID Access
 * First Time Seen NewCredentials Logon Process
+* First Time Seen RMM Signer Across the Environment
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
@@ -336,6 +320,7 @@ invalid-syntax
 * Network Traffic Capture via CAP_NET_RAW
 * New GitHub Self Hosted Action Runner
 * New USB Storage Device Mounted
+* Newly Observed RC4 Kerberos Service Ticket Request
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
@@ -404,9 +389,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (207)
+### Unsupported rule type: esql (208)
 
-207 rules:
+208 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -594,6 +579,7 @@ invalid-syntax
 * PowerShell Obfuscation via Negative Index String Reversal
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
+* Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
@@ -895,20 +881,6 @@ invalid-syntax
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)
-
-1 rules:
-
-* Potential Computer Account NTLM Relay Activity
-
 ### Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -931,9 +903,9 @@ Invalid syntax
 
 ## Generation errors
 
-### Field type solver: constant_keyword (388)
+### Field type solver: constant_keyword (389)
 
-388 rules:
+389 rules:
 * AWS Account Closed
 * AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
 * AWS Attempt to Leave Organization
@@ -1043,6 +1015,7 @@ Invalid syntax
 * Azure AKS Kubelet Proxy to Command Execution Endpoint
 * Azure AKS Kubernetes Events Deleted
 * Azure AKS Secret get or list with Suspicious User Agent
+* Azure AKS Service Account Token Created via TokenRequest API
 * Azure AKS Suspicious Self-Subject Review by Service Account or Node Identity
 * Azure Automation Account Created
 * Azure Automation Runbook Created or Modified
@@ -1526,6 +1499,13 @@ Invalid syntax
 * Unsigned DLL Loaded by a Trusted Process
 * Unsigned DLL Side-Loading from a Suspicious Folder
 
+### Unsupported function: endswith (3)
+
+3 rules:
+* Potential Computer Account NTLM Relay Activity
+* Potential Machine Account Relay Attack via SMB
+* Unusual Execution via Microsoft Common Console File
+
 ### Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)
 
 2 rules:
@@ -1573,12 +1553,6 @@ Invalid syntax
 2 rules:
 * Parent Process PID Spoofing
 * Privileges Elevation via Parent Process PID Spoofing
-
-### Unsupported function: endswith (2)
-
-2 rules:
-* Potential Machine Account Relay Attack via SMB
-* Unusual Execution via Microsoft Common Console File
 
 ### Unsupported is_negated: {'is_negated': True} (2)
 

--- a/tests/reports/documents_from_rules-serverless.md
+++ b/tests/reports/documents_from_rules-serverless.md
@@ -5,33 +5,16 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.2
+Rules version: 9.5.3
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (239)](#unsupported-rule-type-new_terms-239)
-      1. [Unsupported rule type: esql (207)](#unsupported-rule-type-esql-207)
+      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
+      1. [Unsupported rule type: esql (208)](#unsupported-rule-type-esql-208)
       1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
-      1. [Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)](#error-at-line10column3
-comparisons-against-fields-are-not-currently-supported-offender-lengthusername---1-in-
-
---verify-the-machine-account-matches-the-full-hostname-not-just-a-prefix-substring-
--lengthhostname--lengthusername---1-or-substringhostname-lengthusername---1-lengthusername---and
---
-
---verify-if-the-source-ip-belongs-to-the-host-
--not-endswithstringsourceip-stringhostip-and-1)
       1. [Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -51,7 +34,7 @@ invalid-syntax
 --processargs-curl-or-bincurl-or-wget
 -------------------1)
    1. [Generation errors](#generation-errors)
-      1. [Field type solver: constant_keyword (388)](#field-type-solver-constant_keyword-388)
+      1. [Field type solver: constant_keyword (389)](#field-type-solver-constant_keyword-389)
       1. [Unsupported function: match (35)](#unsupported-function-match-35)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
@@ -66,6 +49,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'powershell.exe'}): ('powershell.exe')) (3)](#unsolvable-constraints-processname-excluded-by-stringspowershellexe-powershellexe-3)
       1. [Unsupported argument type(s): <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-types-class-eqlastfunctioncall-3)
       1. [Unsupported argument type: <class 'eql.ast.FunctionCall'> (3)](#unsupported-argument-type-class-eqlastfunctioncall-3)
+      1. [Unsupported function: endswith (3)](#unsupported-function-endswith-3)
       1. [Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)](#unsolvable-constraints-processname-excluded-by-stringsbash-bash-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (2)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-2)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nc.traditional'}): ('nc.traditional')) (2)](#unsolvable-constraints-processname-excluded-by-stringsnctraditional-nctraditional-2)
@@ -74,7 +58,6 @@ invalid-syntax
       1. [Unsupported &keyword 'file.Ext.windows.zone_identifier' constraint: > (2)](#unsupported-keyword-fileextwindowszone_identifier-constraint--2)
       1. [Unsupported &keyword 'process.Ext.relative_file_creation_time' constraint: <= (2)](#unsupported-keyword-processextrelative_file_creation_time-constraint--2)
       1. [Unsupported &keyword 'process.parent.Ext.real.pid' constraint: > (2)](#unsupported-keyword-processparentextrealpid-constraint--2)
-      1. [Unsupported function: endswith (2)](#unsupported-function-endswith-2)
       1. [Unsupported is_negated: {'is_negated': True} (2)](#unsupported-is_negated-is_negated-true-2)
       1. ['NoneType' object is not subscriptable (1)](#nonetype-object-is-not-subscriptable-1)
       1. [<class 'eql.ast.SubqueryBy'> (1)](#class-eqlastsubqueryby-1)
@@ -160,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (239)
+### Unsupported rule type: new_terms (241)
 
-239 rules:
+241 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -285,6 +268,7 @@ invalid-syntax
 * First Time Seen Memcached Writer
 * First Time Seen NFS AUTH_SYS Root UID Access
 * First Time Seen NewCredentials Logon Process
+* First Time Seen RMM Signer Across the Environment
 * First Time Seen Remote Monitoring and Management Tool
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
@@ -336,6 +320,7 @@ invalid-syntax
 * Network Traffic Capture via CAP_NET_RAW
 * New GitHub Self Hosted Action Runner
 * New USB Storage Device Mounted
+* Newly Observed RC4 Kerberos Service Ticket Request
 * Okta Sign-In Events via Third-Party IdP
 * Potential Credential Access via DCSync
 * Potential HTTP Downgrade Attack
@@ -404,9 +389,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (207)
+### Unsupported rule type: esql (208)
 
-207 rules:
+208 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -594,6 +579,7 @@ invalid-syntax
 * PowerShell Obfuscation via Negative Index String Reversal
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
+* Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
@@ -895,20 +881,6 @@ invalid-syntax
 * Threat Intel URL Indicator Match
 * Threat Intel Windows Registry Indicator Match
 
-### Error at line:10,column:3
-Comparisons against fields are not (currently) supported; offender [length(user.name) - 1] in [==]
-
- /* Verify the machine account matches the full hostname, not just a prefix substring */
- (length(host.name) == length(user.name) - 1 or substring(host.name, length(user.name) - 1, length(user.name)) == ".") and
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
- /* Verify if the Source IP belongs to the host */
- not endswith(string(source.ip), string(host.ip)) and (1)
-
-1 rules:
-
-* Potential Computer Account NTLM Relay Activity
-
 ### Error at line:37,column:3
 Invalid syntax
   *confluence/conf/server.xml
@@ -931,9 +903,9 @@ Invalid syntax
 
 ## Generation errors
 
-### Field type solver: constant_keyword (388)
+### Field type solver: constant_keyword (389)
 
-388 rules:
+389 rules:
 * AWS Account Closed
 * AWS AssumeRoleWithWebIdentity from Kubernetes SA and External ASN
 * AWS Attempt to Leave Organization
@@ -1043,6 +1015,7 @@ Invalid syntax
 * Azure AKS Kubelet Proxy to Command Execution Endpoint
 * Azure AKS Kubernetes Events Deleted
 * Azure AKS Secret get or list with Suspicious User Agent
+* Azure AKS Service Account Token Created via TokenRequest API
 * Azure AKS Suspicious Self-Subject Review by Service Account or Node Identity
 * Azure Automation Account Created
 * Azure Automation Runbook Created or Modified
@@ -1526,6 +1499,13 @@ Invalid syntax
 * Unsigned DLL Loaded by a Trusted Process
 * Unsigned DLL Side-Loading from a Suspicious Folder
 
+### Unsupported function: endswith (3)
+
+3 rules:
+* Potential Computer Account NTLM Relay Activity
+* Potential Machine Account Relay Attack via SMB
+* Unusual Execution via Microsoft Common Console File
+
 ### Unsolvable constraints: process.name (excluded by Strings({'bash'}): ('bash')) (2)
 
 2 rules:
@@ -1573,12 +1553,6 @@ Invalid syntax
 2 rules:
 * Parent Process PID Spoofing
 * Privileges Elevation via Parent Process PID Spoofing
-
-### Unsupported function: endswith (2)
-
-2 rules:
-* Potential Machine Account Relay Attack via SMB
-* Unusual Execution via Microsoft Common Console File
 
 ### Unsupported is_negated: {'is_negated': True} (2)
 


### PR DESCRIPTION
Updates `security_detection_engine` package versions in `tests/config.yaml` and applies the corresponding report updates.

## Version bumps

| Deployment | Key | Old version | New version | Renovate PR |
|---|---|---|---|---|
| ECH | `"9.6"` | 9.5.2 | 9.5.3 | #817 |
| ECH | `"9.5"` | 9.5.2 | 9.5.3 | #815 |
| ECH | `"9.4"` | 9.4.9 | 9.4.10 | #809 |
| ECH | `"9.3"` | 9.3.17 | 9.3.18 | #807 |
| ECH | `"8.19"` | 8.19.29 | 8.19.30 | #814 |
| Serverless | `"serverless"` | 9.5.2 | 9.5.3 | #799 |

## Reports updated

- `alerts_from_rules-{8.19,9.3,9.4,9.5,9.6,serverless}.md`
- `documents_from_rules-{8.19,9.3,9.4,9.5,9.6,serverless}.md`

`stack_signals` counts are unchanged across all versions.