### PR TITLE
Update rules to 9.5.4, 9.4.11, 9.3.19, and 8.19.31

### DIFF
--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -35,7 +35,7 @@ emitter_rules:
     # renovate: datasource=epr package=security_detection_engine-8.18
     "8.18": "8.18.15"
     # renovate: datasource=epr package=security_detection_engine-8.19
-    "8.19": "8.19.30"
+    "8.19": "8.19.31"
     # renovate: datasource=epr package=security_detection_engine-9.0
     "9.0": "9.0.19"
     # renovate: datasource=epr package=security_detection_engine-9.1
@@ -43,15 +43,15 @@ emitter_rules:
     # renovate: datasource=epr package=security_detection_engine-9.2
     "9.2": "9.2.19"
     # renovate: datasource=epr package=security_detection_engine-9.3
-    "9.3": "9.3.18"
+    "9.3": "9.3.19"
     # renovate: datasource=epr package=security_detection_engine-9.4
-    "9.4": "9.4.10"
+    "9.4": "9.4.11"
     # renovate: datasource=epr package=security_detection_engine-9.5
-    "9.5": "9.5.3"
+    "9.5": "9.5.4"
     # renovate: datasource=epr package=security_detection_engine-9.6
-    "9.6": "9.5.3"
+    "9.6": "9.5.4"
     # renovate: datasource=epr package=security_detection_engine
-    "serverless": "9.5.3"
+    "serverless": "9.5.4"
 
   stack_signals:
     "8.2":

