### PR TITLE
Improve test timeout handling

### DIFF
--- a/geneve/utils/epr.py
+++ b/geneve/utils/epr.py
@@ -37,7 +37,7 @@ class EPR:
             try:
                 return requests.get(url, timeout=self.timeout)
             except ConnectTimeout:
-                if n == self.retries - 1:
+                if n == self.tries - 1:
                     raise
 
     def search_package(self, name, **conditions):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,11 +20,12 @@
 import os
 import unittest
 from shutil import make_archive
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from elasticsearch import exceptions
+from requests.exceptions import ConnectTimeout
 
-from geneve.utils import deep_merge, resource, tempdir
+from geneve.utils import deep_merge, epr, resource, tempdir
 from geneve.utils.hdict import hdict
 
 from .utils import SignalsTestCase, data_dir, flat_walk, http_server, tempenv
@@ -80,6 +81,19 @@ class TestSignalsTestCase(unittest.TestCase):
         self.assertTrue(replayed)
         es.options.assert_called_with(request_timeout=30)
         es.options.return_value.bulk.assert_called_with(operations="bulk operations")
+
+
+class TestEPR(unittest.TestCase):
+    def test_get_retries_timeout(self):
+        response = Mock()
+        get = Mock(side_effect=[ConnectTimeout("timeout"), response])
+
+        with patch("requests.get", get):
+            actual = epr.EPR(timeout=17, tries=2).get("https://epr.example.test")
+
+        self.assertIs(actual, response)
+        self.assertEqual(get.call_count, 2)
+        get.assert_called_with("https://epr.example.test", timeout=17)
 
 
 class TestResource(unittest.TestCase):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,11 +20,14 @@
 import os
 import unittest
 from shutil import make_archive
+from unittest.mock import Mock
+
+from elasticsearch import exceptions
 
 from geneve.utils import deep_merge, resource, tempdir
 from geneve.utils.hdict import hdict
 
-from .utils import data_dir, flat_walk, http_server, tempenv
+from .utils import SignalsTestCase, data_dir, flat_walk, http_server, tempenv
 
 
 class TestDictUtils(unittest.TestCase):
@@ -61,6 +64,22 @@ class TestTempEnv(unittest.TestCase):
                     self.assertTrue("TEST_VAR" not in os.environ)
                 self.assertEqual("value2", os.environ["TEST_VAR"])
             self.assertEqual("value1", os.environ["TEST_VAR"])
+
+
+class TestSignalsTestCase(unittest.TestCase):
+    def test_load_bulk_chunk_retries_timeout(self):
+        ret = {"items": [{"create": {"status": 409}}]}
+        es = Mock()
+        es.options.return_value.bulk.side_effect = [exceptions.ConnectionTimeout("timeout"), ret]
+        test_case = SignalsTestCase()
+        test_case.es = es
+
+        actual, replayed = test_case.load_bulk_chunk("bulk operations")
+
+        self.assertEqual(actual, ret)
+        self.assertTrue(replayed)
+        es.options.assert_called_with(request_timeout=30)
+        es.options.return_value.bulk.assert_called_with(operations="bulk operations")
 
 
 class TestResource(unittest.TestCase):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -418,7 +418,7 @@ class SignalsTestCase:
 
                 doc_count = 0
                 for event in itertools.chain(*events):
-                    yield json.dumps({"create": {"_index": rule["index"][0]}})
+                    yield json.dumps({"create": {"_index": rule["index"][0], "_id": doc_count}})
                     yield json.dumps(event.doc)
                     if verbose > 2:
                         sys.stderr.write(json.dumps(event.doc, sort_keys=True) + "\n")
@@ -430,7 +430,17 @@ class SignalsTestCase:
 
         return (bulk(), num_docs, se.mappings(extra_fields=corpus_fields))
 
-    def load_rules_and_docs(self, rules, asts, *, docs_chunk_size=200, rules_chunk_size=50):
+    def load_bulk_chunk(self, operations):
+        from elasticsearch import exceptions
+
+        for attempt in range(3):
+            try:
+                return self.es.options(request_timeout=30).bulk(operations=operations), attempt > 0
+            except exceptions.ConnectionTimeout:
+                if attempt == 2:
+                    raise
+
+    def load_rules_and_docs(self, rules, asts, *, docs_chunk_size=100, rules_chunk_size=50):
         bulk, docs_to_go, mappings = self.generate_docs_and_mappings(rules, asts)
 
         # for each doc there are two lines in the bulk: the operation and the doc itself
@@ -484,12 +494,9 @@ class SignalsTestCase:
                 num_chunks = math.ceil(docs_to_go / docs_chunk_size)
                 prev_report_chunk = 0
             for i, chunk in enumerate(batched(bulk, bulk_chunk_size)):
-                kwargs = {
-                    "operations": "\n".join(chunk),
-                }
-                ret = self.es.options(request_timeout=30).bulk(**kwargs)
+                ret, replayed = self.load_bulk_chunk("\n".join(chunk))
                 for item in ret["items"]:
-                    if item["create"]["status"] != 201:
+                    if item["create"]["status"] != 201 and not (replayed and item["create"]["status"] == 409):
                         cells.append(jupyter.Markdown(str(item["create"])))
                         if verbose > 1:
                             sys.stderr.write(f"{item['create']!s}\n")


### PR DESCRIPTION
## Summary

- reduce Elasticsearch bulk test-data loads to 100 documents per request
- retry ambiguous bulk request timeouts safely with deterministic document IDs
- fix EPR connection-timeout retry handling

## Testing

- `make tests`