--- a/tests/reports/alerts_from_rules-8.19.md
+++ b/tests/reports/alerts_from_rules-8.19.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.30
+Rules version: 8.19.31
 
 ## Table of contents
    1. [Failed rules (18)](#failed-rules-18)
    1. [Unsuccessful rules with signals (18)](#unsuccessful-rules-with-signals-18)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (22)](#rules-with-too-few-signals-22)
-   1. [Rules with the correct signals (770)](#rules-with-the-correct-signals-770)
+   1. [Rules with the correct signals (771)](#rules-with-the-correct-signals-771)
 
 ## Failed rules (18)
 
@@ -259,7 +259,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0719  
+Index: geneve-ut-0720  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -290,7 +290,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0897  
+Index: geneve-ut-0898  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -343,7 +343,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1024  
+Index: geneve-ut-1025  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -376,7 +376,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1144  
+Index: geneve-ut-1146  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -402,7 +402,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1162  
+Index: geneve-ut-1164  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -440,7 +440,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1221  
+Index: geneve-ut-1224  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -462,7 +462,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1236  
+Index: geneve-ut-1239  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -501,7 +501,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1318  
+Index: geneve-ut-1321  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -564,7 +564,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1617  
+Index: geneve-ut-1620  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -612,7 +612,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1632  
+Index: geneve-ut-1635  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -647,7 +647,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1653  
+Index: geneve-ut-1656  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -710,7 +710,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1658  
+Index: geneve-ut-1661  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -738,7 +738,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1667  
+Index: geneve-ut-1670  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -770,7 +770,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1758  
+Index: geneve-ut-1761  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0719
+Index: geneve-ut-0720
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1102,7 +1102,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0897
+Index: geneve-ut-0898
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1152,7 +1152,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1024
+Index: geneve-ut-1025
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1182,7 +1182,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1144
+Index: geneve-ut-1146
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1205,7 +1205,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1162
+Index: geneve-ut-1164
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1240,7 +1240,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1221
+Index: geneve-ut-1224
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1259,7 +1259,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1236
+Index: geneve-ut-1239
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1295,7 +1295,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1318
+Index: geneve-ut-1321
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1355,7 +1355,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1617
+Index: geneve-ut-1620
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1400,7 +1400,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1632
+Index: geneve-ut-1635
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1432,7 +1432,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1653
+Index: geneve-ut-1656
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1492,7 +1492,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1658
+Index: geneve-ut-1661
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1517,7 +1517,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1667
+Index: geneve-ut-1670
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -1546,7 +1546,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1758
+Index: geneve-ut-1761
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -1634,7 +1634,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0898
+Index: geneve-ut-0899
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1646,7 +1646,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0904
+Index: geneve-ut-0905
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1658,7 +1658,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1269
+Index: geneve-ut-1272
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1676,7 +1676,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1455
+Index: geneve-ut-1458
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -1928,7 +1928,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0719  
+Index: geneve-ut-0720  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -1958,7 +1958,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0876  
+Index: geneve-ut-0877  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -1977,7 +1977,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0897  
+Index: geneve-ut-0898  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2029,7 +2029,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1005  
+Index: geneve-ut-1006  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2049,7 +2049,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1024  
+Index: geneve-ut-1025  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2081,7 +2081,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1144  
+Index: geneve-ut-1146  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2106,7 +2106,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1162  
+Index: geneve-ut-1164  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2143,7 +2143,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1221  
+Index: geneve-ut-1224  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2164,7 +2164,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1236  
+Index: geneve-ut-1239  
 Failure message(s):  
   got 1000 signals, expected 1085  
 
@@ -2202,7 +2202,7 @@ process.command_line like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1310  
+Index: geneve-ut-1313  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2219,7 +2219,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1318  
+Index: geneve-ut-1321  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2281,7 +2281,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1424  
+Index: geneve-ut-1427  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2306,7 +2306,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1617  
+Index: geneve-ut-1620  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -2353,7 +2353,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1632  
+Index: geneve-ut-1635  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -2387,7 +2387,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1653  
+Index: geneve-ut-1656  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -2449,7 +2449,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1658  
+Index: geneve-ut-1661  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -2476,7 +2476,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1667  
+Index: geneve-ut-1670  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -2507,7 +2507,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1758  
+Index: geneve-ut-1761  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -2577,7 +2577,7 @@ not (
 
 
 
-## Rules with the correct signals (770)
+## Rules with the correct signals (771)
 
 ### A scheduled task was created
 
@@ -5975,7 +5975,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0709
+Index: geneve-ut-0710
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -6014,7 +6014,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0710
+Index: geneve-ut-0711
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6041,7 +6041,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0711
+Index: geneve-ut-0712
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -6056,7 +6056,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0712
+Index: geneve-ut-0713
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -6143,7 +6143,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0720
+Index: geneve-ut-0721
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6161,7 +6161,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0721
+Index: geneve-ut-0722
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -6192,7 +6192,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0722
+Index: geneve-ut-0723
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6219,7 +6219,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0723
+Index: geneve-ut-0724
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -6239,7 +6239,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0727
+Index: geneve-ut-0728
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -6252,7 +6252,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0730
+Index: geneve-ut-0731
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -6264,7 +6264,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0733
+Index: geneve-ut-0734
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -6276,7 +6276,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0737
+Index: geneve-ut-0738
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -6288,7 +6288,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0739
+Index: geneve-ut-0740
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -6305,7 +6305,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0763
+Index: geneve-ut-0764
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6318,7 +6318,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0765
+Index: geneve-ut-0766
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -6342,7 +6342,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0766
+Index: geneve-ut-0767
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -6354,7 +6354,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0779
+Index: geneve-ut-0780
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6372,7 +6372,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0780
+Index: geneve-ut-0781
 
 ```python
 any where process.executable != null and
@@ -6421,7 +6421,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0781
+Index: geneve-ut-0782
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6435,7 +6435,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0785
+Index: geneve-ut-0786
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6450,7 +6450,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0790
+Index: geneve-ut-0791
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6467,7 +6467,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0792
+Index: geneve-ut-0793
 
 ```python
 sequence with maxspan=1m
@@ -6486,7 +6486,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0793
+Index: geneve-ut-0794
 
 ```python
 sequence by host.id with maxspan=1m
@@ -6504,7 +6504,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0794
+Index: geneve-ut-0795
 
 ```python
 sequence by host.id with maxspan=5s
@@ -6523,7 +6523,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0795
+Index: geneve-ut-0796
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -6539,7 +6539,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0796
+Index: geneve-ut-0797
 
 ```python
 sequence by host.id with maxspan=30s
@@ -6555,7 +6555,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0797
+Index: geneve-ut-0798
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6568,7 +6568,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0801
+Index: geneve-ut-0802
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6585,7 +6585,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0803
+Index: geneve-ut-0804
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6598,7 +6598,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0804
+Index: geneve-ut-0805
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -6614,7 +6614,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0805
+Index: geneve-ut-0806
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6641,7 +6641,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0806
+Index: geneve-ut-0807
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6665,7 +6665,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0810
+Index: geneve-ut-0811
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6689,7 +6689,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0812
+Index: geneve-ut-0813
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6725,7 +6725,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0813
+Index: geneve-ut-0814
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -6737,7 +6737,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0814
+Index: geneve-ut-0815
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6751,7 +6751,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0815
+Index: geneve-ut-0816
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -6764,7 +6764,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0816
+Index: geneve-ut-0817
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -6823,7 +6823,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0817
+Index: geneve-ut-0818
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6836,7 +6836,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0818
+Index: geneve-ut-0819
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6849,7 +6849,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0819
+Index: geneve-ut-0820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6870,7 +6870,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0820
+Index: geneve-ut-0821
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6888,7 +6888,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0821
+Index: geneve-ut-0822
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6922,7 +6922,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0822
+Index: geneve-ut-0823
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6958,7 +6958,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0823
+Index: geneve-ut-0824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6980,7 +6980,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0825
+Index: geneve-ut-0826
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7007,7 +7007,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0826
+Index: geneve-ut-0827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7033,7 +7033,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0827
+Index: geneve-ut-0828
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -7049,7 +7049,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0828
+Index: geneve-ut-0829
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -7065,7 +7065,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0830
+Index: geneve-ut-0831
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -7077,7 +7077,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0831
+Index: geneve-ut-0832
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7105,7 +7105,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0833
+Index: geneve-ut-0834
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7121,7 +7121,7 @@ not process.command_line like ("*download.elastic.co*", "*github.com/kubernetes-
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0835
+Index: geneve-ut-0836
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7144,7 +7144,7 @@ process.name == "kubectl" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0836
+Index: geneve-ut-0837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7158,7 +7158,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0837
+Index: geneve-ut-0838
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7181,7 +7181,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0838
+Index: geneve-ut-0839
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -7214,7 +7214,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0840
+Index: geneve-ut-0841
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -7235,7 +7235,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0841
+Index: geneve-ut-0842
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -7262,7 +7262,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-0851
+Index: geneve-ut-0852
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7284,7 +7284,7 @@ process.name in ("curl", "wget") and process.args like~ (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0877
+Index: geneve-ut-0878
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7303,7 +7303,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0880
+Index: geneve-ut-0881
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7347,7 +7347,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0882
+Index: geneve-ut-0883
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -7372,7 +7372,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0888
+Index: geneve-ut-0889
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -7410,7 +7410,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0893
+Index: geneve-ut-0894
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -7428,7 +7428,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0894
+Index: geneve-ut-0895
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7442,7 +7442,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0899
+Index: geneve-ut-0900
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -7457,7 +7457,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0900
+Index: geneve-ut-0901
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -7471,7 +7471,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0903
+Index: geneve-ut-0904
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7485,7 +7485,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0905
+Index: geneve-ut-0906
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7506,7 +7506,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-0906
+Index: geneve-ut-0907
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7536,7 +7536,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0910
+Index: geneve-ut-0911
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -7583,7 +7583,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0911
+Index: geneve-ut-0912
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7614,7 +7614,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0914
+Index: geneve-ut-0915
 
 ```python
 event.dataset:o365.audit and
@@ -7627,7 +7627,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0916
+Index: geneve-ut-0917
 
 ```python
 event.dataset:o365.audit and
@@ -7640,7 +7640,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0917
+Index: geneve-ut-0918
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -7652,7 +7652,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0953
+Index: geneve-ut-0954
 
 ```python
 event.dataset:o365.audit and
@@ -7665,7 +7665,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0954
+Index: geneve-ut-0955
 
 ```python
 event.dataset:o365.audit and
@@ -7678,7 +7678,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0955
+Index: geneve-ut-0956
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -7690,7 +7690,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0956
+Index: geneve-ut-0957
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -7702,7 +7702,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0957
+Index: geneve-ut-0958
 
 ```python
 event.dataset:o365.audit and
@@ -7715,7 +7715,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0965
+Index: geneve-ut-0966
 
 ```python
 event.dataset: "o365.audit" and
@@ -7728,7 +7728,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0968
+Index: geneve-ut-0969
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7748,7 +7748,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0969
+Index: geneve-ut-0970
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -7760,7 +7760,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0970
+Index: geneve-ut-0971
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -7772,7 +7772,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0974
+Index: geneve-ut-0975
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7784,7 +7784,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0975
+Index: geneve-ut-0976
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -7796,7 +7796,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0976
+Index: geneve-ut-0977
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7808,7 +7808,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0977
+Index: geneve-ut-0978
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7820,7 +7820,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0978
+Index: geneve-ut-0979
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7845,7 +7845,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0979
+Index: geneve-ut-0980
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -7865,7 +7865,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0980
+Index: geneve-ut-0981
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -7878,7 +7878,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-0981
+Index: geneve-ut-0982
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7893,7 +7893,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0982
+Index: geneve-ut-0983
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -7918,7 +7918,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0984
+Index: geneve-ut-0985
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -7930,7 +7930,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0987
+Index: geneve-ut-0988
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7942,7 +7942,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0988
+Index: geneve-ut-0989
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -7954,7 +7954,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0989
+Index: geneve-ut-0990
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -7988,7 +7988,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0992
+Index: geneve-ut-0993
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8002,7 +8002,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0993
+Index: geneve-ut-0994
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8023,7 +8023,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0994
+Index: geneve-ut-0995
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8037,7 +8037,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0998
+Index: geneve-ut-0999
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8072,7 +8072,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0999
+Index: geneve-ut-1000
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -8097,7 +8097,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1000
+Index: geneve-ut-1001
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8114,7 +8114,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1004
+Index: geneve-ut-1005
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8128,7 +8128,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1006
+Index: geneve-ut-1007
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8159,7 +8159,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1008
+Index: geneve-ut-1009
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -8213,7 +8213,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1009
+Index: geneve-ut-1010
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -8225,7 +8225,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1010
+Index: geneve-ut-1011
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8243,7 +8243,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1011
+Index: geneve-ut-1012
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8260,7 +8260,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1013
+Index: geneve-ut-1014
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8275,7 +8275,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1015
+Index: geneve-ut-1016
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8291,7 +8291,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1016
+Index: geneve-ut-1017
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -8305,7 +8305,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1018
+Index: geneve-ut-1019
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8334,7 +8334,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1019
+Index: geneve-ut-1020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8356,7 +8356,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1020
+Index: geneve-ut-1021
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8375,7 +8375,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1021
+Index: geneve-ut-1022
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -8408,7 +8408,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1022
+Index: geneve-ut-1023
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -8426,7 +8426,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1023
+Index: geneve-ut-1024
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8467,7 +8467,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1035
+Index: geneve-ut-1036
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -8493,7 +8493,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1043
+Index: geneve-ut-1044
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -8517,7 +8517,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1047
+Index: geneve-ut-1048
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8531,7 +8531,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1048
+Index: geneve-ut-1049
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8550,7 +8550,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1049
+Index: geneve-ut-1050
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -8570,7 +8570,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1050
+Index: geneve-ut-1051
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8591,7 +8591,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1051
+Index: geneve-ut-1052
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8606,7 +8606,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1052
+Index: geneve-ut-1053
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8623,7 +8623,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1054
+Index: geneve-ut-1055
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -8647,7 +8647,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1056
+Index: geneve-ut-1057
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -8693,7 +8693,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1057
+Index: geneve-ut-1058
 
 ```python
 sequence by host.id with maxspan=1s
@@ -8735,7 +8735,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1058
+Index: geneve-ut-1059
 
 ```python
 sequence by host.id with maxspan=10s
@@ -8752,7 +8752,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1060
+Index: geneve-ut-1061
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8767,7 +8767,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1061
+Index: geneve-ut-1062
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -8786,7 +8786,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1062
+Index: geneve-ut-1063
 
 ```python
 sequence by process.entity_id
@@ -8806,7 +8806,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1063
+Index: geneve-ut-1064
 
 ```python
 sequence by process.entity_id
@@ -8825,7 +8825,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1064
+Index: geneve-ut-1065
 
 ```python
 sequence by host.id with maxspan=1m
@@ -8854,7 +8854,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1065
+Index: geneve-ut-1066
 
 ```python
 sequence by process.entity_id
@@ -8879,7 +8879,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1066
+Index: geneve-ut-1067
 
 ```python
 sequence by process.entity_id
@@ -8901,7 +8901,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1067
+Index: geneve-ut-1068
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -8934,7 +8934,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1068
+Index: geneve-ut-1069
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8964,7 +8964,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1071
+Index: geneve-ut-1072
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -8981,7 +8981,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1072
+Index: geneve-ut-1073
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -9018,7 +9018,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1073
+Index: geneve-ut-1074
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9031,7 +9031,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1078
+Index: geneve-ut-1079
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -9043,7 +9043,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1080
+Index: geneve-ut-1081
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -9055,7 +9055,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1089
+Index: geneve-ut-1090
 
 ```python
 sequence by host.id with maxspan=10s
@@ -9069,7 +9069,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1090
+Index: geneve-ut-1091
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9083,7 +9083,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1091
+Index: geneve-ut-1092
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -9103,7 +9103,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1093
+Index: geneve-ut-1094
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -9116,7 +9116,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1094
+Index: geneve-ut-1095
 
 ```python
 event.dataset: "okta.system"
@@ -9131,7 +9131,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1096
+Index: geneve-ut-1097
 
 ```python
 sequence by user.name with maxspan=30m
@@ -9153,7 +9153,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1105
+Index: geneve-ut-1106
 
 ```python
 network where event.action == "connection_accepted" and
@@ -9180,7 +9180,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1106
+Index: geneve-ut-1107
 
 ```python
 network where event.action == "lookup_requested" and
@@ -9200,7 +9200,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1107
+Index: geneve-ut-1108
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9215,7 +9215,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1108
+Index: geneve-ut-1109
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -9242,7 +9242,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1109
+Index: geneve-ut-1110
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -9257,7 +9257,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1110
+Index: geneve-ut-1111
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -9273,7 +9273,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1111
+Index: geneve-ut-1112
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -9287,7 +9287,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1112
+Index: geneve-ut-1113
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -9302,11 +9302,31 @@ file.path like~ "*/wp-content/plugins/*"
 
 
 
+### PKINIT Followed by Same-Principal U2U Service Ticket
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1114
+
+```python
+sequence by winlog.computer_name, source.ip with maxspan=5s
+  [authentication where host.os.type == "windows" and
+    event.code == "4768" and winlog.event_data.PreAuthType == "16" and
+    winlog.event_data.Status == "0x0"
+  ] by winlog.event_data.TargetSid
+  [authentication where host.os.type == "windows" and
+    event.code == "4769" and winlog.event_data.Status == "0x0" and
+    winlog.event_data.TicketOptions in ("0x40810008", "0x40810018")
+  ] by winlog.event_data.ServiceSid
+```
+
+
+
 ### Pbpaste Execution via Unusual Parent Process
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1117
+Index: geneve-ut-1119
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -9321,7 +9341,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1118
+Index: geneve-ut-1120
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9335,7 +9355,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1119
+Index: geneve-ut-1121
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9354,7 +9374,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1120
+Index: geneve-ut-1122
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9366,7 +9386,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1121
+Index: geneve-ut-1123
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9378,7 +9398,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1122
+Index: geneve-ut-1124
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9396,7 +9416,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1123
+Index: geneve-ut-1125
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9409,7 +9429,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1124
+Index: geneve-ut-1126
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9424,7 +9444,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1125
+Index: geneve-ut-1127
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -9439,7 +9459,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1127
+Index: geneve-ut-1129
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -9459,7 +9479,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1128
+Index: geneve-ut-1130
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9483,7 +9503,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1129
+Index: geneve-ut-1131
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9497,7 +9517,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1130
+Index: geneve-ut-1132
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9516,7 +9536,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1131
+Index: geneve-ut-1133
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9544,7 +9564,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1132
+Index: geneve-ut-1134
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -9573,7 +9593,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1133
+Index: geneve-ut-1135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9592,7 +9612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1134
+Index: geneve-ut-1136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9620,7 +9640,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1135
+Index: geneve-ut-1137
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9635,7 +9655,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1136
+Index: geneve-ut-1138
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9698,7 +9718,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1137
+Index: geneve-ut-1139
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -9719,7 +9739,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1138
+Index: geneve-ut-1140
 
 ```python
 any where host.os.type == "windows" and
@@ -9781,7 +9801,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1140
+Index: geneve-ut-1142
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -9810,7 +9830,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1141
+Index: geneve-ut-1143
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -9824,7 +9844,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1142
+Index: geneve-ut-1144
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9857,7 +9877,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1145
+Index: geneve-ut-1147
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -9904,7 +9924,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1146
+Index: geneve-ut-1148
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9931,7 +9951,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1147
+Index: geneve-ut-1149
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -9944,7 +9964,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1158
+Index: geneve-ut-1160
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9961,7 +9981,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1160
+Index: geneve-ut-1162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -9986,7 +10006,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1165
+Index: geneve-ut-1167
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10002,7 +10022,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1166
+Index: geneve-ut-1168
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10023,7 +10043,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1167
+Index: geneve-ut-1170
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -10040,7 +10060,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1168
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10064,7 +10084,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1170
+Index: geneve-ut-1173
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -10093,7 +10113,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1172
+Index: geneve-ut-1175
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -10117,7 +10137,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1175
+Index: geneve-ut-1178
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -10135,7 +10155,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1176
+Index: geneve-ut-1179
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -10158,7 +10178,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1177
+Index: geneve-ut-1180
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -10215,7 +10235,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1178
+Index: geneve-ut-1181
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10232,7 +10252,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1179
+Index: geneve-ut-1182
 
 ```python
 sequence by process.entity_id
@@ -10246,7 +10266,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1193
+Index: geneve-ut-1196
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10261,7 +10281,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1194
+Index: geneve-ut-1197
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10292,7 +10312,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1195
+Index: geneve-ut-1198
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10306,7 +10326,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1196
+Index: geneve-ut-1199
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10319,7 +10339,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1197
+Index: geneve-ut-1200
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -10331,7 +10351,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1198
+Index: geneve-ut-1201
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10344,7 +10364,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1200
+Index: geneve-ut-1203
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -10363,7 +10383,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1201
+Index: geneve-ut-1204
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10384,7 +10404,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1202
+Index: geneve-ut-1205
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10398,7 +10418,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1205
+Index: geneve-ut-1208
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10418,7 +10438,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1206
+Index: geneve-ut-1209
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -10442,7 +10462,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1207
+Index: geneve-ut-1210
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -10458,7 +10478,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1208
+Index: geneve-ut-1211
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -10475,7 +10495,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1209
+Index: geneve-ut-1212
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10496,7 +10516,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1211
+Index: geneve-ut-1214
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -10509,7 +10529,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1213
+Index: geneve-ut-1216
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10537,7 +10557,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1216
+Index: geneve-ut-1219
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10553,7 +10573,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1217
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10576,7 +10596,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1218
+Index: geneve-ut-1221
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10589,7 +10609,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1220
+Index: geneve-ut-1223
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10602,7 +10622,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1225
+Index: geneve-ut-1228
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10616,7 +10636,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1226
+Index: geneve-ut-1229
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10631,7 +10651,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 375  
 Document count: 375  
-Index: geneve-ut-1228
+Index: geneve-ut-1231
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10652,7 +10672,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1231
+Index: geneve-ut-1234
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10695,7 +10715,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1232
+Index: geneve-ut-1235
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10713,7 +10733,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1233
+Index: geneve-ut-1236
 
 ```python
 host.os.type:"windows" and
@@ -10729,7 +10749,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1235
+Index: geneve-ut-1238
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -10741,7 +10761,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1237
+Index: geneve-ut-1240
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -10757,7 +10777,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1238
+Index: geneve-ut-1241
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10775,7 +10795,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1239
+Index: geneve-ut-1242
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -10789,7 +10809,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1241
+Index: geneve-ut-1244
 
 ```python
 sequence by host.id with maxspan=30s
@@ -10812,7 +10832,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1243
+Index: geneve-ut-1246
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -10828,7 +10848,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1244
+Index: geneve-ut-1247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10841,7 +10861,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1245
+Index: geneve-ut-1248
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10871,7 +10891,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1250
+Index: geneve-ut-1253
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10894,7 +10914,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1251
+Index: geneve-ut-1254
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10913,7 +10933,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1256
+Index: geneve-ut-1259
 
 ```python
 process where host.os.type == "windows" and 
@@ -11055,7 +11075,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1257
+Index: geneve-ut-1260
 
 ```python
 process where host.os.type == "windows" and
@@ -11132,7 +11152,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1260
+Index: geneve-ut-1263
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -11149,7 +11169,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1261
+Index: geneve-ut-1264
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -11183,7 +11203,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1263
+Index: geneve-ut-1266
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -11195,7 +11215,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1264
+Index: geneve-ut-1267
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11234,7 +11254,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1266
+Index: geneve-ut-1269
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -11247,7 +11267,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1271
+Index: geneve-ut-1274
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11261,7 +11281,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1278
+Index: geneve-ut-1281
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -11299,7 +11319,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1279
+Index: geneve-ut-1282
 
 ```python
 network where host.os.type == "windows" and
@@ -11325,7 +11345,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1282
+Index: geneve-ut-1285
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11340,7 +11360,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1284
+Index: geneve-ut-1287
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -11354,7 +11374,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1285
+Index: geneve-ut-1288
 
 ```python
 file where host.os.type == "windows" and
@@ -11368,7 +11388,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1286
+Index: geneve-ut-1289
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11381,7 +11401,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1287
+Index: geneve-ut-1290
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11401,7 +11421,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1288
+Index: geneve-ut-1291
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11421,7 +11441,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1290
+Index: geneve-ut-1293
 
 ```python
 host.os.type:windows and event.category:process and
@@ -11460,7 +11480,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1291
+Index: geneve-ut-1294
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11655,7 +11675,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1304
+Index: geneve-ut-1307
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11671,7 +11691,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -11685,7 +11705,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1306
+Index: geneve-ut-1309
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -11699,7 +11719,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1307
+Index: geneve-ut-1310
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -11716,7 +11736,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1308
+Index: geneve-ut-1311
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -11730,7 +11750,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1309
+Index: geneve-ut-1312
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11746,7 +11766,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1313
+Index: geneve-ut-1316
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -11758,7 +11778,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1314
+Index: geneve-ut-1317
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -11774,7 +11794,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1315
+Index: geneve-ut-1318
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11794,7 +11814,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1317
+Index: geneve-ut-1320
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11834,7 +11854,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1319
+Index: geneve-ut-1322
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -11846,7 +11866,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1320
+Index: geneve-ut-1323
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -11867,7 +11887,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1321
+Index: geneve-ut-1324
 
 ```python
 sequence by host.id with maxspan=15s
@@ -11888,7 +11908,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1322
+Index: geneve-ut-1325
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -11909,7 +11929,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1323
+Index: geneve-ut-1326
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -11935,7 +11955,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1324
+Index: geneve-ut-1327
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -11951,7 +11971,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1325
+Index: geneve-ut-1328
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -11965,7 +11985,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1326
+Index: geneve-ut-1329
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -11988,7 +12008,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1328
+Index: geneve-ut-1331
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -12005,7 +12025,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1329
+Index: geneve-ut-1332
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -12028,7 +12048,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1330
+Index: geneve-ut-1333
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12041,7 +12061,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12055,7 +12075,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12072,7 +12092,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1333
+Index: geneve-ut-1336
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12126,7 +12146,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 any where host.os.type == "windows" and
@@ -12153,7 +12173,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 file where host.os.type == "windows" and
@@ -12168,7 +12188,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1341
+Index: geneve-ut-1344
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -12199,7 +12219,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1342
+Index: geneve-ut-1345
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12213,7 +12233,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1343
+Index: geneve-ut-1346
 
 ```python
 sequence with maxspan=1m
@@ -12255,7 +12275,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1344
+Index: geneve-ut-1347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12280,7 +12300,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1345
+Index: geneve-ut-1348
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12334,7 +12354,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1346
+Index: geneve-ut-1349
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12354,7 +12374,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1347
+Index: geneve-ut-1350
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -12375,7 +12395,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1348
+Index: geneve-ut-1351
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12390,7 +12410,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1349
+Index: geneve-ut-1352
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -12410,7 +12430,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1350
+Index: geneve-ut-1353
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12452,7 +12472,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1354
+Index: geneve-ut-1357
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -12467,7 +12487,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -12502,7 +12522,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -12519,7 +12539,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1358
+Index: geneve-ut-1361
 
 ```python
 sequence by host.id with maxspan=3s
@@ -12533,7 +12553,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1361
+Index: geneve-ut-1364
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -12546,7 +12566,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1362
+Index: geneve-ut-1365
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -12558,7 +12578,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -12573,7 +12593,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1365
+Index: geneve-ut-1368
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -12601,7 +12621,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1366
+Index: geneve-ut-1369
 
 ```python
 sequence by host.id with maxspan=1s
@@ -12626,7 +12646,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -12663,7 +12683,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12677,7 +12697,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1372
+Index: geneve-ut-1375
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -12693,7 +12713,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -12707,7 +12727,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -12737,7 +12757,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -12766,7 +12786,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1376
+Index: geneve-ut-1379
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12782,7 +12802,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1377
+Index: geneve-ut-1380
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12796,7 +12816,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1378
+Index: geneve-ut-1381
 
 ```python
 file where host.os.type == "windows" and
@@ -12832,7 +12852,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1381
+Index: geneve-ut-1384
 
 ```python
 process where event.type == "start" and
@@ -12846,7 +12866,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1382
+Index: geneve-ut-1385
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12860,7 +12880,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1383
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12880,7 +12900,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1385
+Index: geneve-ut-1388
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12897,7 +12917,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1386
+Index: geneve-ut-1389
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -12909,7 +12929,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1387
+Index: geneve-ut-1390
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -12926,7 +12946,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1388
+Index: geneve-ut-1391
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12944,7 +12964,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1395
+Index: geneve-ut-1398
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12971,7 +12991,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1396
+Index: geneve-ut-1399
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -12985,7 +13005,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1398
+Index: geneve-ut-1401
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13002,7 +13022,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1399
+Index: geneve-ut-1402
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13025,7 +13045,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13042,7 +13062,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1404
+Index: geneve-ut-1407
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13055,7 +13075,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1406
+Index: geneve-ut-1409
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13079,7 +13099,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1407
+Index: geneve-ut-1410
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13107,7 +13127,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1422
+Index: geneve-ut-1425
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13128,7 +13148,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1425
+Index: geneve-ut-1428
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13168,7 +13188,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1426
+Index: geneve-ut-1429
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -13185,7 +13205,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1427
+Index: geneve-ut-1430
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13199,7 +13219,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 file where host.os.type == "windows" and
@@ -13218,7 +13238,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1429
+Index: geneve-ut-1432
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -13232,7 +13252,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1431
+Index: geneve-ut-1434
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13250,7 +13270,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1433
+Index: geneve-ut-1436
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -13268,7 +13288,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1436
+Index: geneve-ut-1439
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13282,7 +13302,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1438
+Index: geneve-ut-1441
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13297,7 +13317,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1439
+Index: geneve-ut-1442
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -13320,7 +13340,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1441
+Index: geneve-ut-1444
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13402,7 +13422,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1442
+Index: geneve-ut-1445
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -13423,7 +13443,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1443
+Index: geneve-ut-1446
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and
@@ -13442,7 +13462,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1445
+Index: geneve-ut-1448
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13495,7 +13515,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1446
+Index: geneve-ut-1449
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13507,7 +13527,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1447
+Index: geneve-ut-1450
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13519,7 +13539,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1448
+Index: geneve-ut-1451
 
 ```python
 process where host.os.type == "windows" and
@@ -13534,7 +13554,7 @@ process where host.os.type == "windows" and
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1449
+Index: geneve-ut-1452
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -13594,7 +13614,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1452
+Index: geneve-ut-1455
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -13607,7 +13627,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1453
+Index: geneve-ut-1456
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13639,7 +13659,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1454
+Index: geneve-ut-1457
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -13663,7 +13683,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1456
+Index: geneve-ut-1459
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13696,7 +13716,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1457
+Index: geneve-ut-1460
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -13713,7 +13733,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1458
+Index: geneve-ut-1461
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -13742,7 +13762,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1459
+Index: geneve-ut-1462
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13756,7 +13776,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1460
+Index: geneve-ut-1463
 
 ```python
 sequence by process.entity_id
@@ -13781,7 +13801,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1461
+Index: geneve-ut-1464
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -13815,7 +13835,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1462
+Index: geneve-ut-1465
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -13843,7 +13863,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1463
+Index: geneve-ut-1466
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -13862,7 +13882,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1467
+Index: geneve-ut-1470
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13890,7 +13910,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1468
+Index: geneve-ut-1471
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -13909,7 +13929,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1472
+Index: geneve-ut-1475
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -13921,7 +13941,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1473
+Index: geneve-ut-1476
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13933,7 +13953,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1474
+Index: geneve-ut-1477
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -13945,7 +13965,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1475
+Index: geneve-ut-1478
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13957,7 +13977,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1483
+Index: geneve-ut-1486
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13970,7 +13990,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1484
+Index: geneve-ut-1487
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14008,7 +14028,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1486
+Index: geneve-ut-1489
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14023,7 +14043,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1487
+Index: geneve-ut-1490
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14042,7 +14062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1488
+Index: geneve-ut-1491
 
 ```python
 sequence with maxspan=1m
@@ -14090,7 +14110,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1490
+Index: geneve-ut-1493
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -14113,7 +14133,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14127,7 +14147,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14141,7 +14161,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1495
+Index: geneve-ut-1498
 
 ```python
 sequence by host.id, process.entity_id
@@ -14158,7 +14178,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1496
+Index: geneve-ut-1499
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14172,7 +14192,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1497
+Index: geneve-ut-1500
 
 ```python
 sequence by host.id with maxspan=1m
@@ -14192,7 +14212,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1498
+Index: geneve-ut-1501
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14221,7 +14241,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1499
+Index: geneve-ut-1502
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -14241,7 +14261,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1500
+Index: geneve-ut-1503
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -14254,7 +14274,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1502
+Index: geneve-ut-1505
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -14296,7 +14316,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1503
+Index: geneve-ut-1506
 
 ```python
 sequence with maxspan=1m
@@ -14319,7 +14339,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1504
+Index: geneve-ut-1507
 
 ```python
 sequence with maxspan=1s
@@ -14367,7 +14387,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1505
+Index: geneve-ut-1508
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14384,7 +14404,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1507
+Index: geneve-ut-1510
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -14413,7 +14433,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1509
+Index: geneve-ut-1512
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14441,7 +14461,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1510
+Index: geneve-ut-1513
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -14458,7 +14478,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -14477,7 +14497,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1513
+Index: geneve-ut-1516
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -14498,7 +14518,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1519
+Index: geneve-ut-1522
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -14517,7 +14537,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1520
+Index: geneve-ut-1523
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -14531,7 +14551,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1521
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -14551,7 +14571,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1523
+Index: geneve-ut-1526
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14569,7 +14589,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1524
+Index: geneve-ut-1527
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -14590,7 +14610,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14604,7 +14624,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1527
+Index: geneve-ut-1530
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14619,7 +14639,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1528
+Index: geneve-ut-1531
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14660,7 +14680,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1530
+Index: geneve-ut-1533
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -14685,7 +14705,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1531
+Index: geneve-ut-1534
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -14724,7 +14744,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1532
+Index: geneve-ut-1535
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14738,7 +14758,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1533
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14777,7 +14797,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1534
+Index: geneve-ut-1537
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14791,7 +14811,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1535
+Index: geneve-ut-1538
 
 ```python
 process where event.type == "start" and
@@ -14863,7 +14883,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1538
+Index: geneve-ut-1541
 
 ```python
 event.code : "4719" and host.os.type : "windows" and
@@ -14884,7 +14904,7 @@ event.code : "4719" and host.os.type : "windows" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1539
+Index: geneve-ut-1542
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -14905,7 +14925,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1541
+Index: geneve-ut-1544
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14922,7 +14942,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1543
+Index: geneve-ut-1546
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14940,7 +14960,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1544
+Index: geneve-ut-1547
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -14952,7 +14972,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1545
+Index: geneve-ut-1548
 
 ```python
 file where host.os.type == "windows" and
@@ -14985,7 +15005,7 @@ file where host.os.type == "windows" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -15002,7 +15022,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -15022,7 +15042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15037,7 +15057,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1552
+Index: geneve-ut-1555
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15058,7 +15078,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1553
+Index: geneve-ut-1556
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15081,7 +15101,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1554
+Index: geneve-ut-1557
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -15094,7 +15114,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1555
+Index: geneve-ut-1558
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15111,7 +15131,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1557
+Index: geneve-ut-1560
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -15136,7 +15156,7 @@ not (
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1560
+Index: geneve-ut-1563
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -15185,7 +15205,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1561
+Index: geneve-ut-1564
 
 ```python
 sequence by host.id with maxspan=10s
@@ -15199,7 +15219,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1562
+Index: geneve-ut-1565
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -15214,7 +15234,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1563
+Index: geneve-ut-1566
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15229,7 +15249,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1564
+Index: geneve-ut-1567
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -15251,7 +15271,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1565
+Index: geneve-ut-1568
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15272,7 +15292,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1568
+Index: geneve-ut-1571
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15286,7 +15306,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1569
+Index: geneve-ut-1572
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -15309,7 +15329,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1597
+Index: geneve-ut-1600
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -15334,7 +15354,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1598
+Index: geneve-ut-1601
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -15367,7 +15387,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1599
+Index: geneve-ut-1602
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -15426,7 +15446,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1601
+Index: geneve-ut-1604
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -15444,7 +15464,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1602
+Index: geneve-ut-1605
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -15456,7 +15476,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1604
+Index: geneve-ut-1607
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -15481,7 +15501,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1610
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15496,7 +15516,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1611
+Index: geneve-ut-1614
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -15519,7 +15539,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1614
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15533,7 +15553,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1616
+Index: geneve-ut-1619
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15555,7 +15575,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1618
+Index: geneve-ut-1621
 
 ```python
 sequence by host.id with maxspan=5s
@@ -15582,7 +15602,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1622
+Index: geneve-ut-1625
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -15621,7 +15641,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1623
+Index: geneve-ut-1626
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -15644,7 +15664,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1624
+Index: geneve-ut-1627
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -15658,7 +15678,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1625
+Index: geneve-ut-1628
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15674,7 +15694,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1626
+Index: geneve-ut-1629
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -15690,7 +15710,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1627
+Index: geneve-ut-1630
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15704,7 +15724,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1629
+Index: geneve-ut-1632
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15727,7 +15747,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1630
+Index: geneve-ut-1633
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15755,7 +15775,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1631
+Index: geneve-ut-1634
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15770,7 +15790,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1634
+Index: geneve-ut-1637
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15797,7 +15817,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1636
+Index: geneve-ut-1639
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -15813,7 +15833,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1637
+Index: geneve-ut-1640
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -15826,7 +15846,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1639
+Index: geneve-ut-1642
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15842,7 +15862,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1640
+Index: geneve-ut-1643
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -15858,7 +15878,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1641
+Index: geneve-ut-1644
 
 ```python
 any where host.os.type == "windows" and 
@@ -15925,7 +15945,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1643
+Index: geneve-ut-1646
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -15941,7 +15961,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1644
+Index: geneve-ut-1647
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15977,7 +15997,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1645
+Index: geneve-ut-1648
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16015,7 +16035,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1646
+Index: geneve-ut-1649
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -16050,7 +16070,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1647
+Index: geneve-ut-1650
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16084,7 +16104,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1649
+Index: geneve-ut-1652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -16105,7 +16125,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1654
+Index: geneve-ut-1657
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -16182,7 +16202,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1655
+Index: geneve-ut-1658
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16204,7 +16224,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1656
+Index: geneve-ut-1659
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16228,7 +16248,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1657
+Index: geneve-ut-1660
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16249,7 +16269,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1660
+Index: geneve-ut-1663
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16264,7 +16284,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1663
+Index: geneve-ut-1666
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16277,7 +16297,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1664
+Index: geneve-ut-1667
 
 ```python
 any where host.os.type == "windows" and
@@ -16292,7 +16312,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1665
+Index: geneve-ut-1668
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16308,7 +16328,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1666
+Index: geneve-ut-1669
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -16322,7 +16342,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1670
+Index: geneve-ut-1673
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16336,7 +16356,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1672
+Index: geneve-ut-1675
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -16368,7 +16388,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1674
+Index: geneve-ut-1677
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -16381,7 +16401,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1675
+Index: geneve-ut-1678
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16400,7 +16420,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1676
+Index: geneve-ut-1679
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16446,7 +16466,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1678
+Index: geneve-ut-1681
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16467,7 +16487,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1679
+Index: geneve-ut-1682
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16487,7 +16507,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1680
+Index: geneve-ut-1683
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16501,7 +16521,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1681
+Index: geneve-ut-1684
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16533,7 +16553,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1684
+Index: geneve-ut-1687
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -16554,7 +16574,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1686
+Index: geneve-ut-1689
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -16655,7 +16675,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1689
+Index: geneve-ut-1692
 
 ```python
 sequence by host.id with maxspan=5s
@@ -16703,7 +16723,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1691
+Index: geneve-ut-1694
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16729,7 +16749,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1692
+Index: geneve-ut-1695
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16774,7 +16794,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1693
+Index: geneve-ut-1696
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16798,7 +16818,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1694
+Index: geneve-ut-1697
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -16814,7 +16834,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1696
+Index: geneve-ut-1699
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -16839,7 +16859,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1697
+Index: geneve-ut-1700
 
 ```python
 event.category:process and host.os.type:windows and
@@ -16854,7 +16874,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1700
+Index: geneve-ut-1703
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -16868,7 +16888,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1701
+Index: geneve-ut-1704
 
 ```python
 sequence by host.id with maxspan=30s
@@ -16888,7 +16908,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1702
+Index: geneve-ut-1705
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16923,7 +16943,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1706
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16936,7 +16956,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1708
+Index: geneve-ut-1711
 
 ```python
 any where host.os.type == "windows" and
@@ -16969,7 +16989,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1710
+Index: geneve-ut-1713
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -16987,7 +17007,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1711
+Index: geneve-ut-1714
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -17009,7 +17029,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1714
+Index: geneve-ut-1717
 
 ```python
 sequence by host.id with maxspan=30s
@@ -17048,7 +17068,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1715
+Index: geneve-ut-1718
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17078,7 +17098,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1716
+Index: geneve-ut-1719
 
 ```python
 any where host.os.type == "windows" and
@@ -17112,7 +17132,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1717
+Index: geneve-ut-1720
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -17126,7 +17146,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1720
+Index: geneve-ut-1723
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17157,7 +17177,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1721
+Index: geneve-ut-1724
 
 ```python
 any where host.os.type == "windows" and
@@ -17177,7 +17197,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1722
+Index: geneve-ut-1725
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17218,7 +17238,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1723
+Index: geneve-ut-1726
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -17234,7 +17254,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1724
+Index: geneve-ut-1727
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17264,7 +17284,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1728
+Index: geneve-ut-1731
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -17277,7 +17297,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1729
+Index: geneve-ut-1732
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -17301,7 +17321,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1732
+Index: geneve-ut-1735
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17319,7 +17339,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1734
+Index: geneve-ut-1737
 
 ```python
 any where host.os.type == "windows" and
@@ -17334,7 +17354,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1735
+Index: geneve-ut-1738
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -17352,7 +17372,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1736
+Index: geneve-ut-1739
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -17373,7 +17393,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1737
+Index: geneve-ut-1740
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17392,7 +17412,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1740
+Index: geneve-ut-1743
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17417,7 +17437,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1741
+Index: geneve-ut-1744
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17430,7 +17450,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1743
+Index: geneve-ut-1746
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -17443,7 +17463,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1745
+Index: geneve-ut-1748
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17466,7 +17486,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1747
+Index: geneve-ut-1750
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17485,7 +17505,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1748
+Index: geneve-ut-1751
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -17507,7 +17527,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1749
+Index: geneve-ut-1752
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -17540,7 +17560,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1751
+Index: geneve-ut-1754
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17558,7 +17578,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1752
+Index: geneve-ut-1755
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -17572,7 +17592,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1753
+Index: geneve-ut-1756
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17596,7 +17616,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1754
+Index: geneve-ut-1757
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -17619,7 +17639,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1755
+Index: geneve-ut-1758
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -17638,7 +17658,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1759
+Index: geneve-ut-1762
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -17673,7 +17693,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1760
+Index: geneve-ut-1763
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17690,7 +17710,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1761
+Index: geneve-ut-1764
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17710,7 +17730,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1762
+Index: geneve-ut-1765
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -17750,7 +17770,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1763
+Index: geneve-ut-1766
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -17766,7 +17786,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1764
+Index: geneve-ut-1767
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17780,7 +17800,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1765
+Index: geneve-ut-1768
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17818,7 +17838,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1766
+Index: geneve-ut-1769
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17872,7 +17892,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1767
+Index: geneve-ut-1770
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -17900,7 +17920,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1769
+Index: geneve-ut-1772
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -17914,7 +17934,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1770
+Index: geneve-ut-1773
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17960,7 +17980,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1771
+Index: geneve-ut-1774
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -17999,7 +18019,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1772
+Index: geneve-ut-1775
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -18012,7 +18032,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1775
+Index: geneve-ut-1778
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -18045,7 +18065,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1776
+Index: geneve-ut-1779
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -18059,7 +18079,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1777
+Index: geneve-ut-1780
 
 ```python
 sequence by host.id with maxspan=1s
@@ -18073,7 +18093,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1778
+Index: geneve-ut-1781
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -18087,7 +18107,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1779
+Index: geneve-ut-1782
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18126,7 +18146,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1786
+Index: geneve-ut-1789
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -18168,7 +18188,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1787
+Index: geneve-ut-1790
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -18181,7 +18201,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1788
+Index: geneve-ut-1791
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18198,7 +18218,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1789
+Index: geneve-ut-1792
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -18214,7 +18234,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1790
+Index: geneve-ut-1793
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18227,7 +18247,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1791
+Index: geneve-ut-1794
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -18242,7 +18262,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1792
+Index: geneve-ut-1795
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18265,7 +18285,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1793
+Index: geneve-ut-1796
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18281,7 +18301,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1794
+Index: geneve-ut-1797
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18297,7 +18317,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1799
+Index: geneve-ut-1802
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -18309,7 +18329,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1800
+Index: geneve-ut-1803
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18338,7 +18358,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1802
+Index: geneve-ut-1805
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -18352,7 +18372,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1807
+Index: geneve-ut-1810
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -18372,7 +18392,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1808
+Index: geneve-ut-1811
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -18397,7 +18417,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1814
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18411,7 +18431,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1815
+Index: geneve-ut-1818
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18434,7 +18454,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1820
+Index: geneve-ut-1823
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -18468,7 +18488,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1822
+Index: geneve-ut-1825
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18487,7 +18507,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-1829
+Index: geneve-ut-1832
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -18506,7 +18526,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1843
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -18523,7 +18543,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1846
+Index: geneve-ut-1849
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -18540,7 +18560,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1862
+Index: geneve-ut-1865
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -18559,7 +18579,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1866
+Index: geneve-ut-1869
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18601,7 +18621,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1867
+Index: geneve-ut-1870
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18646,7 +18666,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1870
+Index: geneve-ut-1873
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18688,7 +18708,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1872
+Index: geneve-ut-1875
 
 ```python
 host.os.type:"linux" and 
@@ -18716,7 +18736,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1875
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18740,7 +18760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1876
+Index: geneve-ut-1879
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18780,7 +18800,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1877
+Index: geneve-ut-1880
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -18827,7 +18847,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1881
+Index: geneve-ut-1884
 
 ```python
 sequence by process.entity_id
@@ -18864,7 +18884,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1913
+Index: geneve-ut-1916
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18878,7 +18898,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1914
+Index: geneve-ut-1917
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -18921,7 +18941,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1915
+Index: geneve-ut-1918
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -18934,7 +18954,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1917
+Index: geneve-ut-1920
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -18948,7 +18968,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1918
+Index: geneve-ut-1921
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -18961,7 +18981,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1922
+Index: geneve-ut-1925
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -18986,7 +19006,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1923
+Index: geneve-ut-1926
 
 ```python
 process where event.type == "start" and
@@ -19001,7 +19021,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1924
+Index: geneve-ut-1927
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19018,7 +19038,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1925
+Index: geneve-ut-1928
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19032,7 +19052,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1926
+Index: geneve-ut-1929
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19048,7 +19068,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1927
+Index: geneve-ut-1930
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19062,7 +19082,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1928
+Index: geneve-ut-1931
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -19089,7 +19109,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1930
+Index: geneve-ut-1933
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -19101,7 +19121,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1931
+Index: geneve-ut-1934
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19117,7 +19137,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1932
+Index: geneve-ut-1935
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -19140,7 +19160,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1933
+Index: geneve-ut-1936
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -19153,7 +19173,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1934
+Index: geneve-ut-1937
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -19165,7 +19185,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1935
+Index: geneve-ut-1938
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -19177,7 +19197,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1936
+Index: geneve-ut-1939
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -19189,7 +19209,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1937
+Index: geneve-ut-1940
 
 ```python
 web where (
@@ -19217,7 +19237,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-1940
+Index: geneve-ut-1943
 
 ```python
 any where (
@@ -19289,7 +19309,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1942
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19310,7 +19330,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1945
+Index: geneve-ut-1948
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -19324,7 +19344,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1946
+Index: geneve-ut-1949
 
 ```python
 file where event.type == "deletion" and
@@ -19341,7 +19361,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1947
+Index: geneve-ut-1950
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19359,7 +19379,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1949
+Index: geneve-ut-1952
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19397,7 +19417,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1951
+Index: geneve-ut-1954
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19434,7 +19454,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1952
+Index: geneve-ut-1955
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19449,7 +19469,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1953
+Index: geneve-ut-1956
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -19462,7 +19482,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1954
+Index: geneve-ut-1957
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19481,7 +19501,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-1955
+Index: geneve-ut-1958
 
 ```python
 sequence by host.id with maxspan=1m
@@ -19506,7 +19526,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1956
+Index: geneve-ut-1959
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19532,7 +19552,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1957
+Index: geneve-ut-1960
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -19554,7 +19574,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1958
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19571,7 +19591,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-1960
+Index: geneve-ut-1963
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -19590,7 +19610,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-1961
+Index: geneve-ut-1964
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -19630,7 +19650,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1962
+Index: geneve-ut-1965
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19647,7 +19667,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1964
+Index: geneve-ut-1967
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -19660,7 +19680,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1965
+Index: geneve-ut-1968
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -19674,7 +19694,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1966
+Index: geneve-ut-1969
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19702,7 +19722,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1967
+Index: geneve-ut-1970
 
 ```python
 process where event.type == "start" and
@@ -19727,7 +19747,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1968
+Index: geneve-ut-1971
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19741,7 +19761,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1969
+Index: geneve-ut-1972
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19757,7 +19777,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1970
+Index: geneve-ut-1973
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19792,7 +19812,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1971
+Index: geneve-ut-1974
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19810,7 +19830,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1974
+Index: geneve-ut-1977
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.3.md
+++ b/tests/reports/alerts_from_rules-9.3.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.18
+Rules version: 9.3.19
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
    1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
-   1. [Rules with the correct signals (804)](#rules-with-the-correct-signals-804)
+   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
 
 ## Failed rules (24)
 
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0746  
+Index: geneve-ut-0747  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0935  
+Index: geneve-ut-0936  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1063  
+Index: geneve-ut-1064  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1092  
+Index: geneve-ut-1093  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1161  
+Index: geneve-ut-1163  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1189  
+Index: geneve-ut-1191  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1207  
+Index: geneve-ut-1209  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1269  
+Index: geneve-ut-1272  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1284  
+Index: geneve-ut-1287  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1368  
+Index: geneve-ut-1371  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1597  
+Index: geneve-ut-1600  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1601  
+Index: geneve-ut-1604  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1682  
+Index: geneve-ut-1685  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1697  
+Index: geneve-ut-1700  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1710  
+Index: geneve-ut-1713  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1720  
+Index: geneve-ut-1723  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1725  
+Index: geneve-ut-1728  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1734  
+Index: geneve-ut-1737  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1829  
+Index: geneve-ut-1832  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1858  
+Index: geneve-ut-1861  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0746
+Index: geneve-ut-0747
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0935
+Index: geneve-ut-0936
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1063
+Index: geneve-ut-1064
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1092
+Index: geneve-ut-1093
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1161
+Index: geneve-ut-1163
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1189
+Index: geneve-ut-1191
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1207
+Index: geneve-ut-1209
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1269
+Index: geneve-ut-1272
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1284
+Index: geneve-ut-1287
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1368
+Index: geneve-ut-1371
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1597
+Index: geneve-ut-1600
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1601
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1682
+Index: geneve-ut-1685
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1697
+Index: geneve-ut-1700
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1710
+Index: geneve-ut-1713
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1720
+Index: geneve-ut-1723
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1725
+Index: geneve-ut-1728
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1734
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1829
+Index: geneve-ut-1832
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1858
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0936
+Index: geneve-ut-0937
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0942
+Index: geneve-ut-0943
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1319
+Index: geneve-ut-1322
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1509
+Index: geneve-ut-1512
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0746  
+Index: geneve-ut-0747  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0908  
+Index: geneve-ut-0909  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0935  
+Index: geneve-ut-0936  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1042  
+Index: geneve-ut-1043  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1063  
+Index: geneve-ut-1064  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1092  
+Index: geneve-ut-1093  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1161  
+Index: geneve-ut-1163  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1189  
+Index: geneve-ut-1191  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1207  
+Index: geneve-ut-1209  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1269  
+Index: geneve-ut-1272  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1284  
+Index: geneve-ut-1287  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1360  
+Index: geneve-ut-1363  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1368  
+Index: geneve-ut-1371  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1477  
+Index: geneve-ut-1480  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1597  
+Index: geneve-ut-1600  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1601  
+Index: geneve-ut-1604  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1682  
+Index: geneve-ut-1685  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1697  
+Index: geneve-ut-1700  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1710  
+Index: geneve-ut-1713  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1720  
+Index: geneve-ut-1723  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1725  
+Index: geneve-ut-1728  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1734  
+Index: geneve-ut-1737  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1829  
+Index: geneve-ut-1832  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1858  
+Index: geneve-ut-1861  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3381,7 +3381,7 @@ container.id like "*"
 
 
 
-## Rules with the correct signals (804)
+## Rules with the correct signals (805)
 
 ### A scheduled task was created
 
@@ -7231,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0736
+Index: geneve-ut-0737
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0737
+Index: geneve-ut-0738
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0738
+Index: geneve-ut-0739
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0739
+Index: geneve-ut-0740
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0747
+Index: geneve-ut-0748
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0748
+Index: geneve-ut-0749
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0749
+Index: geneve-ut-0750
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0750
+Index: geneve-ut-0751
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0754
+Index: geneve-ut-0755
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0757
+Index: geneve-ut-0758
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0760
+Index: geneve-ut-0761
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0764
+Index: geneve-ut-0765
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0766
+Index: geneve-ut-0767
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0790
+Index: geneve-ut-0791
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0792
+Index: geneve-ut-0793
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0793
+Index: geneve-ut-0794
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0806
+Index: geneve-ut-0807
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0807
+Index: geneve-ut-0808
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0808
+Index: geneve-ut-0809
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0812
+Index: geneve-ut-0813
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0817
+Index: geneve-ut-0818
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0819
+Index: geneve-ut-0820
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0820
+Index: geneve-ut-0821
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0821
+Index: geneve-ut-0822
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0822
+Index: geneve-ut-0823
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0823
+Index: geneve-ut-0824
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0824
+Index: geneve-ut-0825
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0829
+Index: geneve-ut-0830
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0831
+Index: geneve-ut-0832
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0832
+Index: geneve-ut-0833
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0833
+Index: geneve-ut-0834
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7897,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0834
+Index: geneve-ut-0835
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7921,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0839
+Index: geneve-ut-0840
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0841
+Index: geneve-ut-0842
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0842
+Index: geneve-ut-0843
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0843
+Index: geneve-ut-0844
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0844
+Index: geneve-ut-0845
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0845
+Index: geneve-ut-0846
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0846
+Index: geneve-ut-0847
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0847
+Index: geneve-ut-0848
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0848
+Index: geneve-ut-0849
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0849
+Index: geneve-ut-0850
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0850
+Index: geneve-ut-0851
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0852
+Index: geneve-ut-0853
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0854
+Index: geneve-ut-0855
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0855
+Index: geneve-ut-0856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0856
+Index: geneve-ut-0857
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0857
+Index: geneve-ut-0858
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0859
+Index: geneve-ut-0860
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0860
+Index: geneve-ut-0861
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0862
+Index: geneve-ut-0863
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0864
+Index: geneve-ut-0865
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0865
+Index: geneve-ut-0866
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0867
+Index: geneve-ut-0868
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0868
+Index: geneve-ut-0869
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8436,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0869
+Index: geneve-ut-0870
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8463,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0872
+Index: geneve-ut-0873
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0873
+Index: geneve-ut-0874
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0883
+Index: geneve-ut-0884
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0909
+Index: geneve-ut-0910
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0912
+Index: geneve-ut-0913
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0914
+Index: geneve-ut-0915
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0926
+Index: geneve-ut-0927
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0931
+Index: geneve-ut-0932
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0932
+Index: geneve-ut-0933
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0937
+Index: geneve-ut-0938
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0938
+Index: geneve-ut-0939
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0941
+Index: geneve-ut-0942
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0943
+Index: geneve-ut-0944
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-0944
+Index: geneve-ut-0945
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0948
+Index: geneve-ut-0949
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0949
+Index: geneve-ut-0950
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8863,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0952
+Index: geneve-ut-0953
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0954
+Index: geneve-ut-0955
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0955
+Index: geneve-ut-0956
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0991
+Index: geneve-ut-0992
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0992
+Index: geneve-ut-0993
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0993
+Index: geneve-ut-0994
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0994
+Index: geneve-ut-0995
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0995
+Index: geneve-ut-0996
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1003
+Index: geneve-ut-1004
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1006
+Index: geneve-ut-1007
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1007
+Index: geneve-ut-1008
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1008
+Index: geneve-ut-1009
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1012
+Index: geneve-ut-1013
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1013
+Index: geneve-ut-1014
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1014
+Index: geneve-ut-1015
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1015
+Index: geneve-ut-1016
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1016
+Index: geneve-ut-1017
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1017
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1018
+Index: geneve-ut-1019
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1019
+Index: geneve-ut-1020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9142,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1020
+Index: geneve-ut-1021
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9167,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1022
+Index: geneve-ut-1023
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1025
+Index: geneve-ut-1026
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1026
+Index: geneve-ut-1027
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1027
+Index: geneve-ut-1028
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1030
+Index: geneve-ut-1031
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1031
+Index: geneve-ut-1032
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1032
+Index: geneve-ut-1033
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1035
+Index: geneve-ut-1036
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1036
+Index: geneve-ut-1037
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1037
+Index: geneve-ut-1038
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1041
+Index: geneve-ut-1042
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1043
+Index: geneve-ut-1044
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1045
+Index: geneve-ut-1046
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1046
+Index: geneve-ut-1047
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1047
+Index: geneve-ut-1048
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1048
+Index: geneve-ut-1049
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1050
+Index: geneve-ut-1051
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1051
+Index: geneve-ut-1052
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1053
+Index: geneve-ut-1054
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1054
+Index: geneve-ut-1055
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9604,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1056
+Index: geneve-ut-1057
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1057
+Index: geneve-ut-1058
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1058
+Index: geneve-ut-1059
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1059
+Index: geneve-ut-1060
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1060
+Index: geneve-ut-1061
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1061
+Index: geneve-ut-1062
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1062
+Index: geneve-ut-1063
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1074
+Index: geneve-ut-1075
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1083
+Index: geneve-ut-1084
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1087
+Index: geneve-ut-1088
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1088
+Index: geneve-ut-1089
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1089
+Index: geneve-ut-1090
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1090
+Index: geneve-ut-1091
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1091
+Index: geneve-ut-1092
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1093
+Index: geneve-ut-1094
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1094
+Index: geneve-ut-1095
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1096
+Index: geneve-ut-1097
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1098
+Index: geneve-ut-1099
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1099
+Index: geneve-ut-1100
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1100
+Index: geneve-ut-1101
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1102
+Index: geneve-ut-1103
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1103
+Index: geneve-ut-1104
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1104
+Index: geneve-ut-1105
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1105
+Index: geneve-ut-1106
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1106
+Index: geneve-ut-1107
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1107
+Index: geneve-ut-1108
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1108
+Index: geneve-ut-1109
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1109
+Index: geneve-ut-1110
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1110
+Index: geneve-ut-1111
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1113
+Index: geneve-ut-1114
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1114
+Index: geneve-ut-1115
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1115
+Index: geneve-ut-1116
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1120
+Index: geneve-ut-1121
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1123
+Index: geneve-ut-1124
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1132
+Index: geneve-ut-1133
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1133
+Index: geneve-ut-1134
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1134
+Index: geneve-ut-1135
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1135
+Index: geneve-ut-1136
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1137
+Index: geneve-ut-1138
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1138
+Index: geneve-ut-1139
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1140
+Index: geneve-ut-1141
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1149
+Index: geneve-ut-1150
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1150
+Index: geneve-ut-1151
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1151
+Index: geneve-ut-1152
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1152
+Index: geneve-ut-1153
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1153
+Index: geneve-ut-1154
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1154
+Index: geneve-ut-1155
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1155
+Index: geneve-ut-1156
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1156
+Index: geneve-ut-1157
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10666,11 +10666,31 @@ file.path like~ "*/wp-content/plugins/*"
 
 
 
+### PKINIT Followed by Same-Principal U2U Service Ticket
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1158
+
+```python
+sequence by winlog.computer_name, source.ip with maxspan=5s
+  [authentication where host.os.type == "windows" and
+    event.code == "4768" and winlog.event_data.PreAuthType == "16" and
+    winlog.event_data.Status == "0x0"
+  ] by winlog.event_data.TargetSid
+  [authentication where host.os.type == "windows" and
+    event.code == "4769" and winlog.event_data.Status == "0x0" and
+    winlog.event_data.TicketOptions in ("0x40810008", "0x40810018")
+  ] by winlog.event_data.ServiceSid
+```
+
+
+
 ### Pbpaste Execution via Unusual Parent Process
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1162
+Index: geneve-ut-1164
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10685,7 +10705,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1163
+Index: geneve-ut-1165
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10699,7 +10719,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1164
+Index: geneve-ut-1166
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10718,7 +10738,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1165
+Index: geneve-ut-1167
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10730,7 +10750,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1166
+Index: geneve-ut-1168
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10742,7 +10762,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1167
+Index: geneve-ut-1169
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10760,7 +10780,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1168
+Index: geneve-ut-1170
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10773,7 +10793,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1169
+Index: geneve-ut-1171
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10788,7 +10808,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1170
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10803,7 +10823,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1172
+Index: geneve-ut-1174
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10823,7 +10843,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1173
+Index: geneve-ut-1175
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10847,7 +10867,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1174
+Index: geneve-ut-1176
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10861,7 +10881,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1175
+Index: geneve-ut-1177
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10880,7 +10900,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1176
+Index: geneve-ut-1178
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10908,7 +10928,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1177
+Index: geneve-ut-1179
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10937,7 +10957,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1178
+Index: geneve-ut-1180
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10956,7 +10976,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1179
+Index: geneve-ut-1181
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10984,7 +11004,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1180
+Index: geneve-ut-1182
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10999,7 +11019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1181
+Index: geneve-ut-1183
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11062,7 +11082,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1182
+Index: geneve-ut-1184
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11083,7 +11103,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1183
+Index: geneve-ut-1185
 
 ```python
 any where host.os.type == "windows" and
@@ -11145,7 +11165,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1185
+Index: geneve-ut-1187
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11174,7 +11194,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1186
+Index: geneve-ut-1188
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11188,7 +11208,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1187
+Index: geneve-ut-1189
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11221,7 +11241,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1190
+Index: geneve-ut-1192
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11268,7 +11288,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1191
+Index: geneve-ut-1193
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11295,7 +11315,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1192
+Index: geneve-ut-1194
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11308,7 +11328,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1203
+Index: geneve-ut-1205
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11325,7 +11345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1205
+Index: geneve-ut-1207
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11350,7 +11370,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1210
+Index: geneve-ut-1212
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11366,7 +11386,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1211
+Index: geneve-ut-1213
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11387,7 +11407,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1212
+Index: geneve-ut-1215
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11404,7 +11424,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1213
+Index: geneve-ut-1216
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11417,7 +11437,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1214
+Index: geneve-ut-1217
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11441,7 +11461,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1216
+Index: geneve-ut-1219
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11470,7 +11490,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1218
+Index: geneve-ut-1221
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11497,7 +11517,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1219
+Index: geneve-ut-1222
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11521,7 +11541,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1222
+Index: geneve-ut-1225
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11539,7 +11559,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1223
+Index: geneve-ut-1226
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11562,7 +11582,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1224
+Index: geneve-ut-1227
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11619,7 +11639,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1225
+Index: geneve-ut-1228
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11636,7 +11656,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1226
+Index: geneve-ut-1229
 
 ```python
 sequence by process.entity_id
@@ -11650,7 +11670,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1240
+Index: geneve-ut-1243
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11665,7 +11685,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1241
+Index: geneve-ut-1244
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11696,7 +11716,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1242
+Index: geneve-ut-1245
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11710,7 +11730,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1243
+Index: geneve-ut-1246
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11723,7 +11743,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1244
+Index: geneve-ut-1247
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11735,7 +11755,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1245
+Index: geneve-ut-1248
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11748,7 +11768,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1247
+Index: geneve-ut-1250
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11767,7 +11787,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1248
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11780,7 +11800,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1249
+Index: geneve-ut-1252
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11801,7 +11821,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1250
+Index: geneve-ut-1253
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11815,7 +11835,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1253
+Index: geneve-ut-1256
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11835,7 +11855,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1254
+Index: geneve-ut-1257
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11859,7 +11879,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1255
+Index: geneve-ut-1258
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11875,7 +11895,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1256
+Index: geneve-ut-1259
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11892,7 +11912,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1257
+Index: geneve-ut-1260
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11913,7 +11933,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1259
+Index: geneve-ut-1262
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11926,7 +11946,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1261
+Index: geneve-ut-1264
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11954,7 +11974,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1264
+Index: geneve-ut-1267
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11970,7 +11990,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1265
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11993,7 +12013,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1266
+Index: geneve-ut-1269
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12006,7 +12026,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1268
+Index: geneve-ut-1271
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12019,7 +12039,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1273
+Index: geneve-ut-1276
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12033,7 +12053,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1274
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +12068,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1276
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12071,7 +12091,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1279
+Index: geneve-ut-1282
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12114,7 +12134,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1280
+Index: geneve-ut-1283
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12132,7 +12152,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1281
+Index: geneve-ut-1284
 
 ```python
 host.os.type:"windows" and
@@ -12148,7 +12168,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1283
+Index: geneve-ut-1286
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12160,7 +12180,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1285
+Index: geneve-ut-1288
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12176,7 +12196,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1286
+Index: geneve-ut-1289
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12192,7 +12212,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1287
+Index: geneve-ut-1290
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12210,7 +12230,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1288
+Index: geneve-ut-1291
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12224,7 +12244,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1290
+Index: geneve-ut-1293
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12247,7 +12267,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1292
+Index: geneve-ut-1295
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12263,7 +12283,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1293
+Index: geneve-ut-1296
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12276,7 +12296,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1294
+Index: geneve-ut-1297
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12306,7 +12326,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1299
+Index: geneve-ut-1302
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12329,7 +12349,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1300
+Index: geneve-ut-1303
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12348,7 +12368,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 process where host.os.type == "windows" and 
@@ -12490,7 +12510,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1306
+Index: geneve-ut-1309
 
 ```python
 process where host.os.type == "windows" and
@@ -12567,7 +12587,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1310
+Index: geneve-ut-1313
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12584,7 +12604,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12618,7 +12638,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1313
+Index: geneve-ut-1316
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12630,7 +12650,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1314
+Index: geneve-ut-1317
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12669,7 +12689,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1316
+Index: geneve-ut-1319
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12682,7 +12702,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1321
+Index: geneve-ut-1324
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12696,7 +12716,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1328
+Index: geneve-ut-1331
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12734,7 +12754,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1329
+Index: geneve-ut-1332
 
 ```python
 network where host.os.type == "windows" and
@@ -12760,7 +12780,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12775,7 +12795,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12789,7 +12809,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1335
+Index: geneve-ut-1338
 
 ```python
 file where host.os.type == "windows" and
@@ -12803,7 +12823,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1336
+Index: geneve-ut-1339
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12816,7 +12836,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12836,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1338
+Index: geneve-ut-1341
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12876,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12895,7 +12915,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1341
+Index: geneve-ut-1344
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13090,7 +13110,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1354
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13106,7 +13126,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13120,7 +13140,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13134,7 +13154,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1357
+Index: geneve-ut-1360
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13151,7 +13171,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1358
+Index: geneve-ut-1361
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13165,7 +13185,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1359
+Index: geneve-ut-1362
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13181,7 +13201,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13193,7 +13213,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1364
+Index: geneve-ut-1367
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13209,7 +13229,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1365
+Index: geneve-ut-1368
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13229,7 +13249,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1367
+Index: geneve-ut-1370
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13269,7 +13289,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1369
+Index: geneve-ut-1372
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13281,7 +13301,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13302,7 +13322,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13323,7 +13343,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1372
+Index: geneve-ut-1375
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13344,7 +13364,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13370,7 +13390,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13386,7 +13406,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13400,7 +13420,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1376
+Index: geneve-ut-1379
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13423,7 +13443,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1378
+Index: geneve-ut-1381
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13440,7 +13460,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1379
+Index: geneve-ut-1382
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13463,7 +13483,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13476,7 +13496,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1381
+Index: geneve-ut-1384
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13490,7 +13510,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1382
+Index: geneve-ut-1385
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13507,7 +13527,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1383
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13561,7 +13581,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1384
+Index: geneve-ut-1387
 
 ```python
 any where host.os.type == "windows" and
@@ -13588,7 +13608,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1390
+Index: geneve-ut-1393
 
 ```python
 file where host.os.type == "windows" and
@@ -13603,7 +13623,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1391
+Index: geneve-ut-1394
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13634,7 +13654,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1392
+Index: geneve-ut-1395
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +13668,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1393
+Index: geneve-ut-1396
 
 ```python
 sequence with maxspan=1m
@@ -13690,7 +13710,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1394
+Index: geneve-ut-1397
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13715,7 +13735,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1395
+Index: geneve-ut-1398
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13769,7 +13789,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1396
+Index: geneve-ut-1399
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13789,7 +13809,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1397
+Index: geneve-ut-1400
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13810,7 +13830,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1398
+Index: geneve-ut-1401
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13825,7 +13845,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1399
+Index: geneve-ut-1402
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13845,7 +13865,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1400
+Index: geneve-ut-1403
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13887,7 +13907,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1404
+Index: geneve-ut-1407
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13902,7 +13922,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1405
+Index: geneve-ut-1408
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13937,7 +13957,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1406
+Index: geneve-ut-1409
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13954,7 +13974,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1408
+Index: geneve-ut-1411
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13968,7 +13988,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1411
+Index: geneve-ut-1414
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13981,7 +14001,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1412
+Index: geneve-ut-1415
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13993,7 +14013,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1413
+Index: geneve-ut-1416
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14008,7 +14028,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1415
+Index: geneve-ut-1418
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14036,7 +14056,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1416
+Index: geneve-ut-1419
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14061,7 +14081,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1420
+Index: geneve-ut-1423
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14098,7 +14118,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1421
+Index: geneve-ut-1424
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14112,7 +14132,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1422
+Index: geneve-ut-1425
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14128,7 +14148,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1423
+Index: geneve-ut-1426
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14142,7 +14162,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14172,7 +14192,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1425
+Index: geneve-ut-1428
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14201,7 +14221,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1426
+Index: geneve-ut-1429
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14217,7 +14237,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1427
+Index: geneve-ut-1430
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14251,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 file where host.os.type == "windows" and
@@ -14267,7 +14287,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1431
+Index: geneve-ut-1434
 
 ```python
 process where event.type == "start" and
@@ -14281,7 +14301,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1432
+Index: geneve-ut-1435
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14295,7 +14315,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1433
+Index: geneve-ut-1436
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14335,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1435
+Index: geneve-ut-1438
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14332,7 +14352,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1436
+Index: geneve-ut-1439
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14344,7 +14364,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1437
+Index: geneve-ut-1440
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14361,7 +14381,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1438
+Index: geneve-ut-1441
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14379,7 +14399,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1445
+Index: geneve-ut-1448
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14392,7 +14412,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1446
+Index: geneve-ut-1449
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14419,7 +14439,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1447
+Index: geneve-ut-1450
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14432,7 +14452,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1448
+Index: geneve-ut-1451
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14446,7 +14466,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14463,7 +14483,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1451
+Index: geneve-ut-1454
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14486,7 +14506,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1453
+Index: geneve-ut-1456
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14503,7 +14523,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1456
+Index: geneve-ut-1459
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14516,7 +14536,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1458
+Index: geneve-ut-1461
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14540,7 +14560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1459
+Index: geneve-ut-1462
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14568,7 +14588,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1474
+Index: geneve-ut-1477
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14589,7 +14609,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1476
+Index: geneve-ut-1479
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14617,7 +14637,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1478
+Index: geneve-ut-1481
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14657,7 +14677,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1479
+Index: geneve-ut-1482
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14674,7 +14694,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1480
+Index: geneve-ut-1483
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14688,7 +14708,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1481
+Index: geneve-ut-1484
 
 ```python
 file where host.os.type == "windows" and
@@ -14707,7 +14727,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1482
+Index: geneve-ut-1485
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14721,7 +14741,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1484
+Index: geneve-ut-1487
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14739,7 +14759,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1486
+Index: geneve-ut-1489
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14757,7 +14777,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14771,7 +14791,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1491
+Index: geneve-ut-1494
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14786,7 +14806,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14809,7 +14829,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1494
+Index: geneve-ut-1497
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14891,7 +14911,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1495
+Index: geneve-ut-1498
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14912,7 +14932,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1496
+Index: geneve-ut-1499
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14938,7 +14958,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1498
+Index: geneve-ut-1501
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14991,7 +15011,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1499
+Index: geneve-ut-1502
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15003,7 +15023,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1500
+Index: geneve-ut-1503
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15015,7 +15035,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1501
+Index: geneve-ut-1504
 
 ```python
 process where host.os.type == "windows" and
@@ -15030,7 +15050,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1502
+Index: geneve-ut-1505
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15060,7 +15080,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1503
+Index: geneve-ut-1506
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15120,7 +15140,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1506
+Index: geneve-ut-1509
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15133,7 +15153,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1507
+Index: geneve-ut-1510
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15165,7 +15185,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1508
+Index: geneve-ut-1511
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15189,7 +15209,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1510
+Index: geneve-ut-1513
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15222,7 +15242,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1511
+Index: geneve-ut-1514
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15239,7 +15259,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15268,7 +15288,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1513
+Index: geneve-ut-1516
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15282,7 +15302,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1514
+Index: geneve-ut-1517
 
 ```python
 sequence by process.entity_id
@@ -15307,7 +15327,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1515
+Index: geneve-ut-1518
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15341,7 +15361,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1516
+Index: geneve-ut-1519
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15369,7 +15389,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1517
+Index: geneve-ut-1520
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15388,7 +15408,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1521
+Index: geneve-ut-1524
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15416,7 +15436,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1522
+Index: geneve-ut-1525
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15435,7 +15455,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15447,7 +15467,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1527
+Index: geneve-ut-1530
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15459,7 +15479,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1528
+Index: geneve-ut-1531
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15471,7 +15491,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1529
+Index: geneve-ut-1532
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15483,7 +15503,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1539
+Index: geneve-ut-1542
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15496,7 +15516,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1540
+Index: geneve-ut-1543
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15534,7 +15554,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1542
+Index: geneve-ut-1545
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15549,7 +15569,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1543
+Index: geneve-ut-1546
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15568,7 +15588,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1544
+Index: geneve-ut-1547
 
 ```python
 sequence with maxspan=1m
@@ -15616,7 +15636,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1546
+Index: geneve-ut-1549
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15639,7 +15659,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15653,7 +15673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15667,7 +15687,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 sequence by host.id, process.entity_id
@@ -15684,7 +15704,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1552
+Index: geneve-ut-1555
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15698,7 +15718,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1553
+Index: geneve-ut-1556
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15718,7 +15738,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1554
+Index: geneve-ut-1557
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15747,7 +15767,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1555
+Index: geneve-ut-1558
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15767,7 +15787,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1556
+Index: geneve-ut-1559
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15780,7 +15800,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1558
+Index: geneve-ut-1561
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15822,7 +15842,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1559
+Index: geneve-ut-1562
 
 ```python
 sequence with maxspan=1m
@@ -15845,7 +15865,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1560
+Index: geneve-ut-1563
 
 ```python
 sequence with maxspan=1s
@@ -15893,7 +15913,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1561
+Index: geneve-ut-1564
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15910,7 +15930,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1563
+Index: geneve-ut-1566
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15939,7 +15959,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1565
+Index: geneve-ut-1568
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15967,7 +15987,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1566
+Index: geneve-ut-1569
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15984,7 +16004,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1568
+Index: geneve-ut-1571
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16003,7 +16023,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1569
+Index: geneve-ut-1572
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16024,7 +16044,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1574
+Index: geneve-ut-1577
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16038,7 +16058,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1576
+Index: geneve-ut-1579
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16057,7 +16077,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1577
+Index: geneve-ut-1580
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16071,7 +16091,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1578
+Index: geneve-ut-1581
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16091,7 +16111,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1580
+Index: geneve-ut-1583
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16109,7 +16129,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1581
+Index: geneve-ut-1584
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16130,7 +16150,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1583
+Index: geneve-ut-1586
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16144,7 +16164,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1584
+Index: geneve-ut-1587
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16159,7 +16179,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1585
+Index: geneve-ut-1588
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16200,7 +16220,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1587
+Index: geneve-ut-1590
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16225,7 +16245,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1588
+Index: geneve-ut-1591
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16264,7 +16284,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1589
+Index: geneve-ut-1592
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16278,7 +16298,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1590
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16317,7 +16337,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1591
+Index: geneve-ut-1594
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16331,7 +16351,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1592
+Index: geneve-ut-1595
 
 ```python
 process where event.type == "start" and
@@ -16403,7 +16423,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1596
+Index: geneve-ut-1599
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16424,7 +16444,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1599
+Index: geneve-ut-1602
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16441,7 +16461,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1602
+Index: geneve-ut-1605
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16459,7 +16479,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1603
+Index: geneve-ut-1606
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16471,7 +16491,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1604
+Index: geneve-ut-1607
 
 ```python
 file where host.os.type == "windows" and
@@ -16504,7 +16524,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1607
+Index: geneve-ut-1610
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16536,7 +16556,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1609
+Index: geneve-ut-1612
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16572,7 +16592,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1610
+Index: geneve-ut-1613
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16589,7 +16609,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1611
+Index: geneve-ut-1614
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16609,7 +16629,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1613
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16624,7 +16644,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1614
+Index: geneve-ut-1617
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16645,7 +16665,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1615
+Index: geneve-ut-1618
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16668,7 +16688,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1616
+Index: geneve-ut-1619
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16681,7 +16701,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1617
+Index: geneve-ut-1620
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16698,7 +16718,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1619
+Index: geneve-ut-1622
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16723,7 +16743,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1622
+Index: geneve-ut-1625
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16754,7 +16774,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1623
+Index: geneve-ut-1626
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16803,7 +16823,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1624
+Index: geneve-ut-1627
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16817,7 +16837,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1625
+Index: geneve-ut-1628
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16832,7 +16852,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1626
+Index: geneve-ut-1629
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16847,7 +16867,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1627
+Index: geneve-ut-1630
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16869,7 +16889,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1628
+Index: geneve-ut-1631
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16890,7 +16910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1631
+Index: geneve-ut-1634
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16904,7 +16924,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1632
+Index: geneve-ut-1635
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16927,7 +16947,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1662
+Index: geneve-ut-1665
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16952,7 +16972,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1663
+Index: geneve-ut-1666
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16985,7 +17005,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1664
+Index: geneve-ut-1667
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17044,7 +17064,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1666
+Index: geneve-ut-1669
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17062,7 +17082,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1667
+Index: geneve-ut-1670
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17074,7 +17094,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1669
+Index: geneve-ut-1672
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17099,7 +17119,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1675
+Index: geneve-ut-1678
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17114,7 +17134,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1676
+Index: geneve-ut-1679
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17137,7 +17157,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1679
+Index: geneve-ut-1682
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17151,7 +17171,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1681
+Index: geneve-ut-1684
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17173,7 +17193,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1683
+Index: geneve-ut-1686
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17200,7 +17220,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1687
+Index: geneve-ut-1690
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17239,7 +17259,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1688
+Index: geneve-ut-1691
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17262,7 +17282,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1689
+Index: geneve-ut-1692
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17276,7 +17296,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1690
+Index: geneve-ut-1693
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17292,7 +17312,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1691
+Index: geneve-ut-1694
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17308,7 +17328,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1692
+Index: geneve-ut-1695
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17322,7 +17342,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1694
+Index: geneve-ut-1697
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17345,7 +17365,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1695
+Index: geneve-ut-1698
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17373,7 +17393,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1696
+Index: geneve-ut-1699
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +17408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1699
+Index: geneve-ut-1702
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17415,7 +17435,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1701
+Index: geneve-ut-1704
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17446,7 +17466,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1702
+Index: geneve-ut-1705
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17462,7 +17482,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1703
+Index: geneve-ut-1706
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17475,7 +17495,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1705
+Index: geneve-ut-1708
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17491,7 +17511,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1706
+Index: geneve-ut-1709
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17507,7 +17527,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1707
+Index: geneve-ut-1710
 
 ```python
 any where host.os.type == "windows" and 
@@ -17574,7 +17594,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1709
+Index: geneve-ut-1712
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17590,7 +17610,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1711
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17626,7 +17646,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1712
+Index: geneve-ut-1715
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +17684,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1713
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17699,7 +17719,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1714
+Index: geneve-ut-1717
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +17753,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1716
+Index: geneve-ut-1719
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17754,7 +17774,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1721
+Index: geneve-ut-1724
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17831,7 +17851,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1722
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17853,7 +17873,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1723
+Index: geneve-ut-1726
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17877,7 +17897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1724
+Index: geneve-ut-1727
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17898,7 +17918,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1727
+Index: geneve-ut-1730
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17913,7 +17933,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1730
+Index: geneve-ut-1733
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17926,7 +17946,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1731
+Index: geneve-ut-1734
 
 ```python
 any where host.os.type == "windows" and
@@ -17941,7 +17961,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1732
+Index: geneve-ut-1735
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17957,7 +17977,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1733
+Index: geneve-ut-1736
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17971,7 +17991,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1737
+Index: geneve-ut-1740
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18028,7 +18048,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1738
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18042,7 +18062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1740
+Index: geneve-ut-1743
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18074,7 +18094,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1742
+Index: geneve-ut-1745
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18087,7 +18107,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1743
+Index: geneve-ut-1746
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18106,7 +18126,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1744
+Index: geneve-ut-1747
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18152,7 +18172,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1746
+Index: geneve-ut-1749
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18173,7 +18193,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1747
+Index: geneve-ut-1750
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18193,7 +18213,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1748
+Index: geneve-ut-1751
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18207,7 +18227,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1749
+Index: geneve-ut-1752
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18239,7 +18259,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1752
+Index: geneve-ut-1755
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18260,7 +18280,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1754
+Index: geneve-ut-1757
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18361,7 +18381,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1757
+Index: geneve-ut-1760
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18409,7 +18429,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1760
+Index: geneve-ut-1763
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18435,7 +18455,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1761
+Index: geneve-ut-1764
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18480,7 +18500,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1762
+Index: geneve-ut-1765
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18504,7 +18524,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1763
+Index: geneve-ut-1766
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18520,7 +18540,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1765
+Index: geneve-ut-1768
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18545,7 +18565,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1766
+Index: geneve-ut-1769
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18560,7 +18580,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1769
+Index: geneve-ut-1772
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18574,7 +18594,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1770
+Index: geneve-ut-1773
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18594,7 +18614,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1771
+Index: geneve-ut-1774
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18629,7 +18649,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1775
+Index: geneve-ut-1778
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18647,7 +18667,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1776
+Index: geneve-ut-1779
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18660,7 +18680,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1778
+Index: geneve-ut-1781
 
 ```python
 any where host.os.type == "windows" and
@@ -18693,7 +18713,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1780
+Index: geneve-ut-1783
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18711,7 +18731,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1781
+Index: geneve-ut-1784
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18733,7 +18753,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1784
+Index: geneve-ut-1787
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18772,7 +18792,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1785
+Index: geneve-ut-1788
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18802,7 +18822,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1786
+Index: geneve-ut-1789
 
 ```python
 any where host.os.type == "windows" and
@@ -18836,7 +18856,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1787
+Index: geneve-ut-1790
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18850,7 +18870,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1790
+Index: geneve-ut-1793
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18881,7 +18901,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1791
+Index: geneve-ut-1794
 
 ```python
 any where host.os.type == "windows" and
@@ -18901,7 +18921,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1792
+Index: geneve-ut-1795
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18942,7 +18962,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1793
+Index: geneve-ut-1796
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18958,7 +18978,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1794
+Index: geneve-ut-1797
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18988,7 +19008,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1798
+Index: geneve-ut-1801
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19001,7 +19021,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1799
+Index: geneve-ut-1802
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19025,7 +19045,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1802
+Index: geneve-ut-1805
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19043,7 +19063,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1804
+Index: geneve-ut-1807
 
 ```python
 any where host.os.type == "windows" and
@@ -19058,7 +19078,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1805
+Index: geneve-ut-1808
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19076,7 +19096,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1806
+Index: geneve-ut-1809
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19097,7 +19117,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1807
+Index: geneve-ut-1810
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19116,7 +19136,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1810
+Index: geneve-ut-1813
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19141,7 +19161,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1811
+Index: geneve-ut-1814
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19154,7 +19174,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1813
+Index: geneve-ut-1816
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19167,7 +19187,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1815
+Index: geneve-ut-1818
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19190,7 +19210,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1817
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19209,7 +19229,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1818
+Index: geneve-ut-1821
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19231,7 +19251,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1819
+Index: geneve-ut-1822
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19264,7 +19284,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1821
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19282,7 +19302,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1822
+Index: geneve-ut-1825
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19296,7 +19316,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1823
+Index: geneve-ut-1826
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19320,7 +19340,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1824
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19343,7 +19363,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1825
+Index: geneve-ut-1828
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19362,7 +19382,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1828
+Index: geneve-ut-1831
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19381,7 +19401,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1830
+Index: geneve-ut-1833
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19416,7 +19436,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1831
+Index: geneve-ut-1834
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19433,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1832
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19473,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1833
+Index: geneve-ut-1836
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19493,7 +19513,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1834
+Index: geneve-ut-1837
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19509,7 +19529,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1835
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19523,7 +19543,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1836
+Index: geneve-ut-1839
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19561,7 +19581,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1837
+Index: geneve-ut-1840
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19615,7 +19635,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1838
+Index: geneve-ut-1841
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19643,7 +19663,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1840
+Index: geneve-ut-1843
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19657,7 +19677,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1841
+Index: geneve-ut-1844
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19703,7 +19723,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1842
+Index: geneve-ut-1845
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19742,7 +19762,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1843
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19755,7 +19775,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1846
+Index: geneve-ut-1849
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19788,7 +19808,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1847
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19802,7 +19822,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1848
+Index: geneve-ut-1851
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19816,7 +19836,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1849
+Index: geneve-ut-1852
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19830,7 +19850,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1850
+Index: geneve-ut-1853
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19869,7 +19889,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1857
+Index: geneve-ut-1860
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19911,7 +19931,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1859
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19933,7 +19953,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1860
+Index: geneve-ut-1863
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19946,7 +19966,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1862
+Index: geneve-ut-1865
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19963,7 +19983,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1863
+Index: geneve-ut-1866
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19979,7 +19999,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1864
+Index: geneve-ut-1867
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19992,7 +20012,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1865
+Index: geneve-ut-1868
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20007,7 +20027,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1866
+Index: geneve-ut-1869
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20030,7 +20050,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1867
+Index: geneve-ut-1870
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20046,7 +20066,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1868
+Index: geneve-ut-1871
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20062,7 +20082,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1874
+Index: geneve-ut-1877
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20074,7 +20094,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1875
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20103,7 +20123,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1877
+Index: geneve-ut-1880
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20117,7 +20137,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1882
+Index: geneve-ut-1885
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20137,7 +20157,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1883
+Index: geneve-ut-1886
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20162,7 +20182,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1890
+Index: geneve-ut-1893
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20176,7 +20196,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1891
+Index: geneve-ut-1894
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20199,7 +20219,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1900
+Index: geneve-ut-1903
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20233,7 +20253,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1902
+Index: geneve-ut-1905
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20252,7 +20272,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-1909
+Index: geneve-ut-1912
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20271,7 +20291,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1924
+Index: geneve-ut-1927
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20288,7 +20308,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1927
+Index: geneve-ut-1930
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20305,7 +20325,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1943
+Index: geneve-ut-1946
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20324,7 +20344,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1947
+Index: geneve-ut-1950
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20366,7 +20386,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1948
+Index: geneve-ut-1951
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20411,7 +20431,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1951
+Index: geneve-ut-1954
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20453,7 +20473,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1953
+Index: geneve-ut-1956
 
 ```python
 host.os.type:"linux" and 
@@ -20481,7 +20501,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1956
+Index: geneve-ut-1959
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20505,7 +20525,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1957
+Index: geneve-ut-1960
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20545,7 +20565,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1958
+Index: geneve-ut-1961
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20592,7 +20612,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1962
+Index: geneve-ut-1965
 
 ```python
 sequence by process.entity_id
@@ -20629,7 +20649,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1994
+Index: geneve-ut-1997
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20643,7 +20663,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1995
+Index: geneve-ut-1998
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20686,7 +20706,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1996
+Index: geneve-ut-1999
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20699,7 +20719,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1998
+Index: geneve-ut-2001
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20713,7 +20733,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1999
+Index: geneve-ut-2002
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20726,7 +20746,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2003
+Index: geneve-ut-2006
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20751,7 +20771,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2004
+Index: geneve-ut-2007
 
 ```python
 process where event.type == "start" and
@@ -20766,7 +20786,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2005
+Index: geneve-ut-2008
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20783,7 +20803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2006
+Index: geneve-ut-2009
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20797,7 +20817,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2007
+Index: geneve-ut-2010
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20813,7 +20833,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2008
+Index: geneve-ut-2011
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20827,7 +20847,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2009
+Index: geneve-ut-2012
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20854,7 +20874,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2011
+Index: geneve-ut-2014
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20866,7 +20886,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2012
+Index: geneve-ut-2015
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20882,7 +20902,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2013
+Index: geneve-ut-2016
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20905,7 +20925,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2014
+Index: geneve-ut-2017
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20918,7 +20938,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2015
+Index: geneve-ut-2018
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20930,7 +20950,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2016
+Index: geneve-ut-2019
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20942,7 +20962,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2017
+Index: geneve-ut-2020
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20954,7 +20974,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2018
+Index: geneve-ut-2021
 
 ```python
 web where (
@@ -20982,7 +21002,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2024
+Index: geneve-ut-2027
 
 ```python
 any where (
@@ -21054,7 +21074,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2026
+Index: geneve-ut-2029
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21075,7 +21095,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2029
+Index: geneve-ut-2032
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21089,7 +21109,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2030
+Index: geneve-ut-2033
 
 ```python
 file where event.type == "deletion" and
@@ -21106,7 +21126,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2031
+Index: geneve-ut-2034
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21124,7 +21144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2033
+Index: geneve-ut-2036
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21162,7 +21182,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2035
+Index: geneve-ut-2038
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21199,7 +21219,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2036
+Index: geneve-ut-2039
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21214,7 +21234,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2037
+Index: geneve-ut-2040
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21227,7 +21247,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2038
+Index: geneve-ut-2041
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21246,7 +21266,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2039
+Index: geneve-ut-2042
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21271,7 +21291,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2040
+Index: geneve-ut-2043
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21297,7 +21317,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2041
+Index: geneve-ut-2044
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21319,7 +21339,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2042
+Index: geneve-ut-2045
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21336,7 +21356,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2044
+Index: geneve-ut-2047
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21355,7 +21375,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2045
+Index: geneve-ut-2048
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21395,7 +21415,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2046
+Index: geneve-ut-2049
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21412,7 +21432,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2048
+Index: geneve-ut-2051
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21425,7 +21445,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2049
+Index: geneve-ut-2052
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21439,7 +21459,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2050
+Index: geneve-ut-2053
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21467,7 +21487,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2051
+Index: geneve-ut-2054
 
 ```python
 process where event.type == "start" and
@@ -21492,7 +21512,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2052
+Index: geneve-ut-2055
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21506,7 +21526,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2053
+Index: geneve-ut-2056
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21522,7 +21542,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2054
+Index: geneve-ut-2057
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21557,7 +21577,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2055
+Index: geneve-ut-2058
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21575,7 +21595,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2058
+Index: geneve-ut-2061
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.4.md
+++ b/tests/reports/alerts_from_rules-9.4.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.10
+Rules version: 9.4.11
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
    1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
-   1. [Rules with the correct signals (804)](#rules-with-the-correct-signals-804)
+   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
 
 ## Failed rules (24)
 
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807  
+Index: geneve-ut-0808  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000  
+Index: geneve-ut-1001  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145  
+Index: geneve-ut-1146  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175  
+Index: geneve-ut-1176  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248  
+Index: geneve-ut-1250  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277  
+Index: geneve-ut-1279  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295  
+Index: geneve-ut-1297  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359  
+Index: geneve-ut-1362  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374  
+Index: geneve-ut-1377  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464  
+Index: geneve-ut-1467  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709  
+Index: geneve-ut-1712  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713  
+Index: geneve-ut-1716  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797  
+Index: geneve-ut-1800  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812  
+Index: geneve-ut-1815  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825  
+Index: geneve-ut-1828  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835  
+Index: geneve-ut-1838  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841  
+Index: geneve-ut-1844  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850  
+Index: geneve-ut-1853  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947  
+Index: geneve-ut-1950  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978  
+Index: geneve-ut-1981  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807
+Index: geneve-ut-0808
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000
+Index: geneve-ut-1001
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145
+Index: geneve-ut-1146
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248
+Index: geneve-ut-1250
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295
+Index: geneve-ut-1297
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359
+Index: geneve-ut-1362
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464
+Index: geneve-ut-1467
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709
+Index: geneve-ut-1712
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797
+Index: geneve-ut-1800
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812
+Index: geneve-ut-1815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825
+Index: geneve-ut-1828
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841
+Index: geneve-ut-1844
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947
+Index: geneve-ut-1950
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978
+Index: geneve-ut-1981
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1001
+Index: geneve-ut-1002
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1021
+Index: geneve-ut-1022
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1411
+Index: geneve-ut-1414
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1612
+Index: geneve-ut-1615
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807  
+Index: geneve-ut-0808  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0973  
+Index: geneve-ut-0974  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000  
+Index: geneve-ut-1001  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1123  
+Index: geneve-ut-1124  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145  
+Index: geneve-ut-1146  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175  
+Index: geneve-ut-1176  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248  
+Index: geneve-ut-1250  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277  
+Index: geneve-ut-1279  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295  
+Index: geneve-ut-1297  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359  
+Index: geneve-ut-1362  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374  
+Index: geneve-ut-1377  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1455  
+Index: geneve-ut-1458  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464  
+Index: geneve-ut-1467  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1579  
+Index: geneve-ut-1582  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709  
+Index: geneve-ut-1712  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713  
+Index: geneve-ut-1716  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797  
+Index: geneve-ut-1800  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812  
+Index: geneve-ut-1815  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825  
+Index: geneve-ut-1828  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835  
+Index: geneve-ut-1838  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841  
+Index: geneve-ut-1844  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850  
+Index: geneve-ut-1853  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947  
+Index: geneve-ut-1950  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978  
+Index: geneve-ut-1981  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3381,7 +3381,7 @@ container.id like "*"
 
 
 
-## Rules with the correct signals (804)
+## Rules with the correct signals (805)
 
 ### A scheduled task was created
 
@@ -7231,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0797
+Index: geneve-ut-0798
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0798
+Index: geneve-ut-0799
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0799
+Index: geneve-ut-0800
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0800
+Index: geneve-ut-0801
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0808
+Index: geneve-ut-0809
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0809
+Index: geneve-ut-0810
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0810
+Index: geneve-ut-0811
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0811
+Index: geneve-ut-0812
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0815
+Index: geneve-ut-0816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0818
+Index: geneve-ut-0819
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0821
+Index: geneve-ut-0822
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0825
+Index: geneve-ut-0826
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0827
+Index: geneve-ut-0828
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0853
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0856
+Index: geneve-ut-0857
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0857
+Index: geneve-ut-0858
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0870
+Index: geneve-ut-0871
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0871
+Index: geneve-ut-0872
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0872
+Index: geneve-ut-0873
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0876
+Index: geneve-ut-0877
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0882
+Index: geneve-ut-0883
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0884
+Index: geneve-ut-0885
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0885
+Index: geneve-ut-0886
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0886
+Index: geneve-ut-0887
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0887
+Index: geneve-ut-0888
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0888
+Index: geneve-ut-0889
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0889
+Index: geneve-ut-0890
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0894
+Index: geneve-ut-0895
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0896
+Index: geneve-ut-0897
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0897
+Index: geneve-ut-0898
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0898
+Index: geneve-ut-0899
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7897,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0899
+Index: geneve-ut-0900
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7921,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0904
+Index: geneve-ut-0905
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0906
+Index: geneve-ut-0907
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0907
+Index: geneve-ut-0908
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0908
+Index: geneve-ut-0909
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0909
+Index: geneve-ut-0910
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0910
+Index: geneve-ut-0911
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0911
+Index: geneve-ut-0912
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0912
+Index: geneve-ut-0913
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0913
+Index: geneve-ut-0914
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0914
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0915
+Index: geneve-ut-0916
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0917
+Index: geneve-ut-0918
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0919
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0920
+Index: geneve-ut-0921
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0921
+Index: geneve-ut-0922
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0922
+Index: geneve-ut-0923
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0924
+Index: geneve-ut-0925
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0925
+Index: geneve-ut-0926
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0927
+Index: geneve-ut-0928
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0929
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0930
+Index: geneve-ut-0931
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0932
+Index: geneve-ut-0933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0933
+Index: geneve-ut-0934
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8436,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0934
+Index: geneve-ut-0935
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8463,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0937
+Index: geneve-ut-0938
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0938
+Index: geneve-ut-0939
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0948
+Index: geneve-ut-0949
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0974
+Index: geneve-ut-0975
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0977
+Index: geneve-ut-0978
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0979
+Index: geneve-ut-0980
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0991
+Index: geneve-ut-0992
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0996
+Index: geneve-ut-0997
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0997
+Index: geneve-ut-0998
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1002
+Index: geneve-ut-1003
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1017
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1020
+Index: geneve-ut-1021
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1022
+Index: geneve-ut-1023
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1023
+Index: geneve-ut-1024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1027
+Index: geneve-ut-1028
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1028
+Index: geneve-ut-1029
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8863,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1031
+Index: geneve-ut-1032
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1033
+Index: geneve-ut-1034
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1034
+Index: geneve-ut-1035
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1070
+Index: geneve-ut-1071
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1071
+Index: geneve-ut-1072
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1072
+Index: geneve-ut-1073
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1073
+Index: geneve-ut-1074
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1074
+Index: geneve-ut-1075
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1082
+Index: geneve-ut-1083
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1085
+Index: geneve-ut-1086
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1086
+Index: geneve-ut-1087
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1087
+Index: geneve-ut-1088
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1091
+Index: geneve-ut-1092
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1092
+Index: geneve-ut-1093
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1094
+Index: geneve-ut-1095
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1095
+Index: geneve-ut-1096
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1096
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1097
+Index: geneve-ut-1098
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1098
+Index: geneve-ut-1099
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1099
+Index: geneve-ut-1100
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9142,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1100
+Index: geneve-ut-1101
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9167,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1102
+Index: geneve-ut-1103
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1105
+Index: geneve-ut-1106
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1106
+Index: geneve-ut-1107
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1107
+Index: geneve-ut-1108
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1110
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1111
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1112
+Index: geneve-ut-1113
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1116
+Index: geneve-ut-1117
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1117
+Index: geneve-ut-1118
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1118
+Index: geneve-ut-1119
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1122
+Index: geneve-ut-1123
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1124
+Index: geneve-ut-1125
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1126
+Index: geneve-ut-1127
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1127
+Index: geneve-ut-1128
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1129
+Index: geneve-ut-1130
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1132
+Index: geneve-ut-1133
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1133
+Index: geneve-ut-1134
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1135
+Index: geneve-ut-1136
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1136
+Index: geneve-ut-1137
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9604,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1138
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1139
+Index: geneve-ut-1140
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1140
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1141
+Index: geneve-ut-1142
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1142
+Index: geneve-ut-1143
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1143
+Index: geneve-ut-1144
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1144
+Index: geneve-ut-1145
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1157
+Index: geneve-ut-1158
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1166
+Index: geneve-ut-1167
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1170
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1171
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1172
+Index: geneve-ut-1173
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1173
+Index: geneve-ut-1174
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1174
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1176
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1177
+Index: geneve-ut-1178
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1179
+Index: geneve-ut-1180
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1181
+Index: geneve-ut-1182
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1182
+Index: geneve-ut-1183
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1183
+Index: geneve-ut-1184
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1185
+Index: geneve-ut-1186
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1186
+Index: geneve-ut-1187
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1187
+Index: geneve-ut-1188
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1188
+Index: geneve-ut-1189
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1190
+Index: geneve-ut-1191
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1191
+Index: geneve-ut-1192
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1192
+Index: geneve-ut-1193
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1193
+Index: geneve-ut-1194
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1194
+Index: geneve-ut-1195
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1198
+Index: geneve-ut-1199
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1199
+Index: geneve-ut-1200
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1200
+Index: geneve-ut-1201
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1205
+Index: geneve-ut-1206
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1208
+Index: geneve-ut-1209
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1218
+Index: geneve-ut-1219
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1219
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1220
+Index: geneve-ut-1221
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1221
+Index: geneve-ut-1222
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1223
+Index: geneve-ut-1224
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1224
+Index: geneve-ut-1225
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1226
+Index: geneve-ut-1227
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1235
+Index: geneve-ut-1236
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1236
+Index: geneve-ut-1237
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1237
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1238
+Index: geneve-ut-1239
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1239
+Index: geneve-ut-1240
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1240
+Index: geneve-ut-1241
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1241
+Index: geneve-ut-1242
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1242
+Index: geneve-ut-1243
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10666,11 +10666,31 @@ file.path like~ "*/wp-content/plugins/*"
 
 
 
+### PKINIT Followed by Same-Principal U2U Service Ticket
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1244
+
+```python
+sequence by winlog.computer_name, source.ip with maxspan=5s
+  [authentication where host.os.type == "windows" and
+    event.code == "4768" and winlog.event_data.PreAuthType == "16" and
+    winlog.event_data.Status == "0x0"
+  ] by winlog.event_data.TargetSid
+  [authentication where host.os.type == "windows" and
+    event.code == "4769" and winlog.event_data.Status == "0x0" and
+    winlog.event_data.TicketOptions in ("0x40810008", "0x40810018")
+  ] by winlog.event_data.ServiceSid
+```
+
+
+
 ### Pbpaste Execution via Unusual Parent Process
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1249
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10685,7 +10705,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1250
+Index: geneve-ut-1252
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10699,7 +10719,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1251
+Index: geneve-ut-1253
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10718,7 +10738,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1252
+Index: geneve-ut-1254
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10730,7 +10750,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1253
+Index: geneve-ut-1255
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10742,7 +10762,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1254
+Index: geneve-ut-1256
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10760,7 +10780,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1255
+Index: geneve-ut-1257
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10773,7 +10793,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1256
+Index: geneve-ut-1258
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10788,7 +10808,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1257
+Index: geneve-ut-1259
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10803,7 +10823,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1260
+Index: geneve-ut-1262
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10823,7 +10843,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1261
+Index: geneve-ut-1263
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10847,7 +10867,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1262
+Index: geneve-ut-1264
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10861,7 +10881,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1263
+Index: geneve-ut-1265
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10880,7 +10900,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1264
+Index: geneve-ut-1266
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10908,7 +10928,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1265
+Index: geneve-ut-1267
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10937,7 +10957,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1266
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10956,7 +10976,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1267
+Index: geneve-ut-1269
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10984,7 +11004,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1268
+Index: geneve-ut-1270
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10999,7 +11019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1269
+Index: geneve-ut-1271
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11062,7 +11082,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1270
+Index: geneve-ut-1272
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11083,7 +11103,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1271
+Index: geneve-ut-1273
 
 ```python
 any where host.os.type == "windows" and
@@ -11145,7 +11165,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1273
+Index: geneve-ut-1275
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11174,7 +11194,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1274
+Index: geneve-ut-1276
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11188,7 +11208,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1275
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11221,7 +11241,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1278
+Index: geneve-ut-1280
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11268,7 +11288,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1279
+Index: geneve-ut-1281
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11295,7 +11315,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1280
+Index: geneve-ut-1282
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11308,7 +11328,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1291
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11325,7 +11345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1293
+Index: geneve-ut-1295
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11350,7 +11370,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1298
+Index: geneve-ut-1300
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11366,7 +11386,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1299
+Index: geneve-ut-1301
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11387,7 +11407,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1301
+Index: geneve-ut-1304
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11404,7 +11424,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1302
+Index: geneve-ut-1305
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11417,7 +11437,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1303
+Index: geneve-ut-1306
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11441,7 +11461,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11470,7 +11490,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1307
+Index: geneve-ut-1310
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11497,7 +11517,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1308
+Index: geneve-ut-1311
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11521,7 +11541,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11539,7 +11559,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1312
+Index: geneve-ut-1315
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11562,7 +11582,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1313
+Index: geneve-ut-1316
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11619,7 +11639,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1314
+Index: geneve-ut-1317
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11636,7 +11656,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1315
+Index: geneve-ut-1318
 
 ```python
 sequence by process.entity_id
@@ -11650,7 +11670,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1330
+Index: geneve-ut-1333
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11665,7 +11685,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11696,7 +11716,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11710,7 +11730,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1333
+Index: geneve-ut-1336
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11723,7 +11743,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11735,7 +11755,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1335
+Index: geneve-ut-1338
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11748,7 +11768,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11767,7 +11787,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1338
+Index: geneve-ut-1341
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11780,7 +11800,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1339
+Index: geneve-ut-1342
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11801,7 +11821,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11815,7 +11835,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1343
+Index: geneve-ut-1346
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11835,7 +11855,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1344
+Index: geneve-ut-1347
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11859,7 +11879,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1345
+Index: geneve-ut-1348
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11875,7 +11895,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1346
+Index: geneve-ut-1349
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11892,7 +11912,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1347
+Index: geneve-ut-1350
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11913,7 +11933,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1349
+Index: geneve-ut-1352
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11926,7 +11946,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1351
+Index: geneve-ut-1354
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11954,7 +11974,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1354
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11970,7 +11990,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11993,7 +12013,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12006,7 +12026,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1358
+Index: geneve-ut-1361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12019,7 +12039,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12033,7 +12053,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1364
+Index: geneve-ut-1367
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +12068,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1366
+Index: geneve-ut-1369
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12071,7 +12091,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1369
+Index: geneve-ut-1372
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12114,7 +12134,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12132,7 +12152,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 host.os.type:"windows" and
@@ -12148,7 +12168,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12160,7 +12180,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12176,7 +12196,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1376
+Index: geneve-ut-1379
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12192,7 +12212,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1377
+Index: geneve-ut-1380
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12210,7 +12230,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1378
+Index: geneve-ut-1381
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12224,7 +12244,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12247,7 +12267,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1382
+Index: geneve-ut-1385
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12263,7 +12283,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1383
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12276,7 +12296,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1384
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12306,7 +12326,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1390
+Index: geneve-ut-1393
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12329,7 +12349,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1391
+Index: geneve-ut-1394
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12348,7 +12368,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1396
+Index: geneve-ut-1399
 
 ```python
 process where host.os.type == "windows" and 
@@ -12490,7 +12510,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1397
+Index: geneve-ut-1400
 
 ```python
 process where host.os.type == "windows" and
@@ -12567,7 +12587,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12584,7 +12604,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1402
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12618,7 +12638,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1404
+Index: geneve-ut-1407
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12630,7 +12650,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1405
+Index: geneve-ut-1408
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12669,7 +12689,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1408
+Index: geneve-ut-1411
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12682,7 +12702,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1413
+Index: geneve-ut-1416
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12696,7 +12716,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1420
+Index: geneve-ut-1423
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12734,7 +12754,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1421
+Index: geneve-ut-1424
 
 ```python
 network where host.os.type == "windows" and
@@ -12760,7 +12780,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12775,7 +12795,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1427
+Index: geneve-ut-1430
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12789,7 +12809,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 file where host.os.type == "windows" and
@@ -12803,7 +12823,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1429
+Index: geneve-ut-1432
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12816,7 +12836,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1430
+Index: geneve-ut-1433
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12836,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1431
+Index: geneve-ut-1434
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12876,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1433
+Index: geneve-ut-1436
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12895,7 +12915,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1434
+Index: geneve-ut-1437
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13090,7 +13110,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1449
+Index: geneve-ut-1452
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13106,7 +13126,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13120,7 +13140,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1451
+Index: geneve-ut-1454
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13134,7 +13154,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1452
+Index: geneve-ut-1455
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13151,7 +13171,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1453
+Index: geneve-ut-1456
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13165,7 +13185,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1454
+Index: geneve-ut-1457
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13181,7 +13201,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1459
+Index: geneve-ut-1462
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13193,7 +13213,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1460
+Index: geneve-ut-1463
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13209,7 +13229,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1461
+Index: geneve-ut-1464
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13229,7 +13249,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1463
+Index: geneve-ut-1466
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13269,7 +13289,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1465
+Index: geneve-ut-1468
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13281,7 +13301,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1466
+Index: geneve-ut-1469
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13302,7 +13322,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1467
+Index: geneve-ut-1470
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13323,7 +13343,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1468
+Index: geneve-ut-1471
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13344,7 +13364,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1469
+Index: geneve-ut-1472
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13370,7 +13390,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1470
+Index: geneve-ut-1473
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13386,7 +13406,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1471
+Index: geneve-ut-1474
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13400,7 +13420,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1473
+Index: geneve-ut-1476
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13423,7 +13443,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1475
+Index: geneve-ut-1478
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13440,7 +13460,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1476
+Index: geneve-ut-1479
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13463,7 +13483,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1477
+Index: geneve-ut-1480
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13476,7 +13496,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1478
+Index: geneve-ut-1481
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13490,7 +13510,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1479
+Index: geneve-ut-1482
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13507,7 +13527,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1480
+Index: geneve-ut-1483
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13561,7 +13581,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1481
+Index: geneve-ut-1484
 
 ```python
 any where host.os.type == "windows" and
@@ -13588,7 +13608,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1487
+Index: geneve-ut-1490
 
 ```python
 file where host.os.type == "windows" and
@@ -13603,7 +13623,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1488
+Index: geneve-ut-1491
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13634,7 +13654,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +13668,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1490
+Index: geneve-ut-1493
 
 ```python
 sequence with maxspan=1m
@@ -13690,7 +13710,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1491
+Index: geneve-ut-1494
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13715,7 +13735,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13769,7 +13789,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13789,7 +13809,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1494
+Index: geneve-ut-1497
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13810,7 +13830,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1495
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13825,7 +13845,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1496
+Index: geneve-ut-1499
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13845,7 +13865,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1497
+Index: geneve-ut-1500
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13887,7 +13907,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1501
+Index: geneve-ut-1504
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13902,7 +13922,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1502
+Index: geneve-ut-1505
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13937,7 +13957,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1503
+Index: geneve-ut-1506
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13954,7 +13974,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1508
+Index: geneve-ut-1511
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13968,7 +13988,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1511
+Index: geneve-ut-1514
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13981,7 +14001,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13993,7 +14013,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1513
+Index: geneve-ut-1516
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14008,7 +14028,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1515
+Index: geneve-ut-1518
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14036,7 +14056,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1517
+Index: geneve-ut-1520
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14061,7 +14081,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1521
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14098,7 +14118,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1522
+Index: geneve-ut-1525
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14112,7 +14132,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1523
+Index: geneve-ut-1526
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14128,7 +14148,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1524
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14142,7 +14162,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1525
+Index: geneve-ut-1528
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14172,7 +14192,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14201,7 +14221,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1527
+Index: geneve-ut-1530
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14217,7 +14237,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1528
+Index: geneve-ut-1531
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14251,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1529
+Index: geneve-ut-1532
 
 ```python
 file where host.os.type == "windows" and
@@ -14267,7 +14287,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1532
+Index: geneve-ut-1535
 
 ```python
 process where event.type == "start" and
@@ -14281,7 +14301,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1533
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14295,7 +14315,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1534
+Index: geneve-ut-1537
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14335,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1536
+Index: geneve-ut-1539
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14332,7 +14352,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1537
+Index: geneve-ut-1540
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14344,7 +14364,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1538
+Index: geneve-ut-1541
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14361,7 +14381,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1539
+Index: geneve-ut-1542
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14379,7 +14399,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1546
+Index: geneve-ut-1549
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14392,7 +14412,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1547
+Index: geneve-ut-1550
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14419,7 +14439,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14432,7 +14452,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14446,7 +14466,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14463,7 +14483,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1552
+Index: geneve-ut-1555
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14486,7 +14506,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1554
+Index: geneve-ut-1557
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14503,7 +14523,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1557
+Index: geneve-ut-1560
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14516,7 +14536,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1559
+Index: geneve-ut-1562
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14540,7 +14560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1560
+Index: geneve-ut-1563
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14568,7 +14588,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1576
+Index: geneve-ut-1579
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14589,7 +14609,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1578
+Index: geneve-ut-1581
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14617,7 +14637,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1580
+Index: geneve-ut-1583
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14657,7 +14677,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1581
+Index: geneve-ut-1584
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14674,7 +14694,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1582
+Index: geneve-ut-1585
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14688,7 +14708,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1583
+Index: geneve-ut-1586
 
 ```python
 file where host.os.type == "windows" and
@@ -14707,7 +14727,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1584
+Index: geneve-ut-1587
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14721,7 +14741,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1586
+Index: geneve-ut-1589
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14739,7 +14759,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1588
+Index: geneve-ut-1591
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14757,7 +14777,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1591
+Index: geneve-ut-1594
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14771,7 +14791,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1593
+Index: geneve-ut-1596
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14786,7 +14806,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1594
+Index: geneve-ut-1597
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14809,7 +14829,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1596
+Index: geneve-ut-1599
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14891,7 +14911,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1597
+Index: geneve-ut-1600
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14912,7 +14932,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1598
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14938,7 +14958,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1601
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14991,7 +15011,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1602
+Index: geneve-ut-1605
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15003,7 +15023,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1603
+Index: geneve-ut-1606
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15015,7 +15035,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1604
+Index: geneve-ut-1607
 
 ```python
 process where host.os.type == "windows" and
@@ -15030,7 +15050,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1605
+Index: geneve-ut-1608
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15060,7 +15080,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1606
+Index: geneve-ut-1609
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15120,7 +15140,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1609
+Index: geneve-ut-1612
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15133,7 +15153,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1610
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15165,7 +15185,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1611
+Index: geneve-ut-1614
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15189,7 +15209,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1613
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15222,7 +15242,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1614
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15239,7 +15259,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1616
+Index: geneve-ut-1619
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15268,7 +15288,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1617
+Index: geneve-ut-1620
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15282,7 +15302,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1618
+Index: geneve-ut-1621
 
 ```python
 sequence by process.entity_id
@@ -15307,7 +15327,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1619
+Index: geneve-ut-1622
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15341,7 +15361,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1620
+Index: geneve-ut-1623
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15369,7 +15389,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1621
+Index: geneve-ut-1624
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15388,7 +15408,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1627
+Index: geneve-ut-1630
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15416,7 +15436,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1628
+Index: geneve-ut-1631
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15435,7 +15455,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1632
+Index: geneve-ut-1635
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15447,7 +15467,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1633
+Index: geneve-ut-1636
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15459,7 +15479,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1634
+Index: geneve-ut-1637
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15471,7 +15491,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1635
+Index: geneve-ut-1638
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15483,7 +15503,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1646
+Index: geneve-ut-1649
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15496,7 +15516,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1647
+Index: geneve-ut-1650
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15534,7 +15554,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1649
+Index: geneve-ut-1652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15549,7 +15569,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1650
+Index: geneve-ut-1653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15568,7 +15588,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1651
+Index: geneve-ut-1654
 
 ```python
 sequence with maxspan=1m
@@ -15616,7 +15636,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1653
+Index: geneve-ut-1656
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15639,7 +15659,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1655
+Index: geneve-ut-1658
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15653,7 +15673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1656
+Index: geneve-ut-1659
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15667,7 +15687,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1658
+Index: geneve-ut-1661
 
 ```python
 sequence by host.id, process.entity_id
@@ -15684,7 +15704,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1659
+Index: geneve-ut-1662
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15698,7 +15718,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1660
+Index: geneve-ut-1663
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15718,7 +15738,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1661
+Index: geneve-ut-1664
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15747,7 +15767,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1662
+Index: geneve-ut-1665
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15767,7 +15787,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1663
+Index: geneve-ut-1666
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15780,7 +15800,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1665
+Index: geneve-ut-1668
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15822,7 +15842,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1666
+Index: geneve-ut-1669
 
 ```python
 sequence with maxspan=1m
@@ -15845,7 +15865,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1667
+Index: geneve-ut-1670
 
 ```python
 sequence with maxspan=1s
@@ -15893,7 +15913,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1668
+Index: geneve-ut-1671
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15910,7 +15930,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1670
+Index: geneve-ut-1673
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15939,7 +15959,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1673
+Index: geneve-ut-1676
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15967,7 +15987,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1674
+Index: geneve-ut-1677
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15984,7 +16004,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1676
+Index: geneve-ut-1679
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16003,7 +16023,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1677
+Index: geneve-ut-1680
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16024,7 +16044,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1686
+Index: geneve-ut-1689
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16038,7 +16058,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1688
+Index: geneve-ut-1691
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16057,7 +16077,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1689
+Index: geneve-ut-1692
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16071,7 +16091,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1690
+Index: geneve-ut-1693
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16091,7 +16111,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1692
+Index: geneve-ut-1695
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16109,7 +16129,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1693
+Index: geneve-ut-1696
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16130,7 +16150,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1695
+Index: geneve-ut-1698
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16144,7 +16164,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1696
+Index: geneve-ut-1699
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16159,7 +16179,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1697
+Index: geneve-ut-1700
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16200,7 +16220,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1699
+Index: geneve-ut-1702
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16225,7 +16245,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1700
+Index: geneve-ut-1703
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16264,7 +16284,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1701
+Index: geneve-ut-1704
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16278,7 +16298,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1702
+Index: geneve-ut-1705
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16317,7 +16337,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1703
+Index: geneve-ut-1706
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16331,7 +16351,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1704
+Index: geneve-ut-1707
 
 ```python
 process where event.type == "start" and
@@ -16403,7 +16423,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1708
+Index: geneve-ut-1711
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16424,7 +16444,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1711
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16441,7 +16461,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1714
+Index: geneve-ut-1717
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16459,7 +16479,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1715
+Index: geneve-ut-1718
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16471,7 +16491,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1716
+Index: geneve-ut-1719
 
 ```python
 file where host.os.type == "windows" and
@@ -16504,7 +16524,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1719
+Index: geneve-ut-1722
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16536,7 +16556,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1721
+Index: geneve-ut-1724
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16572,7 +16592,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1722
+Index: geneve-ut-1725
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16589,7 +16609,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1723
+Index: geneve-ut-1726
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16609,7 +16629,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1725
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16624,7 +16644,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1726
+Index: geneve-ut-1729
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16645,7 +16665,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1727
+Index: geneve-ut-1730
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16668,7 +16688,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1728
+Index: geneve-ut-1731
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16681,7 +16701,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1729
+Index: geneve-ut-1732
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16698,7 +16718,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1732
+Index: geneve-ut-1735
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16723,7 +16743,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1735
+Index: geneve-ut-1738
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16754,7 +16774,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1736
+Index: geneve-ut-1739
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16803,7 +16823,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1737
+Index: geneve-ut-1740
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16817,7 +16837,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1738
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16832,7 +16852,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1739
+Index: geneve-ut-1742
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16847,7 +16867,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1740
+Index: geneve-ut-1743
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16869,7 +16889,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1741
+Index: geneve-ut-1744
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16890,7 +16910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1745
+Index: geneve-ut-1748
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16904,7 +16924,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1746
+Index: geneve-ut-1749
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16927,7 +16947,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1776
+Index: geneve-ut-1779
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16952,7 +16972,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1777
+Index: geneve-ut-1780
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16985,7 +17005,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1778
+Index: geneve-ut-1781
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17044,7 +17064,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1780
+Index: geneve-ut-1783
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17062,7 +17082,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1781
+Index: geneve-ut-1784
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17074,7 +17094,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1784
+Index: geneve-ut-1787
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17099,7 +17119,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1790
+Index: geneve-ut-1793
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17114,7 +17134,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1791
+Index: geneve-ut-1794
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17137,7 +17157,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1794
+Index: geneve-ut-1797
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17151,7 +17171,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1796
+Index: geneve-ut-1799
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17173,7 +17193,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1798
+Index: geneve-ut-1801
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17200,7 +17220,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1802
+Index: geneve-ut-1805
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17239,7 +17259,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1803
+Index: geneve-ut-1806
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17262,7 +17282,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1804
+Index: geneve-ut-1807
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17276,7 +17296,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1805
+Index: geneve-ut-1808
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17292,7 +17312,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1806
+Index: geneve-ut-1809
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17308,7 +17328,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1807
+Index: geneve-ut-1810
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17322,7 +17342,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1809
+Index: geneve-ut-1812
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17345,7 +17365,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1810
+Index: geneve-ut-1813
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17373,7 +17393,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1811
+Index: geneve-ut-1814
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +17408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1814
+Index: geneve-ut-1817
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17415,7 +17435,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1816
+Index: geneve-ut-1819
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17446,7 +17466,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1817
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17462,7 +17482,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1818
+Index: geneve-ut-1821
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17475,7 +17495,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1820
+Index: geneve-ut-1823
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17491,7 +17511,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1821
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17507,7 +17527,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1822
+Index: geneve-ut-1825
 
 ```python
 any where host.os.type == "windows" and 
@@ -17574,7 +17594,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1824
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17590,7 +17610,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1826
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17626,7 +17646,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1827
+Index: geneve-ut-1830
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +17684,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1828
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17699,7 +17719,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1829
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +17753,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1831
+Index: geneve-ut-1834
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17754,7 +17774,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1836
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17831,7 +17851,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1837
+Index: geneve-ut-1840
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17853,7 +17873,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1838
+Index: geneve-ut-1841
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17877,7 +17897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1840
+Index: geneve-ut-1843
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17898,7 +17918,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1843
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17913,7 +17933,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1846
+Index: geneve-ut-1849
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17926,7 +17946,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1847
+Index: geneve-ut-1850
 
 ```python
 any where host.os.type == "windows" and
@@ -17941,7 +17961,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1848
+Index: geneve-ut-1851
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17957,7 +17977,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1849
+Index: geneve-ut-1852
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17971,7 +17991,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1853
+Index: geneve-ut-1856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18028,7 +18048,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1854
+Index: geneve-ut-1857
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18042,7 +18062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1856
+Index: geneve-ut-1859
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18074,7 +18094,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1858
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18087,7 +18107,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1859
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18106,7 +18126,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1860
+Index: geneve-ut-1863
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18152,7 +18172,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1862
+Index: geneve-ut-1865
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18173,7 +18193,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1863
+Index: geneve-ut-1866
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18193,7 +18213,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1864
+Index: geneve-ut-1867
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18207,7 +18227,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1865
+Index: geneve-ut-1868
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18239,7 +18259,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1868
+Index: geneve-ut-1871
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18260,7 +18280,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1870
+Index: geneve-ut-1873
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18361,7 +18381,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1874
+Index: geneve-ut-1877
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18409,7 +18429,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1877
+Index: geneve-ut-1880
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18435,7 +18455,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1878
+Index: geneve-ut-1881
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18480,7 +18500,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1879
+Index: geneve-ut-1882
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18504,7 +18524,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1880
+Index: geneve-ut-1883
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18520,7 +18540,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1882
+Index: geneve-ut-1885
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18545,7 +18565,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1883
+Index: geneve-ut-1886
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18560,7 +18580,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1886
+Index: geneve-ut-1889
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18574,7 +18594,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1887
+Index: geneve-ut-1890
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18594,7 +18614,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1888
+Index: geneve-ut-1891
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18629,7 +18649,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1892
+Index: geneve-ut-1895
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18647,7 +18667,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1893
+Index: geneve-ut-1896
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18660,7 +18680,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1896
+Index: geneve-ut-1899
 
 ```python
 any where host.os.type == "windows" and
@@ -18693,7 +18713,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1898
+Index: geneve-ut-1901
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18711,7 +18731,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1899
+Index: geneve-ut-1902
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18733,7 +18753,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1902
+Index: geneve-ut-1905
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18772,7 +18792,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1903
+Index: geneve-ut-1906
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18802,7 +18822,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1904
+Index: geneve-ut-1907
 
 ```python
 any where host.os.type == "windows" and
@@ -18836,7 +18856,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1905
+Index: geneve-ut-1908
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18850,7 +18870,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1908
+Index: geneve-ut-1911
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18881,7 +18901,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1909
+Index: geneve-ut-1912
 
 ```python
 any where host.os.type == "windows" and
@@ -18901,7 +18921,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1910
+Index: geneve-ut-1913
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18942,7 +18962,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1911
+Index: geneve-ut-1914
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18958,7 +18978,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1912
+Index: geneve-ut-1915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18988,7 +19008,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1916
+Index: geneve-ut-1919
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19001,7 +19021,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1917
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19025,7 +19045,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1920
+Index: geneve-ut-1923
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19043,7 +19063,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1922
+Index: geneve-ut-1925
 
 ```python
 any where host.os.type == "windows" and
@@ -19058,7 +19078,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1923
+Index: geneve-ut-1926
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19076,7 +19096,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1924
+Index: geneve-ut-1927
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19097,7 +19117,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1925
+Index: geneve-ut-1928
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19116,7 +19136,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1928
+Index: geneve-ut-1931
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19141,7 +19161,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1929
+Index: geneve-ut-1932
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19154,7 +19174,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1931
+Index: geneve-ut-1934
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19167,7 +19187,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1933
+Index: geneve-ut-1936
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19190,7 +19210,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1935
+Index: geneve-ut-1938
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19209,7 +19229,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1936
+Index: geneve-ut-1939
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19231,7 +19251,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1937
+Index: geneve-ut-1940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19264,7 +19284,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1939
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19282,7 +19302,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1940
+Index: geneve-ut-1943
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19296,7 +19316,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1941
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19320,7 +19340,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1942
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19343,7 +19363,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1943
+Index: geneve-ut-1946
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19362,7 +19382,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1946
+Index: geneve-ut-1949
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19381,7 +19401,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1948
+Index: geneve-ut-1951
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19416,7 +19436,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1949
+Index: geneve-ut-1952
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19433,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1950
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19473,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1951
+Index: geneve-ut-1954
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19493,7 +19513,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1952
+Index: geneve-ut-1955
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19509,7 +19529,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1953
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19523,7 +19543,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1954
+Index: geneve-ut-1957
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19561,7 +19581,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1955
+Index: geneve-ut-1958
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19615,7 +19635,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1956
+Index: geneve-ut-1959
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19643,7 +19663,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1958
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19657,7 +19677,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1959
+Index: geneve-ut-1962
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19703,7 +19723,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1960
+Index: geneve-ut-1963
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19742,7 +19762,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1961
+Index: geneve-ut-1964
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19755,7 +19775,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1965
+Index: geneve-ut-1968
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19788,7 +19808,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1966
+Index: geneve-ut-1969
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19802,7 +19822,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1967
+Index: geneve-ut-1970
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19816,7 +19836,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1968
+Index: geneve-ut-1971
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19830,7 +19850,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1969
+Index: geneve-ut-1972
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19869,7 +19889,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1977
+Index: geneve-ut-1980
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19911,7 +19931,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1979
+Index: geneve-ut-1982
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19933,7 +19953,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1981
+Index: geneve-ut-1984
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19946,7 +19966,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1984
+Index: geneve-ut-1987
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19963,7 +19983,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1985
+Index: geneve-ut-1988
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19979,7 +19999,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1986
+Index: geneve-ut-1989
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19992,7 +20012,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1987
+Index: geneve-ut-1990
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20007,7 +20027,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1988
+Index: geneve-ut-1991
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20030,7 +20050,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1989
+Index: geneve-ut-1992
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20046,7 +20066,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1990
+Index: geneve-ut-1993
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20062,7 +20082,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1996
+Index: geneve-ut-1999
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20074,7 +20094,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1997
+Index: geneve-ut-2000
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20103,7 +20123,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1999
+Index: geneve-ut-2002
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20117,7 +20137,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2004
+Index: geneve-ut-2007
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20137,7 +20157,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2005
+Index: geneve-ut-2008
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20162,7 +20182,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2012
+Index: geneve-ut-2015
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20176,7 +20196,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2013
+Index: geneve-ut-2016
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20199,7 +20219,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2022
+Index: geneve-ut-2025
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20233,7 +20253,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2024
+Index: geneve-ut-2027
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20252,7 +20272,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2031
+Index: geneve-ut-2034
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20271,7 +20291,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2046
+Index: geneve-ut-2049
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20288,7 +20308,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2049
+Index: geneve-ut-2052
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20305,7 +20325,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2065
+Index: geneve-ut-2068
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20324,7 +20344,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2069
+Index: geneve-ut-2072
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20366,7 +20386,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2070
+Index: geneve-ut-2073
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20411,7 +20431,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2073
+Index: geneve-ut-2076
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20453,7 +20473,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2075
+Index: geneve-ut-2078
 
 ```python
 host.os.type:"linux" and 
@@ -20481,7 +20501,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2079
+Index: geneve-ut-2082
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20505,7 +20525,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2080
+Index: geneve-ut-2083
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20545,7 +20565,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2081
+Index: geneve-ut-2084
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20592,7 +20612,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2085
+Index: geneve-ut-2088
 
 ```python
 sequence by process.entity_id
@@ -20629,7 +20649,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2117
+Index: geneve-ut-2120
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20643,7 +20663,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2118
+Index: geneve-ut-2121
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20686,7 +20706,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2119
+Index: geneve-ut-2122
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20699,7 +20719,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2122
+Index: geneve-ut-2125
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20713,7 +20733,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2123
+Index: geneve-ut-2126
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20726,7 +20746,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2127
+Index: geneve-ut-2130
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20751,7 +20771,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2128
+Index: geneve-ut-2131
 
 ```python
 process where event.type == "start" and
@@ -20766,7 +20786,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2129
+Index: geneve-ut-2132
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20783,7 +20803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2130
+Index: geneve-ut-2133
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20797,7 +20817,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2131
+Index: geneve-ut-2134
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20813,7 +20833,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2132
+Index: geneve-ut-2135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20827,7 +20847,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2133
+Index: geneve-ut-2136
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20854,7 +20874,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2135
+Index: geneve-ut-2138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20866,7 +20886,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2136
+Index: geneve-ut-2139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20882,7 +20902,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2137
+Index: geneve-ut-2140
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20905,7 +20925,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2138
+Index: geneve-ut-2141
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20918,7 +20938,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2140
+Index: geneve-ut-2143
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20930,7 +20950,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2141
+Index: geneve-ut-2144
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20942,7 +20962,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2142
+Index: geneve-ut-2145
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20954,7 +20974,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2143
+Index: geneve-ut-2146
 
 ```python
 web where (
@@ -20982,7 +21002,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2149
+Index: geneve-ut-2152
 
 ```python
 any where (
@@ -21054,7 +21074,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2151
+Index: geneve-ut-2154
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21075,7 +21095,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2154
+Index: geneve-ut-2157
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21089,7 +21109,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2155
+Index: geneve-ut-2158
 
 ```python
 file where event.type == "deletion" and
@@ -21106,7 +21126,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2156
+Index: geneve-ut-2159
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21124,7 +21144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2159
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21162,7 +21182,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2161
+Index: geneve-ut-2164
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21199,7 +21219,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2162
+Index: geneve-ut-2165
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21214,7 +21234,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2163
+Index: geneve-ut-2166
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21227,7 +21247,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2164
+Index: geneve-ut-2167
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21246,7 +21266,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2165
+Index: geneve-ut-2168
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21271,7 +21291,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2166
+Index: geneve-ut-2169
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21297,7 +21317,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2167
+Index: geneve-ut-2170
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21319,7 +21339,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2168
+Index: geneve-ut-2171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21336,7 +21356,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2170
+Index: geneve-ut-2173
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21355,7 +21375,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2171
+Index: geneve-ut-2174
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21395,7 +21415,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2172
+Index: geneve-ut-2175
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21412,7 +21432,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2174
+Index: geneve-ut-2177
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21425,7 +21445,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2175
+Index: geneve-ut-2178
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21439,7 +21459,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2176
+Index: geneve-ut-2179
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21467,7 +21487,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2177
+Index: geneve-ut-2180
 
 ```python
 process where event.type == "start" and
@@ -21492,7 +21512,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2178
+Index: geneve-ut-2181
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21506,7 +21526,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2179
+Index: geneve-ut-2182
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21522,7 +21542,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2180
+Index: geneve-ut-2183
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21557,7 +21577,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2181
+Index: geneve-ut-2184
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21575,7 +21595,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2184
+Index: geneve-ut-2187
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.5.md
+++ b/tests/reports/alerts_from_rules-9.5.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.3
+Rules version: 9.5.4
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
    1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
-   1. [Rules with the correct signals (804)](#rules-with-the-correct-signals-804)
+   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
 
 ## Failed rules (24)
 
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807  
+Index: geneve-ut-0808  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000  
+Index: geneve-ut-1001  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145  
+Index: geneve-ut-1146  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175  
+Index: geneve-ut-1176  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248  
+Index: geneve-ut-1250  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277  
+Index: geneve-ut-1279  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295  
+Index: geneve-ut-1297  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359  
+Index: geneve-ut-1362  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374  
+Index: geneve-ut-1377  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464  
+Index: geneve-ut-1467  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709  
+Index: geneve-ut-1712  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713  
+Index: geneve-ut-1716  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797  
+Index: geneve-ut-1800  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812  
+Index: geneve-ut-1815  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825  
+Index: geneve-ut-1828  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835  
+Index: geneve-ut-1838  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841  
+Index: geneve-ut-1844  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850  
+Index: geneve-ut-1853  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947  
+Index: geneve-ut-1950  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978  
+Index: geneve-ut-1981  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807
+Index: geneve-ut-0808
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000
+Index: geneve-ut-1001
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145
+Index: geneve-ut-1146
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248
+Index: geneve-ut-1250
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295
+Index: geneve-ut-1297
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359
+Index: geneve-ut-1362
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464
+Index: geneve-ut-1467
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709
+Index: geneve-ut-1712
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797
+Index: geneve-ut-1800
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812
+Index: geneve-ut-1815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825
+Index: geneve-ut-1828
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841
+Index: geneve-ut-1844
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947
+Index: geneve-ut-1950
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978
+Index: geneve-ut-1981
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1001
+Index: geneve-ut-1002
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1021
+Index: geneve-ut-1022
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1411
+Index: geneve-ut-1414
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1612
+Index: geneve-ut-1615
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807  
+Index: geneve-ut-0808  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0973  
+Index: geneve-ut-0974  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000  
+Index: geneve-ut-1001  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1123  
+Index: geneve-ut-1124  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145  
+Index: geneve-ut-1146  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175  
+Index: geneve-ut-1176  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248  
+Index: geneve-ut-1250  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277  
+Index: geneve-ut-1279  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295  
+Index: geneve-ut-1297  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359  
+Index: geneve-ut-1362  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374  
+Index: geneve-ut-1377  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1455  
+Index: geneve-ut-1458  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464  
+Index: geneve-ut-1467  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1579  
+Index: geneve-ut-1582  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709  
+Index: geneve-ut-1712  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713  
+Index: geneve-ut-1716  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797  
+Index: geneve-ut-1800  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812  
+Index: geneve-ut-1815  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825  
+Index: geneve-ut-1828  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835  
+Index: geneve-ut-1838  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841  
+Index: geneve-ut-1844  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850  
+Index: geneve-ut-1853  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947  
+Index: geneve-ut-1950  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978  
+Index: geneve-ut-1981  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3381,7 +3381,7 @@ container.id like "*"
 
 
 
-## Rules with the correct signals (804)
+## Rules with the correct signals (805)
 
 ### A scheduled task was created
 
@@ -7231,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0797
+Index: geneve-ut-0798
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0798
+Index: geneve-ut-0799
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0799
+Index: geneve-ut-0800
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0800
+Index: geneve-ut-0801
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0808
+Index: geneve-ut-0809
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0809
+Index: geneve-ut-0810
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0810
+Index: geneve-ut-0811
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0811
+Index: geneve-ut-0812
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0815
+Index: geneve-ut-0816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0818
+Index: geneve-ut-0819
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0821
+Index: geneve-ut-0822
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0825
+Index: geneve-ut-0826
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0827
+Index: geneve-ut-0828
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0853
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0856
+Index: geneve-ut-0857
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0857
+Index: geneve-ut-0858
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0870
+Index: geneve-ut-0871
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0871
+Index: geneve-ut-0872
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0872
+Index: geneve-ut-0873
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0876
+Index: geneve-ut-0877
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0882
+Index: geneve-ut-0883
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0884
+Index: geneve-ut-0885
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0885
+Index: geneve-ut-0886
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0886
+Index: geneve-ut-0887
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0887
+Index: geneve-ut-0888
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0888
+Index: geneve-ut-0889
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0889
+Index: geneve-ut-0890
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0894
+Index: geneve-ut-0895
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0896
+Index: geneve-ut-0897
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0897
+Index: geneve-ut-0898
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0898
+Index: geneve-ut-0899
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7897,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0899
+Index: geneve-ut-0900
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7921,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0904
+Index: geneve-ut-0905
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0906
+Index: geneve-ut-0907
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0907
+Index: geneve-ut-0908
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0908
+Index: geneve-ut-0909
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0909
+Index: geneve-ut-0910
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0910
+Index: geneve-ut-0911
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0911
+Index: geneve-ut-0912
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0912
+Index: geneve-ut-0913
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0913
+Index: geneve-ut-0914
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0914
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0915
+Index: geneve-ut-0916
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0917
+Index: geneve-ut-0918
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0919
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0920
+Index: geneve-ut-0921
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0921
+Index: geneve-ut-0922
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0922
+Index: geneve-ut-0923
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0924
+Index: geneve-ut-0925
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0925
+Index: geneve-ut-0926
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0927
+Index: geneve-ut-0928
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0929
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0930
+Index: geneve-ut-0931
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0932
+Index: geneve-ut-0933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0933
+Index: geneve-ut-0934
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8436,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0934
+Index: geneve-ut-0935
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8463,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0937
+Index: geneve-ut-0938
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0938
+Index: geneve-ut-0939
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0948
+Index: geneve-ut-0949
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0974
+Index: geneve-ut-0975
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0977
+Index: geneve-ut-0978
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0979
+Index: geneve-ut-0980
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0991
+Index: geneve-ut-0992
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0996
+Index: geneve-ut-0997
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0997
+Index: geneve-ut-0998
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1002
+Index: geneve-ut-1003
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1017
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1020
+Index: geneve-ut-1021
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1022
+Index: geneve-ut-1023
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1023
+Index: geneve-ut-1024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1027
+Index: geneve-ut-1028
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1028
+Index: geneve-ut-1029
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8863,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1031
+Index: geneve-ut-1032
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1033
+Index: geneve-ut-1034
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1034
+Index: geneve-ut-1035
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1070
+Index: geneve-ut-1071
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1071
+Index: geneve-ut-1072
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1072
+Index: geneve-ut-1073
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1073
+Index: geneve-ut-1074
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1074
+Index: geneve-ut-1075
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1082
+Index: geneve-ut-1083
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1085
+Index: geneve-ut-1086
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1086
+Index: geneve-ut-1087
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1087
+Index: geneve-ut-1088
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1091
+Index: geneve-ut-1092
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1092
+Index: geneve-ut-1093
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1094
+Index: geneve-ut-1095
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1095
+Index: geneve-ut-1096
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1096
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1097
+Index: geneve-ut-1098
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1098
+Index: geneve-ut-1099
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1099
+Index: geneve-ut-1100
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9142,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1100
+Index: geneve-ut-1101
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9167,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1102
+Index: geneve-ut-1103
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1105
+Index: geneve-ut-1106
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1106
+Index: geneve-ut-1107
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1107
+Index: geneve-ut-1108
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1110
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1111
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1112
+Index: geneve-ut-1113
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1116
+Index: geneve-ut-1117
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1117
+Index: geneve-ut-1118
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1118
+Index: geneve-ut-1119
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1122
+Index: geneve-ut-1123
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1124
+Index: geneve-ut-1125
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1126
+Index: geneve-ut-1127
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1127
+Index: geneve-ut-1128
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1129
+Index: geneve-ut-1130
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1132
+Index: geneve-ut-1133
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1133
+Index: geneve-ut-1134
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1135
+Index: geneve-ut-1136
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1136
+Index: geneve-ut-1137
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9604,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1138
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1139
+Index: geneve-ut-1140
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1140
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1141
+Index: geneve-ut-1142
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1142
+Index: geneve-ut-1143
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1143
+Index: geneve-ut-1144
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1144
+Index: geneve-ut-1145
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1157
+Index: geneve-ut-1158
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1166
+Index: geneve-ut-1167
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1170
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1171
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1172
+Index: geneve-ut-1173
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1173
+Index: geneve-ut-1174
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1174
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1176
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1177
+Index: geneve-ut-1178
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1179
+Index: geneve-ut-1180
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1181
+Index: geneve-ut-1182
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1182
+Index: geneve-ut-1183
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1183
+Index: geneve-ut-1184
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1185
+Index: geneve-ut-1186
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1186
+Index: geneve-ut-1187
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1187
+Index: geneve-ut-1188
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1188
+Index: geneve-ut-1189
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1190
+Index: geneve-ut-1191
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1191
+Index: geneve-ut-1192
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1192
+Index: geneve-ut-1193
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1193
+Index: geneve-ut-1194
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1194
+Index: geneve-ut-1195
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1198
+Index: geneve-ut-1199
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1199
+Index: geneve-ut-1200
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1200
+Index: geneve-ut-1201
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1205
+Index: geneve-ut-1206
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1208
+Index: geneve-ut-1209
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1218
+Index: geneve-ut-1219
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1219
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1220
+Index: geneve-ut-1221
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1221
+Index: geneve-ut-1222
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1223
+Index: geneve-ut-1224
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1224
+Index: geneve-ut-1225
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1226
+Index: geneve-ut-1227
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1235
+Index: geneve-ut-1236
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1236
+Index: geneve-ut-1237
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1237
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1238
+Index: geneve-ut-1239
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1239
+Index: geneve-ut-1240
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1240
+Index: geneve-ut-1241
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1241
+Index: geneve-ut-1242
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1242
+Index: geneve-ut-1243
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10666,11 +10666,31 @@ file.path like~ "*/wp-content/plugins/*"
 
 
 
+### PKINIT Followed by Same-Principal U2U Service Ticket
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1244
+
+```python
+sequence by winlog.computer_name, source.ip with maxspan=5s
+  [authentication where host.os.type == "windows" and
+    event.code == "4768" and winlog.event_data.PreAuthType == "16" and
+    winlog.event_data.Status == "0x0"
+  ] by winlog.event_data.TargetSid
+  [authentication where host.os.type == "windows" and
+    event.code == "4769" and winlog.event_data.Status == "0x0" and
+    winlog.event_data.TicketOptions in ("0x40810008", "0x40810018")
+  ] by winlog.event_data.ServiceSid
+```
+
+
+
 ### Pbpaste Execution via Unusual Parent Process
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1249
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10685,7 +10705,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1250
+Index: geneve-ut-1252
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10699,7 +10719,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1251
+Index: geneve-ut-1253
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10718,7 +10738,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1252
+Index: geneve-ut-1254
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10730,7 +10750,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1253
+Index: geneve-ut-1255
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10742,7 +10762,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1254
+Index: geneve-ut-1256
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10760,7 +10780,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1255
+Index: geneve-ut-1257
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10773,7 +10793,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1256
+Index: geneve-ut-1258
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10788,7 +10808,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1257
+Index: geneve-ut-1259
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10803,7 +10823,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1260
+Index: geneve-ut-1262
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10823,7 +10843,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1261
+Index: geneve-ut-1263
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10847,7 +10867,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1262
+Index: geneve-ut-1264
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10861,7 +10881,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1263
+Index: geneve-ut-1265
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10880,7 +10900,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1264
+Index: geneve-ut-1266
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10908,7 +10928,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1265
+Index: geneve-ut-1267
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10937,7 +10957,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1266
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10956,7 +10976,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1267
+Index: geneve-ut-1269
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10984,7 +11004,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1268
+Index: geneve-ut-1270
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10999,7 +11019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1269
+Index: geneve-ut-1271
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11062,7 +11082,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1270
+Index: geneve-ut-1272
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11083,7 +11103,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1271
+Index: geneve-ut-1273
 
 ```python
 any where host.os.type == "windows" and
@@ -11145,7 +11165,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1273
+Index: geneve-ut-1275
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11174,7 +11194,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1274
+Index: geneve-ut-1276
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11188,7 +11208,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1275
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11221,7 +11241,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1278
+Index: geneve-ut-1280
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11268,7 +11288,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1279
+Index: geneve-ut-1281
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11295,7 +11315,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1280
+Index: geneve-ut-1282
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11308,7 +11328,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1291
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11325,7 +11345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1293
+Index: geneve-ut-1295
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11350,7 +11370,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1298
+Index: geneve-ut-1300
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11366,7 +11386,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1299
+Index: geneve-ut-1301
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11387,7 +11407,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1301
+Index: geneve-ut-1304
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11404,7 +11424,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1302
+Index: geneve-ut-1305
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11417,7 +11437,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1303
+Index: geneve-ut-1306
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11441,7 +11461,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11470,7 +11490,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1307
+Index: geneve-ut-1310
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11497,7 +11517,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1308
+Index: geneve-ut-1311
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11521,7 +11541,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11539,7 +11559,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1312
+Index: geneve-ut-1315
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11562,7 +11582,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1313
+Index: geneve-ut-1316
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11619,7 +11639,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1314
+Index: geneve-ut-1317
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11636,7 +11656,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1315
+Index: geneve-ut-1318
 
 ```python
 sequence by process.entity_id
@@ -11650,7 +11670,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1330
+Index: geneve-ut-1333
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11665,7 +11685,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11696,7 +11716,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11710,7 +11730,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1333
+Index: geneve-ut-1336
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11723,7 +11743,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11735,7 +11755,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1335
+Index: geneve-ut-1338
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11748,7 +11768,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11767,7 +11787,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1338
+Index: geneve-ut-1341
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11780,7 +11800,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1339
+Index: geneve-ut-1342
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11801,7 +11821,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11815,7 +11835,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1343
+Index: geneve-ut-1346
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11835,7 +11855,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1344
+Index: geneve-ut-1347
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11859,7 +11879,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1345
+Index: geneve-ut-1348
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11875,7 +11895,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1346
+Index: geneve-ut-1349
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11892,7 +11912,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1347
+Index: geneve-ut-1350
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11913,7 +11933,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1349
+Index: geneve-ut-1352
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11926,7 +11946,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1351
+Index: geneve-ut-1354
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11954,7 +11974,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1354
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11970,7 +11990,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11993,7 +12013,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12006,7 +12026,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1358
+Index: geneve-ut-1361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12019,7 +12039,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12033,7 +12053,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1364
+Index: geneve-ut-1367
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +12068,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1366
+Index: geneve-ut-1369
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12071,7 +12091,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1369
+Index: geneve-ut-1372
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12114,7 +12134,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12132,7 +12152,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 host.os.type:"windows" and
@@ -12148,7 +12168,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12160,7 +12180,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12176,7 +12196,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1376
+Index: geneve-ut-1379
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12192,7 +12212,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1377
+Index: geneve-ut-1380
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12210,7 +12230,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1378
+Index: geneve-ut-1381
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12224,7 +12244,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12247,7 +12267,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1382
+Index: geneve-ut-1385
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12263,7 +12283,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1383
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12276,7 +12296,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1384
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12306,7 +12326,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1390
+Index: geneve-ut-1393
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12329,7 +12349,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1391
+Index: geneve-ut-1394
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12348,7 +12368,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1396
+Index: geneve-ut-1399
 
 ```python
 process where host.os.type == "windows" and 
@@ -12490,7 +12510,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1397
+Index: geneve-ut-1400
 
 ```python
 process where host.os.type == "windows" and
@@ -12567,7 +12587,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12584,7 +12604,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1402
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12618,7 +12638,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1404
+Index: geneve-ut-1407
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12630,7 +12650,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1405
+Index: geneve-ut-1408
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12669,7 +12689,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1408
+Index: geneve-ut-1411
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12682,7 +12702,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1413
+Index: geneve-ut-1416
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12696,7 +12716,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1420
+Index: geneve-ut-1423
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12734,7 +12754,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1421
+Index: geneve-ut-1424
 
 ```python
 network where host.os.type == "windows" and
@@ -12760,7 +12780,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12775,7 +12795,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1427
+Index: geneve-ut-1430
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12789,7 +12809,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 file where host.os.type == "windows" and
@@ -12803,7 +12823,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1429
+Index: geneve-ut-1432
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12816,7 +12836,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1430
+Index: geneve-ut-1433
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12836,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1431
+Index: geneve-ut-1434
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12876,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1433
+Index: geneve-ut-1436
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12895,7 +12915,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1434
+Index: geneve-ut-1437
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13090,7 +13110,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1449
+Index: geneve-ut-1452
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13106,7 +13126,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13120,7 +13140,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1451
+Index: geneve-ut-1454
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13134,7 +13154,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1452
+Index: geneve-ut-1455
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13151,7 +13171,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1453
+Index: geneve-ut-1456
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13165,7 +13185,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1454
+Index: geneve-ut-1457
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13181,7 +13201,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1459
+Index: geneve-ut-1462
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13193,7 +13213,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1460
+Index: geneve-ut-1463
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13209,7 +13229,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1461
+Index: geneve-ut-1464
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13229,7 +13249,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1463
+Index: geneve-ut-1466
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13269,7 +13289,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1465
+Index: geneve-ut-1468
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13281,7 +13301,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1466
+Index: geneve-ut-1469
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13302,7 +13322,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1467
+Index: geneve-ut-1470
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13323,7 +13343,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1468
+Index: geneve-ut-1471
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13344,7 +13364,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1469
+Index: geneve-ut-1472
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13370,7 +13390,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1470
+Index: geneve-ut-1473
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13386,7 +13406,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1471
+Index: geneve-ut-1474
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13400,7 +13420,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1473
+Index: geneve-ut-1476
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13423,7 +13443,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1475
+Index: geneve-ut-1478
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13440,7 +13460,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1476
+Index: geneve-ut-1479
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13463,7 +13483,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1477
+Index: geneve-ut-1480
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13476,7 +13496,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1478
+Index: geneve-ut-1481
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13490,7 +13510,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1479
+Index: geneve-ut-1482
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13507,7 +13527,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1480
+Index: geneve-ut-1483
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13561,7 +13581,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1481
+Index: geneve-ut-1484
 
 ```python
 any where host.os.type == "windows" and
@@ -13588,7 +13608,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1487
+Index: geneve-ut-1490
 
 ```python
 file where host.os.type == "windows" and
@@ -13603,7 +13623,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1488
+Index: geneve-ut-1491
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13634,7 +13654,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +13668,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1490
+Index: geneve-ut-1493
 
 ```python
 sequence with maxspan=1m
@@ -13690,7 +13710,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1491
+Index: geneve-ut-1494
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13715,7 +13735,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13769,7 +13789,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13789,7 +13809,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1494
+Index: geneve-ut-1497
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13810,7 +13830,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1495
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13825,7 +13845,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1496
+Index: geneve-ut-1499
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13845,7 +13865,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1497
+Index: geneve-ut-1500
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13887,7 +13907,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1501
+Index: geneve-ut-1504
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13902,7 +13922,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1502
+Index: geneve-ut-1505
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13937,7 +13957,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1503
+Index: geneve-ut-1506
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13954,7 +13974,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1508
+Index: geneve-ut-1511
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13968,7 +13988,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1511
+Index: geneve-ut-1514
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13981,7 +14001,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13993,7 +14013,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1513
+Index: geneve-ut-1516
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14008,7 +14028,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1515
+Index: geneve-ut-1518
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14036,7 +14056,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1517
+Index: geneve-ut-1520
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14061,7 +14081,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1521
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14098,7 +14118,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1522
+Index: geneve-ut-1525
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14112,7 +14132,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1523
+Index: geneve-ut-1526
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14128,7 +14148,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1524
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14142,7 +14162,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1525
+Index: geneve-ut-1528
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14172,7 +14192,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14201,7 +14221,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1527
+Index: geneve-ut-1530
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14217,7 +14237,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1528
+Index: geneve-ut-1531
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14251,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1529
+Index: geneve-ut-1532
 
 ```python
 file where host.os.type == "windows" and
@@ -14267,7 +14287,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1532
+Index: geneve-ut-1535
 
 ```python
 process where event.type == "start" and
@@ -14281,7 +14301,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1533
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14295,7 +14315,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1534
+Index: geneve-ut-1537
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14335,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1536
+Index: geneve-ut-1539
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14332,7 +14352,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1537
+Index: geneve-ut-1540
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14344,7 +14364,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1538
+Index: geneve-ut-1541
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14361,7 +14381,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1539
+Index: geneve-ut-1542
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14379,7 +14399,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1546
+Index: geneve-ut-1549
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14392,7 +14412,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1547
+Index: geneve-ut-1550
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14419,7 +14439,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14432,7 +14452,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14446,7 +14466,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14463,7 +14483,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1552
+Index: geneve-ut-1555
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14486,7 +14506,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1554
+Index: geneve-ut-1557
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14503,7 +14523,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1557
+Index: geneve-ut-1560
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14516,7 +14536,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1559
+Index: geneve-ut-1562
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14540,7 +14560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1560
+Index: geneve-ut-1563
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14568,7 +14588,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1576
+Index: geneve-ut-1579
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14589,7 +14609,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1578
+Index: geneve-ut-1581
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14617,7 +14637,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1580
+Index: geneve-ut-1583
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14657,7 +14677,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1581
+Index: geneve-ut-1584
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14674,7 +14694,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1582
+Index: geneve-ut-1585
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14688,7 +14708,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1583
+Index: geneve-ut-1586
 
 ```python
 file where host.os.type == "windows" and
@@ -14707,7 +14727,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1584
+Index: geneve-ut-1587
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14721,7 +14741,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1586
+Index: geneve-ut-1589
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14739,7 +14759,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1588
+Index: geneve-ut-1591
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14757,7 +14777,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1591
+Index: geneve-ut-1594
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14771,7 +14791,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1593
+Index: geneve-ut-1596
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14786,7 +14806,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1594
+Index: geneve-ut-1597
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14809,7 +14829,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1596
+Index: geneve-ut-1599
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14891,7 +14911,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1597
+Index: geneve-ut-1600
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14912,7 +14932,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1598
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14938,7 +14958,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1601
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14991,7 +15011,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1602
+Index: geneve-ut-1605
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15003,7 +15023,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1603
+Index: geneve-ut-1606
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15015,7 +15035,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1604
+Index: geneve-ut-1607
 
 ```python
 process where host.os.type == "windows" and
@@ -15030,7 +15050,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1605
+Index: geneve-ut-1608
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15060,7 +15080,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1606
+Index: geneve-ut-1609
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15120,7 +15140,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1609
+Index: geneve-ut-1612
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15133,7 +15153,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1610
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15165,7 +15185,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1611
+Index: geneve-ut-1614
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15189,7 +15209,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1613
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15222,7 +15242,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1614
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15239,7 +15259,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1616
+Index: geneve-ut-1619
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15268,7 +15288,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1617
+Index: geneve-ut-1620
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15282,7 +15302,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1618
+Index: geneve-ut-1621
 
 ```python
 sequence by process.entity_id
@@ -15307,7 +15327,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1619
+Index: geneve-ut-1622
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15341,7 +15361,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1620
+Index: geneve-ut-1623
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15369,7 +15389,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1621
+Index: geneve-ut-1624
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15388,7 +15408,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1627
+Index: geneve-ut-1630
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15416,7 +15436,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1628
+Index: geneve-ut-1631
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15435,7 +15455,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1632
+Index: geneve-ut-1635
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15447,7 +15467,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1633
+Index: geneve-ut-1636
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15459,7 +15479,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1634
+Index: geneve-ut-1637
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15471,7 +15491,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1635
+Index: geneve-ut-1638
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15483,7 +15503,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1646
+Index: geneve-ut-1649
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15496,7 +15516,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1647
+Index: geneve-ut-1650
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15534,7 +15554,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1649
+Index: geneve-ut-1652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15549,7 +15569,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1650
+Index: geneve-ut-1653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15568,7 +15588,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1651
+Index: geneve-ut-1654
 
 ```python
 sequence with maxspan=1m
@@ -15616,7 +15636,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1653
+Index: geneve-ut-1656
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15639,7 +15659,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1655
+Index: geneve-ut-1658
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15653,7 +15673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1656
+Index: geneve-ut-1659
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15667,7 +15687,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1658
+Index: geneve-ut-1661
 
 ```python
 sequence by host.id, process.entity_id
@@ -15684,7 +15704,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1659
+Index: geneve-ut-1662
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15698,7 +15718,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1660
+Index: geneve-ut-1663
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15718,7 +15738,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1661
+Index: geneve-ut-1664
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15747,7 +15767,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1662
+Index: geneve-ut-1665
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15767,7 +15787,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1663
+Index: geneve-ut-1666
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15780,7 +15800,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1665
+Index: geneve-ut-1668
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15822,7 +15842,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1666
+Index: geneve-ut-1669
 
 ```python
 sequence with maxspan=1m
@@ -15845,7 +15865,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1667
+Index: geneve-ut-1670
 
 ```python
 sequence with maxspan=1s
@@ -15893,7 +15913,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1668
+Index: geneve-ut-1671
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15910,7 +15930,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1670
+Index: geneve-ut-1673
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15939,7 +15959,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1673
+Index: geneve-ut-1676
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15967,7 +15987,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1674
+Index: geneve-ut-1677
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15984,7 +16004,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1676
+Index: geneve-ut-1679
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16003,7 +16023,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1677
+Index: geneve-ut-1680
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16024,7 +16044,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1686
+Index: geneve-ut-1689
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16038,7 +16058,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1688
+Index: geneve-ut-1691
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16057,7 +16077,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1689
+Index: geneve-ut-1692
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16071,7 +16091,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1690
+Index: geneve-ut-1693
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16091,7 +16111,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1692
+Index: geneve-ut-1695
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16109,7 +16129,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1693
+Index: geneve-ut-1696
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16130,7 +16150,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1695
+Index: geneve-ut-1698
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16144,7 +16164,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1696
+Index: geneve-ut-1699
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16159,7 +16179,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1697
+Index: geneve-ut-1700
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16200,7 +16220,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1699
+Index: geneve-ut-1702
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16225,7 +16245,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1700
+Index: geneve-ut-1703
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16264,7 +16284,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1701
+Index: geneve-ut-1704
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16278,7 +16298,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1702
+Index: geneve-ut-1705
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16317,7 +16337,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1703
+Index: geneve-ut-1706
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16331,7 +16351,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1704
+Index: geneve-ut-1707
 
 ```python
 process where event.type == "start" and
@@ -16403,7 +16423,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1708
+Index: geneve-ut-1711
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16424,7 +16444,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1711
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16441,7 +16461,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1714
+Index: geneve-ut-1717
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16459,7 +16479,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1715
+Index: geneve-ut-1718
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16471,7 +16491,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1716
+Index: geneve-ut-1719
 
 ```python
 file where host.os.type == "windows" and
@@ -16504,7 +16524,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1719
+Index: geneve-ut-1722
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16536,7 +16556,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1721
+Index: geneve-ut-1724
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16572,7 +16592,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1722
+Index: geneve-ut-1725
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16589,7 +16609,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1723
+Index: geneve-ut-1726
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16609,7 +16629,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1725
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16624,7 +16644,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1726
+Index: geneve-ut-1729
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16645,7 +16665,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1727
+Index: geneve-ut-1730
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16668,7 +16688,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1728
+Index: geneve-ut-1731
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16681,7 +16701,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1729
+Index: geneve-ut-1732
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16698,7 +16718,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1732
+Index: geneve-ut-1735
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16723,7 +16743,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1735
+Index: geneve-ut-1738
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16754,7 +16774,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1736
+Index: geneve-ut-1739
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16803,7 +16823,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1737
+Index: geneve-ut-1740
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16817,7 +16837,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1738
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16832,7 +16852,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1739
+Index: geneve-ut-1742
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16847,7 +16867,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1740
+Index: geneve-ut-1743
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16869,7 +16889,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1741
+Index: geneve-ut-1744
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16890,7 +16910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1745
+Index: geneve-ut-1748
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16904,7 +16924,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1746
+Index: geneve-ut-1749
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16927,7 +16947,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1776
+Index: geneve-ut-1779
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16952,7 +16972,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1777
+Index: geneve-ut-1780
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16985,7 +17005,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1778
+Index: geneve-ut-1781
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17044,7 +17064,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1780
+Index: geneve-ut-1783
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17062,7 +17082,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1781
+Index: geneve-ut-1784
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17074,7 +17094,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1784
+Index: geneve-ut-1787
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17099,7 +17119,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1790
+Index: geneve-ut-1793
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17114,7 +17134,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1791
+Index: geneve-ut-1794
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17137,7 +17157,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1794
+Index: geneve-ut-1797
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17151,7 +17171,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1796
+Index: geneve-ut-1799
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17173,7 +17193,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1798
+Index: geneve-ut-1801
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17200,7 +17220,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1802
+Index: geneve-ut-1805
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17239,7 +17259,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1803
+Index: geneve-ut-1806
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17262,7 +17282,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1804
+Index: geneve-ut-1807
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17276,7 +17296,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1805
+Index: geneve-ut-1808
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17292,7 +17312,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1806
+Index: geneve-ut-1809
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17308,7 +17328,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1807
+Index: geneve-ut-1810
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17322,7 +17342,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1809
+Index: geneve-ut-1812
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17345,7 +17365,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1810
+Index: geneve-ut-1813
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17373,7 +17393,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1811
+Index: geneve-ut-1814
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +17408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1814
+Index: geneve-ut-1817
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17415,7 +17435,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1816
+Index: geneve-ut-1819
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17446,7 +17466,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1817
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17462,7 +17482,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1818
+Index: geneve-ut-1821
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17475,7 +17495,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1820
+Index: geneve-ut-1823
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17491,7 +17511,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1821
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17507,7 +17527,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1822
+Index: geneve-ut-1825
 
 ```python
 any where host.os.type == "windows" and 
@@ -17574,7 +17594,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1824
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17590,7 +17610,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1826
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17626,7 +17646,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1827
+Index: geneve-ut-1830
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +17684,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1828
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17699,7 +17719,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1829
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +17753,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1831
+Index: geneve-ut-1834
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17754,7 +17774,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1836
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17831,7 +17851,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1837
+Index: geneve-ut-1840
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17853,7 +17873,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1838
+Index: geneve-ut-1841
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17877,7 +17897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1840
+Index: geneve-ut-1843
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17898,7 +17918,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1843
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17913,7 +17933,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1846
+Index: geneve-ut-1849
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17926,7 +17946,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1847
+Index: geneve-ut-1850
 
 ```python
 any where host.os.type == "windows" and
@@ -17941,7 +17961,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1848
+Index: geneve-ut-1851
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17957,7 +17977,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1849
+Index: geneve-ut-1852
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17971,7 +17991,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1853
+Index: geneve-ut-1856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18028,7 +18048,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1854
+Index: geneve-ut-1857
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18042,7 +18062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1856
+Index: geneve-ut-1859
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18074,7 +18094,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1858
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18087,7 +18107,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1859
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18106,7 +18126,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1860
+Index: geneve-ut-1863
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18152,7 +18172,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1862
+Index: geneve-ut-1865
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18173,7 +18193,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1863
+Index: geneve-ut-1866
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18193,7 +18213,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1864
+Index: geneve-ut-1867
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18207,7 +18227,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1865
+Index: geneve-ut-1868
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18239,7 +18259,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1868
+Index: geneve-ut-1871
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18260,7 +18280,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1870
+Index: geneve-ut-1873
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18361,7 +18381,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1874
+Index: geneve-ut-1877
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18409,7 +18429,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1877
+Index: geneve-ut-1880
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18435,7 +18455,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1878
+Index: geneve-ut-1881
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18480,7 +18500,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1879
+Index: geneve-ut-1882
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18504,7 +18524,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1880
+Index: geneve-ut-1883
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18520,7 +18540,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1882
+Index: geneve-ut-1885
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18545,7 +18565,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1883
+Index: geneve-ut-1886
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18560,7 +18580,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1886
+Index: geneve-ut-1889
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18574,7 +18594,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1887
+Index: geneve-ut-1890
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18594,7 +18614,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1888
+Index: geneve-ut-1891
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18629,7 +18649,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1892
+Index: geneve-ut-1895
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18647,7 +18667,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1893
+Index: geneve-ut-1896
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18660,7 +18680,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1896
+Index: geneve-ut-1899
 
 ```python
 any where host.os.type == "windows" and
@@ -18693,7 +18713,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1898
+Index: geneve-ut-1901
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18711,7 +18731,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1899
+Index: geneve-ut-1902
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18733,7 +18753,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1902
+Index: geneve-ut-1905
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18772,7 +18792,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1903
+Index: geneve-ut-1906
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18802,7 +18822,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1904
+Index: geneve-ut-1907
 
 ```python
 any where host.os.type == "windows" and
@@ -18836,7 +18856,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1905
+Index: geneve-ut-1908
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18850,7 +18870,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1908
+Index: geneve-ut-1911
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18881,7 +18901,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1909
+Index: geneve-ut-1912
 
 ```python
 any where host.os.type == "windows" and
@@ -18901,7 +18921,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1910
+Index: geneve-ut-1913
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18942,7 +18962,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1911
+Index: geneve-ut-1914
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18958,7 +18978,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1912
+Index: geneve-ut-1915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18988,7 +19008,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1916
+Index: geneve-ut-1919
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19001,7 +19021,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1917
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19025,7 +19045,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1920
+Index: geneve-ut-1923
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19043,7 +19063,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1922
+Index: geneve-ut-1925
 
 ```python
 any where host.os.type == "windows" and
@@ -19058,7 +19078,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1923
+Index: geneve-ut-1926
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19076,7 +19096,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1924
+Index: geneve-ut-1927
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19097,7 +19117,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1925
+Index: geneve-ut-1928
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19116,7 +19136,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1928
+Index: geneve-ut-1931
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19141,7 +19161,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1929
+Index: geneve-ut-1932
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19154,7 +19174,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1931
+Index: geneve-ut-1934
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19167,7 +19187,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1933
+Index: geneve-ut-1936
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19190,7 +19210,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1935
+Index: geneve-ut-1938
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19209,7 +19229,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1936
+Index: geneve-ut-1939
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19231,7 +19251,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1937
+Index: geneve-ut-1940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19264,7 +19284,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1939
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19282,7 +19302,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1940
+Index: geneve-ut-1943
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19296,7 +19316,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1941
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19320,7 +19340,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1942
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19343,7 +19363,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1943
+Index: geneve-ut-1946
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19362,7 +19382,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1946
+Index: geneve-ut-1949
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19381,7 +19401,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1948
+Index: geneve-ut-1951
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19416,7 +19436,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1949
+Index: geneve-ut-1952
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19433,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1950
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19473,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1951
+Index: geneve-ut-1954
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19493,7 +19513,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1952
+Index: geneve-ut-1955
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19509,7 +19529,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1953
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19523,7 +19543,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1954
+Index: geneve-ut-1957
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19561,7 +19581,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1955
+Index: geneve-ut-1958
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19615,7 +19635,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1956
+Index: geneve-ut-1959
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19643,7 +19663,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1958
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19657,7 +19677,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1959
+Index: geneve-ut-1962
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19703,7 +19723,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1960
+Index: geneve-ut-1963
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19742,7 +19762,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1961
+Index: geneve-ut-1964
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19755,7 +19775,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1965
+Index: geneve-ut-1968
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19788,7 +19808,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1966
+Index: geneve-ut-1969
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19802,7 +19822,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1967
+Index: geneve-ut-1970
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19816,7 +19836,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1968
+Index: geneve-ut-1971
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19830,7 +19850,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1969
+Index: geneve-ut-1972
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19869,7 +19889,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1977
+Index: geneve-ut-1980
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19911,7 +19931,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1979
+Index: geneve-ut-1982
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19933,7 +19953,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1981
+Index: geneve-ut-1984
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19946,7 +19966,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1984
+Index: geneve-ut-1987
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19963,7 +19983,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1985
+Index: geneve-ut-1988
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19979,7 +19999,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1986
+Index: geneve-ut-1989
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19992,7 +20012,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1987
+Index: geneve-ut-1990
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20007,7 +20027,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1988
+Index: geneve-ut-1991
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20030,7 +20050,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1989
+Index: geneve-ut-1992
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20046,7 +20066,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1990
+Index: geneve-ut-1993
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20062,7 +20082,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1996
+Index: geneve-ut-1999
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20074,7 +20094,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1997
+Index: geneve-ut-2000
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20103,7 +20123,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1999
+Index: geneve-ut-2002
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20117,7 +20137,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2004
+Index: geneve-ut-2007
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20137,7 +20157,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2005
+Index: geneve-ut-2008
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20162,7 +20182,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2012
+Index: geneve-ut-2015
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20176,7 +20196,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2013
+Index: geneve-ut-2016
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20199,7 +20219,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2022
+Index: geneve-ut-2025
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20233,7 +20253,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2024
+Index: geneve-ut-2027
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20252,7 +20272,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2031
+Index: geneve-ut-2034
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20271,7 +20291,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2046
+Index: geneve-ut-2049
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20288,7 +20308,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2049
+Index: geneve-ut-2052
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20305,7 +20325,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2065
+Index: geneve-ut-2068
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20324,7 +20344,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2069
+Index: geneve-ut-2072
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20366,7 +20386,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2070
+Index: geneve-ut-2073
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20411,7 +20431,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2073
+Index: geneve-ut-2076
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20453,7 +20473,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2075
+Index: geneve-ut-2078
 
 ```python
 host.os.type:"linux" and 
@@ -20481,7 +20501,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2079
+Index: geneve-ut-2082
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20505,7 +20525,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2080
+Index: geneve-ut-2083
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20545,7 +20565,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2081
+Index: geneve-ut-2084
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20592,7 +20612,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2085
+Index: geneve-ut-2088
 
 ```python
 sequence by process.entity_id
@@ -20629,7 +20649,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2117
+Index: geneve-ut-2120
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20643,7 +20663,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2118
+Index: geneve-ut-2121
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20686,7 +20706,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2119
+Index: geneve-ut-2122
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20699,7 +20719,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2122
+Index: geneve-ut-2125
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20713,7 +20733,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2123
+Index: geneve-ut-2126
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20726,7 +20746,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2127
+Index: geneve-ut-2130
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20751,7 +20771,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2128
+Index: geneve-ut-2131
 
 ```python
 process where event.type == "start" and
@@ -20766,7 +20786,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2129
+Index: geneve-ut-2132
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20783,7 +20803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2130
+Index: geneve-ut-2133
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20797,7 +20817,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2131
+Index: geneve-ut-2134
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20813,7 +20833,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2132
+Index: geneve-ut-2135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20827,7 +20847,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2133
+Index: geneve-ut-2136
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20854,7 +20874,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2135
+Index: geneve-ut-2138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20866,7 +20886,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2136
+Index: geneve-ut-2139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20882,7 +20902,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2137
+Index: geneve-ut-2140
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20905,7 +20925,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2138
+Index: geneve-ut-2141
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20918,7 +20938,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2140
+Index: geneve-ut-2143
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20930,7 +20950,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2141
+Index: geneve-ut-2144
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20942,7 +20962,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2142
+Index: geneve-ut-2145
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20954,7 +20974,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2143
+Index: geneve-ut-2146
 
 ```python
 web where (
@@ -20982,7 +21002,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2149
+Index: geneve-ut-2152
 
 ```python
 any where (
@@ -21054,7 +21074,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2151
+Index: geneve-ut-2154
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21075,7 +21095,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2154
+Index: geneve-ut-2157
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21089,7 +21109,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2155
+Index: geneve-ut-2158
 
 ```python
 file where event.type == "deletion" and
@@ -21106,7 +21126,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2156
+Index: geneve-ut-2159
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21124,7 +21144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2159
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21162,7 +21182,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2161
+Index: geneve-ut-2164
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21199,7 +21219,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2162
+Index: geneve-ut-2165
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21214,7 +21234,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2163
+Index: geneve-ut-2166
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21227,7 +21247,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2164
+Index: geneve-ut-2167
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21246,7 +21266,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2165
+Index: geneve-ut-2168
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21271,7 +21291,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2166
+Index: geneve-ut-2169
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21297,7 +21317,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2167
+Index: geneve-ut-2170
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21319,7 +21339,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2168
+Index: geneve-ut-2171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21336,7 +21356,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2170
+Index: geneve-ut-2173
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21355,7 +21375,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2171
+Index: geneve-ut-2174
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21395,7 +21415,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2172
+Index: geneve-ut-2175
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21412,7 +21432,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2174
+Index: geneve-ut-2177
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21425,7 +21445,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2175
+Index: geneve-ut-2178
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21439,7 +21459,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2176
+Index: geneve-ut-2179
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21467,7 +21487,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2177
+Index: geneve-ut-2180
 
 ```python
 process where event.type == "start" and
@@ -21492,7 +21512,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2178
+Index: geneve-ut-2181
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21506,7 +21526,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2179
+Index: geneve-ut-2182
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21522,7 +21542,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2180
+Index: geneve-ut-2183
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21557,7 +21577,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2181
+Index: geneve-ut-2184
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21575,7 +21595,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2184
+Index: geneve-ut-2187
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.6.md
+++ b/tests/reports/alerts_from_rules-9.6.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.3
+Rules version: 9.5.4
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
    1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
-   1. [Rules with the correct signals (804)](#rules-with-the-correct-signals-804)
+   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
 
 ## Failed rules (24)
 
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807  
+Index: geneve-ut-0808  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000  
+Index: geneve-ut-1001  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145  
+Index: geneve-ut-1146  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175  
+Index: geneve-ut-1176  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248  
+Index: geneve-ut-1250  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277  
+Index: geneve-ut-1279  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295  
+Index: geneve-ut-1297  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359  
+Index: geneve-ut-1362  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374  
+Index: geneve-ut-1377  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464  
+Index: geneve-ut-1467  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709  
+Index: geneve-ut-1712  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713  
+Index: geneve-ut-1716  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797  
+Index: geneve-ut-1800  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812  
+Index: geneve-ut-1815  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825  
+Index: geneve-ut-1828  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835  
+Index: geneve-ut-1838  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841  
+Index: geneve-ut-1844  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850  
+Index: geneve-ut-1853  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947  
+Index: geneve-ut-1950  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978  
+Index: geneve-ut-1981  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807
+Index: geneve-ut-0808
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000
+Index: geneve-ut-1001
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145
+Index: geneve-ut-1146
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248
+Index: geneve-ut-1250
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295
+Index: geneve-ut-1297
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359
+Index: geneve-ut-1362
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464
+Index: geneve-ut-1467
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709
+Index: geneve-ut-1712
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797
+Index: geneve-ut-1800
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812
+Index: geneve-ut-1815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825
+Index: geneve-ut-1828
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841
+Index: geneve-ut-1844
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947
+Index: geneve-ut-1950
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978
+Index: geneve-ut-1981
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1001
+Index: geneve-ut-1002
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1021
+Index: geneve-ut-1022
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1411
+Index: geneve-ut-1414
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1612
+Index: geneve-ut-1615
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807  
+Index: geneve-ut-0808  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0973  
+Index: geneve-ut-0974  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000  
+Index: geneve-ut-1001  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1123  
+Index: geneve-ut-1124  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145  
+Index: geneve-ut-1146  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175  
+Index: geneve-ut-1176  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248  
+Index: geneve-ut-1250  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277  
+Index: geneve-ut-1279  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295  
+Index: geneve-ut-1297  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359  
+Index: geneve-ut-1362  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374  
+Index: geneve-ut-1377  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1455  
+Index: geneve-ut-1458  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464  
+Index: geneve-ut-1467  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1579  
+Index: geneve-ut-1582  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709  
+Index: geneve-ut-1712  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713  
+Index: geneve-ut-1716  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797  
+Index: geneve-ut-1800  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812  
+Index: geneve-ut-1815  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825  
+Index: geneve-ut-1828  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835  
+Index: geneve-ut-1838  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841  
+Index: geneve-ut-1844  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850  
+Index: geneve-ut-1853  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947  
+Index: geneve-ut-1950  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978  
+Index: geneve-ut-1981  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3381,7 +3381,7 @@ container.id like "*"
 
 
 
-## Rules with the correct signals (804)
+## Rules with the correct signals (805)
 
 ### A scheduled task was created
 
@@ -7231,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0797
+Index: geneve-ut-0798
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0798
+Index: geneve-ut-0799
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0799
+Index: geneve-ut-0800
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0800
+Index: geneve-ut-0801
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0808
+Index: geneve-ut-0809
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0809
+Index: geneve-ut-0810
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0810
+Index: geneve-ut-0811
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0811
+Index: geneve-ut-0812
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0815
+Index: geneve-ut-0816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0818
+Index: geneve-ut-0819
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0821
+Index: geneve-ut-0822
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0825
+Index: geneve-ut-0826
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0827
+Index: geneve-ut-0828
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0853
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0856
+Index: geneve-ut-0857
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0857
+Index: geneve-ut-0858
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0870
+Index: geneve-ut-0871
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0871
+Index: geneve-ut-0872
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0872
+Index: geneve-ut-0873
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0876
+Index: geneve-ut-0877
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0882
+Index: geneve-ut-0883
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0884
+Index: geneve-ut-0885
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0885
+Index: geneve-ut-0886
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0886
+Index: geneve-ut-0887
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0887
+Index: geneve-ut-0888
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0888
+Index: geneve-ut-0889
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0889
+Index: geneve-ut-0890
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0894
+Index: geneve-ut-0895
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0896
+Index: geneve-ut-0897
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0897
+Index: geneve-ut-0898
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0898
+Index: geneve-ut-0899
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7897,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0899
+Index: geneve-ut-0900
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7921,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0904
+Index: geneve-ut-0905
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0906
+Index: geneve-ut-0907
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0907
+Index: geneve-ut-0908
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0908
+Index: geneve-ut-0909
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0909
+Index: geneve-ut-0910
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0910
+Index: geneve-ut-0911
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0911
+Index: geneve-ut-0912
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0912
+Index: geneve-ut-0913
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0913
+Index: geneve-ut-0914
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0914
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0915
+Index: geneve-ut-0916
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0917
+Index: geneve-ut-0918
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0919
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0920
+Index: geneve-ut-0921
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0921
+Index: geneve-ut-0922
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0922
+Index: geneve-ut-0923
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0924
+Index: geneve-ut-0925
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0925
+Index: geneve-ut-0926
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0927
+Index: geneve-ut-0928
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0929
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0930
+Index: geneve-ut-0931
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0932
+Index: geneve-ut-0933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0933
+Index: geneve-ut-0934
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8436,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0934
+Index: geneve-ut-0935
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8463,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0937
+Index: geneve-ut-0938
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0938
+Index: geneve-ut-0939
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0948
+Index: geneve-ut-0949
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0974
+Index: geneve-ut-0975
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0977
+Index: geneve-ut-0978
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0979
+Index: geneve-ut-0980
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0991
+Index: geneve-ut-0992
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0996
+Index: geneve-ut-0997
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0997
+Index: geneve-ut-0998
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1002
+Index: geneve-ut-1003
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1017
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1020
+Index: geneve-ut-1021
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1022
+Index: geneve-ut-1023
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1023
+Index: geneve-ut-1024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1027
+Index: geneve-ut-1028
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1028
+Index: geneve-ut-1029
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8863,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1031
+Index: geneve-ut-1032
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1033
+Index: geneve-ut-1034
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1034
+Index: geneve-ut-1035
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1070
+Index: geneve-ut-1071
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1071
+Index: geneve-ut-1072
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1072
+Index: geneve-ut-1073
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1073
+Index: geneve-ut-1074
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1074
+Index: geneve-ut-1075
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1082
+Index: geneve-ut-1083
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1085
+Index: geneve-ut-1086
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1086
+Index: geneve-ut-1087
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1087
+Index: geneve-ut-1088
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1091
+Index: geneve-ut-1092
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1092
+Index: geneve-ut-1093
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1094
+Index: geneve-ut-1095
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1095
+Index: geneve-ut-1096
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1096
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1097
+Index: geneve-ut-1098
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1098
+Index: geneve-ut-1099
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1099
+Index: geneve-ut-1100
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9142,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1100
+Index: geneve-ut-1101
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9167,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1102
+Index: geneve-ut-1103
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1105
+Index: geneve-ut-1106
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1106
+Index: geneve-ut-1107
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1107
+Index: geneve-ut-1108
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1110
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1111
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1112
+Index: geneve-ut-1113
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1116
+Index: geneve-ut-1117
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1117
+Index: geneve-ut-1118
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1118
+Index: geneve-ut-1119
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1122
+Index: geneve-ut-1123
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1124
+Index: geneve-ut-1125
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1126
+Index: geneve-ut-1127
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1127
+Index: geneve-ut-1128
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1129
+Index: geneve-ut-1130
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1132
+Index: geneve-ut-1133
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1133
+Index: geneve-ut-1134
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1135
+Index: geneve-ut-1136
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1136
+Index: geneve-ut-1137
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9604,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1138
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1139
+Index: geneve-ut-1140
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1140
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1141
+Index: geneve-ut-1142
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1142
+Index: geneve-ut-1143
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1143
+Index: geneve-ut-1144
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1144
+Index: geneve-ut-1145
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1157
+Index: geneve-ut-1158
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1166
+Index: geneve-ut-1167
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1170
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1171
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1172
+Index: geneve-ut-1173
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1173
+Index: geneve-ut-1174
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1174
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1176
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1177
+Index: geneve-ut-1178
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1179
+Index: geneve-ut-1180
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1181
+Index: geneve-ut-1182
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1182
+Index: geneve-ut-1183
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1183
+Index: geneve-ut-1184
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1185
+Index: geneve-ut-1186
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1186
+Index: geneve-ut-1187
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1187
+Index: geneve-ut-1188
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1188
+Index: geneve-ut-1189
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1190
+Index: geneve-ut-1191
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1191
+Index: geneve-ut-1192
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1192
+Index: geneve-ut-1193
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1193
+Index: geneve-ut-1194
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1194
+Index: geneve-ut-1195
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1198
+Index: geneve-ut-1199
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1199
+Index: geneve-ut-1200
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1200
+Index: geneve-ut-1201
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1205
+Index: geneve-ut-1206
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1208
+Index: geneve-ut-1209
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1218
+Index: geneve-ut-1219
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1219
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1220
+Index: geneve-ut-1221
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1221
+Index: geneve-ut-1222
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1223
+Index: geneve-ut-1224
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1224
+Index: geneve-ut-1225
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1226
+Index: geneve-ut-1227
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1235
+Index: geneve-ut-1236
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1236
+Index: geneve-ut-1237
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1237
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1238
+Index: geneve-ut-1239
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1239
+Index: geneve-ut-1240
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1240
+Index: geneve-ut-1241
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1241
+Index: geneve-ut-1242
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1242
+Index: geneve-ut-1243
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10666,11 +10666,31 @@ file.path like~ "*/wp-content/plugins/*"
 
 
 
+### PKINIT Followed by Same-Principal U2U Service Ticket
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1244
+
+```python
+sequence by winlog.computer_name, source.ip with maxspan=5s
+  [authentication where host.os.type == "windows" and
+    event.code == "4768" and winlog.event_data.PreAuthType == "16" and
+    winlog.event_data.Status == "0x0"
+  ] by winlog.event_data.TargetSid
+  [authentication where host.os.type == "windows" and
+    event.code == "4769" and winlog.event_data.Status == "0x0" and
+    winlog.event_data.TicketOptions in ("0x40810008", "0x40810018")
+  ] by winlog.event_data.ServiceSid
+```
+
+
+
 ### Pbpaste Execution via Unusual Parent Process
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1249
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10685,7 +10705,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1250
+Index: geneve-ut-1252
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10699,7 +10719,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1251
+Index: geneve-ut-1253
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10718,7 +10738,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1252
+Index: geneve-ut-1254
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10730,7 +10750,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1253
+Index: geneve-ut-1255
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10742,7 +10762,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1254
+Index: geneve-ut-1256
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10760,7 +10780,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1255
+Index: geneve-ut-1257
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10773,7 +10793,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1256
+Index: geneve-ut-1258
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10788,7 +10808,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1257
+Index: geneve-ut-1259
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10803,7 +10823,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1260
+Index: geneve-ut-1262
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10823,7 +10843,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1261
+Index: geneve-ut-1263
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10847,7 +10867,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1262
+Index: geneve-ut-1264
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10861,7 +10881,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1263
+Index: geneve-ut-1265
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10880,7 +10900,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1264
+Index: geneve-ut-1266
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10908,7 +10928,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1265
+Index: geneve-ut-1267
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10937,7 +10957,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1266
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10956,7 +10976,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1267
+Index: geneve-ut-1269
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10984,7 +11004,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1268
+Index: geneve-ut-1270
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10999,7 +11019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1269
+Index: geneve-ut-1271
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11062,7 +11082,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1270
+Index: geneve-ut-1272
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11083,7 +11103,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1271
+Index: geneve-ut-1273
 
 ```python
 any where host.os.type == "windows" and
@@ -11145,7 +11165,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1273
+Index: geneve-ut-1275
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11174,7 +11194,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1274
+Index: geneve-ut-1276
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11188,7 +11208,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1275
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11221,7 +11241,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1278
+Index: geneve-ut-1280
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11268,7 +11288,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1279
+Index: geneve-ut-1281
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11295,7 +11315,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1280
+Index: geneve-ut-1282
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11308,7 +11328,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1291
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11325,7 +11345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1293
+Index: geneve-ut-1295
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11350,7 +11370,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1298
+Index: geneve-ut-1300
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11366,7 +11386,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1299
+Index: geneve-ut-1301
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11387,7 +11407,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1301
+Index: geneve-ut-1304
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11404,7 +11424,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1302
+Index: geneve-ut-1305
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11417,7 +11437,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1303
+Index: geneve-ut-1306
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11441,7 +11461,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11470,7 +11490,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1307
+Index: geneve-ut-1310
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11497,7 +11517,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1308
+Index: geneve-ut-1311
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11521,7 +11541,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11539,7 +11559,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1312
+Index: geneve-ut-1315
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11562,7 +11582,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1313
+Index: geneve-ut-1316
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11619,7 +11639,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1314
+Index: geneve-ut-1317
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11636,7 +11656,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1315
+Index: geneve-ut-1318
 
 ```python
 sequence by process.entity_id
@@ -11650,7 +11670,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1330
+Index: geneve-ut-1333
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11665,7 +11685,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11696,7 +11716,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11710,7 +11730,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1333
+Index: geneve-ut-1336
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11723,7 +11743,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11735,7 +11755,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1335
+Index: geneve-ut-1338
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11748,7 +11768,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11767,7 +11787,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1338
+Index: geneve-ut-1341
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11780,7 +11800,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1339
+Index: geneve-ut-1342
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11801,7 +11821,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11815,7 +11835,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1343
+Index: geneve-ut-1346
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11835,7 +11855,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1344
+Index: geneve-ut-1347
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11859,7 +11879,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1345
+Index: geneve-ut-1348
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11875,7 +11895,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1346
+Index: geneve-ut-1349
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11892,7 +11912,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1347
+Index: geneve-ut-1350
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11913,7 +11933,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1349
+Index: geneve-ut-1352
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11926,7 +11946,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1351
+Index: geneve-ut-1354
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11954,7 +11974,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1354
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11970,7 +11990,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11993,7 +12013,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12006,7 +12026,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1358
+Index: geneve-ut-1361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12019,7 +12039,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12033,7 +12053,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1364
+Index: geneve-ut-1367
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +12068,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1366
+Index: geneve-ut-1369
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12071,7 +12091,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1369
+Index: geneve-ut-1372
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12114,7 +12134,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12132,7 +12152,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 host.os.type:"windows" and
@@ -12148,7 +12168,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12160,7 +12180,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12176,7 +12196,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1376
+Index: geneve-ut-1379
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12192,7 +12212,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1377
+Index: geneve-ut-1380
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12210,7 +12230,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1378
+Index: geneve-ut-1381
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12224,7 +12244,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12247,7 +12267,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1382
+Index: geneve-ut-1385
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12263,7 +12283,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1383
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12276,7 +12296,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1384
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12306,7 +12326,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1390
+Index: geneve-ut-1393
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12329,7 +12349,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1391
+Index: geneve-ut-1394
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12348,7 +12368,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1396
+Index: geneve-ut-1399
 
 ```python
 process where host.os.type == "windows" and 
@@ -12490,7 +12510,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1397
+Index: geneve-ut-1400
 
 ```python
 process where host.os.type == "windows" and
@@ -12567,7 +12587,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12584,7 +12604,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1402
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12618,7 +12638,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1404
+Index: geneve-ut-1407
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12630,7 +12650,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1405
+Index: geneve-ut-1408
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12669,7 +12689,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1408
+Index: geneve-ut-1411
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12682,7 +12702,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1413
+Index: geneve-ut-1416
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12696,7 +12716,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1420
+Index: geneve-ut-1423
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12734,7 +12754,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1421
+Index: geneve-ut-1424
 
 ```python
 network where host.os.type == "windows" and
@@ -12760,7 +12780,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12775,7 +12795,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1427
+Index: geneve-ut-1430
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12789,7 +12809,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 file where host.os.type == "windows" and
@@ -12803,7 +12823,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1429
+Index: geneve-ut-1432
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12816,7 +12836,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1430
+Index: geneve-ut-1433
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12836,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1431
+Index: geneve-ut-1434
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12876,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1433
+Index: geneve-ut-1436
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12895,7 +12915,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1434
+Index: geneve-ut-1437
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13090,7 +13110,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1449
+Index: geneve-ut-1452
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13106,7 +13126,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13120,7 +13140,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1451
+Index: geneve-ut-1454
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13134,7 +13154,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1452
+Index: geneve-ut-1455
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13151,7 +13171,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1453
+Index: geneve-ut-1456
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13165,7 +13185,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1454
+Index: geneve-ut-1457
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13181,7 +13201,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1459
+Index: geneve-ut-1462
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13193,7 +13213,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1460
+Index: geneve-ut-1463
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13209,7 +13229,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1461
+Index: geneve-ut-1464
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13229,7 +13249,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1463
+Index: geneve-ut-1466
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13269,7 +13289,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1465
+Index: geneve-ut-1468
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13281,7 +13301,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1466
+Index: geneve-ut-1469
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13302,7 +13322,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1467
+Index: geneve-ut-1470
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13323,7 +13343,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1468
+Index: geneve-ut-1471
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13344,7 +13364,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1469
+Index: geneve-ut-1472
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13370,7 +13390,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1470
+Index: geneve-ut-1473
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13386,7 +13406,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1471
+Index: geneve-ut-1474
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13400,7 +13420,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1473
+Index: geneve-ut-1476
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13423,7 +13443,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1475
+Index: geneve-ut-1478
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13440,7 +13460,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1476
+Index: geneve-ut-1479
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13463,7 +13483,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1477
+Index: geneve-ut-1480
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13476,7 +13496,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1478
+Index: geneve-ut-1481
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13490,7 +13510,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1479
+Index: geneve-ut-1482
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13507,7 +13527,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1480
+Index: geneve-ut-1483
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13561,7 +13581,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1481
+Index: geneve-ut-1484
 
 ```python
 any where host.os.type == "windows" and
@@ -13588,7 +13608,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1487
+Index: geneve-ut-1490
 
 ```python
 file where host.os.type == "windows" and
@@ -13603,7 +13623,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1488
+Index: geneve-ut-1491
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13634,7 +13654,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +13668,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1490
+Index: geneve-ut-1493
 
 ```python
 sequence with maxspan=1m
@@ -13690,7 +13710,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1491
+Index: geneve-ut-1494
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13715,7 +13735,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13769,7 +13789,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13789,7 +13809,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1494
+Index: geneve-ut-1497
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13810,7 +13830,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1495
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13825,7 +13845,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1496
+Index: geneve-ut-1499
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13845,7 +13865,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1497
+Index: geneve-ut-1500
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13887,7 +13907,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1501
+Index: geneve-ut-1504
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13902,7 +13922,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1502
+Index: geneve-ut-1505
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13937,7 +13957,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1503
+Index: geneve-ut-1506
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13954,7 +13974,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1508
+Index: geneve-ut-1511
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13968,7 +13988,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1511
+Index: geneve-ut-1514
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13981,7 +14001,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13993,7 +14013,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1513
+Index: geneve-ut-1516
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14008,7 +14028,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1515
+Index: geneve-ut-1518
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14036,7 +14056,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1517
+Index: geneve-ut-1520
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14061,7 +14081,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1521
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14098,7 +14118,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1522
+Index: geneve-ut-1525
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14112,7 +14132,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1523
+Index: geneve-ut-1526
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14128,7 +14148,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1524
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14142,7 +14162,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1525
+Index: geneve-ut-1528
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14172,7 +14192,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14201,7 +14221,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1527
+Index: geneve-ut-1530
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14217,7 +14237,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1528
+Index: geneve-ut-1531
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14251,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1529
+Index: geneve-ut-1532
 
 ```python
 file where host.os.type == "windows" and
@@ -14267,7 +14287,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1532
+Index: geneve-ut-1535
 
 ```python
 process where event.type == "start" and
@@ -14281,7 +14301,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1533
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14295,7 +14315,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1534
+Index: geneve-ut-1537
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14335,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1536
+Index: geneve-ut-1539
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14332,7 +14352,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1537
+Index: geneve-ut-1540
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14344,7 +14364,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1538
+Index: geneve-ut-1541
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14361,7 +14381,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1539
+Index: geneve-ut-1542
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14379,7 +14399,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1546
+Index: geneve-ut-1549
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14392,7 +14412,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1547
+Index: geneve-ut-1550
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14419,7 +14439,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14432,7 +14452,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14446,7 +14466,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14463,7 +14483,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1552
+Index: geneve-ut-1555
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14486,7 +14506,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1554
+Index: geneve-ut-1557
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14503,7 +14523,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1557
+Index: geneve-ut-1560
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14516,7 +14536,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1559
+Index: geneve-ut-1562
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14540,7 +14560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1560
+Index: geneve-ut-1563
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14568,7 +14588,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1576
+Index: geneve-ut-1579
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14589,7 +14609,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1578
+Index: geneve-ut-1581
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14617,7 +14637,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1580
+Index: geneve-ut-1583
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14657,7 +14677,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1581
+Index: geneve-ut-1584
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14674,7 +14694,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1582
+Index: geneve-ut-1585
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14688,7 +14708,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1583
+Index: geneve-ut-1586
 
 ```python
 file where host.os.type == "windows" and
@@ -14707,7 +14727,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1584
+Index: geneve-ut-1587
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14721,7 +14741,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1586
+Index: geneve-ut-1589
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14739,7 +14759,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1588
+Index: geneve-ut-1591
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14757,7 +14777,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1591
+Index: geneve-ut-1594
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14771,7 +14791,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1593
+Index: geneve-ut-1596
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14786,7 +14806,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1594
+Index: geneve-ut-1597
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14809,7 +14829,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1596
+Index: geneve-ut-1599
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14891,7 +14911,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1597
+Index: geneve-ut-1600
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14912,7 +14932,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1598
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14938,7 +14958,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1601
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14991,7 +15011,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1602
+Index: geneve-ut-1605
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15003,7 +15023,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1603
+Index: geneve-ut-1606
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15015,7 +15035,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1604
+Index: geneve-ut-1607
 
 ```python
 process where host.os.type == "windows" and
@@ -15030,7 +15050,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1605
+Index: geneve-ut-1608
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15060,7 +15080,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1606
+Index: geneve-ut-1609
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15120,7 +15140,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1609
+Index: geneve-ut-1612
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15133,7 +15153,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1610
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15165,7 +15185,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1611
+Index: geneve-ut-1614
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15189,7 +15209,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1613
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15222,7 +15242,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1614
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15239,7 +15259,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1616
+Index: geneve-ut-1619
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15268,7 +15288,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1617
+Index: geneve-ut-1620
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15282,7 +15302,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1618
+Index: geneve-ut-1621
 
 ```python
 sequence by process.entity_id
@@ -15307,7 +15327,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1619
+Index: geneve-ut-1622
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15341,7 +15361,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1620
+Index: geneve-ut-1623
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15369,7 +15389,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1621
+Index: geneve-ut-1624
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15388,7 +15408,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1627
+Index: geneve-ut-1630
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15416,7 +15436,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1628
+Index: geneve-ut-1631
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15435,7 +15455,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1632
+Index: geneve-ut-1635
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15447,7 +15467,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1633
+Index: geneve-ut-1636
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15459,7 +15479,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1634
+Index: geneve-ut-1637
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15471,7 +15491,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1635
+Index: geneve-ut-1638
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15483,7 +15503,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1646
+Index: geneve-ut-1649
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15496,7 +15516,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1647
+Index: geneve-ut-1650
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15534,7 +15554,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1649
+Index: geneve-ut-1652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15549,7 +15569,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1650
+Index: geneve-ut-1653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15568,7 +15588,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1651
+Index: geneve-ut-1654
 
 ```python
 sequence with maxspan=1m
@@ -15616,7 +15636,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1653
+Index: geneve-ut-1656
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15639,7 +15659,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1655
+Index: geneve-ut-1658
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15653,7 +15673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1656
+Index: geneve-ut-1659
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15667,7 +15687,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1658
+Index: geneve-ut-1661
 
 ```python
 sequence by host.id, process.entity_id
@@ -15684,7 +15704,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1659
+Index: geneve-ut-1662
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15698,7 +15718,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1660
+Index: geneve-ut-1663
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15718,7 +15738,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1661
+Index: geneve-ut-1664
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15747,7 +15767,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1662
+Index: geneve-ut-1665
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15767,7 +15787,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1663
+Index: geneve-ut-1666
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15780,7 +15800,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1665
+Index: geneve-ut-1668
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15822,7 +15842,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1666
+Index: geneve-ut-1669
 
 ```python
 sequence with maxspan=1m
@@ -15845,7 +15865,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1667
+Index: geneve-ut-1670
 
 ```python
 sequence with maxspan=1s
@@ -15893,7 +15913,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1668
+Index: geneve-ut-1671
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15910,7 +15930,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1670
+Index: geneve-ut-1673
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15939,7 +15959,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1673
+Index: geneve-ut-1676
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15967,7 +15987,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1674
+Index: geneve-ut-1677
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15984,7 +16004,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1676
+Index: geneve-ut-1679
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16003,7 +16023,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1677
+Index: geneve-ut-1680
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16024,7 +16044,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1686
+Index: geneve-ut-1689
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16038,7 +16058,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1688
+Index: geneve-ut-1691
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16057,7 +16077,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1689
+Index: geneve-ut-1692
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16071,7 +16091,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1690
+Index: geneve-ut-1693
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16091,7 +16111,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1692
+Index: geneve-ut-1695
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16109,7 +16129,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1693
+Index: geneve-ut-1696
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16130,7 +16150,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1695
+Index: geneve-ut-1698
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16144,7 +16164,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1696
+Index: geneve-ut-1699
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16159,7 +16179,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1697
+Index: geneve-ut-1700
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16200,7 +16220,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1699
+Index: geneve-ut-1702
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16225,7 +16245,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1700
+Index: geneve-ut-1703
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16264,7 +16284,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1701
+Index: geneve-ut-1704
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16278,7 +16298,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1702
+Index: geneve-ut-1705
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16317,7 +16337,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1703
+Index: geneve-ut-1706
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16331,7 +16351,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1704
+Index: geneve-ut-1707
 
 ```python
 process where event.type == "start" and
@@ -16403,7 +16423,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1708
+Index: geneve-ut-1711
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16424,7 +16444,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1711
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16441,7 +16461,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1714
+Index: geneve-ut-1717
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16459,7 +16479,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1715
+Index: geneve-ut-1718
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16471,7 +16491,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1716
+Index: geneve-ut-1719
 
 ```python
 file where host.os.type == "windows" and
@@ -16504,7 +16524,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1719
+Index: geneve-ut-1722
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16536,7 +16556,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1721
+Index: geneve-ut-1724
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16572,7 +16592,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1722
+Index: geneve-ut-1725
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16589,7 +16609,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1723
+Index: geneve-ut-1726
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16609,7 +16629,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1725
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16624,7 +16644,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1726
+Index: geneve-ut-1729
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16645,7 +16665,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1727
+Index: geneve-ut-1730
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16668,7 +16688,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1728
+Index: geneve-ut-1731
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16681,7 +16701,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1729
+Index: geneve-ut-1732
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16698,7 +16718,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1732
+Index: geneve-ut-1735
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16723,7 +16743,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1735
+Index: geneve-ut-1738
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16754,7 +16774,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1736
+Index: geneve-ut-1739
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16803,7 +16823,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1737
+Index: geneve-ut-1740
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16817,7 +16837,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1738
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16832,7 +16852,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1739
+Index: geneve-ut-1742
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16847,7 +16867,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1740
+Index: geneve-ut-1743
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16869,7 +16889,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1741
+Index: geneve-ut-1744
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16890,7 +16910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1745
+Index: geneve-ut-1748
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16904,7 +16924,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1746
+Index: geneve-ut-1749
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16927,7 +16947,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1776
+Index: geneve-ut-1779
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16952,7 +16972,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1777
+Index: geneve-ut-1780
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16985,7 +17005,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1778
+Index: geneve-ut-1781
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17044,7 +17064,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1780
+Index: geneve-ut-1783
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17062,7 +17082,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1781
+Index: geneve-ut-1784
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17074,7 +17094,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1784
+Index: geneve-ut-1787
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17099,7 +17119,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1790
+Index: geneve-ut-1793
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17114,7 +17134,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1791
+Index: geneve-ut-1794
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17137,7 +17157,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1794
+Index: geneve-ut-1797
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17151,7 +17171,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1796
+Index: geneve-ut-1799
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17173,7 +17193,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1798
+Index: geneve-ut-1801
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17200,7 +17220,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1802
+Index: geneve-ut-1805
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17239,7 +17259,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1803
+Index: geneve-ut-1806
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17262,7 +17282,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1804
+Index: geneve-ut-1807
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17276,7 +17296,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1805
+Index: geneve-ut-1808
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17292,7 +17312,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1806
+Index: geneve-ut-1809
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17308,7 +17328,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1807
+Index: geneve-ut-1810
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17322,7 +17342,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1809
+Index: geneve-ut-1812
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17345,7 +17365,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1810
+Index: geneve-ut-1813
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17373,7 +17393,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1811
+Index: geneve-ut-1814
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +17408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1814
+Index: geneve-ut-1817
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17415,7 +17435,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1816
+Index: geneve-ut-1819
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17446,7 +17466,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1817
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17462,7 +17482,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1818
+Index: geneve-ut-1821
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17475,7 +17495,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1820
+Index: geneve-ut-1823
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17491,7 +17511,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1821
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17507,7 +17527,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1822
+Index: geneve-ut-1825
 
 ```python
 any where host.os.type == "windows" and 
@@ -17574,7 +17594,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1824
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17590,7 +17610,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1826
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17626,7 +17646,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1827
+Index: geneve-ut-1830
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +17684,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1828
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17699,7 +17719,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1829
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +17753,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1831
+Index: geneve-ut-1834
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17754,7 +17774,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1836
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17831,7 +17851,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1837
+Index: geneve-ut-1840
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17853,7 +17873,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1838
+Index: geneve-ut-1841
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17877,7 +17897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1840
+Index: geneve-ut-1843
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17898,7 +17918,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1843
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17913,7 +17933,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1846
+Index: geneve-ut-1849
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17926,7 +17946,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1847
+Index: geneve-ut-1850
 
 ```python
 any where host.os.type == "windows" and
@@ -17941,7 +17961,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1848
+Index: geneve-ut-1851
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17957,7 +17977,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1849
+Index: geneve-ut-1852
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17971,7 +17991,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1853
+Index: geneve-ut-1856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18028,7 +18048,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1854
+Index: geneve-ut-1857
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18042,7 +18062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1856
+Index: geneve-ut-1859
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18074,7 +18094,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1858
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18087,7 +18107,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1859
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18106,7 +18126,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1860
+Index: geneve-ut-1863
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18152,7 +18172,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1862
+Index: geneve-ut-1865
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18173,7 +18193,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1863
+Index: geneve-ut-1866
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18193,7 +18213,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1864
+Index: geneve-ut-1867
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18207,7 +18227,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1865
+Index: geneve-ut-1868
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18239,7 +18259,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1868
+Index: geneve-ut-1871
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18260,7 +18280,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1870
+Index: geneve-ut-1873
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18361,7 +18381,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1874
+Index: geneve-ut-1877
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18409,7 +18429,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1877
+Index: geneve-ut-1880
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18435,7 +18455,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1878
+Index: geneve-ut-1881
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18480,7 +18500,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1879
+Index: geneve-ut-1882
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18504,7 +18524,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1880
+Index: geneve-ut-1883
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18520,7 +18540,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1882
+Index: geneve-ut-1885
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18545,7 +18565,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1883
+Index: geneve-ut-1886
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18560,7 +18580,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1886
+Index: geneve-ut-1889
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18574,7 +18594,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1887
+Index: geneve-ut-1890
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18594,7 +18614,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1888
+Index: geneve-ut-1891
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18629,7 +18649,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1892
+Index: geneve-ut-1895
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18647,7 +18667,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1893
+Index: geneve-ut-1896
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18660,7 +18680,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1896
+Index: geneve-ut-1899
 
 ```python
 any where host.os.type == "windows" and
@@ -18693,7 +18713,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1898
+Index: geneve-ut-1901
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18711,7 +18731,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1899
+Index: geneve-ut-1902
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18733,7 +18753,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1902
+Index: geneve-ut-1905
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18772,7 +18792,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1903
+Index: geneve-ut-1906
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18802,7 +18822,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1904
+Index: geneve-ut-1907
 
 ```python
 any where host.os.type == "windows" and
@@ -18836,7 +18856,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1905
+Index: geneve-ut-1908
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18850,7 +18870,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1908
+Index: geneve-ut-1911
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18881,7 +18901,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1909
+Index: geneve-ut-1912
 
 ```python
 any where host.os.type == "windows" and
@@ -18901,7 +18921,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1910
+Index: geneve-ut-1913
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18942,7 +18962,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1911
+Index: geneve-ut-1914
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18958,7 +18978,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1912
+Index: geneve-ut-1915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18988,7 +19008,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1916
+Index: geneve-ut-1919
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19001,7 +19021,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1917
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19025,7 +19045,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1920
+Index: geneve-ut-1923
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19043,7 +19063,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1922
+Index: geneve-ut-1925
 
 ```python
 any where host.os.type == "windows" and
@@ -19058,7 +19078,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1923
+Index: geneve-ut-1926
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19076,7 +19096,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1924
+Index: geneve-ut-1927
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19097,7 +19117,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1925
+Index: geneve-ut-1928
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19116,7 +19136,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1928
+Index: geneve-ut-1931
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19141,7 +19161,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1929
+Index: geneve-ut-1932
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19154,7 +19174,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1931
+Index: geneve-ut-1934
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19167,7 +19187,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1933
+Index: geneve-ut-1936
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19190,7 +19210,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1935
+Index: geneve-ut-1938
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19209,7 +19229,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1936
+Index: geneve-ut-1939
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19231,7 +19251,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1937
+Index: geneve-ut-1940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19264,7 +19284,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1939
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19282,7 +19302,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1940
+Index: geneve-ut-1943
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19296,7 +19316,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1941
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19320,7 +19340,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1942
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19343,7 +19363,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1943
+Index: geneve-ut-1946
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19362,7 +19382,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1946
+Index: geneve-ut-1949
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19381,7 +19401,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1948
+Index: geneve-ut-1951
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19416,7 +19436,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1949
+Index: geneve-ut-1952
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19433,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1950
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19473,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1951
+Index: geneve-ut-1954
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19493,7 +19513,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1952
+Index: geneve-ut-1955
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19509,7 +19529,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1953
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19523,7 +19543,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1954
+Index: geneve-ut-1957
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19561,7 +19581,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1955
+Index: geneve-ut-1958
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19615,7 +19635,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1956
+Index: geneve-ut-1959
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19643,7 +19663,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1958
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19657,7 +19677,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1959
+Index: geneve-ut-1962
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19703,7 +19723,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1960
+Index: geneve-ut-1963
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19742,7 +19762,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1961
+Index: geneve-ut-1964
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19755,7 +19775,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1965
+Index: geneve-ut-1968
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19788,7 +19808,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1966
+Index: geneve-ut-1969
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19802,7 +19822,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1967
+Index: geneve-ut-1970
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19816,7 +19836,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1968
+Index: geneve-ut-1971
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19830,7 +19850,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1969
+Index: geneve-ut-1972
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19869,7 +19889,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1977
+Index: geneve-ut-1980
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19911,7 +19931,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1979
+Index: geneve-ut-1982
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19933,7 +19953,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1981
+Index: geneve-ut-1984
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19946,7 +19966,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1984
+Index: geneve-ut-1987
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19963,7 +19983,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1985
+Index: geneve-ut-1988
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19979,7 +19999,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1986
+Index: geneve-ut-1989
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19992,7 +20012,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1987
+Index: geneve-ut-1990
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20007,7 +20027,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1988
+Index: geneve-ut-1991
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20030,7 +20050,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1989
+Index: geneve-ut-1992
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20046,7 +20066,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1990
+Index: geneve-ut-1993
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20062,7 +20082,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1996
+Index: geneve-ut-1999
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20074,7 +20094,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1997
+Index: geneve-ut-2000
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20103,7 +20123,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1999
+Index: geneve-ut-2002
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20117,7 +20137,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2004
+Index: geneve-ut-2007
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20137,7 +20157,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2005
+Index: geneve-ut-2008
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20162,7 +20182,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2012
+Index: geneve-ut-2015
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20176,7 +20196,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2013
+Index: geneve-ut-2016
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20199,7 +20219,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2022
+Index: geneve-ut-2025
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20233,7 +20253,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2024
+Index: geneve-ut-2027
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20252,7 +20272,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2031
+Index: geneve-ut-2034
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20271,7 +20291,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2046
+Index: geneve-ut-2049
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20288,7 +20308,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2049
+Index: geneve-ut-2052
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20305,7 +20325,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2065
+Index: geneve-ut-2068
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20324,7 +20344,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2069
+Index: geneve-ut-2072
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20366,7 +20386,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2070
+Index: geneve-ut-2073
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20411,7 +20431,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2073
+Index: geneve-ut-2076
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20453,7 +20473,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2075
+Index: geneve-ut-2078
 
 ```python
 host.os.type:"linux" and 
@@ -20481,7 +20501,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2079
+Index: geneve-ut-2082
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20505,7 +20525,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2080
+Index: geneve-ut-2083
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20545,7 +20565,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2081
+Index: geneve-ut-2084
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20592,7 +20612,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2085
+Index: geneve-ut-2088
 
 ```python
 sequence by process.entity_id
@@ -20629,7 +20649,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2117
+Index: geneve-ut-2120
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20643,7 +20663,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2118
+Index: geneve-ut-2121
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20686,7 +20706,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2119
+Index: geneve-ut-2122
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20699,7 +20719,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2122
+Index: geneve-ut-2125
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20713,7 +20733,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2123
+Index: geneve-ut-2126
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20726,7 +20746,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2127
+Index: geneve-ut-2130
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20751,7 +20771,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2128
+Index: geneve-ut-2131
 
 ```python
 process where event.type == "start" and
@@ -20766,7 +20786,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2129
+Index: geneve-ut-2132
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20783,7 +20803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2130
+Index: geneve-ut-2133
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20797,7 +20817,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2131
+Index: geneve-ut-2134
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20813,7 +20833,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2132
+Index: geneve-ut-2135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20827,7 +20847,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2133
+Index: geneve-ut-2136
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20854,7 +20874,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2135
+Index: geneve-ut-2138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20866,7 +20886,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2136
+Index: geneve-ut-2139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20882,7 +20902,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2137
+Index: geneve-ut-2140
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20905,7 +20925,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2138
+Index: geneve-ut-2141
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20918,7 +20938,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2140
+Index: geneve-ut-2143
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20930,7 +20950,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2141
+Index: geneve-ut-2144
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20942,7 +20962,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2142
+Index: geneve-ut-2145
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20954,7 +20974,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2143
+Index: geneve-ut-2146
 
 ```python
 web where (
@@ -20982,7 +21002,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2149
+Index: geneve-ut-2152
 
 ```python
 any where (
@@ -21054,7 +21074,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2151
+Index: geneve-ut-2154
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21075,7 +21095,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2154
+Index: geneve-ut-2157
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21089,7 +21109,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2155
+Index: geneve-ut-2158
 
 ```python
 file where event.type == "deletion" and
@@ -21106,7 +21126,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2156
+Index: geneve-ut-2159
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21124,7 +21144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2159
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21162,7 +21182,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2161
+Index: geneve-ut-2164
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21199,7 +21219,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2162
+Index: geneve-ut-2165
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21214,7 +21234,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2163
+Index: geneve-ut-2166
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21227,7 +21247,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2164
+Index: geneve-ut-2167
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21246,7 +21266,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2165
+Index: geneve-ut-2168
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21271,7 +21291,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2166
+Index: geneve-ut-2169
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21297,7 +21317,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2167
+Index: geneve-ut-2170
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21319,7 +21339,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2168
+Index: geneve-ut-2171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21336,7 +21356,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2170
+Index: geneve-ut-2173
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21355,7 +21375,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2171
+Index: geneve-ut-2174
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21395,7 +21415,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2172
+Index: geneve-ut-2175
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21412,7 +21432,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2174
+Index: geneve-ut-2177
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21425,7 +21445,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2175
+Index: geneve-ut-2178
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21439,7 +21459,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2176
+Index: geneve-ut-2179
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21467,7 +21487,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2177
+Index: geneve-ut-2180
 
 ```python
 process where event.type == "start" and
@@ -21492,7 +21512,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2178
+Index: geneve-ut-2181
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21506,7 +21526,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2179
+Index: geneve-ut-2182
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21522,7 +21542,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2180
+Index: geneve-ut-2183
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21557,7 +21577,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2181
+Index: geneve-ut-2184
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21575,7 +21595,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2184
+Index: geneve-ut-2187
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-serverless.md
+++ b/tests/reports/alerts_from_rules-serverless.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.3
+Rules version: 9.5.4
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
    1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
-   1. [Rules with the correct signals (804)](#rules-with-the-correct-signals-804)
+   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
 
 ## Failed rules (24)
 
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807  
+Index: geneve-ut-0808  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000  
+Index: geneve-ut-1001  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145  
+Index: geneve-ut-1146  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175  
+Index: geneve-ut-1176  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248  
+Index: geneve-ut-1250  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277  
+Index: geneve-ut-1279  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295  
+Index: geneve-ut-1297  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359  
+Index: geneve-ut-1362  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374  
+Index: geneve-ut-1377  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464  
+Index: geneve-ut-1467  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709  
+Index: geneve-ut-1712  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713  
+Index: geneve-ut-1716  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797  
+Index: geneve-ut-1800  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812  
+Index: geneve-ut-1815  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825  
+Index: geneve-ut-1828  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835  
+Index: geneve-ut-1838  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841  
+Index: geneve-ut-1844  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850  
+Index: geneve-ut-1853  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947  
+Index: geneve-ut-1950  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978  
+Index: geneve-ut-1981  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807
+Index: geneve-ut-0808
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000
+Index: geneve-ut-1001
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145
+Index: geneve-ut-1146
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175
+Index: geneve-ut-1176
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248
+Index: geneve-ut-1250
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277
+Index: geneve-ut-1279
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295
+Index: geneve-ut-1297
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359
+Index: geneve-ut-1362
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374
+Index: geneve-ut-1377
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464
+Index: geneve-ut-1467
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709
+Index: geneve-ut-1712
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797
+Index: geneve-ut-1800
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812
+Index: geneve-ut-1815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825
+Index: geneve-ut-1828
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841
+Index: geneve-ut-1844
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947
+Index: geneve-ut-1950
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978
+Index: geneve-ut-1981
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1001
+Index: geneve-ut-1002
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1021
+Index: geneve-ut-1022
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1411
+Index: geneve-ut-1414
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1612
+Index: geneve-ut-1615
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0807  
+Index: geneve-ut-0808  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0973  
+Index: geneve-ut-0974  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1000  
+Index: geneve-ut-1001  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1123  
+Index: geneve-ut-1124  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1145  
+Index: geneve-ut-1146  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1175  
+Index: geneve-ut-1176  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1248  
+Index: geneve-ut-1250  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1277  
+Index: geneve-ut-1279  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1295  
+Index: geneve-ut-1297  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1359  
+Index: geneve-ut-1362  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1374  
+Index: geneve-ut-1377  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1455  
+Index: geneve-ut-1458  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1464  
+Index: geneve-ut-1467  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1579  
+Index: geneve-ut-1582  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1709  
+Index: geneve-ut-1712  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1713  
+Index: geneve-ut-1716  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1797  
+Index: geneve-ut-1800  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1812  
+Index: geneve-ut-1815  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1825  
+Index: geneve-ut-1828  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1835  
+Index: geneve-ut-1838  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1841  
+Index: geneve-ut-1844  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1850  
+Index: geneve-ut-1853  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1947  
+Index: geneve-ut-1950  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1978  
+Index: geneve-ut-1981  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3381,7 +3381,7 @@ container.id like "*"
 
 
 
-## Rules with the correct signals (804)
+## Rules with the correct signals (805)
 
 ### A scheduled task was created
 
@@ -7231,7 +7231,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0797
+Index: geneve-ut-0798
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7270,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0798
+Index: geneve-ut-0799
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7297,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0799
+Index: geneve-ut-0800
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7312,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0800
+Index: geneve-ut-0801
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7399,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0808
+Index: geneve-ut-0809
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7417,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0809
+Index: geneve-ut-0810
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7448,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0810
+Index: geneve-ut-0811
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7475,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0811
+Index: geneve-ut-0812
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7495,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0815
+Index: geneve-ut-0816
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7508,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0818
+Index: geneve-ut-0819
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7520,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0821
+Index: geneve-ut-0822
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7532,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0825
+Index: geneve-ut-0826
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7544,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0827
+Index: geneve-ut-0828
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7561,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0853
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7574,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0856
+Index: geneve-ut-0857
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7598,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0857
+Index: geneve-ut-0858
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7610,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0870
+Index: geneve-ut-0871
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7628,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0871
+Index: geneve-ut-0872
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7677,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0872
+Index: geneve-ut-0873
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7691,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0876
+Index: geneve-ut-0877
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0882
+Index: geneve-ut-0883
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0884
+Index: geneve-ut-0885
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7742,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0885
+Index: geneve-ut-0886
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7760,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0886
+Index: geneve-ut-0887
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7779,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0887
+Index: geneve-ut-0888
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7795,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0888
+Index: geneve-ut-0889
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7811,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0889
+Index: geneve-ut-0890
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7824,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0894
+Index: geneve-ut-0895
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7841,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0896
+Index: geneve-ut-0897
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0897
+Index: geneve-ut-0898
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7870,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0898
+Index: geneve-ut-0899
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7897,7 +7897,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0899
+Index: geneve-ut-0900
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7921,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0904
+Index: geneve-ut-0905
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7945,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0906
+Index: geneve-ut-0907
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +7981,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0907
+Index: geneve-ut-0908
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +7993,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0908
+Index: geneve-ut-0909
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8007,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0909
+Index: geneve-ut-0910
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8020,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0910
+Index: geneve-ut-0911
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8079,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0911
+Index: geneve-ut-0912
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8092,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0912
+Index: geneve-ut-0913
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8105,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0913
+Index: geneve-ut-0914
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8126,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0914
+Index: geneve-ut-0915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8144,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0915
+Index: geneve-ut-0916
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8178,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0917
+Index: geneve-ut-0918
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8200,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0919
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8227,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0920
+Index: geneve-ut-0921
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8253,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0921
+Index: geneve-ut-0922
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8269,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0922
+Index: geneve-ut-0923
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8285,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0924
+Index: geneve-ut-0925
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8297,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0925
+Index: geneve-ut-0926
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8325,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0927
+Index: geneve-ut-0928
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8341,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0929
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8366,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0930
+Index: geneve-ut-0931
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8380,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0932
+Index: geneve-ut-0933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8403,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0933
+Index: geneve-ut-0934
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8436,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0934
+Index: geneve-ut-0935
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8463,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0937
+Index: geneve-ut-0938
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8484,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0938
+Index: geneve-ut-0939
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8511,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0948
+Index: geneve-ut-0949
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8533,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0974
+Index: geneve-ut-0975
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8552,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0977
+Index: geneve-ut-0978
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8596,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0979
+Index: geneve-ut-0980
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8621,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0991
+Index: geneve-ut-0992
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8659,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0996
+Index: geneve-ut-0997
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8677,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0997
+Index: geneve-ut-0998
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8691,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1002
+Index: geneve-ut-1003
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8706,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1017
+Index: geneve-ut-1018
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8720,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1020
+Index: geneve-ut-1021
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8734,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1022
+Index: geneve-ut-1023
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8755,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1023
+Index: geneve-ut-1024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8785,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1027
+Index: geneve-ut-1028
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8832,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1028
+Index: geneve-ut-1029
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8863,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1031
+Index: geneve-ut-1032
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8876,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1033
+Index: geneve-ut-1034
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8889,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1034
+Index: geneve-ut-1035
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8901,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1070
+Index: geneve-ut-1071
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8914,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1071
+Index: geneve-ut-1072
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8927,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1072
+Index: geneve-ut-1073
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8939,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1073
+Index: geneve-ut-1074
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8951,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1074
+Index: geneve-ut-1075
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8964,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1082
+Index: geneve-ut-1083
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +8977,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1085
+Index: geneve-ut-1086
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +8997,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1086
+Index: geneve-ut-1087
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9009,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1087
+Index: geneve-ut-1088
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9021,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1091
+Index: geneve-ut-1092
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9033,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1092
+Index: geneve-ut-1093
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9045,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1094
+Index: geneve-ut-1095
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9057,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1095
+Index: geneve-ut-1096
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9069,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1096
+Index: geneve-ut-1097
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9094,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1097
+Index: geneve-ut-1098
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9114,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1098
+Index: geneve-ut-1099
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9127,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1099
+Index: geneve-ut-1100
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9142,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1100
+Index: geneve-ut-1101
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9167,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1102
+Index: geneve-ut-1103
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9179,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1105
+Index: geneve-ut-1106
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9191,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1106
+Index: geneve-ut-1107
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9203,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1107
+Index: geneve-ut-1108
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9237,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1110
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9251,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1111
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9272,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1112
+Index: geneve-ut-1113
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9286,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1116
+Index: geneve-ut-1117
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9321,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1117
+Index: geneve-ut-1118
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9346,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1118
+Index: geneve-ut-1119
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9363,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1122
+Index: geneve-ut-1123
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9377,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1124
+Index: geneve-ut-1125
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1126
+Index: geneve-ut-1127
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9462,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1127
+Index: geneve-ut-1128
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9474,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1129
+Index: geneve-ut-1130
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9492,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9509,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1132
+Index: geneve-ut-1133
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9524,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1133
+Index: geneve-ut-1134
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9574,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1135
+Index: geneve-ut-1136
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9590,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1136
+Index: geneve-ut-1137
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9604,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1138
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1139
+Index: geneve-ut-1140
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9661,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1140
+Index: geneve-ut-1141
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9683,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1141
+Index: geneve-ut-1142
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9702,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1142
+Index: geneve-ut-1143
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9735,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1143
+Index: geneve-ut-1144
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9753,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1144
+Index: geneve-ut-1145
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9794,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1157
+Index: geneve-ut-1158
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9820,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1166
+Index: geneve-ut-1167
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9844,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1170
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1171
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9877,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1172
+Index: geneve-ut-1173
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9897,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1173
+Index: geneve-ut-1174
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9920,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1174
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9941,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1176
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9956,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1177
+Index: geneve-ut-1178
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +9973,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1179
+Index: geneve-ut-1180
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +9997,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1181
+Index: geneve-ut-1182
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10043,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1182
+Index: geneve-ut-1183
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10085,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1183
+Index: geneve-ut-1184
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10102,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1185
+Index: geneve-ut-1186
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10117,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1186
+Index: geneve-ut-1187
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10136,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1187
+Index: geneve-ut-1188
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10156,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1188
+Index: geneve-ut-1189
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10175,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1190
+Index: geneve-ut-1191
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10204,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1191
+Index: geneve-ut-1192
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10229,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1192
+Index: geneve-ut-1193
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10251,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1193
+Index: geneve-ut-1194
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10284,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1194
+Index: geneve-ut-1195
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10314,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1198
+Index: geneve-ut-1199
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10331,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1199
+Index: geneve-ut-1200
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10368,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1200
+Index: geneve-ut-1201
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10381,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1205
+Index: geneve-ut-1206
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10393,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1208
+Index: geneve-ut-1209
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10405,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1218
+Index: geneve-ut-1219
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10419,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1219
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10433,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1220
+Index: geneve-ut-1221
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10447,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1221
+Index: geneve-ut-1222
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10467,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1223
+Index: geneve-ut-1224
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10480,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1224
+Index: geneve-ut-1225
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10495,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1226
+Index: geneve-ut-1227
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10517,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1235
+Index: geneve-ut-1236
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10544,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1236
+Index: geneve-ut-1237
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10564,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1237
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10579,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1238
+Index: geneve-ut-1239
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10606,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1239
+Index: geneve-ut-1240
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10621,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1240
+Index: geneve-ut-1241
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10637,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1241
+Index: geneve-ut-1242
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10651,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1242
+Index: geneve-ut-1243
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10666,11 +10666,31 @@ file.path like~ "*/wp-content/plugins/*"
 
 
 
+### PKINIT Followed by Same-Principal U2U Service Ticket
+
+Branch count: 2  
+Document count: 4  
+Index: geneve-ut-1244
+
+```python
+sequence by winlog.computer_name, source.ip with maxspan=5s
+  [authentication where host.os.type == "windows" and
+    event.code == "4768" and winlog.event_data.PreAuthType == "16" and
+    winlog.event_data.Status == "0x0"
+  ] by winlog.event_data.TargetSid
+  [authentication where host.os.type == "windows" and
+    event.code == "4769" and winlog.event_data.Status == "0x0" and
+    winlog.event_data.TicketOptions in ("0x40810008", "0x40810018")
+  ] by winlog.event_data.ServiceSid
+```
+
+
+
 ### Pbpaste Execution via Unusual Parent Process
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1249
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10685,7 +10705,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1250
+Index: geneve-ut-1252
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10699,7 +10719,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1251
+Index: geneve-ut-1253
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10718,7 +10738,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1252
+Index: geneve-ut-1254
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10730,7 +10750,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1253
+Index: geneve-ut-1255
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10742,7 +10762,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1254
+Index: geneve-ut-1256
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10760,7 +10780,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1255
+Index: geneve-ut-1257
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10773,7 +10793,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1256
+Index: geneve-ut-1258
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10788,7 +10808,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1257
+Index: geneve-ut-1259
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10803,7 +10823,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1260
+Index: geneve-ut-1262
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10823,7 +10843,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1261
+Index: geneve-ut-1263
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10847,7 +10867,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1262
+Index: geneve-ut-1264
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10861,7 +10881,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1263
+Index: geneve-ut-1265
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10880,7 +10900,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1264
+Index: geneve-ut-1266
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10908,7 +10928,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1265
+Index: geneve-ut-1267
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10937,7 +10957,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1266
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10956,7 +10976,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1267
+Index: geneve-ut-1269
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10984,7 +11004,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1268
+Index: geneve-ut-1270
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10999,7 +11019,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1269
+Index: geneve-ut-1271
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11062,7 +11082,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1270
+Index: geneve-ut-1272
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11083,7 +11103,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1271
+Index: geneve-ut-1273
 
 ```python
 any where host.os.type == "windows" and
@@ -11145,7 +11165,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1273
+Index: geneve-ut-1275
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11174,7 +11194,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1274
+Index: geneve-ut-1276
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11188,7 +11208,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1275
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11221,7 +11241,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1278
+Index: geneve-ut-1280
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11268,7 +11288,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1279
+Index: geneve-ut-1281
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11295,7 +11315,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1280
+Index: geneve-ut-1282
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11308,7 +11328,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1291
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11325,7 +11345,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1293
+Index: geneve-ut-1295
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11350,7 +11370,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1298
+Index: geneve-ut-1300
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11366,7 +11386,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1299
+Index: geneve-ut-1301
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11387,7 +11407,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1301
+Index: geneve-ut-1304
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11404,7 +11424,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1302
+Index: geneve-ut-1305
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11417,7 +11437,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1303
+Index: geneve-ut-1306
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11441,7 +11461,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1305
+Index: geneve-ut-1308
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11470,7 +11490,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1307
+Index: geneve-ut-1310
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11497,7 +11517,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1308
+Index: geneve-ut-1311
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11521,7 +11541,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1311
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11539,7 +11559,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1312
+Index: geneve-ut-1315
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11562,7 +11582,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1313
+Index: geneve-ut-1316
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11619,7 +11639,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1314
+Index: geneve-ut-1317
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11636,7 +11656,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1315
+Index: geneve-ut-1318
 
 ```python
 sequence by process.entity_id
@@ -11650,7 +11670,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1330
+Index: geneve-ut-1333
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11665,7 +11685,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1331
+Index: geneve-ut-1334
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11696,7 +11716,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1332
+Index: geneve-ut-1335
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11710,7 +11730,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1333
+Index: geneve-ut-1336
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11723,7 +11743,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1334
+Index: geneve-ut-1337
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11735,7 +11755,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1335
+Index: geneve-ut-1338
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11748,7 +11768,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1337
+Index: geneve-ut-1340
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11767,7 +11787,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1338
+Index: geneve-ut-1341
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11780,7 +11800,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1339
+Index: geneve-ut-1342
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11801,7 +11821,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1340
+Index: geneve-ut-1343
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11815,7 +11835,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1343
+Index: geneve-ut-1346
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11835,7 +11855,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1344
+Index: geneve-ut-1347
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11859,7 +11879,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1345
+Index: geneve-ut-1348
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11875,7 +11895,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1346
+Index: geneve-ut-1349
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11892,7 +11912,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1347
+Index: geneve-ut-1350
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11913,7 +11933,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1349
+Index: geneve-ut-1352
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11926,7 +11946,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1351
+Index: geneve-ut-1354
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11954,7 +11974,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1354
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11970,7 +11990,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1355
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11993,7 +12013,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1356
+Index: geneve-ut-1359
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12006,7 +12026,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1358
+Index: geneve-ut-1361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12019,7 +12039,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1363
+Index: geneve-ut-1366
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12033,7 +12053,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1364
+Index: geneve-ut-1367
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12048,7 +12068,7 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1366
+Index: geneve-ut-1369
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12071,7 +12091,7 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1369
+Index: geneve-ut-1372
 
 ```python
 sequence by host.id with maxspan=1m
@@ -12114,7 +12134,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1370
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12132,7 +12152,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1371
+Index: geneve-ut-1374
 
 ```python
 host.os.type:"windows" and
@@ -12148,7 +12168,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1373
+Index: geneve-ut-1376
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12160,7 +12180,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1375
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12176,7 +12196,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1376
+Index: geneve-ut-1379
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12192,7 +12212,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1377
+Index: geneve-ut-1380
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12210,7 +12230,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1378
+Index: geneve-ut-1381
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12224,7 +12244,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1380
+Index: geneve-ut-1383
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12247,7 +12267,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1382
+Index: geneve-ut-1385
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12263,7 +12283,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1383
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12276,7 +12296,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1384
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12306,7 +12326,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1390
+Index: geneve-ut-1393
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12329,7 +12349,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1391
+Index: geneve-ut-1394
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12348,7 +12368,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1396
+Index: geneve-ut-1399
 
 ```python
 process where host.os.type == "windows" and 
@@ -12490,7 +12510,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1397
+Index: geneve-ut-1400
 
 ```python
 process where host.os.type == "windows" and
@@ -12567,7 +12587,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1401
+Index: geneve-ut-1404
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12584,7 +12604,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1402
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12618,7 +12638,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1404
+Index: geneve-ut-1407
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12630,7 +12650,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1405
+Index: geneve-ut-1408
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12669,7 +12689,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1408
+Index: geneve-ut-1411
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12682,7 +12702,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1413
+Index: geneve-ut-1416
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12696,7 +12716,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1420
+Index: geneve-ut-1423
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12734,7 +12754,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1421
+Index: geneve-ut-1424
 
 ```python
 network where host.os.type == "windows" and
@@ -12760,7 +12780,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1424
+Index: geneve-ut-1427
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12775,7 +12795,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1427
+Index: geneve-ut-1430
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12789,7 +12809,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1428
+Index: geneve-ut-1431
 
 ```python
 file where host.os.type == "windows" and
@@ -12803,7 +12823,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1429
+Index: geneve-ut-1432
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12816,7 +12836,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1430
+Index: geneve-ut-1433
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12836,7 +12856,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1431
+Index: geneve-ut-1434
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12876,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1433
+Index: geneve-ut-1436
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12895,7 +12915,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1434
+Index: geneve-ut-1437
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13090,7 +13110,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1449
+Index: geneve-ut-1452
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13106,7 +13126,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1450
+Index: geneve-ut-1453
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13120,7 +13140,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1451
+Index: geneve-ut-1454
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13134,7 +13154,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1452
+Index: geneve-ut-1455
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13151,7 +13171,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1453
+Index: geneve-ut-1456
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13165,7 +13185,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1454
+Index: geneve-ut-1457
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13181,7 +13201,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1459
+Index: geneve-ut-1462
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13193,7 +13213,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1460
+Index: geneve-ut-1463
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13209,7 +13229,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1461
+Index: geneve-ut-1464
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13229,7 +13249,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1463
+Index: geneve-ut-1466
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13269,7 +13289,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1465
+Index: geneve-ut-1468
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13281,7 +13301,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1466
+Index: geneve-ut-1469
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13302,7 +13322,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1467
+Index: geneve-ut-1470
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13323,7 +13343,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1468
+Index: geneve-ut-1471
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13344,7 +13364,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1469
+Index: geneve-ut-1472
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13370,7 +13390,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1470
+Index: geneve-ut-1473
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13386,7 +13406,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1471
+Index: geneve-ut-1474
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13400,7 +13420,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1473
+Index: geneve-ut-1476
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13423,7 +13443,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1475
+Index: geneve-ut-1478
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13440,7 +13460,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1476
+Index: geneve-ut-1479
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13463,7 +13483,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1477
+Index: geneve-ut-1480
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13476,7 +13496,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1478
+Index: geneve-ut-1481
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13490,7 +13510,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1479
+Index: geneve-ut-1482
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13507,7 +13527,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1480
+Index: geneve-ut-1483
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13561,7 +13581,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1481
+Index: geneve-ut-1484
 
 ```python
 any where host.os.type == "windows" and
@@ -13588,7 +13608,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1487
+Index: geneve-ut-1490
 
 ```python
 file where host.os.type == "windows" and
@@ -13603,7 +13623,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1488
+Index: geneve-ut-1491
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13634,7 +13654,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1489
+Index: geneve-ut-1492
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13648,7 +13668,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1490
+Index: geneve-ut-1493
 
 ```python
 sequence with maxspan=1m
@@ -13690,7 +13710,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1491
+Index: geneve-ut-1494
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13715,7 +13735,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1492
+Index: geneve-ut-1495
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13769,7 +13789,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1493
+Index: geneve-ut-1496
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13789,7 +13809,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1494
+Index: geneve-ut-1497
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13810,7 +13830,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1495
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13825,7 +13845,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1496
+Index: geneve-ut-1499
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13845,7 +13865,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1497
+Index: geneve-ut-1500
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13887,7 +13907,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1501
+Index: geneve-ut-1504
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13902,7 +13922,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1502
+Index: geneve-ut-1505
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13937,7 +13957,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1503
+Index: geneve-ut-1506
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13954,7 +13974,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1508
+Index: geneve-ut-1511
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13968,7 +13988,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1511
+Index: geneve-ut-1514
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -13981,7 +14001,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1512
+Index: geneve-ut-1515
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -13993,7 +14013,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1513
+Index: geneve-ut-1516
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14008,7 +14028,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1515
+Index: geneve-ut-1518
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14036,7 +14056,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1517
+Index: geneve-ut-1520
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14061,7 +14081,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1521
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14098,7 +14118,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1522
+Index: geneve-ut-1525
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14112,7 +14132,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1523
+Index: geneve-ut-1526
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14128,7 +14148,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1524
+Index: geneve-ut-1527
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14142,7 +14162,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1525
+Index: geneve-ut-1528
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14172,7 +14192,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1526
+Index: geneve-ut-1529
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14201,7 +14221,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1527
+Index: geneve-ut-1530
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14217,7 +14237,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1528
+Index: geneve-ut-1531
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14231,7 +14251,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1529
+Index: geneve-ut-1532
 
 ```python
 file where host.os.type == "windows" and
@@ -14267,7 +14287,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1532
+Index: geneve-ut-1535
 
 ```python
 process where event.type == "start" and
@@ -14281,7 +14301,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1533
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14295,7 +14315,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1534
+Index: geneve-ut-1537
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14335,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1536
+Index: geneve-ut-1539
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14332,7 +14352,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1537
+Index: geneve-ut-1540
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14344,7 +14364,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1538
+Index: geneve-ut-1541
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14361,7 +14381,7 @@ process.executable : (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1539
+Index: geneve-ut-1542
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14379,7 +14399,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1546
+Index: geneve-ut-1549
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14392,7 +14412,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1547
+Index: geneve-ut-1550
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14419,7 +14439,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1548
+Index: geneve-ut-1551
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14432,7 +14452,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1549
+Index: geneve-ut-1552
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14446,7 +14466,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1551
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14463,7 +14483,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1552
+Index: geneve-ut-1555
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14486,7 +14506,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1554
+Index: geneve-ut-1557
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14503,7 +14523,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1557
+Index: geneve-ut-1560
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14516,7 +14536,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1559
+Index: geneve-ut-1562
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14540,7 +14560,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1560
+Index: geneve-ut-1563
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14568,7 +14588,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1576
+Index: geneve-ut-1579
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14589,7 +14609,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1578
+Index: geneve-ut-1581
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14617,7 +14637,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1580
+Index: geneve-ut-1583
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14657,7 +14677,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1581
+Index: geneve-ut-1584
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14674,7 +14694,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1582
+Index: geneve-ut-1585
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14688,7 +14708,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1583
+Index: geneve-ut-1586
 
 ```python
 file where host.os.type == "windows" and
@@ -14707,7 +14727,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1584
+Index: geneve-ut-1587
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14721,7 +14741,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1586
+Index: geneve-ut-1589
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14739,7 +14759,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1588
+Index: geneve-ut-1591
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14757,7 +14777,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1591
+Index: geneve-ut-1594
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14771,7 +14791,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1593
+Index: geneve-ut-1596
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14786,7 +14806,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1594
+Index: geneve-ut-1597
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14809,7 +14829,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1596
+Index: geneve-ut-1599
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14891,7 +14911,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1597
+Index: geneve-ut-1600
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14912,7 +14932,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1598
+Index: geneve-ut-1601
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14938,7 +14958,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1601
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14991,7 +15011,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1602
+Index: geneve-ut-1605
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15003,7 +15023,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1603
+Index: geneve-ut-1606
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15015,7 +15035,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1604
+Index: geneve-ut-1607
 
 ```python
 process where host.os.type == "windows" and
@@ -15030,7 +15050,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1605
+Index: geneve-ut-1608
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15060,7 +15080,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1606
+Index: geneve-ut-1609
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15120,7 +15140,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1609
+Index: geneve-ut-1612
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15133,7 +15153,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1610
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15165,7 +15185,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1611
+Index: geneve-ut-1614
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15189,7 +15209,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1613
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15222,7 +15242,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1614
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15239,7 +15259,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1616
+Index: geneve-ut-1619
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15268,7 +15288,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1617
+Index: geneve-ut-1620
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15282,7 +15302,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1618
+Index: geneve-ut-1621
 
 ```python
 sequence by process.entity_id
@@ -15307,7 +15327,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1619
+Index: geneve-ut-1622
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15341,7 +15361,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1620
+Index: geneve-ut-1623
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15369,7 +15389,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1621
+Index: geneve-ut-1624
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15388,7 +15408,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1627
+Index: geneve-ut-1630
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15416,7 +15436,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1628
+Index: geneve-ut-1631
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15435,7 +15455,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1632
+Index: geneve-ut-1635
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15447,7 +15467,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1633
+Index: geneve-ut-1636
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15459,7 +15479,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1634
+Index: geneve-ut-1637
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15471,7 +15491,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1635
+Index: geneve-ut-1638
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15483,7 +15503,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1646
+Index: geneve-ut-1649
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15496,7 +15516,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1647
+Index: geneve-ut-1650
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15534,7 +15554,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1649
+Index: geneve-ut-1652
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15549,7 +15569,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1650
+Index: geneve-ut-1653
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15568,7 +15588,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1651
+Index: geneve-ut-1654
 
 ```python
 sequence with maxspan=1m
@@ -15616,7 +15636,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1653
+Index: geneve-ut-1656
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15639,7 +15659,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1655
+Index: geneve-ut-1658
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15653,7 +15673,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1656
+Index: geneve-ut-1659
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15667,7 +15687,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1658
+Index: geneve-ut-1661
 
 ```python
 sequence by host.id, process.entity_id
@@ -15684,7 +15704,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1659
+Index: geneve-ut-1662
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15698,7 +15718,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1660
+Index: geneve-ut-1663
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15718,7 +15738,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1661
+Index: geneve-ut-1664
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15747,7 +15767,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1662
+Index: geneve-ut-1665
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15767,7 +15787,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1663
+Index: geneve-ut-1666
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15780,7 +15800,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1665
+Index: geneve-ut-1668
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15822,7 +15842,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1666
+Index: geneve-ut-1669
 
 ```python
 sequence with maxspan=1m
@@ -15845,7 +15865,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1667
+Index: geneve-ut-1670
 
 ```python
 sequence with maxspan=1s
@@ -15893,7 +15913,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1668
+Index: geneve-ut-1671
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15910,7 +15930,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1670
+Index: geneve-ut-1673
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15939,7 +15959,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1673
+Index: geneve-ut-1676
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15967,7 +15987,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1674
+Index: geneve-ut-1677
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -15984,7 +16004,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1676
+Index: geneve-ut-1679
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16003,7 +16023,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1677
+Index: geneve-ut-1680
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16024,7 +16044,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1686
+Index: geneve-ut-1689
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16038,7 +16058,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1688
+Index: geneve-ut-1691
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16057,7 +16077,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1689
+Index: geneve-ut-1692
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16071,7 +16091,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1690
+Index: geneve-ut-1693
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16091,7 +16111,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1692
+Index: geneve-ut-1695
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16109,7 +16129,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1693
+Index: geneve-ut-1696
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16130,7 +16150,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1695
+Index: geneve-ut-1698
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16144,7 +16164,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1696
+Index: geneve-ut-1699
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16159,7 +16179,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1697
+Index: geneve-ut-1700
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16200,7 +16220,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1699
+Index: geneve-ut-1702
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16225,7 +16245,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1700
+Index: geneve-ut-1703
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16264,7 +16284,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1701
+Index: geneve-ut-1704
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16278,7 +16298,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1702
+Index: geneve-ut-1705
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16317,7 +16337,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1703
+Index: geneve-ut-1706
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16331,7 +16351,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1704
+Index: geneve-ut-1707
 
 ```python
 process where event.type == "start" and
@@ -16403,7 +16423,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1708
+Index: geneve-ut-1711
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16424,7 +16444,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1711
+Index: geneve-ut-1714
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16441,7 +16461,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1714
+Index: geneve-ut-1717
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16459,7 +16479,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1715
+Index: geneve-ut-1718
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16471,7 +16491,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1716
+Index: geneve-ut-1719
 
 ```python
 file where host.os.type == "windows" and
@@ -16504,7 +16524,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1719
+Index: geneve-ut-1722
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16536,7 +16556,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1721
+Index: geneve-ut-1724
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16572,7 +16592,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1722
+Index: geneve-ut-1725
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16589,7 +16609,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1723
+Index: geneve-ut-1726
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16609,7 +16629,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1725
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16624,7 +16644,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1726
+Index: geneve-ut-1729
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16645,7 +16665,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1727
+Index: geneve-ut-1730
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16668,7 +16688,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1728
+Index: geneve-ut-1731
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16681,7 +16701,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1729
+Index: geneve-ut-1732
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16698,7 +16718,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1732
+Index: geneve-ut-1735
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16723,7 +16743,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1735
+Index: geneve-ut-1738
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16754,7 +16774,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1736
+Index: geneve-ut-1739
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16803,7 +16823,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1737
+Index: geneve-ut-1740
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16817,7 +16837,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1738
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16832,7 +16852,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1739
+Index: geneve-ut-1742
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16847,7 +16867,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1740
+Index: geneve-ut-1743
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16869,7 +16889,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1741
+Index: geneve-ut-1744
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16890,7 +16910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1745
+Index: geneve-ut-1748
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16904,7 +16924,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1746
+Index: geneve-ut-1749
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16927,7 +16947,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1776
+Index: geneve-ut-1779
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16952,7 +16972,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1777
+Index: geneve-ut-1780
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16985,7 +17005,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1778
+Index: geneve-ut-1781
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17044,7 +17064,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1780
+Index: geneve-ut-1783
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17062,7 +17082,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1781
+Index: geneve-ut-1784
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17074,7 +17094,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1784
+Index: geneve-ut-1787
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17099,7 +17119,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1790
+Index: geneve-ut-1793
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17114,7 +17134,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1791
+Index: geneve-ut-1794
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17137,7 +17157,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1794
+Index: geneve-ut-1797
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17151,7 +17171,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1796
+Index: geneve-ut-1799
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17173,7 +17193,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1798
+Index: geneve-ut-1801
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17200,7 +17220,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1802
+Index: geneve-ut-1805
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17239,7 +17259,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1803
+Index: geneve-ut-1806
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17262,7 +17282,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1804
+Index: geneve-ut-1807
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17276,7 +17296,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1805
+Index: geneve-ut-1808
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17292,7 +17312,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1806
+Index: geneve-ut-1809
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17308,7 +17328,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1807
+Index: geneve-ut-1810
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17322,7 +17342,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1809
+Index: geneve-ut-1812
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17345,7 +17365,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1810
+Index: geneve-ut-1813
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17373,7 +17393,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1811
+Index: geneve-ut-1814
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17388,7 +17408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1814
+Index: geneve-ut-1817
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17415,7 +17435,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1816
+Index: geneve-ut-1819
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17446,7 +17466,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1817
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17462,7 +17482,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1818
+Index: geneve-ut-1821
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17475,7 +17495,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1820
+Index: geneve-ut-1823
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17491,7 +17511,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1821
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17507,7 +17527,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1822
+Index: geneve-ut-1825
 
 ```python
 any where host.os.type == "windows" and 
@@ -17574,7 +17594,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1824
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17590,7 +17610,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1826
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17626,7 +17646,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1827
+Index: geneve-ut-1830
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17664,7 +17684,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1828
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17699,7 +17719,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1829
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17733,7 +17753,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1831
+Index: geneve-ut-1834
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17754,7 +17774,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1836
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17831,7 +17851,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1837
+Index: geneve-ut-1840
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17853,7 +17873,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1838
+Index: geneve-ut-1841
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17877,7 +17897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1840
+Index: geneve-ut-1843
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17898,7 +17918,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1843
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17913,7 +17933,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1846
+Index: geneve-ut-1849
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17926,7 +17946,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1847
+Index: geneve-ut-1850
 
 ```python
 any where host.os.type == "windows" and
@@ -17941,7 +17961,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1848
+Index: geneve-ut-1851
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17957,7 +17977,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1849
+Index: geneve-ut-1852
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17971,7 +17991,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1853
+Index: geneve-ut-1856
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18028,7 +18048,7 @@ process.parent.executable != null and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1854
+Index: geneve-ut-1857
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18042,7 +18062,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1856
+Index: geneve-ut-1859
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18074,7 +18094,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1858
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18087,7 +18107,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1859
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18106,7 +18126,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1860
+Index: geneve-ut-1863
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18152,7 +18172,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1862
+Index: geneve-ut-1865
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18173,7 +18193,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1863
+Index: geneve-ut-1866
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18193,7 +18213,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1864
+Index: geneve-ut-1867
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18207,7 +18227,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1865
+Index: geneve-ut-1868
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18239,7 +18259,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1868
+Index: geneve-ut-1871
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18260,7 +18280,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1870
+Index: geneve-ut-1873
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18361,7 +18381,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1874
+Index: geneve-ut-1877
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18409,7 +18429,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1877
+Index: geneve-ut-1880
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18435,7 +18455,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1878
+Index: geneve-ut-1881
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18480,7 +18500,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1879
+Index: geneve-ut-1882
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18504,7 +18524,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1880
+Index: geneve-ut-1883
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18520,7 +18540,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1882
+Index: geneve-ut-1885
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18545,7 +18565,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1883
+Index: geneve-ut-1886
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18560,7 +18580,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1886
+Index: geneve-ut-1889
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18574,7 +18594,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1887
+Index: geneve-ut-1890
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18594,7 +18614,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1888
+Index: geneve-ut-1891
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18629,7 +18649,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1892
+Index: geneve-ut-1895
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18647,7 +18667,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1893
+Index: geneve-ut-1896
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18660,7 +18680,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1896
+Index: geneve-ut-1899
 
 ```python
 any where host.os.type == "windows" and
@@ -18693,7 +18713,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1898
+Index: geneve-ut-1901
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18711,7 +18731,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1899
+Index: geneve-ut-1902
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18733,7 +18753,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1902
+Index: geneve-ut-1905
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18772,7 +18792,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1903
+Index: geneve-ut-1906
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18802,7 +18822,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1904
+Index: geneve-ut-1907
 
 ```python
 any where host.os.type == "windows" and
@@ -18836,7 +18856,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1905
+Index: geneve-ut-1908
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18850,7 +18870,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1908
+Index: geneve-ut-1911
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18881,7 +18901,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1909
+Index: geneve-ut-1912
 
 ```python
 any where host.os.type == "windows" and
@@ -18901,7 +18921,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1910
+Index: geneve-ut-1913
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18942,7 +18962,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1911
+Index: geneve-ut-1914
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18958,7 +18978,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1912
+Index: geneve-ut-1915
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18988,7 +19008,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1916
+Index: geneve-ut-1919
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19001,7 +19021,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1917
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19025,7 +19045,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1920
+Index: geneve-ut-1923
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19043,7 +19063,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1922
+Index: geneve-ut-1925
 
 ```python
 any where host.os.type == "windows" and
@@ -19058,7 +19078,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1923
+Index: geneve-ut-1926
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19076,7 +19096,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1924
+Index: geneve-ut-1927
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19097,7 +19117,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1925
+Index: geneve-ut-1928
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19116,7 +19136,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1928
+Index: geneve-ut-1931
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19141,7 +19161,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1929
+Index: geneve-ut-1932
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19154,7 +19174,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1931
+Index: geneve-ut-1934
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19167,7 +19187,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1933
+Index: geneve-ut-1936
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19190,7 +19210,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1935
+Index: geneve-ut-1938
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19209,7 +19229,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1936
+Index: geneve-ut-1939
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19231,7 +19251,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1937
+Index: geneve-ut-1940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19264,7 +19284,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1939
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19282,7 +19302,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1940
+Index: geneve-ut-1943
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19296,7 +19316,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1941
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19320,7 +19340,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1942
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19343,7 +19363,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1943
+Index: geneve-ut-1946
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19362,7 +19382,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1946
+Index: geneve-ut-1949
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19381,7 +19401,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1948
+Index: geneve-ut-1951
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19416,7 +19436,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1949
+Index: geneve-ut-1952
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19433,7 +19453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1950
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19473,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1951
+Index: geneve-ut-1954
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19493,7 +19513,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1952
+Index: geneve-ut-1955
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19509,7 +19529,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1953
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19523,7 +19543,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1954
+Index: geneve-ut-1957
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19561,7 +19581,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1955
+Index: geneve-ut-1958
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19615,7 +19635,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1956
+Index: geneve-ut-1959
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19643,7 +19663,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1958
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19657,7 +19677,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1959
+Index: geneve-ut-1962
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19703,7 +19723,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1960
+Index: geneve-ut-1963
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19742,7 +19762,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1961
+Index: geneve-ut-1964
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19755,7 +19775,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1965
+Index: geneve-ut-1968
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19788,7 +19808,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1966
+Index: geneve-ut-1969
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19802,7 +19822,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1967
+Index: geneve-ut-1970
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19816,7 +19836,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1968
+Index: geneve-ut-1971
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19830,7 +19850,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1969
+Index: geneve-ut-1972
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19869,7 +19889,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1977
+Index: geneve-ut-1980
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19911,7 +19931,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1979
+Index: geneve-ut-1982
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19933,7 +19953,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1981
+Index: geneve-ut-1984
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19946,7 +19966,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1984
+Index: geneve-ut-1987
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19963,7 +19983,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1985
+Index: geneve-ut-1988
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19979,7 +19999,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1986
+Index: geneve-ut-1989
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19992,7 +20012,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1987
+Index: geneve-ut-1990
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20007,7 +20027,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1988
+Index: geneve-ut-1991
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20030,7 +20050,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1989
+Index: geneve-ut-1992
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20046,7 +20066,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1990
+Index: geneve-ut-1993
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20062,7 +20082,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1996
+Index: geneve-ut-1999
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20074,7 +20094,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1997
+Index: geneve-ut-2000
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20103,7 +20123,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1999
+Index: geneve-ut-2002
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20117,7 +20137,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2004
+Index: geneve-ut-2007
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20137,7 +20157,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2005
+Index: geneve-ut-2008
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20162,7 +20182,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2012
+Index: geneve-ut-2015
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20176,7 +20196,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2013
+Index: geneve-ut-2016
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20199,7 +20219,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2022
+Index: geneve-ut-2025
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20233,7 +20253,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2024
+Index: geneve-ut-2027
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20252,7 +20272,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2031
+Index: geneve-ut-2034
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20271,7 +20291,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2046
+Index: geneve-ut-2049
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20288,7 +20308,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2049
+Index: geneve-ut-2052
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20305,7 +20325,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2065
+Index: geneve-ut-2068
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20324,7 +20344,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2069
+Index: geneve-ut-2072
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20366,7 +20386,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2070
+Index: geneve-ut-2073
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20411,7 +20431,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2073
+Index: geneve-ut-2076
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20453,7 +20473,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2075
+Index: geneve-ut-2078
 
 ```python
 host.os.type:"linux" and 
@@ -20481,7 +20501,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2079
+Index: geneve-ut-2082
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20505,7 +20525,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2080
+Index: geneve-ut-2083
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20545,7 +20565,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2081
+Index: geneve-ut-2084
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20592,7 +20612,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2085
+Index: geneve-ut-2088
 
 ```python
 sequence by process.entity_id
@@ -20629,7 +20649,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2117
+Index: geneve-ut-2120
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20643,7 +20663,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2118
+Index: geneve-ut-2121
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20686,7 +20706,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2119
+Index: geneve-ut-2122
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20699,7 +20719,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2122
+Index: geneve-ut-2125
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20713,7 +20733,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2123
+Index: geneve-ut-2126
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20726,7 +20746,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2127
+Index: geneve-ut-2130
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20751,7 +20771,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2128
+Index: geneve-ut-2131
 
 ```python
 process where event.type == "start" and
@@ -20766,7 +20786,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2129
+Index: geneve-ut-2132
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20783,7 +20803,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2130
+Index: geneve-ut-2133
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20797,7 +20817,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2131
+Index: geneve-ut-2134
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20813,7 +20833,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2132
+Index: geneve-ut-2135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20827,7 +20847,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2133
+Index: geneve-ut-2136
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20854,7 +20874,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2135
+Index: geneve-ut-2138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20866,7 +20886,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2136
+Index: geneve-ut-2139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20882,7 +20902,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2137
+Index: geneve-ut-2140
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20905,7 +20925,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2138
+Index: geneve-ut-2141
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20918,7 +20938,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2140
+Index: geneve-ut-2143
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20930,7 +20950,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2141
+Index: geneve-ut-2144
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20942,7 +20962,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2142
+Index: geneve-ut-2145
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20954,7 +20974,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2143
+Index: geneve-ut-2146
 
 ```python
 web where (
@@ -20982,7 +21002,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2149
+Index: geneve-ut-2152
 
 ```python
 any where (
@@ -21054,7 +21074,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2151
+Index: geneve-ut-2154
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21075,7 +21095,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2154
+Index: geneve-ut-2157
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21089,7 +21109,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2155
+Index: geneve-ut-2158
 
 ```python
 file where event.type == "deletion" and
@@ -21106,7 +21126,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2156
+Index: geneve-ut-2159
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21124,7 +21144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2159
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21162,7 +21182,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2161
+Index: geneve-ut-2164
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21199,7 +21219,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2162
+Index: geneve-ut-2165
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21214,7 +21234,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2163
+Index: geneve-ut-2166
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21227,7 +21247,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2164
+Index: geneve-ut-2167
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21246,7 +21266,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2165
+Index: geneve-ut-2168
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21271,7 +21291,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2166
+Index: geneve-ut-2169
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21297,7 +21317,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2167
+Index: geneve-ut-2170
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21319,7 +21339,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2168
+Index: geneve-ut-2171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21336,7 +21356,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2170
+Index: geneve-ut-2173
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21355,7 +21375,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2171
+Index: geneve-ut-2174
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21395,7 +21415,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2172
+Index: geneve-ut-2175
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21412,7 +21432,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2174
+Index: geneve-ut-2177
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21425,7 +21445,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2175
+Index: geneve-ut-2178
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21439,7 +21459,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2176
+Index: geneve-ut-2179
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21467,7 +21487,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2177
+Index: geneve-ut-2180
 
 ```python
 process where event.type == "start" and
@@ -21492,7 +21512,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2178
+Index: geneve-ut-2181
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21506,7 +21526,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2179
+Index: geneve-ut-2182
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21522,7 +21542,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2180
+Index: geneve-ut-2183
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21557,7 +21577,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2181
+Index: geneve-ut-2184
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21575,7 +21595,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2184
+Index: geneve-ut-2187
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/documents_from_rules-8.19.md
+++ b/tests/reports/documents_from_rules-8.19.md
@@ -5,12 +5,12 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.30
+Rules version: 8.19.31
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (238)](#unsupported-rule-type-new_terms-238)
-      1. [Unsupported rule type: esql (188)](#unsupported-rule-type-esql-188)
+      1. [Unsupported rule type: new_terms (239)](#unsupported-rule-type-new_terms-239)
+      1. [Unsupported rule type: esql (189)](#unsupported-rule-type-esql-189)
       1. [Unsupported rule type: machine_learning (95)](#unsupported-rule-type-machine_learning-95)
       1. [Unsupported rule type: threshold (27)](#unsupported-rule-type-threshold-27)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -141,9 +141,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (238)
+### Unsupported rule type: new_terms (239)
 
-238 rules:
+239 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Batch Job Submitted with Container Override by Unusual Identity
@@ -270,6 +270,7 @@ invalid-syntax
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
 * FortiGate Administrator Account Creation from Unusual Source
+* GCP IAM Service Account Impersonation Role Granted
 * GKE Anonymous Request Authorized by Unusual User Agent
 * GKE Forbidden Request from Unusual User Agent
 * GKE Secret Access via Unusual User Agent
@@ -384,9 +385,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (188)
+### Unsupported rule type: esql (189)
 
-188 rules:
+189 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -523,6 +524,7 @@ invalid-syntax
 * Potential Account Takeover - Logon from New Source IP
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
+* Potential CertiGhost AD CS Machine Identity Mismatch (CVE-2026-54121)
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries

--- a/tests/reports/documents_from_rules-9.3.md
+++ b/tests/reports/documents_from_rules-9.3.md
@@ -5,12 +5,12 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.18
+Rules version: 9.3.19
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
-      1. [Unsupported rule type: esql (202)](#unsupported-rule-type-esql-202)
+      1. [Unsupported rule type: new_terms (242)](#unsupported-rule-type-new_terms-242)
+      1. [Unsupported rule type: esql (203)](#unsupported-rule-type-esql-203)
       1. [Unsupported rule type: machine_learning (105)](#unsupported-rule-type-machine_learning-105)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -142,9 +142,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (241)
+### Unsupported rule type: new_terms (242)
 
-241 rules:
+242 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -272,6 +272,7 @@ invalid-syntax
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
 * FortiGate Administrator Account Creation from Unusual Source
+* GCP IAM Service Account Impersonation Role Granted
 * GKE Anonymous Request Authorized by Unusual User Agent
 * GKE Forbidden Request from Unusual User Agent
 * GKE Secret Access via Unusual User Agent
@@ -388,9 +389,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (202)
+### Unsupported rule type: esql (203)
 
-202 rules:
+203 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -537,6 +538,7 @@ invalid-syntax
 * Potential Account Takeover - Logon from New Source IP
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
+* Potential CertiGhost AD CS Machine Identity Mismatch (CVE-2026-54121)
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries

--- a/tests/reports/documents_from_rules-9.4.md
+++ b/tests/reports/documents_from_rules-9.4.md
@@ -5,12 +5,12 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.10
+Rules version: 9.4.11
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
-      1. [Unsupported rule type: esql (208)](#unsupported-rule-type-esql-208)
+      1. [Unsupported rule type: new_terms (242)](#unsupported-rule-type-new_terms-242)
+      1. [Unsupported rule type: esql (209)](#unsupported-rule-type-esql-209)
       1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
@@ -143,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (241)
+### Unsupported rule type: new_terms (242)
 
-241 rules:
+242 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -273,6 +273,7 @@ invalid-syntax
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
 * FortiGate Administrator Account Creation from Unusual Source
+* GCP IAM Service Account Impersonation Role Granted
 * GKE Anonymous Request Authorized by Unusual User Agent
 * GKE Forbidden Request from Unusual User Agent
 * GKE Secret Access via Unusual User Agent
@@ -389,9 +390,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (208)
+### Unsupported rule type: esql (209)
 
-208 rules:
+209 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -541,6 +542,7 @@ invalid-syntax
 * Potential Account Takeover - Logon from New Source IP
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
+* Potential CertiGhost AD CS Machine Identity Mismatch (CVE-2026-54121)
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries

--- a/tests/reports/documents_from_rules-9.5.md
+++ b/tests/reports/documents_from_rules-9.5.md
@@ -5,12 +5,12 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.3
+Rules version: 9.5.4
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
-      1. [Unsupported rule type: esql (208)](#unsupported-rule-type-esql-208)
+      1. [Unsupported rule type: new_terms (242)](#unsupported-rule-type-new_terms-242)
+      1. [Unsupported rule type: esql (209)](#unsupported-rule-type-esql-209)
       1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
@@ -143,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (241)
+### Unsupported rule type: new_terms (242)
 
-241 rules:
+242 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -273,6 +273,7 @@ invalid-syntax
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
 * FortiGate Administrator Account Creation from Unusual Source
+* GCP IAM Service Account Impersonation Role Granted
 * GKE Anonymous Request Authorized by Unusual User Agent
 * GKE Forbidden Request from Unusual User Agent
 * GKE Secret Access via Unusual User Agent
@@ -389,9 +390,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (208)
+### Unsupported rule type: esql (209)
 
-208 rules:
+209 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -541,6 +542,7 @@ invalid-syntax
 * Potential Account Takeover - Logon from New Source IP
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
+* Potential CertiGhost AD CS Machine Identity Mismatch (CVE-2026-54121)
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries

--- a/tests/reports/documents_from_rules-9.6.md
+++ b/tests/reports/documents_from_rules-9.6.md
@@ -5,12 +5,12 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.3
+Rules version: 9.5.4
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
-      1. [Unsupported rule type: esql (208)](#unsupported-rule-type-esql-208)
+      1. [Unsupported rule type: new_terms (242)](#unsupported-rule-type-new_terms-242)
+      1. [Unsupported rule type: esql (209)](#unsupported-rule-type-esql-209)
       1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
@@ -143,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (241)
+### Unsupported rule type: new_terms (242)
 
-241 rules:
+242 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -273,6 +273,7 @@ invalid-syntax
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
 * FortiGate Administrator Account Creation from Unusual Source
+* GCP IAM Service Account Impersonation Role Granted
 * GKE Anonymous Request Authorized by Unusual User Agent
 * GKE Forbidden Request from Unusual User Agent
 * GKE Secret Access via Unusual User Agent
@@ -389,9 +390,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (208)
+### Unsupported rule type: esql (209)
 
-208 rules:
+209 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -541,6 +542,7 @@ invalid-syntax
 * Potential Account Takeover - Logon from New Source IP
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
+* Potential CertiGhost AD CS Machine Identity Mismatch (CVE-2026-54121)
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries

--- a/tests/reports/documents_from_rules-serverless.md
+++ b/tests/reports/documents_from_rules-serverless.md
@@ -5,12 +5,12 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.3
+Rules version: 9.5.4
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
-      1. [Unsupported rule type: esql (208)](#unsupported-rule-type-esql-208)
+      1. [Unsupported rule type: new_terms (242)](#unsupported-rule-type-new_terms-242)
+      1. [Unsupported rule type: esql (209)](#unsupported-rule-type-esql-209)
       1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
@@ -143,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (241)
+### Unsupported rule type: new_terms (242)
 
-241 rules:
+242 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -273,6 +273,7 @@ invalid-syntax
 * First Time Seen Removable Device
 * First-Time Destructive MongoDB Command from a Client IP
 * FortiGate Administrator Account Creation from Unusual Source
+* GCP IAM Service Account Impersonation Role Granted
 * GKE Anonymous Request Authorized by Unusual User Agent
 * GKE Forbidden Request from Unusual User Agent
 * GKE Secret Access via Unusual User Agent
@@ -389,9 +390,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (208)
+### Unsupported rule type: esql (209)
 
-208 rules:
+209 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -541,6 +542,7 @@ invalid-syntax
 * Potential Account Takeover - Logon from New Source IP
 * Potential Account Takeover - Mixed Logon Types
 * Potential Azure OpenAI Model Theft
+* Potential CertiGhost AD CS Machine Identity Mismatch (CVE-2026-54121)
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries


### PR DESCRIPTION
## Summary

Updates `security_detection_engine` package versions in `tests/config.yaml` and refreshes test reports.

### ECH

| Key | Old version | New version | Renovate PR |
|-----|-------------|-------------|-------------|
| `9.5` | 9.5.3 | 9.5.4 | #815 |
| `9.6` | 9.5.3 | 9.5.4 | #817 |
| `9.4` | 9.4.10 | 9.4.11 | #809 |
| `9.3` | 9.3.18 | 9.3.19 | #807 |
| `8.19` | 8.19.30 | 8.19.31 | #814 |

### Serverless

| Key | Old version | New version | Renovate PR |
|-----|-------------|-------------|-------------|
| `serverless` | 9.5.3 | 9.5.4 | #799 |

### Reports updated

- `documents_from_rules-{8.19,9.3,9.4,9.5,9.6,serverless}.md`
- `alerts_from_rules-{8.19,9.3,9.4,9.5,9.6,serverless}.md`

`stack_signals` counts are unchanged for all updated versions.