### PR TITLE
Update rules to 8.19.32, 9.3.20, 9.4.12, 9.5.5, and 9.5.5

### DIFF
--- a/tests/config.yaml
+++ b/tests/config.yaml
@@ -35,7 +35,7 @@ emitter_rules:
     # renovate: datasource=epr package=security_detection_engine-8.18
     "8.18": "8.18.15"
     # renovate: datasource=epr package=security_detection_engine-8.19
-    "8.19": "8.19.31"
+    "8.19": "8.19.32"
     # renovate: datasource=epr package=security_detection_engine-9.0
     "9.0": "9.0.19"
     # renovate: datasource=epr package=security_detection_engine-9.1
@@ -43,15 +43,15 @@ emitter_rules:
     # renovate: datasource=epr package=security_detection_engine-9.2
     "9.2": "9.2.19"
     # renovate: datasource=epr package=security_detection_engine-9.3
-    "9.3": "9.3.19"
+    "9.3": "9.3.20"
     # renovate: datasource=epr package=security_detection_engine-9.4
-    "9.4": "9.4.11"
+    "9.4": "9.4.12"
     # renovate: datasource=epr package=security_detection_engine-9.5
-    "9.5": "9.5.4"
+    "9.5": "9.5.5"
     # renovate: datasource=epr package=security_detection_engine-9.6
     "9.6": "9.5.4"
     # renovate: datasource=epr package=security_detection_engine
-    "serverless": "9.5.4"
+    "serverless": "9.5.5"
 
   stack_signals:
     "8.2":

--- a/tests/reports/alerts_from_rules-8.19.md
+++ b/tests/reports/alerts_from_rules-8.19.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.31
+Rules version: 8.19.32
 
 ## Table of contents
    1. [Failed rules (18)](#failed-rules-18)
    1. [Unsuccessful rules with signals (18)](#unsuccessful-rules-with-signals-18)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (22)](#rules-with-too-few-signals-22)
-   1. [Rules with the correct signals (771)](#rules-with-the-correct-signals-771)
+   1. [Rules with the correct signals (776)](#rules-with-the-correct-signals-776)
 
 ## Failed rules (18)
 
@@ -20,7 +20,7 @@ Rules version: 8.19.31
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0367  
+Index: geneve-ut-0377  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -135,7 +135,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0565  
+Index: geneve-ut-0568  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -161,7 +161,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0568  
+Index: geneve-ut-0571  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -230,7 +230,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0590  
+Index: geneve-ut-0593  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0720  
+Index: geneve-ut-0725  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -290,7 +290,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0898  
+Index: geneve-ut-0900  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -343,7 +343,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1025  
+Index: geneve-ut-1027  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -376,7 +376,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1146  
+Index: geneve-ut-1149  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -402,7 +402,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1164  
+Index: geneve-ut-1167  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -440,7 +440,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1224  
+Index: geneve-ut-1230  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -462,7 +462,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1239  
+Index: geneve-ut-1246  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -501,7 +501,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1321  
+Index: geneve-ut-1328  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -564,7 +564,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1620  
+Index: geneve-ut-1630  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -612,7 +612,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1635  
+Index: geneve-ut-1646  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -647,7 +647,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1656  
+Index: geneve-ut-1667  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -710,7 +710,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1661  
+Index: geneve-ut-1672  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -738,7 +738,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1670  
+Index: geneve-ut-1681  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -770,7 +770,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1761  
+Index: geneve-ut-1775  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -847,7 +847,7 @@ not (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0367
+Index: geneve-ut-0377
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -959,7 +959,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0565
+Index: geneve-ut-0568
 
 ```python
 sequence by host.id, user.id with maxspan=3m
@@ -982,7 +982,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0568
+Index: geneve-ut-0571
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1048,7 +1048,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0590
+Index: geneve-ut-0593
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1074,7 +1074,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0720
+Index: geneve-ut-0725
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1102,7 +1102,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0898
+Index: geneve-ut-0900
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1152,7 +1152,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1025
+Index: geneve-ut-1027
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1182,7 +1182,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1146
+Index: geneve-ut-1149
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1205,7 +1205,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1164
+Index: geneve-ut-1167
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1240,7 +1240,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1224
+Index: geneve-ut-1230
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1259,7 +1259,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1239
+Index: geneve-ut-1246
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1295,7 +1295,7 @@ process.command_line like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1321
+Index: geneve-ut-1328
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1355,7 +1355,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1620
+Index: geneve-ut-1630
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1400,7 +1400,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1635
+Index: geneve-ut-1646
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1432,7 +1432,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1656
+Index: geneve-ut-1667
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1492,7 +1492,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1661
+Index: geneve-ut-1672
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -1517,7 +1517,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1670
+Index: geneve-ut-1681
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -1546,7 +1546,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1761
+Index: geneve-ut-1775
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -1620,7 +1620,7 @@ not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0235
+Index: geneve-ut-0243
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1634,7 +1634,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0899
+Index: geneve-ut-0901
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -1646,7 +1646,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0905
+Index: geneve-ut-0907
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -1658,7 +1658,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1272
+Index: geneve-ut-1279
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -1676,7 +1676,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1458
+Index: geneve-ut-1466
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -1693,7 +1693,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0367  
+Index: geneve-ut-0377  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -1807,7 +1807,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 8448  
 Document count: 16896  
-Index: geneve-ut-0565  
+Index: geneve-ut-0568  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -1832,7 +1832,7 @@ sequence by host.id, user.id with maxspan=3m
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0568  
+Index: geneve-ut-0571  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -1900,7 +1900,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0590  
+Index: geneve-ut-0593  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -1928,7 +1928,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0720  
+Index: geneve-ut-0725  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -1958,7 +1958,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0877  
+Index: geneve-ut-0880  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -1967,8 +1967,8 @@ event.dataset:"kubernetes.audit_logs" and event.action:list and
 kubernetes.audit.objectRef.resource:secrets and 
 kubernetes.audit.requestURI :(/api/v1/secrets or /api/v1/secrets?limit* or /api/v1/namespaces/kube-system/secrets or /api/v1/namespaces/kube-system/secrets?limit* or /api/v1/namespaces/default/secrets or /api/v1/namespaces/default/secrets?limit*) and 
 source.ip:(* and not ("::1" or "127.0.0.1")) and 
-not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator) and 
-not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
+not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator or "system:serviceaccount:argocd:argocd-application-controller" or "system:serviceaccount:elastic:kube-state-metrics" or "system:serviceaccount:cert-manager:cert-manager-cainjector" or "system:serviceaccount:elastic-system:elastic-agent" or "system:serviceaccount:longhorn-system:longhorn-service-account") and 
+not kubernetes.audit.user.groups:("system:serviceaccounts:ibm-csi" or "system:serviceaccounts:argocd" or "system:serviceaccounts:elastic")
 ```
 
 
@@ -1977,7 +1977,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0898  
+Index: geneve-ut-0900  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2029,7 +2029,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1006  
+Index: geneve-ut-1008  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2049,7 +2049,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1025  
+Index: geneve-ut-1027  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2081,7 +2081,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1146  
+Index: geneve-ut-1149  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2106,7 +2106,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1164  
+Index: geneve-ut-1167  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2143,7 +2143,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1224  
+Index: geneve-ut-1230  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2164,7 +2164,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 1085  
 Document count: 1085  
-Index: geneve-ut-1239  
+Index: geneve-ut-1246  
 Failure message(s):  
   got 1000 signals, expected 1085  
 
@@ -2202,7 +2202,7 @@ process.command_line like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1313  
+Index: geneve-ut-1320  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2219,7 +2219,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1321  
+Index: geneve-ut-1328  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2281,7 +2281,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1427  
+Index: geneve-ut-1434  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2306,7 +2306,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1620  
+Index: geneve-ut-1630  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -2353,7 +2353,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1635  
+Index: geneve-ut-1646  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -2387,7 +2387,7 @@ process.name == "busybox" and (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1656  
+Index: geneve-ut-1667  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -2449,7 +2449,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1661  
+Index: geneve-ut-1672  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -2476,7 +2476,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1670  
+Index: geneve-ut-1681  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -2507,7 +2507,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1761  
+Index: geneve-ut-1775  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -2577,7 +2577,7 @@ not (
 
 
 
-## Rules with the correct signals (771)
+## Rules with the correct signals (776)
 
 ### A scheduled task was created
 
@@ -2666,11 +2666,33 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 
 
+### AWS Bedrock AgentCore Resource Created with IAM Execution Role
+
+Branch count: 8  
+Document count: 8  
+Index: geneve-ut-0015
+
+```python
+event.dataset: "aws.cloudtrail" and
+  event.provider: "bedrock-agentcore.amazonaws.com" and
+  event.action: (
+    "CreateCodeInterpreter" or
+    "CreateAgentRuntime" or
+    "CreateBrowser" or
+    "CreateHarness"
+  ) and
+  event.outcome: "success" and
+  aws.cloudtrail.request_parameters: (*executionRoleArn* or *roleArn*) and
+  not aws.cloudtrail.user_identity.invoked_by: ("bedrock-agentcore.amazonaws.com" or "cloudformation.amazonaws.com")
+```
+
+
+
 ### AWS Credentials Searched For Inside A Container
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0051
+Index: geneve-ut-0052
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -2688,7 +2710,7 @@ process.command_line like~ (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0068
+Index: geneve-ut-0070
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2701,11 +2723,32 @@ event.dataset: "aws.cloudtrail"
 
 
 
+### AWS GetFederationToken Followed by Console Login via Federation Exchange
+
+Branch count: 1  
+Document count: 3  
+Index: geneve-ut-0092
+
+```python
+sequence by source.ip with maxspan=2m
+  [any where event.provider == "sts.amazonaws.com"
+   and event.action == "GetFederationToken"
+   and event.outcome == "success"]
+  [any where event.provider == "signin.amazonaws.com"
+   and event.action == "GetSigninToken"
+   and event.outcome == "success"]
+  [any where event.provider == "signin.amazonaws.com"
+   and event.action == "ConsoleLogin"
+   and event.outcome == "success"]
+```
+
+
+
 ### AWS IAM Customer Managed Policy Version Created or Default Version Set
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0101
+Index: geneve-ut-0107
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2716,6 +2759,7 @@ event.dataset: "aws.cloudtrail"
     and not aws.cloudtrail.user_identity.arn:arn*/terraform 
     and not source.as.organization.name:(Amazon* or AMAZON* or "Google LLC" or "MongoDB, Inc.")
     and not source.address: ( "cloudformation.amazonaws.com" or "servicecatalog.amazonaws.com")
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -2724,11 +2768,12 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0108
+Index: geneve-ut-0114
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
     and event.action: "CreateLoginProfile" and event.outcome: success
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -2737,7 +2782,7 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0119
+Index: geneve-ut-0125
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2769,7 +2814,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0128
+Index: geneve-ut-0134
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2777,6 +2822,7 @@ event.dataset: "aws.cloudtrail"
     and event.action: "PutKeyPolicy"
     and event.outcome: "success"
     and not aws.cloudtrail.user_identity.type: "AWSService"
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -2785,13 +2831,14 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0130
+Index: geneve-ut-0136
 
 ```python
 event.dataset: "aws.cloudtrail"
     and event.provider: "lambda.amazonaws.com"
     and event.outcome: "success"
     and event.action: (CreateFunction* or UpdateFunctionCode*)
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -2800,11 +2847,12 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0150
+Index: geneve-ut-0156
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
-    and event.action: ("CreateDBSnapshot" or "CreateDBClusterSnapshot") and event.outcome: "success"
+    and event.action: ("CreateDBSnapshot" or "CreateDBClusterSnapshot") and event.outcome: "success" 
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -2813,7 +2861,7 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0185
+Index: geneve-ut-0193
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -2829,7 +2877,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0186
+Index: geneve-ut-0194
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -2844,7 +2892,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0197
+Index: geneve-ut-0205
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -2859,7 +2907,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0206
+Index: geneve-ut-0214
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2883,7 +2931,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0207
+Index: geneve-ut-0215
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -2918,7 +2966,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0208
+Index: geneve-ut-0216
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -2935,7 +2983,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0209
+Index: geneve-ut-0217
 
 ```python
 any where host.os.type == "windows" and
@@ -2960,7 +3008,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0211
+Index: geneve-ut-0219
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -2988,7 +3036,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0213
+Index: geneve-ut-0221
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3001,7 +3049,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0215
+Index: geneve-ut-0223
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -3017,7 +3065,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0216
+Index: geneve-ut-0224
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3037,7 +3085,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0217
+Index: geneve-ut-0225
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3058,7 +3106,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0218
+Index: geneve-ut-0226
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3070,7 +3118,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0221
+Index: geneve-ut-0229
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3082,7 +3130,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0233
+Index: geneve-ut-0241
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3099,7 +3147,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0234
+Index: geneve-ut-0242
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3111,7 +3159,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0236
+Index: geneve-ut-0244
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3131,7 +3179,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0237
+Index: geneve-ut-0245
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3145,7 +3193,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0241
+Index: geneve-ut-0249
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3176,7 +3224,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0242
+Index: geneve-ut-0250
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3188,7 +3236,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0243
+Index: geneve-ut-0251
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3202,7 +3250,7 @@ process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clea
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0244
+Index: geneve-ut-0252
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3217,7 +3265,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0254
+Index: geneve-ut-0262
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -3236,7 +3284,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0255
+Index: geneve-ut-0263
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3250,7 +3298,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0256
+Index: geneve-ut-0264
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -3281,7 +3329,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0257
+Index: geneve-ut-0265
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3304,7 +3352,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0258
+Index: geneve-ut-0266
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3318,7 +3366,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0259
+Index: geneve-ut-0267
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3337,7 +3385,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0260
+Index: geneve-ut-0268
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3351,7 +3399,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0261
+Index: geneve-ut-0269
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3376,7 +3424,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0266
+Index: geneve-ut-0274
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3395,7 +3443,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0269
+Index: geneve-ut-0277
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -3408,7 +3456,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0271
+Index: geneve-ut-0279
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3450,7 +3498,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0274
+Index: geneve-ut-0282
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -3465,7 +3513,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0315
+Index: geneve-ut-0323
 
 ```python
 event.dataset:azure.activitylogs and
@@ -3479,7 +3527,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0318
+Index: geneve-ut-0326
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -3497,7 +3545,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0336
+Index: geneve-ut-0344
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3515,7 +3563,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0337
+Index: geneve-ut-0345
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3533,7 +3581,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0338
+Index: geneve-ut-0346
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3548,7 +3596,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0339
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3562,7 +3610,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0340
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3577,7 +3625,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0342
+Index: geneve-ut-0350
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -3594,7 +3642,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0343
+Index: geneve-ut-0351
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -3606,7 +3654,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0344
+Index: geneve-ut-0352
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -3618,7 +3666,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0345
+Index: geneve-ut-0353
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3633,7 +3681,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0346
+Index: geneve-ut-0354
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -3649,11 +3697,34 @@ not (
 
 
 
+### Binfmt Configuration File Creation
+
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0355
+
+```python
+file where host.os.type == "linux" and event.action != "deletion" and process.executable != null and
+file.path like (
+  "/etc/binfmt.d/*.conf", "/run/binfmt.d/*.conf", "/usr/local/lib/binfmt.d/*.conf", "/usr/lib/binfmt.d/*.conf",
+  "/proc/sys/fs/binfmt_misc/register", "/proc/sys/fs/binfmt_misc/*"
+) and
+not (
+  file.path like (
+    "/usr/lib/binfmt.d/python3.*.conf", "/usr/lib/binfmt.d/qemu-*-static.conf",
+    "/proc/sys/fs/binfmt_misc/status"
+  ) or
+  process.executable == "/usr/lib/systemd/systemd-binfmt"
+)
+```
+
+
+
 ### Bitsadmin Activity
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0347
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3675,7 +3746,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0349
+Index: geneve-ut-0358
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -3721,7 +3792,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0350
+Index: geneve-ut-0359
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3755,7 +3826,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0351
+Index: geneve-ut-0360
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3778,7 +3849,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0353
+Index: geneve-ut-0362
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -3800,7 +3871,7 @@ process.executable != null and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0354
+Index: geneve-ut-0363
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -3812,11 +3883,43 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 
 
+### Claude Cowork VM Boot Image Tamper
+
+Branch count: 320  
+Document count: 320  
+Index: geneve-ut-0364
+
+```python
+file where host.os.type in ("windows", "macos") and
+  event.action in ("creation", "modification", "overwrite", "rename") and
+  event.outcome == "success" and
+  file.path : (
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/initrd",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/initrd.zst",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/vmlinuz",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/vmlinuz.zst",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/rootfs.img",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\initrd",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\initrd.zst",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\vmlinuz",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\rootfs.vhdx",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\smol-bin.vhdx"
+  ) and
+  not (
+    (process.name : "claude.exe" and
+     process.executable : "?:\\Program Files\\WindowsApps\\Claude_*\\app\\claude.exe") or
+    (process.name : ("Claude", "Claude Helper") and
+     process.executable like "/Applications/Claude.app/*")
+  )
+```
+
+
+
 ### Clearing Windows Event Logs
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0356
+Index: geneve-ut-0366
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3841,7 +3944,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0357
+Index: geneve-ut-0367
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -3871,7 +3974,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0359
+Index: geneve-ut-0369
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3885,7 +3988,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0360
+Index: geneve-ut-0370
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -3907,7 +4010,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0361
+Index: geneve-ut-0371
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -3921,7 +4024,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0362
+Index: geneve-ut-0372
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -3941,7 +4044,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0365
+Index: geneve-ut-0375
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3958,7 +4061,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0368
+Index: geneve-ut-0378
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -3988,7 +4091,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0371
+Index: geneve-ut-0381
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4013,7 +4116,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0373
+Index: geneve-ut-0383
 
 ```python
 sequence by process.entity_id
@@ -4034,7 +4137,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0374
+Index: geneve-ut-0384
 
 ```python
 sequence by process.entity_id
@@ -4055,7 +4158,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0376
+Index: geneve-ut-0386
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4086,7 +4189,7 @@ not process.parent.executable in (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0377
+Index: geneve-ut-0387
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4109,7 +4212,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0380
+Index: geneve-ut-0390
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4122,7 +4225,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0381
+Index: geneve-ut-0391
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4135,7 +4238,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0383
+Index: geneve-ut-0393
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4152,7 +4255,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0384
+Index: geneve-ut-0394
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -4165,7 +4268,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0385
+Index: geneve-ut-0395
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -4182,7 +4285,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0386
+Index: geneve-ut-0396
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -4194,7 +4297,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0387
+Index: geneve-ut-0397
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -4262,7 +4365,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0388
+Index: geneve-ut-0398
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -4280,7 +4383,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0389
+Index: geneve-ut-0399
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -4293,7 +4396,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0390
+Index: geneve-ut-0400
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4311,7 +4414,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0391
+Index: geneve-ut-0401
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4323,7 +4426,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0392
+Index: geneve-ut-0402
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -4335,7 +4438,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0393
+Index: geneve-ut-0403
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4347,7 +4450,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0394
+Index: geneve-ut-0404
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -4359,7 +4462,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0395
+Index: geneve-ut-0405
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -4404,7 +4507,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0397
+Index: geneve-ut-0407
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4424,7 +4527,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0398
+Index: geneve-ut-0408
 
 ```python
 sequence with maxspan=10s
@@ -4444,7 +4547,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0399
+Index: geneve-ut-0409
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -4471,7 +4574,7 @@ process.name == "curl" and (
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0402
+Index: geneve-ut-0412
 
 ```python
 process where event.type == "start" and
@@ -4496,7 +4599,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0405
+Index: geneve-ut-0415
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4540,7 +4643,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0406
+Index: geneve-ut-0416
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -4574,7 +4677,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0407
+Index: geneve-ut-0417
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -4590,7 +4693,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0408
+Index: geneve-ut-0418
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -4615,7 +4718,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0410
+Index: geneve-ut-0420
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4633,7 +4736,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0412
+Index: geneve-ut-0422
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -4646,7 +4749,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0417
+Index: geneve-ut-0427
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4656,46 +4759,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Deprecated - Adobe Hijack Persistence
-
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-0418
-
-```python
-file where host.os.type == "windows" and event.type == "creation" and
-  file.path : (
-    "?:\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-    "?:\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-
-    /* Crowdstrike specific condition as it uses NT Object paths */
-    "\\Device\\HarddiskVolume*\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-    "\\Device\\HarddiskVolume*\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe"
-  ) and
-  not process.name : ("msiexec.exe", "AdobeARM.exe")
-```
-
-
-
-### Deprecated - Encoded Executable Stored in the Registry
-
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-0419
-
-```python
-registry where host.os.type == "windows" and
-/* update here with encoding combinations */
- registry.data.strings : "TVqQAAMAAAAEAAAA*"
-```
-
-
-
 ### Deprecated - Microsoft Exchange Transport Agent Install Script
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0428
+Index: geneve-ut-0434
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -4719,7 +4787,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0438
+Index: geneve-ut-0441
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4735,7 +4803,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0439
+Index: geneve-ut-0442
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4763,7 +4831,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0440
+Index: geneve-ut-0443
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4780,7 +4848,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0441
+Index: geneve-ut-0444
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4797,7 +4865,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0442
+Index: geneve-ut-0445
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4818,7 +4886,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0444
+Index: geneve-ut-0447
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4838,7 +4906,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0445
+Index: geneve-ut-0448
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -4853,7 +4921,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0447
+Index: geneve-ut-0450
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -4866,7 +4934,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0448
+Index: geneve-ut-0451
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4886,7 +4954,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0451
+Index: geneve-ut-0454
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -4899,7 +4967,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0452
+Index: geneve-ut-0455
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -4937,7 +5005,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0453
+Index: geneve-ut-0456
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -4957,7 +5025,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0454
+Index: geneve-ut-0457
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -4970,7 +5038,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0455
+Index: geneve-ut-0458
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -4993,7 +5061,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0457
+Index: geneve-ut-0460
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5024,7 +5092,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0458
+Index: geneve-ut-0461
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -5043,7 +5111,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0459
+Index: geneve-ut-0462
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -5086,7 +5154,7 @@ not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0461
+Index: geneve-ut-0464
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5101,7 +5169,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0462
+Index: geneve-ut-0465
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5117,7 +5185,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0463
+Index: geneve-ut-0466
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5131,7 +5199,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0464
+Index: geneve-ut-0467
 
 ```python
 sequence by host.id with maxspan=3s
@@ -5153,49 +5221,11 @@ sequence by host.id with maxspan=3s
 
 
 
-### Elastic Agent Service Terminated
-
-Branch count: 419  
-Document count: 419  
-Index: geneve-ut-0465
-
-```python
-process where event.type == "start" and
-(
-  /* net, sc or wmic stopping or deleting Elastic Agent on Windows */
-  (
-    process.name : ("net.exe", "sc.exe", "wmic.exe","powershell.exe","taskkill.exe","PsKill.exe","ProcessHacker.exe") and
-    process.args : ("stopservice","uninstall", "stop", "disabled","Stop-Process","terminate","suspend") and
-    process.args : ("elasticendpoint", "Elastic Agent","elastic-agent","elastic-endpoint")
-  ) or
-
-  /* service or systemctl used to stop Elastic Agent on Linux */
-  (
-    process.name in ("systemctl", "service", "chkconfig", "update-rc.d") and
-    process.args : ("elastic-agent", "elastic-agent.service", "ElasticEndpoint") and
-    process.args : ("stop", "disable", "remove", "off", "kill", "mask") and
-    not (
-      process.parent.executable : "/opt/Elastic/Agent/data/elastic-agent-*/components/previous/elastic-endpoint" and
-      process.parent.args : "uninstall" and
-      process.parent.args : "--keepstate"
-    )
-  ) or
-
-  /* pkill, killall used to stop Elastic Agent or Endpoint on Linux */
-  (process.name in ("pkill", "killall", "kill") and process.args : ("elastic-agent", "elastic-endpoint")) or
-
-  /* Unload Elastic Defend extension on MacOS */
-  (process.name : "kextunload" and process.args : "com.apple.iokit.EndpointSecurity")
-)
-```
-
-
-
 ### Emond Rules Creation or Modification
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0470
+Index: geneve-ut-0473
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -5208,7 +5238,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0471
+Index: geneve-ut-0474
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5222,7 +5252,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0472
+Index: geneve-ut-0475
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5257,7 +5287,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0473
+Index: geneve-ut-0476
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -5269,7 +5299,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0520
+Index: geneve-ut-0523
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -5281,7 +5311,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0546
+Index: geneve-ut-0549
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5295,7 +5325,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0549
+Index: geneve-ut-0552
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5322,7 +5352,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0552
+Index: geneve-ut-0555
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5343,7 +5373,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0555
+Index: geneve-ut-0558
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -5376,7 +5406,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0557
+Index: geneve-ut-0560
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -5393,7 +5423,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0558
+Index: geneve-ut-0561
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -5421,7 +5451,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0559
+Index: geneve-ut-0562
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -5434,7 +5464,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0561
+Index: geneve-ut-0564
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -5454,7 +5484,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0562
+Index: geneve-ut-0565
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5480,7 +5510,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0563
+Index: geneve-ut-0566
 
 ```python
 sequence with maxspan=2h
@@ -5502,7 +5532,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0564
+Index: geneve-ut-0567
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -5531,7 +5561,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0567
+Index: geneve-ut-0570
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -5544,7 +5574,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0571
+Index: geneve-ut-0574
 
 ```python
 sequence by user.id with maxspan=5s
@@ -5559,7 +5589,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0572
+Index: geneve-ut-0575
 
 ```python
 process where event.type == "start" and
@@ -5581,7 +5611,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0573
+Index: geneve-ut-0576
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -5593,7 +5623,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0574
+Index: geneve-ut-0577
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5615,7 +5645,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0576
+Index: geneve-ut-0579
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -5632,7 +5662,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0577
+Index: geneve-ut-0580
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -5646,7 +5676,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0578
+Index: geneve-ut-0581
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -5659,7 +5689,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0579
+Index: geneve-ut-0582
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5671,7 +5701,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0580
+Index: geneve-ut-0583
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -5683,7 +5713,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0581
+Index: geneve-ut-0584
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5697,7 +5727,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0582
+Index: geneve-ut-0585
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -5709,7 +5739,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0583
+Index: geneve-ut-0586
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -5731,7 +5761,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0586
+Index: geneve-ut-0589
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -5780,7 +5810,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0587
+Index: geneve-ut-0590
 
 ```python
 sequence by host.id with maxspan=10s
@@ -5800,7 +5830,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0593
+Index: geneve-ut-0597
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -5815,7 +5845,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0594
+Index: geneve-ut-0598
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5829,7 +5859,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0596
+Index: geneve-ut-0600
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5851,7 +5881,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0597
+Index: geneve-ut-0601
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -5872,7 +5902,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0598
+Index: geneve-ut-0602
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5898,7 +5928,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0599
+Index: geneve-ut-0603
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -5926,7 +5956,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0602
+Index: geneve-ut-0606
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -5940,7 +5970,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0640
+Index: geneve-ut-0645
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -5957,7 +5987,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0641
+Index: geneve-ut-0646
 
 ```python
 registry where host.os.type == "windows" and
@@ -5975,7 +6005,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0710
+Index: geneve-ut-0715
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -6014,7 +6044,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0711
+Index: geneve-ut-0716
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6041,7 +6071,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0712
+Index: geneve-ut-0717
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -6056,7 +6086,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0713
+Index: geneve-ut-0718
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -6143,7 +6173,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0721
+Index: geneve-ut-0726
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6161,7 +6191,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0722
+Index: geneve-ut-0727
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -6192,7 +6222,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0723
+Index: geneve-ut-0728
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6219,7 +6249,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0724
+Index: geneve-ut-0729
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -6239,7 +6269,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0728
+Index: geneve-ut-0733
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -6252,7 +6282,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0731
+Index: geneve-ut-0736
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -6264,7 +6294,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0734
+Index: geneve-ut-0739
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -6276,7 +6306,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0738
+Index: geneve-ut-0743
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -6288,7 +6318,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0740
+Index: geneve-ut-0745
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -6305,7 +6335,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0764
+Index: geneve-ut-0769
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6318,7 +6348,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0766
+Index: geneve-ut-0771
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -6342,7 +6372,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0767
+Index: geneve-ut-0772
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -6354,7 +6384,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0780
+Index: geneve-ut-0785
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6372,7 +6402,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0781
+Index: geneve-ut-0786
 
 ```python
 any where process.executable != null and
@@ -6421,7 +6451,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0782
+Index: geneve-ut-0787
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6435,7 +6465,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0786
+Index: geneve-ut-0791
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6450,7 +6480,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0791
+Index: geneve-ut-0795
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6467,7 +6497,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0793
+Index: geneve-ut-0797
 
 ```python
 sequence with maxspan=1m
@@ -6486,7 +6516,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0794
+Index: geneve-ut-0798
 
 ```python
 sequence by host.id with maxspan=1m
@@ -6504,7 +6534,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0795
+Index: geneve-ut-0799
 
 ```python
 sequence by host.id with maxspan=5s
@@ -6523,7 +6553,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0796
+Index: geneve-ut-0800
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -6539,7 +6569,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0797
+Index: geneve-ut-0801
 
 ```python
 sequence by host.id with maxspan=30s
@@ -6555,7 +6585,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0798
+Index: geneve-ut-0802
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6568,7 +6598,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0802
+Index: geneve-ut-0806
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6585,7 +6615,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0804
+Index: geneve-ut-0808
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6598,7 +6628,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0805
+Index: geneve-ut-0809
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -6614,7 +6644,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0806
+Index: geneve-ut-0810
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6632,7 +6662,9 @@ registry where host.os.type == "windows" and event.type == "change" and
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\SAP\\SAPsetup\\setup\\NwSapSetup.exe",
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\SAP\\SapSetup\\OnRebootSvc\\NWSAPSetupOnRebootInstSvc.exe",
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\Kaspersky Lab\\Kaspersky Security for Windows Server\\kavfs.exe"
-  )
+  ) and
+  /* Microsoft Cloud AppCompat SDB test registrations */
+  not registry.path : "*\\AppCompatFlags\\Custom\\*\\{22221111-1111-1111-1111-111111111111}.sdb"
 ```
 
 
@@ -6641,7 +6673,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0807
+Index: geneve-ut-0811
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -6665,7 +6697,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0811
+Index: geneve-ut-0815
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6689,7 +6721,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0813
+Index: geneve-ut-0817
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6725,7 +6757,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0814
+Index: geneve-ut-0818
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -6737,7 +6769,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0815
+Index: geneve-ut-0819
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6751,7 +6783,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0816
+Index: geneve-ut-0820
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -6764,7 +6796,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0817
+Index: geneve-ut-0821
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -6823,7 +6855,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0818
+Index: geneve-ut-0822
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6836,7 +6868,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0819
+Index: geneve-ut-0823
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -6849,7 +6881,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0820
+Index: geneve-ut-0824
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6870,7 +6902,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0821
+Index: geneve-ut-0825
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6888,7 +6920,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0822
+Index: geneve-ut-0826
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6922,7 +6954,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0823
+Index: geneve-ut-0827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6958,7 +6990,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0824
+Index: geneve-ut-0828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6980,7 +7012,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0826
+Index: geneve-ut-0830
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7007,7 +7039,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0827
+Index: geneve-ut-0831
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7033,7 +7065,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0828
+Index: geneve-ut-0832
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -7049,7 +7081,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0829
+Index: geneve-ut-0833
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -7065,7 +7097,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0831
+Index: geneve-ut-0835
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -7077,7 +7109,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0832
+Index: geneve-ut-0836
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7105,7 +7137,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0834
+Index: geneve-ut-0838
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7121,7 +7153,7 @@ not process.command_line like ("*download.elastic.co*", "*github.com/kubernetes-
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0836
+Index: geneve-ut-0840
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7144,7 +7176,7 @@ process.name == "kubectl" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0837
+Index: geneve-ut-0841
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7158,7 +7190,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0838
+Index: geneve-ut-0842
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7181,7 +7213,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0839
+Index: geneve-ut-0843
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -7214,7 +7246,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0841
+Index: geneve-ut-0845
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -7235,7 +7267,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0842
+Index: geneve-ut-0846
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -7262,7 +7294,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-0852
+Index: geneve-ut-0855
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7284,7 +7316,7 @@ process.name in ("curl", "wget") and process.args like~ (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0878
+Index: geneve-ut-0881
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -7303,7 +7335,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0881
+Index: geneve-ut-0884
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7347,7 +7379,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0883
+Index: geneve-ut-0886
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -7372,7 +7404,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0889
+Index: geneve-ut-0891
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -7410,7 +7442,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0894
+Index: geneve-ut-0896
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -7428,7 +7460,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0895
+Index: geneve-ut-0897
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7442,7 +7474,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0900
+Index: geneve-ut-0902
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -7457,7 +7489,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0901
+Index: geneve-ut-0903
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -7471,7 +7503,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0904
+Index: geneve-ut-0906
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7485,7 +7517,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0906
+Index: geneve-ut-0908
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7506,7 +7538,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-0907
+Index: geneve-ut-0909
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7536,7 +7568,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0911
+Index: geneve-ut-0913
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -7583,7 +7615,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0912
+Index: geneve-ut-0914
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7614,7 +7646,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0915
+Index: geneve-ut-0917
 
 ```python
 event.dataset:o365.audit and
@@ -7627,7 +7659,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0917
+Index: geneve-ut-0919
 
 ```python
 event.dataset:o365.audit and
@@ -7640,7 +7672,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0918
+Index: geneve-ut-0920
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -7652,7 +7684,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0954
+Index: geneve-ut-0956
 
 ```python
 event.dataset:o365.audit and
@@ -7665,7 +7697,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0955
+Index: geneve-ut-0957
 
 ```python
 event.dataset:o365.audit and
@@ -7678,7 +7710,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0956
+Index: geneve-ut-0958
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -7690,7 +7722,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0957
+Index: geneve-ut-0959
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -7702,7 +7734,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0958
+Index: geneve-ut-0960
 
 ```python
 event.dataset:o365.audit and
@@ -7715,7 +7747,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0966
+Index: geneve-ut-0968
 
 ```python
 event.dataset: "o365.audit" and
@@ -7728,7 +7760,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0969
+Index: geneve-ut-0971
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7748,7 +7780,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0970
+Index: geneve-ut-0972
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -7760,7 +7792,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0971
+Index: geneve-ut-0973
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -7772,7 +7804,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0975
+Index: geneve-ut-0977
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7784,7 +7816,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0976
+Index: geneve-ut-0978
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -7796,7 +7828,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0977
+Index: geneve-ut-0979
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7808,7 +7840,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0978
+Index: geneve-ut-0980
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -7820,7 +7852,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0979
+Index: geneve-ut-0981
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7845,7 +7877,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0980
+Index: geneve-ut-0982
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -7865,7 +7897,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-0981
+Index: geneve-ut-0983
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -7878,7 +7910,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-0982
+Index: geneve-ut-0984
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7893,7 +7925,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0983
+Index: geneve-ut-0985
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -7918,7 +7950,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0985
+Index: geneve-ut-0987
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -7930,7 +7962,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0988
+Index: geneve-ut-0990
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -7942,7 +7974,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0989
+Index: geneve-ut-0991
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -7954,7 +7986,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0990
+Index: geneve-ut-0992
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -7988,7 +8020,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0993
+Index: geneve-ut-0995
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8002,7 +8034,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0994
+Index: geneve-ut-0996
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8023,7 +8055,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0995
+Index: geneve-ut-0997
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8037,7 +8069,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0999
+Index: geneve-ut-1001
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8072,7 +8104,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1000
+Index: geneve-ut-1002
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -8097,7 +8129,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1001
+Index: geneve-ut-1003
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8114,7 +8146,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1005
+Index: geneve-ut-1007
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8128,7 +8160,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1007
+Index: geneve-ut-1009
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8159,7 +8191,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1009
+Index: geneve-ut-1011
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -8213,7 +8245,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1010
+Index: geneve-ut-1012
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -8225,7 +8257,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1011
+Index: geneve-ut-1013
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8243,7 +8275,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1012
+Index: geneve-ut-1014
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8260,7 +8292,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1014
+Index: geneve-ut-1016
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8275,7 +8307,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1016
+Index: geneve-ut-1018
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8291,7 +8323,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1017
+Index: geneve-ut-1019
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -8305,7 +8337,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1019
+Index: geneve-ut-1021
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8334,7 +8366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1020
+Index: geneve-ut-1022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8356,7 +8388,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1021
+Index: geneve-ut-1023
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8375,7 +8407,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1022
+Index: geneve-ut-1024
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -8408,7 +8440,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1023
+Index: geneve-ut-1025
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -8426,7 +8458,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1024
+Index: geneve-ut-1026
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8467,7 +8499,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1036
+Index: geneve-ut-1038
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -8493,7 +8525,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1044
+Index: geneve-ut-1046
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -8517,7 +8549,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1048
+Index: geneve-ut-1050
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8531,7 +8563,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1049
+Index: geneve-ut-1051
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8550,7 +8582,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1050
+Index: geneve-ut-1052
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -8570,7 +8602,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1051
+Index: geneve-ut-1053
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -8591,7 +8623,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1052
+Index: geneve-ut-1054
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8606,7 +8638,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1053
+Index: geneve-ut-1055
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8623,7 +8655,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1055
+Index: geneve-ut-1057
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -8647,7 +8679,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1057
+Index: geneve-ut-1059
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -8693,7 +8725,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1058
+Index: geneve-ut-1060
 
 ```python
 sequence by host.id with maxspan=1s
@@ -8735,7 +8767,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1059
+Index: geneve-ut-1061
 
 ```python
 sequence by host.id with maxspan=10s
@@ -8752,7 +8784,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1061
+Index: geneve-ut-1063
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -8767,7 +8799,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1062
+Index: geneve-ut-1064
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -8786,7 +8818,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1063
+Index: geneve-ut-1065
 
 ```python
 sequence by process.entity_id
@@ -8806,7 +8838,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1064
+Index: geneve-ut-1066
 
 ```python
 sequence by process.entity_id
@@ -8825,7 +8857,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1065
+Index: geneve-ut-1067
 
 ```python
 sequence by host.id with maxspan=1m
@@ -8854,7 +8886,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1066
+Index: geneve-ut-1068
 
 ```python
 sequence by process.entity_id
@@ -8879,7 +8911,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1067
+Index: geneve-ut-1069
 
 ```python
 sequence by process.entity_id
@@ -8901,7 +8933,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1068
+Index: geneve-ut-1070
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -8934,7 +8966,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1069
+Index: geneve-ut-1071
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8964,7 +8996,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1072
+Index: geneve-ut-1074
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -8981,7 +9013,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1073
+Index: geneve-ut-1075
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -9018,7 +9050,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1074
+Index: geneve-ut-1076
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9031,7 +9063,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1079
+Index: geneve-ut-1081
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -9043,7 +9075,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1081
+Index: geneve-ut-1083
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -9055,7 +9087,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1090
+Index: geneve-ut-1093
 
 ```python
 sequence by host.id with maxspan=10s
@@ -9069,7 +9101,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1091
+Index: geneve-ut-1094
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9083,7 +9115,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1092
+Index: geneve-ut-1095
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -9103,7 +9135,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1094
+Index: geneve-ut-1097
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -9116,7 +9148,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1095
+Index: geneve-ut-1098
 
 ```python
 event.dataset: "okta.system"
@@ -9131,7 +9163,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1097
+Index: geneve-ut-1100
 
 ```python
 sequence by user.name with maxspan=30m
@@ -9153,7 +9185,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1106
+Index: geneve-ut-1109
 
 ```python
 network where event.action == "connection_accepted" and
@@ -9180,7 +9212,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1107
+Index: geneve-ut-1110
 
 ```python
 network where event.action == "lookup_requested" and
@@ -9200,7 +9232,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1108
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9215,7 +9247,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1109
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -9242,7 +9274,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1110
+Index: geneve-ut-1113
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -9257,7 +9289,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1111
+Index: geneve-ut-1114
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -9273,7 +9305,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1112
+Index: geneve-ut-1115
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -9287,7 +9319,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1113
+Index: geneve-ut-1116
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -9306,7 +9338,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1114
+Index: geneve-ut-1117
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9326,7 +9358,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1119
+Index: geneve-ut-1122
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -9341,7 +9373,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1120
+Index: geneve-ut-1123
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9355,7 +9387,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1121
+Index: geneve-ut-1124
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9374,7 +9406,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1122
+Index: geneve-ut-1125
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9386,7 +9418,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1123
+Index: geneve-ut-1126
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -9398,7 +9430,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1124
+Index: geneve-ut-1127
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9416,7 +9448,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1125
+Index: geneve-ut-1128
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9429,7 +9461,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1126
+Index: geneve-ut-1129
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -9444,7 +9476,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1127
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -9459,7 +9491,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1129
+Index: geneve-ut-1132
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -9479,7 +9511,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1130
+Index: geneve-ut-1133
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9503,7 +9535,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1131
+Index: geneve-ut-1134
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9517,7 +9549,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1132
+Index: geneve-ut-1135
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9536,7 +9568,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1133
+Index: geneve-ut-1136
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -9564,7 +9596,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1134
+Index: geneve-ut-1137
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -9593,7 +9625,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1135
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9612,7 +9644,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1136
+Index: geneve-ut-1139
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9640,7 +9672,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1137
+Index: geneve-ut-1140
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9655,7 +9687,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1138
+Index: geneve-ut-1141
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9718,7 +9750,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1139
+Index: geneve-ut-1142
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -9739,7 +9771,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1140
+Index: geneve-ut-1143
 
 ```python
 any where host.os.type == "windows" and
@@ -9801,7 +9833,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1142
+Index: geneve-ut-1145
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -9830,7 +9862,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1143
+Index: geneve-ut-1146
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -9844,7 +9876,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1144
+Index: geneve-ut-1147
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9877,7 +9909,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1147
+Index: geneve-ut-1150
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -9924,7 +9956,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1148
+Index: geneve-ut-1151
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9951,7 +9983,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1149
+Index: geneve-ut-1152
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -9964,7 +9996,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1160
+Index: geneve-ut-1163
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9981,7 +10013,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1162
+Index: geneve-ut-1165
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -9989,6 +10021,8 @@ process where host.os.type == "windows" and event.type == "start" and process.na
   not (process.args : "-m" and process.args : "-bg") and
   not process.args : (
     "-mm",
+    "?:\\Windows\\appcompat\\cloudsdb\\apppatch.sdb",
+    "\"?:\\Windows\\appcompat\\cloudsdb\\apppatch.sdb\"",
     "?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\sysMergeInboxStoreApp.sdb",
     "\"?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\sysMergeInboxStoreApp.sdb\"",
     "?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\msiMergeInboxStoreApp.sdb",
@@ -10006,7 +10040,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1167
+Index: geneve-ut-1170
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10022,7 +10056,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1168
+Index: geneve-ut-1171
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10043,7 +10077,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1170
+Index: geneve-ut-1173
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -10060,7 +10094,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1171
+Index: geneve-ut-1174
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10084,7 +10118,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1173
+Index: geneve-ut-1176
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -10113,7 +10147,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1175
+Index: geneve-ut-1178
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -10137,7 +10171,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1178
+Index: geneve-ut-1181
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -10155,7 +10189,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1179
+Index: geneve-ut-1182
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -10178,7 +10212,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1180
+Index: geneve-ut-1183
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -10235,7 +10269,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1181
+Index: geneve-ut-1184
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10252,7 +10286,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1182
+Index: geneve-ut-1185
 
 ```python
 sequence by process.entity_id
@@ -10266,7 +10300,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1196
+Index: geneve-ut-1201
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10281,7 +10315,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1197
+Index: geneve-ut-1202
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10312,7 +10346,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1198
+Index: geneve-ut-1203
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10326,7 +10360,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1199
+Index: geneve-ut-1204
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10339,7 +10373,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1200
+Index: geneve-ut-1205
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -10351,7 +10385,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1201
+Index: geneve-ut-1206
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10364,7 +10398,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1203
+Index: geneve-ut-1208
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -10383,7 +10417,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1204
+Index: geneve-ut-1209
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10404,7 +10438,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1205
+Index: geneve-ut-1210
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10418,7 +10452,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1208
+Index: geneve-ut-1213
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10438,7 +10472,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1209
+Index: geneve-ut-1214
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -10462,7 +10496,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1210
+Index: geneve-ut-1215
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -10478,7 +10512,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1211
+Index: geneve-ut-1216
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -10495,7 +10529,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1212
+Index: geneve-ut-1218
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10516,7 +10550,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1214
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -10529,7 +10563,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1216
+Index: geneve-ut-1222
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10557,7 +10591,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1219
+Index: geneve-ut-1225
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10573,7 +10607,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1220
+Index: geneve-ut-1226
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10596,7 +10630,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1221
+Index: geneve-ut-1227
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10609,7 +10643,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1223
+Index: geneve-ut-1229
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10622,7 +10656,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1228
+Index: geneve-ut-1234
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10636,7 +10670,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1229
+Index: geneve-ut-1235
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10647,11 +10681,37 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 
 
+### Potential IIS Web Shell File Creation
+
+Branch count: 165  
+Document count: 165  
+Index: geneve-ut-1237
+
+```python
+file where host.os.type == "windows" and event.type != "deletion" and file.extension : ("aspx", "ashx", "asmx") and
+ process.name : ("w3wp.exe", "MSExchangeMailboxReplication.exe", "EdgeTransport.exe", "Microsoft.Exchange.*.exe", "UMWorkerProcess.exe", "umservice.exe", "cmd.exe", "powershell.exe", "pwsh.exe", "certutil.exe", "xcopy.exe") and 
+  (
+   (file.path : ("?:\\Program Files\\Common Files\\microsoft shared\\Web Server Extensions\\*\\TEMPLATE\\LAYOUTS\\*",
+                 "?:\\inetpub\\wwwroot\\aspnet_client\\system_web\\*", 
+                 "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\owa\\auth\\*", 
+                 "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\ecp\\auth\\*") and 
+    /* not sub-dirs */
+    not file.path : ("?:\\inetpub\\wwwroot\\aspnet_client\\system_web\\*\\*", 
+                     "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\*\\auth\\*\\*", 
+                     "?:\\Program Files\\Common Files\\microsoft shared\\Web Server Extensions\\*\\TEMPLATE\\LAYOUTS\\*\\*")) or 
+
+    /* not sub-dirs */
+   (file.path : "?:\\inetpub\\wwwroot\\aspnet_client\\*" and not file.path : "?:\\inetpub\\wwwroot\\aspnet_client\\*\\*")
+  )
+```
+
+
+
 ### Potential Impersonation Attempt via Kubectl
 
 Branch count: 375  
 Document count: 375  
-Index: geneve-ut-1231
+Index: geneve-ut-1238
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10668,38 +10728,28 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 
 
-### Potential JAVA/JNDI Exploitation Attempt
+### Potential Java Service Exploitation via Suspicious Child Process
 
-Branch count: 60  
-Document count: 120  
-Index: geneve-ut-1234
+Branch count: 30  
+Document count: 60  
+Index: geneve-ut-1241
 
 ```python
-sequence by host.id with maxspan=1m
- [network where event.action == "connection_attempted" and
+sequence by host.id with maxspan=5s
+ [network where event.action == "connection_accepted" and network.direction == "ingress" and
+
   process.name : "java" and
-  /*
-     outbound connection attempt to
-     LDAP, RMI or DNS standard ports
-     by JAVA process
-   */
-  destination.port in (1389, 389, 1099, 53, 5353)] by process.pid
+  destination.port < 49152  and source.port >= 32768] by process.pid
  [process where event.type == "start" and
 
   /* Suspicious JAVA child process */
   process.parent.name : "java" and
-   process.name : ("sh",
-                   "bash",
-                   "dash",
-                   "ksh",
-                   "tcsh",
-                   "zsh",
-                   "curl",
-                   "perl*",
-                   "python*",
-                   "ruby*",
-                   "php*",
-                   "wget") and
+  process.name : (
+    "sh", "bash", "dash", "ksh", "tcsh", "zsh", "ash",  "mksh", "busybox",
+    "curl", "wget", "perl*", "python*", "ruby*", "php*", "lua*", "socat",
+    "nc", "ncat", "netcat", "netcat.openbsd", "netcat.traditional", "nc.openbsd",
+    "nc.traditional", "nohup", "setsid", "disown", "hostname", "whoami", "id"
+  ) and
     not process.command_line like~ (
       "bash -c ulimit -u",
       "bash /opt/flutter/bin/flutter*",
@@ -10715,7 +10765,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1235
+Index: geneve-ut-1242
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -10733,7 +10783,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1236
+Index: geneve-ut-1243
 
 ```python
 host.os.type:"windows" and
@@ -10749,7 +10799,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1238
+Index: geneve-ut-1245
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -10761,7 +10811,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1240
+Index: geneve-ut-1247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -10777,7 +10827,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1241
+Index: geneve-ut-1248
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10795,7 +10845,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1242
+Index: geneve-ut-1249
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -10809,7 +10859,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1244
+Index: geneve-ut-1251
 
 ```python
 sequence by host.id with maxspan=30s
@@ -10832,7 +10882,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1246
+Index: geneve-ut-1253
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -10848,7 +10898,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1247
+Index: geneve-ut-1254
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10861,7 +10911,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1248
+Index: geneve-ut-1255
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10891,7 +10941,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1253
+Index: geneve-ut-1260
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -10914,7 +10964,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1254
+Index: geneve-ut-1261
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10933,7 +10983,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1259
+Index: geneve-ut-1266
 
 ```python
 process where host.os.type == "windows" and 
@@ -11075,7 +11125,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1260
+Index: geneve-ut-1267
 
 ```python
 process where host.os.type == "windows" and
@@ -11152,7 +11202,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1263
+Index: geneve-ut-1270
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -11169,7 +11219,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1264
+Index: geneve-ut-1271
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -11203,7 +11253,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1266
+Index: geneve-ut-1273
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -11215,7 +11265,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1267
+Index: geneve-ut-1274
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11254,7 +11304,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1269
+Index: geneve-ut-1276
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -11267,7 +11317,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1274
+Index: geneve-ut-1281
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11281,7 +11331,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1281
+Index: geneve-ut-1288
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -11319,7 +11369,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1282
+Index: geneve-ut-1289
 
 ```python
 network where host.os.type == "windows" and
@@ -11345,7 +11395,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1285
+Index: geneve-ut-1292
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11360,7 +11410,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1287
+Index: geneve-ut-1294
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -11374,7 +11424,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1288
+Index: geneve-ut-1295
 
 ```python
 file where host.os.type == "windows" and
@@ -11388,7 +11438,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1289
+Index: geneve-ut-1296
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -11401,7 +11451,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1290
+Index: geneve-ut-1297
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11421,7 +11471,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1291
+Index: geneve-ut-1298
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11441,7 +11491,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1293
+Index: geneve-ut-1300
 
 ```python
 host.os.type:windows and event.category:process and
@@ -11480,7 +11530,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1294
+Index: geneve-ut-1301
 
 ```python
 event.category:process and host.os.type:windows and
@@ -11675,7 +11725,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1307
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11691,7 +11741,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1308
+Index: geneve-ut-1315
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -11705,7 +11755,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1309
+Index: geneve-ut-1316
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -11719,7 +11769,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1310
+Index: geneve-ut-1317
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -11736,7 +11786,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1311
+Index: geneve-ut-1318
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -11750,7 +11800,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1312
+Index: geneve-ut-1319
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11766,7 +11816,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1316
+Index: geneve-ut-1323
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -11778,7 +11828,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1317
+Index: geneve-ut-1324
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -11794,7 +11844,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1318
+Index: geneve-ut-1325
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11814,7 +11864,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1320
+Index: geneve-ut-1327
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -11854,7 +11904,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1322
+Index: geneve-ut-1329
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -11866,7 +11916,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1323
+Index: geneve-ut-1330
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -11887,7 +11937,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1324
+Index: geneve-ut-1331
 
 ```python
 sequence by host.id with maxspan=15s
@@ -11908,7 +11958,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1325
+Index: geneve-ut-1332
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -11929,7 +11979,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1326
+Index: geneve-ut-1333
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -11955,7 +12005,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1327
+Index: geneve-ut-1334
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -11971,7 +12021,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1328
+Index: geneve-ut-1335
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -11985,7 +12035,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1329
+Index: geneve-ut-1336
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -12008,7 +12058,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1331
+Index: geneve-ut-1338
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -12025,7 +12075,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1332
+Index: geneve-ut-1339
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -12048,7 +12098,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1333
+Index: geneve-ut-1340
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12061,7 +12111,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1334
+Index: geneve-ut-1341
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12075,7 +12125,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1335
+Index: geneve-ut-1342
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12092,7 +12142,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1336
+Index: geneve-ut-1343
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12146,7 +12196,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1337
+Index: geneve-ut-1344
 
 ```python
 any where host.os.type == "windows" and
@@ -12173,7 +12223,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1343
+Index: geneve-ut-1350
 
 ```python
 file where host.os.type == "windows" and
@@ -12188,7 +12238,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1344
+Index: geneve-ut-1351
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -12219,7 +12269,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1345
+Index: geneve-ut-1352
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12233,7 +12283,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1346
+Index: geneve-ut-1353
 
 ```python
 sequence with maxspan=1m
@@ -12275,7 +12325,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1347
+Index: geneve-ut-1354
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12300,7 +12350,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1348
+Index: geneve-ut-1355
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12354,7 +12404,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1349
+Index: geneve-ut-1356
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12374,7 +12424,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1350
+Index: geneve-ut-1357
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -12395,7 +12445,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1351
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12410,7 +12460,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1352
+Index: geneve-ut-1359
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -12430,7 +12480,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1353
+Index: geneve-ut-1360
 
 ```python
 sequence by host.id with maxspan=5s
@@ -12472,7 +12522,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1357
+Index: geneve-ut-1364
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -12487,7 +12537,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1358
+Index: geneve-ut-1365
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -12522,7 +12572,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1359
+Index: geneve-ut-1366
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -12539,7 +12589,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1361
+Index: geneve-ut-1368
 
 ```python
 sequence by host.id with maxspan=3s
@@ -12553,7 +12603,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1364
+Index: geneve-ut-1371
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -12566,7 +12616,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1365
+Index: geneve-ut-1372
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -12578,7 +12628,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1366
+Index: geneve-ut-1374
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -12593,7 +12643,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1368
+Index: geneve-ut-1376
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -12621,7 +12671,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1369
+Index: geneve-ut-1377
 
 ```python
 sequence by host.id with maxspan=1s
@@ -12646,7 +12696,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1373
+Index: geneve-ut-1381
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -12683,7 +12733,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1374
+Index: geneve-ut-1382
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12697,7 +12747,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1375
+Index: geneve-ut-1383
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -12713,7 +12763,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1376
+Index: geneve-ut-1384
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -12727,7 +12777,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1377
+Index: geneve-ut-1385
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -12757,7 +12807,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1378
+Index: geneve-ut-1386
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -12786,7 +12836,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1379
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12802,7 +12852,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1380
+Index: geneve-ut-1388
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12816,7 +12866,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1381
+Index: geneve-ut-1389
 
 ```python
 file where host.os.type == "windows" and
@@ -12835,12 +12885,26 @@ file where host.os.type == "windows" and
   not process.executable : (
     "?:\\Program Files\\*",
     "?:\\Program Files (x86)\\*",
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\*",
     "?:\\Windows\\system32\\cleanmgr.exe",
     "?:\\Windows\\system32\\msiexec.exe",
     "?:\\Windows\\syswow64\\msiexec.exe",
     "?:\\Windows\\system32\\svchost.exe",
     "?:\\Windows\\System32\\Robocopy.exe",
-    "?:\\Windows\\SysWOW64\\Robocopy.exe"
+    "?:\\Windows\\SysWOW64\\Robocopy.exe",
+    "?:\\Windows\\explorer.exe",
+    "?:\\Windows\\system32\\Dism.exe",
+    "?:\\Windows\\system32\\DFSRs.exe",
+    "?:\\Windows\\system32\\wbengine.exe",
+    "?:\\Windows\\system32\\CompatTelRunner.exe",
+    "?:\\Windows\\system32\\SearchIndexer.exe",
+    "?:\\Windows\\system32\\wuauclt.exe",
+    "?:\\Windows\\servicing\\TrustedInstaller.exe",
+    "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+    "?:\\Windows\\Microsoft.NET\\*",
+    "?:\\Windows\\SystemApps\\*",
+    "?:\\Windows\\uus\\*\\wuaucltcore.exe",
+    "?:\\$WINDOWS.~BT\\Sources\\mighost.exe"
   ) and
   not (process.executable : "?:\\Windows\\System32\\spoolsv.exe" and file.path : "?:\\Windows\\System32\\spool\\*") and
   not user.name : ("SYSTEM", "Local Service", "Network Service")
@@ -12852,7 +12916,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1384
+Index: geneve-ut-1392
 
 ```python
 process where event.type == "start" and
@@ -12866,7 +12930,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1385
+Index: geneve-ut-1393
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12880,7 +12944,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1386
+Index: geneve-ut-1394
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12900,7 +12964,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1388
+Index: geneve-ut-1396
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12917,7 +12981,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1389
+Index: geneve-ut-1397
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -12929,7 +12993,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1390
+Index: geneve-ut-1398
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -12942,29 +13006,11 @@ process.executable : (
 
 
 
-### Potential Web Shell ASPX File Creation
-
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-1391
-
-```python
-file where host.os.type == "windows" and event.type != "deletion" and
-  file.extension : "aspx" and
-  file.path : "?:\\Program Files\\Common Files\\Microsoft Shared\\Web Server Extensions\\*" and
-  not process.executable: (
-        "?:\\Windows\\System32\\msiexec.exe",
-        "?:\\Program Files\\Common Files\\Microsoft Shared\\Web Server Extensions\\16\\BIN\\psconfigui.exe"
-  )
-```
-
-
-
 ### Potential privilege escalation via CVE-2022-38028
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1398
+Index: geneve-ut-1405
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -12991,7 +13037,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1399
+Index: geneve-ut-1406
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -13005,7 +13051,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1401
+Index: geneve-ut-1408
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13022,7 +13068,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1402
+Index: geneve-ut-1409
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13045,7 +13091,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1404
+Index: geneve-ut-1411
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13062,7 +13108,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1407
+Index: geneve-ut-1414
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13075,7 +13121,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1409
+Index: geneve-ut-1416
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13099,7 +13145,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1410
+Index: geneve-ut-1417
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13127,7 +13173,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1425
+Index: geneve-ut-1432
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13148,7 +13194,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1428
+Index: geneve-ut-1435
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13188,7 +13234,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1429
+Index: geneve-ut-1436
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -13205,7 +13251,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1430
+Index: geneve-ut-1437
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13219,7 +13265,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1431
+Index: geneve-ut-1438
 
 ```python
 file where host.os.type == "windows" and
@@ -13238,7 +13284,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1432
+Index: geneve-ut-1439
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -13252,7 +13298,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1434
+Index: geneve-ut-1441
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13270,7 +13316,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1436
+Index: geneve-ut-1443
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -13288,7 +13334,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1439
+Index: geneve-ut-1446
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13302,7 +13348,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1441
+Index: geneve-ut-1448
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13317,7 +13363,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1442
+Index: geneve-ut-1449
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -13340,7 +13386,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1444
+Index: geneve-ut-1451
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13422,7 +13468,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1445
+Index: geneve-ut-1452
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -13443,7 +13489,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1446
+Index: geneve-ut-1453
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and
@@ -13458,11 +13504,29 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 
 
+### Process Execution Followed by Self-Deletion
+
+Branch count: 9  
+Document count: 18  
+Index: geneve-ut-1455
+
+```python
+sequence by process.entity_id, host.id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
+  process.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/*", "/var/run/*", "/var/www/*",
+    "/proc/*/fd/*", "?memfd:*", "memfd:*"
+  )] by process.executable
+  [file where host.os.type == "linux" and event.action == "deletion"] by file.path
+```
+
+
+
 ### Process Execution from an Unusual Directory
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1448
+Index: geneve-ut-1456
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13515,7 +13579,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1449
+Index: geneve-ut-1457
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13527,7 +13591,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1450
+Index: geneve-ut-1458
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -13539,7 +13603,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1451
+Index: geneve-ut-1459
 
 ```python
 process where host.os.type == "windows" and
@@ -13554,7 +13618,7 @@ process where host.os.type == "windows" and
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1452
+Index: geneve-ut-1460
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -13614,7 +13678,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1455
+Index: geneve-ut-1463
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -13627,7 +13691,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1456
+Index: geneve-ut-1464
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13659,7 +13723,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1457
+Index: geneve-ut-1465
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -13683,7 +13747,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1459
+Index: geneve-ut-1467
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13716,7 +13780,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1460
+Index: geneve-ut-1468
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -13733,7 +13797,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1461
+Index: geneve-ut-1469
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -13762,7 +13826,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1462
+Index: geneve-ut-1470
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13776,7 +13840,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1463
+Index: geneve-ut-1471
 
 ```python
 sequence by process.entity_id
@@ -13801,7 +13865,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1464
+Index: geneve-ut-1472
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -13835,7 +13899,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1465
+Index: geneve-ut-1473
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -13863,7 +13927,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1466
+Index: geneve-ut-1474
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -13882,7 +13946,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1470
+Index: geneve-ut-1478
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13910,7 +13974,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1471
+Index: geneve-ut-1479
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -13929,7 +13993,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1475
+Index: geneve-ut-1483
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -13941,7 +14005,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1476
+Index: geneve-ut-1484
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13953,7 +14017,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1477
+Index: geneve-ut-1485
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -13965,7 +14029,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1478
+Index: geneve-ut-1486
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -13977,7 +14041,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1486
+Index: geneve-ut-1494
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -13990,7 +14054,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1487
+Index: geneve-ut-1495
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14028,7 +14092,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1489
+Index: geneve-ut-1497
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14043,7 +14107,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1490
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14062,7 +14126,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1491
+Index: geneve-ut-1499
 
 ```python
 sequence with maxspan=1m
@@ -14110,7 +14174,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1493
+Index: geneve-ut-1501
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -14133,7 +14197,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1495
+Index: geneve-ut-1503
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14147,7 +14211,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1496
+Index: geneve-ut-1504
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14161,7 +14225,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1498
+Index: geneve-ut-1506
 
 ```python
 sequence by host.id, process.entity_id
@@ -14178,7 +14242,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1499
+Index: geneve-ut-1507
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14192,7 +14256,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1500
+Index: geneve-ut-1508
 
 ```python
 sequence by host.id with maxspan=1m
@@ -14212,7 +14276,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1501
+Index: geneve-ut-1509
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -14241,7 +14305,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1502
+Index: geneve-ut-1510
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -14261,7 +14325,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1503
+Index: geneve-ut-1511
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -14274,7 +14338,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1505
+Index: geneve-ut-1513
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -14316,7 +14380,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1506
+Index: geneve-ut-1514
 
 ```python
 sequence with maxspan=1m
@@ -14339,7 +14403,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1507
+Index: geneve-ut-1515
 
 ```python
 sequence with maxspan=1s
@@ -14387,7 +14451,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1508
+Index: geneve-ut-1516
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14404,7 +14468,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1510
+Index: geneve-ut-1518
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -14433,7 +14497,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1512
+Index: geneve-ut-1520
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14461,7 +14525,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1513
+Index: geneve-ut-1521
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -14478,7 +14542,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1515
+Index: geneve-ut-1523
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -14497,7 +14561,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1516
+Index: geneve-ut-1524
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -14518,7 +14582,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1522
+Index: geneve-ut-1532
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -14537,7 +14601,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1523
+Index: geneve-ut-1533
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -14551,7 +14615,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1524
+Index: geneve-ut-1534
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -14571,7 +14635,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1526
+Index: geneve-ut-1536
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14589,7 +14653,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1527
+Index: geneve-ut-1537
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -14610,7 +14674,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1529
+Index: geneve-ut-1539
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14624,7 +14688,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1530
+Index: geneve-ut-1540
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14639,7 +14703,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1531
+Index: geneve-ut-1541
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14680,7 +14744,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1533
+Index: geneve-ut-1543
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -14705,7 +14769,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1534
+Index: geneve-ut-1544
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -14744,7 +14808,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1535
+Index: geneve-ut-1545
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14758,7 +14822,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1536
+Index: geneve-ut-1546
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14797,7 +14861,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1537
+Index: geneve-ut-1547
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14811,7 +14875,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1538
+Index: geneve-ut-1548
 
 ```python
 process where event.type == "start" and
@@ -14883,7 +14947,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1541
+Index: geneve-ut-1551
 
 ```python
 event.code : "4719" and host.os.type : "windows" and
@@ -14904,7 +14968,7 @@ event.code : "4719" and host.os.type : "windows" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1542
+Index: geneve-ut-1552
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -14925,7 +14989,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1544
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14942,7 +15006,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1546
+Index: geneve-ut-1556
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14960,7 +15024,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1547
+Index: geneve-ut-1557
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -14972,7 +15036,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1548
+Index: geneve-ut-1558
 
 ```python
 file where host.os.type == "windows" and
@@ -15005,7 +15069,7 @@ file where host.os.type == "windows" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1551
+Index: geneve-ut-1561
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -15022,7 +15086,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1552
+Index: geneve-ut-1562
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -15042,7 +15106,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1554
+Index: geneve-ut-1564
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15057,7 +15121,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1555
+Index: geneve-ut-1565
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15078,7 +15142,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1556
+Index: geneve-ut-1566
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15101,7 +15165,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1557
+Index: geneve-ut-1567
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -15114,7 +15178,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1558
+Index: geneve-ut-1568
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15131,7 +15195,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1560
+Index: geneve-ut-1570
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -15156,7 +15220,7 @@ not (
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1563
+Index: geneve-ut-1573
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -15205,7 +15269,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1564
+Index: geneve-ut-1574
 
 ```python
 sequence by host.id with maxspan=10s
@@ -15219,7 +15283,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1565
+Index: geneve-ut-1575
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -15234,7 +15298,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1566
+Index: geneve-ut-1576
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -15249,7 +15313,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1567
+Index: geneve-ut-1577
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -15271,7 +15335,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1568
+Index: geneve-ut-1578
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15292,7 +15356,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1571
+Index: geneve-ut-1581
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15306,7 +15370,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1572
+Index: geneve-ut-1582
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -15329,7 +15393,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1600
+Index: geneve-ut-1610
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -15354,7 +15418,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1601
+Index: geneve-ut-1611
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -15387,7 +15451,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1602
+Index: geneve-ut-1612
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -15446,7 +15510,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1604
+Index: geneve-ut-1614
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -15464,7 +15528,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1605
+Index: geneve-ut-1615
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -15476,7 +15540,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1607
+Index: geneve-ut-1617
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -15501,7 +15565,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1613
+Index: geneve-ut-1623
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15516,7 +15580,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1614
+Index: geneve-ut-1624
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -15539,7 +15603,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1617
+Index: geneve-ut-1627
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15551,9 +15615,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### Suspicious /proc/maps Discovery
 
-Branch count: 48  
-Document count: 48  
-Index: geneve-ut-1619
+Branch count: 96  
+Document count: 96  
+Index: geneve-ut-1629
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15565,7 +15629,9 @@ not (
   ?process.parent.name == "uac" or
   ?process.parent.executable in ("/opt/secl/linux-ir-scripts-v3/thieves.sh", "/opt/traps/rpm-installer/setup.sh") or
   ?process.working_directory like ("/opt/traps/deb-installer", "/opt/Tanium/TaniumClient/*") or
-  ?process.parent.executable like ("/home/*/sunlight/thieves.sh")
+  ?process.parent.executable like ("/home/*/sunlight/thieves.sh") or
+  (?process.parent.executable == "/usr/lib/systemd/systemd" and ?process.parent.command_line == "/sbin/init") or
+  ?process.group_leader.executable in ("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/opt/traps/bin/cytool")
 )
 ```
 
@@ -15575,7 +15641,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1621
+Index: geneve-ut-1631
 
 ```python
 sequence by host.id with maxspan=5s
@@ -15602,7 +15668,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1625
+Index: geneve-ut-1635
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -15641,7 +15707,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1626
+Index: geneve-ut-1636
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -15664,7 +15730,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1627
+Index: geneve-ut-1637
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -15678,7 +15744,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1628
+Index: geneve-ut-1638
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15694,7 +15760,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1629
+Index: geneve-ut-1639
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -15710,7 +15776,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1630
+Index: geneve-ut-1640
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15724,7 +15790,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1632
+Index: geneve-ut-1642
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15743,11 +15809,76 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 
 
+### Suspicious Child Process of PaperCut Server Component
+
+Branch count: 92  
+Document count: 92  
+Index: geneve-ut-1643
+
+```python
+process where host.os.type == "windows" and event.type == "start" and
+  process.parent.name : ("pc-app.exe", "pc-printjob-spooler.exe") and
+  (
+    process.name : (
+      "cmd.exe",
+      "powershell.exe",
+      "pwsh.exe",
+      "powershell_ise.exe",
+      "wscript.exe",
+      "cscript.exe",
+      "mshta.exe",
+      "rundll32.exe",
+      "regsvr32.exe",
+      "bitsadmin.exe",
+      "certutil.exe",
+      "curl.exe",
+      "wget.exe",
+      "net.exe",
+      "net1.exe",
+      "whoami.exe",
+      "tasklist.exe",
+      "ipconfig.exe",
+      "nltest.exe",
+      "systeminfo.exe",
+      "charmap.exe",
+      "calc.exe",
+      "mspaint.exe"
+    ) or
+    ?process.pe.original_file_name : (
+      "Cmd.Exe",
+      "PowerShell.EXE",
+      "pwsh.dll",
+      "powershell_ise.EXE",
+      "wscript.exe",
+      "cscript.exe",
+      "MSHTA.EXE",
+      "RUNDLL32.EXE",
+      "REGSVR32.EXE",
+      "bitsadmin.exe",
+      "CertUtil.exe",
+      "curl.exe",
+      "wget.exe",
+      "net.exe",
+      "net1.exe",
+      "whoami.exe",
+      "tasklist.exe",
+      "ipconfig.exe",
+      "nltest.exe",
+      "systeminfo.exe",
+      "charmap.exe",
+      "CALC.EXE",
+      "mspaint.exe"
+    )
+  )
+```
+
+
+
 ### Suspicious Child Process via Azure VM CustomScript Extension
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1633
+Index: geneve-ut-1644
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15775,7 +15906,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1634
+Index: geneve-ut-1645
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15790,7 +15921,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1637
+Index: geneve-ut-1648
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15817,7 +15948,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1639
+Index: geneve-ut-1650
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -15833,7 +15964,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1640
+Index: geneve-ut-1651
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -15846,7 +15977,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1642
+Index: geneve-ut-1653
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -15862,7 +15993,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1643
+Index: geneve-ut-1654
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -15878,7 +16009,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1644
+Index: geneve-ut-1655
 
 ```python
 any where host.os.type == "windows" and 
@@ -15945,7 +16076,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1646
+Index: geneve-ut-1657
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -15961,7 +16092,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1647
+Index: geneve-ut-1658
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15997,7 +16128,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1648
+Index: geneve-ut-1659
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16035,7 +16166,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1649
+Index: geneve-ut-1660
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -16070,7 +16201,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1650
+Index: geneve-ut-1661
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16104,7 +16235,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1652
+Index: geneve-ut-1663
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -16125,7 +16256,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1657
+Index: geneve-ut-1668
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -16202,7 +16333,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1658
+Index: geneve-ut-1669
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16224,7 +16355,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1659
+Index: geneve-ut-1670
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16248,7 +16379,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1660
+Index: geneve-ut-1671
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16269,7 +16400,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1663
+Index: geneve-ut-1674
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16284,7 +16415,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1666
+Index: geneve-ut-1677
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16297,7 +16428,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1667
+Index: geneve-ut-1678
 
 ```python
 any where host.os.type == "windows" and
@@ -16312,7 +16443,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1668
+Index: geneve-ut-1679
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16328,7 +16459,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1669
+Index: geneve-ut-1680
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -16338,11 +16469,32 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 
 
+### Suspicious Java Class File Created in PaperCut Server Library
+
+Branch count: 30  
+Document count: 30  
+Index: geneve-ut-1684
+
+```python
+file where host.os.type in ("windows", "linux", "macos") and
+  event.action in ("creation", "overwrite") and
+  file.extension : "class" and
+  file.path : (
+    "?:\\Program Files\\PaperCut*\\server\\lib\\*",
+    "?:\\Program Files (x86)\\PaperCut*\\server\\lib\\*",
+    "/opt/papercut/server/lib/*",
+    "/usr/local/papercut/server/lib/*",
+    "/Applications/PaperCut*/server/lib/*"
+  )
+```
+
+
+
 ### Suspicious JavaScript Execution via Deno
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1673
+Index: geneve-ut-1685
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16356,7 +16508,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1675
+Index: geneve-ut-1687
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -16388,7 +16540,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1677
+Index: geneve-ut-1689
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -16401,7 +16553,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1678
+Index: geneve-ut-1690
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16420,7 +16572,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1679
+Index: geneve-ut-1691
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -16466,7 +16618,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1681
+Index: geneve-ut-1693
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16487,7 +16639,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1682
+Index: geneve-ut-1694
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16507,7 +16659,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1683
+Index: geneve-ut-1695
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16521,7 +16673,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1684
+Index: geneve-ut-1696
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16553,7 +16705,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1687
+Index: geneve-ut-1699
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -16574,7 +16726,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1689
+Index: geneve-ut-1701
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -16675,7 +16827,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1692
+Index: geneve-ut-1704
 
 ```python
 sequence by host.id with maxspan=5s
@@ -16723,7 +16875,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1694
+Index: geneve-ut-1706
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16749,7 +16901,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1695
+Index: geneve-ut-1707
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16794,7 +16946,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1696
+Index: geneve-ut-1708
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16818,7 +16970,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1697
+Index: geneve-ut-1709
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -16834,7 +16986,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1699
+Index: geneve-ut-1711
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -16859,7 +17011,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1700
+Index: geneve-ut-1712
 
 ```python
 event.category:process and host.os.type:windows and
@@ -16874,7 +17026,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1703
+Index: geneve-ut-1715
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -16888,7 +17040,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1704
+Index: geneve-ut-1716
 
 ```python
 sequence by host.id with maxspan=30s
@@ -16908,7 +17060,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1705
+Index: geneve-ut-1717
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -16943,7 +17095,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1709
+Index: geneve-ut-1722
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16956,7 +17108,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1711
+Index: geneve-ut-1724
 
 ```python
 any where host.os.type == "windows" and
@@ -16985,11 +17137,41 @@ any where host.os.type == "windows" and
 
 
 
+### Suspicious Reading of procfs Syscall File
+
+Branch count: 120  
+Document count: 120  
+Index: geneve-ut-1726
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+(
+  process.name in (
+    "cat", "less", "more", "head", "tail", "nano", "vi", "vim", "strings", "nvim", "vim.basic",
+    "vim.tiny", "od", "hexdump", "xxd", "hx", "hexedit", "pager", "tr"
+  ) or
+  (
+    process.name in (
+      "find", "awk", "gawk", "mawk", "nawk", "grep", "fgrep", "rgrep", "xargs", "sed", "tee"
+    ) and
+    process.args_count <= 20
+  )
+) and
+process.command_line like "*/proc/*/syscall*" and
+not (
+  process.command_line like ("*/proc/self/syscall*", "*/proc/thread-self/syscall*") or
+  process.args like "/proc/*/syscall/comm"
+)
+```
+
+
+
 ### Suspicious Remote Registry Access via SeBackupPrivilege
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1713
+Index: geneve-ut-1727
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -17007,7 +17189,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1714
+Index: geneve-ut-1728
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -17029,7 +17211,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1717
+Index: geneve-ut-1731
 
 ```python
 sequence by host.id with maxspan=30s
@@ -17068,7 +17250,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1718
+Index: geneve-ut-1732
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17098,7 +17280,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1719
+Index: geneve-ut-1733
 
 ```python
 any where host.os.type == "windows" and
@@ -17132,7 +17314,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1720
+Index: geneve-ut-1734
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -17146,7 +17328,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1723
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17177,7 +17359,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1724
+Index: geneve-ut-1738
 
 ```python
 any where host.os.type == "windows" and
@@ -17197,7 +17379,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1725
+Index: geneve-ut-1739
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17238,7 +17420,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1726
+Index: geneve-ut-1740
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -17254,7 +17436,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1727
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17284,7 +17466,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1731
+Index: geneve-ut-1745
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -17297,7 +17479,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1732
+Index: geneve-ut-1746
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -17321,7 +17503,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1735
+Index: geneve-ut-1749
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17339,7 +17521,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1737
+Index: geneve-ut-1751
 
 ```python
 any where host.os.type == "windows" and
@@ -17354,7 +17536,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1738
+Index: geneve-ut-1752
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -17372,7 +17554,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1739
+Index: geneve-ut-1753
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -17393,7 +17575,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1740
+Index: geneve-ut-1754
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17412,7 +17594,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1743
+Index: geneve-ut-1757
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17437,7 +17619,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1744
+Index: geneve-ut-1758
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17450,7 +17632,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1746
+Index: geneve-ut-1760
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -17463,7 +17645,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1748
+Index: geneve-ut-1762
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17486,7 +17668,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1750
+Index: geneve-ut-1764
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17505,7 +17687,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1751
+Index: geneve-ut-1765
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -17527,7 +17709,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1752
+Index: geneve-ut-1766
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -17560,7 +17742,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1754
+Index: geneve-ut-1768
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17578,7 +17760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1755
+Index: geneve-ut-1769
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -17592,7 +17774,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1756
+Index: geneve-ut-1770
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17616,7 +17798,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1757
+Index: geneve-ut-1771
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -17639,7 +17821,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1758
+Index: geneve-ut-1772
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -17658,7 +17840,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1762
+Index: geneve-ut-1776
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -17693,7 +17875,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1763
+Index: geneve-ut-1777
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17710,7 +17892,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1764
+Index: geneve-ut-1778
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17730,7 +17912,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1765
+Index: geneve-ut-1779
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -17770,7 +17952,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1766
+Index: geneve-ut-1780
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -17786,7 +17968,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1767
+Index: geneve-ut-1781
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17800,7 +17982,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1768
+Index: geneve-ut-1782
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17838,7 +18020,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1769
+Index: geneve-ut-1783
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17892,7 +18074,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1770
+Index: geneve-ut-1784
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -17920,7 +18102,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1772
+Index: geneve-ut-1786
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -17934,7 +18116,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1773
+Index: geneve-ut-1787
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -17980,7 +18162,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1774
+Index: geneve-ut-1788
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -18019,7 +18201,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1775
+Index: geneve-ut-1789
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -18032,7 +18214,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1778
+Index: geneve-ut-1792
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -18065,7 +18247,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1779
+Index: geneve-ut-1793
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -18079,7 +18261,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1780
+Index: geneve-ut-1794
 
 ```python
 sequence by host.id with maxspan=1s
@@ -18093,7 +18275,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1781
+Index: geneve-ut-1795
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -18107,7 +18289,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1782
+Index: geneve-ut-1796
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18146,7 +18328,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1789
+Index: geneve-ut-1803
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -18188,7 +18370,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1790
+Index: geneve-ut-1804
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -18201,7 +18383,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1791
+Index: geneve-ut-1805
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18218,7 +18400,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1792
+Index: geneve-ut-1806
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -18234,7 +18416,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1793
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18247,7 +18429,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1794
+Index: geneve-ut-1808
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -18262,7 +18444,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1795
+Index: geneve-ut-1809
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18285,7 +18467,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1796
+Index: geneve-ut-1810
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18301,7 +18483,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1797
+Index: geneve-ut-1811
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18317,7 +18499,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1802
+Index: geneve-ut-1816
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -18329,7 +18511,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1803
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18358,7 +18540,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1805
+Index: geneve-ut-1819
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -18372,7 +18554,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1810
+Index: geneve-ut-1824
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -18392,7 +18574,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1811
+Index: geneve-ut-1825
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -18417,7 +18599,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1817
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18431,7 +18613,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1818
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18454,7 +18636,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1823
+Index: geneve-ut-1837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -18488,7 +18670,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1825
+Index: geneve-ut-1839
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18507,7 +18689,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-1832
+Index: geneve-ut-1846
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -18526,7 +18708,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1846
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -18543,7 +18725,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1849
+Index: geneve-ut-1863
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -18560,7 +18742,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1865
+Index: geneve-ut-1879
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -18579,7 +18761,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1869
+Index: geneve-ut-1883
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18621,7 +18803,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1870
+Index: geneve-ut-1884
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18666,7 +18848,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1873
+Index: geneve-ut-1887
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18708,7 +18890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1875
+Index: geneve-ut-1889
 
 ```python
 host.os.type:"linux" and 
@@ -18736,7 +18918,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1878
+Index: geneve-ut-1892
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18760,7 +18942,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1879
+Index: geneve-ut-1893
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18800,7 +18982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1880
+Index: geneve-ut-1894
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -18847,7 +19029,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1884
+Index: geneve-ut-1898
 
 ```python
 sequence by process.entity_id
@@ -18884,7 +19066,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1916
+Index: geneve-ut-1930
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18898,7 +19080,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1917
+Index: geneve-ut-1931
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -18941,7 +19123,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1918
+Index: geneve-ut-1932
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -18954,7 +19136,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1920
+Index: geneve-ut-1934
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -18968,7 +19150,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1921
+Index: geneve-ut-1935
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -18981,7 +19163,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1925
+Index: geneve-ut-1939
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -19006,7 +19188,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1926
+Index: geneve-ut-1940
 
 ```python
 process where event.type == "start" and
@@ -19021,7 +19203,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1927
+Index: geneve-ut-1941
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19038,7 +19220,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1928
+Index: geneve-ut-1942
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19052,7 +19234,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1929
+Index: geneve-ut-1943
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19068,7 +19250,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1930
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19082,7 +19264,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1931
+Index: geneve-ut-1945
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -19109,7 +19291,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1933
+Index: geneve-ut-1947
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -19121,7 +19303,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1934
+Index: geneve-ut-1948
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19137,7 +19319,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1935
+Index: geneve-ut-1949
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -19160,7 +19342,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1936
+Index: geneve-ut-1950
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -19173,7 +19355,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1937
+Index: geneve-ut-1951
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -19185,7 +19367,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1938
+Index: geneve-ut-1952
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -19197,7 +19379,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1939
+Index: geneve-ut-1953
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -19209,7 +19391,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1940
+Index: geneve-ut-1954
 
 ```python
 web where (
@@ -19237,7 +19419,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-1943
+Index: geneve-ut-1957
 
 ```python
 any where (
@@ -19300,6 +19482,11 @@ url.original like~ (
     "*select @@version*", "*select user()*", "*select current_user()*", "*select database()*",
     "*sp_executesql*exec*", "*xp_dirtree*"
   )
+) and
+not user_agent.original like~ (
+    "*Nessus*", "*Qualys*", "*Acunetix*",  "*Tenable*", "*CensysInspect*", "*Detectify*",
+    "*Assetnote*", "*ExposureScan*", "*RecordedFuture*", "*AppSpider*", "*WebInspect*",
+    "*Rapid7*", "*InsightVM*", "*Probely*"
 )
 ```
 
@@ -19309,7 +19496,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1945
+Index: geneve-ut-1959
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19330,7 +19517,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1948
+Index: geneve-ut-1962
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -19344,7 +19531,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1949
+Index: geneve-ut-1963
 
 ```python
 file where event.type == "deletion" and
@@ -19361,7 +19548,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1950
+Index: geneve-ut-1964
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19379,7 +19566,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1952
+Index: geneve-ut-1966
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19417,7 +19604,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1954
+Index: geneve-ut-1968
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -19454,7 +19641,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1955
+Index: geneve-ut-1969
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19469,7 +19656,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1956
+Index: geneve-ut-1970
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -19482,7 +19669,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1957
+Index: geneve-ut-1971
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19501,7 +19688,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-1958
+Index: geneve-ut-1972
 
 ```python
 sequence by host.id with maxspan=1m
@@ -19526,7 +19713,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1959
+Index: geneve-ut-1973
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19552,7 +19739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1960
+Index: geneve-ut-1974
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -19574,7 +19761,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1961
+Index: geneve-ut-1975
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19591,7 +19778,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-1963
+Index: geneve-ut-1977
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -19610,7 +19797,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-1964
+Index: geneve-ut-1978
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -19650,7 +19837,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1965
+Index: geneve-ut-1979
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19667,7 +19854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1967
+Index: geneve-ut-1981
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -19680,7 +19867,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1968
+Index: geneve-ut-1982
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -19694,7 +19881,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1969
+Index: geneve-ut-1983
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19722,7 +19909,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1970
+Index: geneve-ut-1984
 
 ```python
 process where event.type == "start" and
@@ -19747,7 +19934,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1971
+Index: geneve-ut-1985
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19761,7 +19948,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1972
+Index: geneve-ut-1986
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19777,7 +19964,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1973
+Index: geneve-ut-1987
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19812,7 +19999,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1974
+Index: geneve-ut-1988
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19830,7 +20017,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1977
+Index: geneve-ut-1991
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.3.md
+++ b/tests/reports/alerts_from_rules-9.3.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.19
+Rules version: 9.3.20
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
    1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
-   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
+   1. [Rules with the correct signals (810)](#rules-with-the-correct-signals-810)
 
 ## Failed rules (24)
 
@@ -20,7 +20,7 @@ Rules version: 9.3.19
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0361  
+Index: geneve-ut-0371  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0372  
+Index: geneve-ut-0382  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -190,7 +190,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0591  
+Index: geneve-ut-0594  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0614  
+Index: geneve-ut-0617  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0747  
+Index: geneve-ut-0752  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0936  
+Index: geneve-ut-0938  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1064  
+Index: geneve-ut-1066  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1093  
+Index: geneve-ut-1095  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1163  
+Index: geneve-ut-1166  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1191  
+Index: geneve-ut-1194  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1209  
+Index: geneve-ut-1212  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1272  
+Index: geneve-ut-1278  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1287  
+Index: geneve-ut-1294  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1371  
+Index: geneve-ut-1378  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1600  
+Index: geneve-ut-1610  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1604  
+Index: geneve-ut-1614  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1685  
+Index: geneve-ut-1695  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1700  
+Index: geneve-ut-1711  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1713  
+Index: geneve-ut-1724  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1723  
+Index: geneve-ut-1734  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1728  
+Index: geneve-ut-1739  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1737  
+Index: geneve-ut-1748  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1832  
+Index: geneve-ut-1846  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1861  
+Index: geneve-ut-1875  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1123,7 +1123,7 @@ container.id like "*"
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0361
+Index: geneve-ut-0371
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1175,7 +1175,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0372
+Index: geneve-ut-0382
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -1287,7 +1287,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0591
+Index: geneve-ut-0594
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1353,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0614
+Index: geneve-ut-0617
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0747
+Index: geneve-ut-0752
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0936
+Index: geneve-ut-0938
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1064
+Index: geneve-ut-1066
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1093
+Index: geneve-ut-1095
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1163
+Index: geneve-ut-1166
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1191
+Index: geneve-ut-1194
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1209
+Index: geneve-ut-1212
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1272
+Index: geneve-ut-1278
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1287
+Index: geneve-ut-1294
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1371
+Index: geneve-ut-1378
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1600
+Index: geneve-ut-1610
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1604
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1685
+Index: geneve-ut-1695
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1700
+Index: geneve-ut-1711
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1713
+Index: geneve-ut-1724
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1723
+Index: geneve-ut-1734
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1728
+Index: geneve-ut-1739
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1737
+Index: geneve-ut-1748
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1832
+Index: geneve-ut-1846
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1861
+Index: geneve-ut-1875
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2154,7 +2154,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0238
+Index: geneve-ut-0246
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0937
+Index: geneve-ut-0939
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0943
+Index: geneve-ut-0945
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1322
+Index: geneve-ut-1329
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1512
+Index: geneve-ut-1520
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2227,7 +2227,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0361  
+Index: geneve-ut-0371  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2281,7 +2281,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0372  
+Index: geneve-ut-0382  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -2395,7 +2395,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0591  
+Index: geneve-ut-0594  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2463,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0614  
+Index: geneve-ut-0617  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0747  
+Index: geneve-ut-0752  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0909  
+Index: geneve-ut-0912  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2530,8 +2530,8 @@ event.dataset:"kubernetes.audit_logs" and event.action:list and
 kubernetes.audit.objectRef.resource:secrets and 
 kubernetes.audit.requestURI :(/api/v1/secrets or /api/v1/secrets?limit* or /api/v1/namespaces/kube-system/secrets or /api/v1/namespaces/kube-system/secrets?limit* or /api/v1/namespaces/default/secrets or /api/v1/namespaces/default/secrets?limit*) and 
 source.ip:(* and not ("::1" or "127.0.0.1")) and 
-not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator) and 
-not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
+not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator or "system:serviceaccount:argocd:argocd-application-controller" or "system:serviceaccount:elastic:kube-state-metrics" or "system:serviceaccount:cert-manager:cert-manager-cainjector" or "system:serviceaccount:elastic-system:elastic-agent" or "system:serviceaccount:longhorn-system:longhorn-service-account") and 
+not kubernetes.audit.user.groups:("system:serviceaccounts:ibm-csi" or "system:serviceaccounts:argocd" or "system:serviceaccounts:elastic")
 ```
 
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-0936  
+Index: geneve-ut-0938  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1043  
+Index: geneve-ut-1045  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1064  
+Index: geneve-ut-1066  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1093  
+Index: geneve-ut-1095  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1163  
+Index: geneve-ut-1166  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1191  
+Index: geneve-ut-1194  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1209  
+Index: geneve-ut-1212  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1272  
+Index: geneve-ut-1278  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1287  
+Index: geneve-ut-1294  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1363  
+Index: geneve-ut-1370  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1371  
+Index: geneve-ut-1378  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1480  
+Index: geneve-ut-1487  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1600  
+Index: geneve-ut-1610  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1604  
+Index: geneve-ut-1614  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1685  
+Index: geneve-ut-1695  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1700  
+Index: geneve-ut-1711  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1713  
+Index: geneve-ut-1724  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1723  
+Index: geneve-ut-1734  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1728  
+Index: geneve-ut-1739  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1737  
+Index: geneve-ut-1748  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1832  
+Index: geneve-ut-1846  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1861  
+Index: geneve-ut-1875  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3381,7 +3381,7 @@ container.id like "*"
 
 
 
-## Rules with the correct signals (805)
+## Rules with the correct signals (810)
 
 ### A scheduled task was created
 
@@ -3470,11 +3470,33 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 
 
+### AWS Bedrock AgentCore Resource Created with IAM Execution Role
+
+Branch count: 8  
+Document count: 8  
+Index: geneve-ut-0016
+
+```python
+event.dataset: "aws.cloudtrail" and
+  event.provider: "bedrock-agentcore.amazonaws.com" and
+  event.action: (
+    "CreateCodeInterpreter" or
+    "CreateAgentRuntime" or
+    "CreateBrowser" or
+    "CreateHarness"
+  ) and
+  event.outcome: "success" and
+  aws.cloudtrail.request_parameters: (*executionRoleArn* or *roleArn*) and
+  not aws.cloudtrail.user_identity.invoked_by: ("bedrock-agentcore.amazonaws.com" or "cloudformation.amazonaws.com")
+```
+
+
+
 ### AWS Credentials Searched For Inside A Container
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0052
+Index: geneve-ut-0053
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -3492,7 +3514,7 @@ process.command_line like~ (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0069
+Index: geneve-ut-0071
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3505,11 +3527,32 @@ event.dataset: "aws.cloudtrail"
 
 
 
+### AWS GetFederationToken Followed by Console Login via Federation Exchange
+
+Branch count: 1  
+Document count: 3  
+Index: geneve-ut-0093
+
+```python
+sequence by source.ip with maxspan=2m
+  [any where event.provider == "sts.amazonaws.com"
+   and event.action == "GetFederationToken"
+   and event.outcome == "success"]
+  [any where event.provider == "signin.amazonaws.com"
+   and event.action == "GetSigninToken"
+   and event.outcome == "success"]
+  [any where event.provider == "signin.amazonaws.com"
+   and event.action == "ConsoleLogin"
+   and event.outcome == "success"]
+```
+
+
+
 ### AWS IAM Customer Managed Policy Version Created or Default Version Set
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0102
+Index: geneve-ut-0108
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3520,6 +3563,7 @@ event.dataset: "aws.cloudtrail"
     and not aws.cloudtrail.user_identity.arn:arn*/terraform 
     and not source.as.organization.name:(Amazon* or AMAZON* or "Google LLC" or "MongoDB, Inc.")
     and not source.address: ( "cloudformation.amazonaws.com" or "servicecatalog.amazonaws.com")
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3528,11 +3572,12 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0109
+Index: geneve-ut-0115
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
     and event.action: "CreateLoginProfile" and event.outcome: success
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3541,7 +3586,7 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0121
+Index: geneve-ut-0127
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3573,7 +3618,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0130
+Index: geneve-ut-0136
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3581,6 +3626,7 @@ event.dataset: "aws.cloudtrail"
     and event.action: "PutKeyPolicy"
     and event.outcome: "success"
     and not aws.cloudtrail.user_identity.type: "AWSService"
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3589,13 +3635,14 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0132
+Index: geneve-ut-0138
 
 ```python
 event.dataset: "aws.cloudtrail"
     and event.provider: "lambda.amazonaws.com"
     and event.outcome: "success"
     and event.action: (CreateFunction* or UpdateFunctionCode*)
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3604,11 +3651,12 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0152
+Index: geneve-ut-0158
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
-    and event.action: ("CreateDBSnapshot" or "CreateDBClusterSnapshot") and event.outcome: "success"
+    and event.action: ("CreateDBSnapshot" or "CreateDBClusterSnapshot") and event.outcome: "success" 
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3617,7 +3665,7 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0188
+Index: geneve-ut-0196
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3633,7 +3681,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0189
+Index: geneve-ut-0197
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -3648,7 +3696,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0200
+Index: geneve-ut-0208
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -3663,7 +3711,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0209
+Index: geneve-ut-0217
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3687,7 +3735,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0210
+Index: geneve-ut-0218
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -3722,7 +3770,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0211
+Index: geneve-ut-0219
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -3739,7 +3787,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0212
+Index: geneve-ut-0220
 
 ```python
 any where host.os.type == "windows" and
@@ -3764,7 +3812,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0214
+Index: geneve-ut-0222
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -3792,7 +3840,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0216
+Index: geneve-ut-0224
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3805,7 +3853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0218
+Index: geneve-ut-0226
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -3821,7 +3869,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0219
+Index: geneve-ut-0227
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3841,7 +3889,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0220
+Index: geneve-ut-0228
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3862,7 +3910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0221
+Index: geneve-ut-0229
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3874,7 +3922,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0224
+Index: geneve-ut-0232
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3886,7 +3934,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0236
+Index: geneve-ut-0244
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3903,7 +3951,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0237
+Index: geneve-ut-0245
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3915,7 +3963,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0239
+Index: geneve-ut-0247
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3935,7 +3983,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0240
+Index: geneve-ut-0248
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3949,7 +3997,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0244
+Index: geneve-ut-0252
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3980,7 +4028,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0245
+Index: geneve-ut-0253
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3992,7 +4040,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0246
+Index: geneve-ut-0254
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4006,7 +4054,7 @@ process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clea
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0247
+Index: geneve-ut-0255
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4021,7 +4069,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0257
+Index: geneve-ut-0265
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -4040,7 +4088,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0258
+Index: geneve-ut-0266
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4054,7 +4102,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0259
+Index: geneve-ut-0267
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -4085,7 +4133,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0260
+Index: geneve-ut-0268
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4108,7 +4156,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0261
+Index: geneve-ut-0269
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4122,7 +4170,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0262
+Index: geneve-ut-0270
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4141,7 +4189,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0263
+Index: geneve-ut-0271
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4155,7 +4203,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0264
+Index: geneve-ut-0272
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4180,7 +4228,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0269
+Index: geneve-ut-0277
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4199,7 +4247,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0272
+Index: geneve-ut-0280
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4212,7 +4260,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0274
+Index: geneve-ut-0282
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4254,7 +4302,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0277
+Index: geneve-ut-0285
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -4269,7 +4317,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0318
+Index: geneve-ut-0326
 
 ```python
 event.dataset:azure.activitylogs and
@@ -4283,7 +4331,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0321
+Index: geneve-ut-0329
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -4301,7 +4349,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0339
+Index: geneve-ut-0347
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4319,7 +4367,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0340
+Index: geneve-ut-0348
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4337,7 +4385,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0341
+Index: geneve-ut-0349
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4352,7 +4400,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0342
+Index: geneve-ut-0350
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4366,7 +4414,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0343
+Index: geneve-ut-0351
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4381,7 +4429,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0345
+Index: geneve-ut-0353
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4398,7 +4446,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0346
+Index: geneve-ut-0354
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4410,7 +4458,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0347
+Index: geneve-ut-0355
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4422,7 +4470,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0348
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4437,7 +4485,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0349
+Index: geneve-ut-0357
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4453,11 +4501,34 @@ not (
 
 
 
+### Binfmt Configuration File Creation
+
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0358
+
+```python
+file where host.os.type == "linux" and event.action != "deletion" and process.executable != null and
+file.path like (
+  "/etc/binfmt.d/*.conf", "/run/binfmt.d/*.conf", "/usr/local/lib/binfmt.d/*.conf", "/usr/lib/binfmt.d/*.conf",
+  "/proc/sys/fs/binfmt_misc/register", "/proc/sys/fs/binfmt_misc/*"
+) and
+not (
+  file.path like (
+    "/usr/lib/binfmt.d/python3.*.conf", "/usr/lib/binfmt.d/qemu-*-static.conf",
+    "/proc/sys/fs/binfmt_misc/status"
+  ) or
+  process.executable == "/usr/lib/systemd/systemd-binfmt"
+)
+```
+
+
+
 ### Bitsadmin Activity
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0350
+Index: geneve-ut-0359
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4479,7 +4550,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0352
+Index: geneve-ut-0361
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4525,7 +4596,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0353
+Index: geneve-ut-0362
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4559,7 +4630,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0354
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4582,7 +4653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0356
+Index: geneve-ut-0365
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4604,7 +4675,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0357
+Index: geneve-ut-0366
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4632,7 +4703,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0358
+Index: geneve-ut-0367
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4644,11 +4715,43 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 
 
+### Claude Cowork VM Boot Image Tamper
+
+Branch count: 320  
+Document count: 320  
+Index: geneve-ut-0368
+
+```python
+file where host.os.type in ("windows", "macos") and
+  event.action in ("creation", "modification", "overwrite", "rename") and
+  event.outcome == "success" and
+  file.path : (
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/initrd",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/initrd.zst",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/vmlinuz",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/vmlinuz.zst",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/rootfs.img",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\initrd",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\initrd.zst",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\vmlinuz",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\rootfs.vhdx",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\smol-bin.vhdx"
+  ) and
+  not (
+    (process.name : "claude.exe" and
+     process.executable : "?:\\Program Files\\WindowsApps\\Claude_*\\app\\claude.exe") or
+    (process.name : ("Claude", "Claude Helper") and
+     process.executable like "/Applications/Claude.app/*")
+  )
+```
+
+
+
 ### Clearing Windows Event Logs
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0360
+Index: geneve-ut-0370
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4673,7 +4776,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0362
+Index: geneve-ut-0372
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4703,7 +4806,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0364
+Index: geneve-ut-0374
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4717,7 +4820,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0365
+Index: geneve-ut-0375
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4739,7 +4842,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0366
+Index: geneve-ut-0376
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4753,7 +4856,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0367
+Index: geneve-ut-0377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4773,7 +4876,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0370
+Index: geneve-ut-0380
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4790,7 +4893,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0373
+Index: geneve-ut-0383
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4820,7 +4923,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0376
+Index: geneve-ut-0386
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4845,7 +4948,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0378
+Index: geneve-ut-0388
 
 ```python
 sequence by process.entity_id
@@ -4866,7 +4969,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0379
+Index: geneve-ut-0389
 
 ```python
 sequence by process.entity_id
@@ -4887,7 +4990,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0382
+Index: geneve-ut-0392
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4918,7 +5021,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0383
+Index: geneve-ut-0393
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4930,7 +5033,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0384
+Index: geneve-ut-0394
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4953,7 +5056,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0387
+Index: geneve-ut-0397
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4966,7 +5069,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0388
+Index: geneve-ut-0398
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4979,7 +5082,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0390
+Index: geneve-ut-0400
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4996,7 +5099,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0391
+Index: geneve-ut-0401
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -5009,7 +5112,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0392
+Index: geneve-ut-0402
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -5026,7 +5129,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0393
+Index: geneve-ut-0403
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -5038,7 +5141,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0394
+Index: geneve-ut-0404
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -5106,7 +5209,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0395
+Index: geneve-ut-0405
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -5124,7 +5227,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0396
+Index: geneve-ut-0406
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -5137,7 +5240,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0397
+Index: geneve-ut-0407
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5155,7 +5258,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0398
+Index: geneve-ut-0408
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5167,7 +5270,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0399
+Index: geneve-ut-0409
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5179,7 +5282,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0400
+Index: geneve-ut-0410
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5191,7 +5294,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0401
+Index: geneve-ut-0411
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5203,7 +5306,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0402
+Index: geneve-ut-0412
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -5248,7 +5351,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0404
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5268,7 +5371,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0405
+Index: geneve-ut-0415
 
 ```python
 sequence with maxspan=10s
@@ -5288,7 +5391,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0406
+Index: geneve-ut-0416
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5315,7 +5418,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0407
+Index: geneve-ut-0417
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5329,7 +5432,7 @@ container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0410
+Index: geneve-ut-0420
 
 ```python
 process where event.type == "start" and
@@ -5354,7 +5457,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0413
+Index: geneve-ut-0423
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5398,7 +5501,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0414
+Index: geneve-ut-0424
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5432,7 +5535,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0415
+Index: geneve-ut-0425
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5477,7 +5580,7 @@ container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0416
+Index: geneve-ut-0426
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5493,7 +5596,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0417
+Index: geneve-ut-0427
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5518,7 +5621,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0418
+Index: geneve-ut-0428
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5537,7 +5640,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0420
+Index: geneve-ut-0430
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5664,7 +5767,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0421
+Index: geneve-ut-0431
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5682,7 +5785,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0423
+Index: geneve-ut-0433
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5695,7 +5798,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0424
+Index: geneve-ut-0434
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5725,7 +5828,7 @@ container.security_context.privileged == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0430
+Index: geneve-ut-0440
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5735,46 +5838,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Deprecated - Adobe Hijack Persistence
-
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-0431
-
-```python
-file where host.os.type == "windows" and event.type == "creation" and
-  file.path : (
-    "?:\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-    "?:\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-
-    /* Crowdstrike specific condition as it uses NT Object paths */
-    "\\Device\\HarddiskVolume*\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-    "\\Device\\HarddiskVolume*\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe"
-  ) and
-  not process.name : ("msiexec.exe", "AdobeARM.exe")
-```
-
-
-
-### Deprecated - Encoded Executable Stored in the Registry
-
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-0432
-
-```python
-registry where host.os.type == "windows" and
-/* update here with encoding combinations */
- registry.data.strings : "TVqQAAMAAAAEAAAA*"
-```
-
-
-
 ### Deprecated - Microsoft Exchange Transport Agent Install Script
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0441
+Index: geneve-ut-0447
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5798,7 +5866,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0452
+Index: geneve-ut-0455
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5852,7 +5920,7 @@ container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0454
+Index: geneve-ut-0457
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5868,7 +5936,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0455
+Index: geneve-ut-0458
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5896,7 +5964,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0456
+Index: geneve-ut-0459
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5913,7 +5981,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0457
+Index: geneve-ut-0460
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5930,7 +5998,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0458
+Index: geneve-ut-0461
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5951,7 +6019,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0460
+Index: geneve-ut-0463
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5971,7 +6039,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0461
+Index: geneve-ut-0464
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5986,7 +6054,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0463
+Index: geneve-ut-0466
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5999,7 +6067,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0464
+Index: geneve-ut-0467
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6019,7 +6087,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0467
+Index: geneve-ut-0470
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -6032,7 +6100,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0468
+Index: geneve-ut-0471
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6070,7 +6138,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0469
+Index: geneve-ut-0472
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -6090,7 +6158,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0470
+Index: geneve-ut-0473
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6103,7 +6171,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0471
+Index: geneve-ut-0474
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -6126,7 +6194,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0473
+Index: geneve-ut-0476
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6157,7 +6225,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0474
+Index: geneve-ut-0477
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -6176,7 +6244,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0475
+Index: geneve-ut-0478
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6219,7 +6287,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0476
+Index: geneve-ut-0479
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -6233,7 +6301,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0478
+Index: geneve-ut-0481
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6248,7 +6316,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0479
+Index: geneve-ut-0482
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6264,7 +6332,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0480
+Index: geneve-ut-0483
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6278,7 +6346,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0481
+Index: geneve-ut-0484
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6300,49 +6368,11 @@ sequence by host.id with maxspan=3s
 
 
 
-### Elastic Agent Service Terminated
-
-Branch count: 419  
-Document count: 419  
-Index: geneve-ut-0482
-
-```python
-process where event.type == "start" and
-(
-  /* net, sc or wmic stopping or deleting Elastic Agent on Windows */
-  (
-    process.name : ("net.exe", "sc.exe", "wmic.exe","powershell.exe","taskkill.exe","PsKill.exe","ProcessHacker.exe") and
-    process.args : ("stopservice","uninstall", "stop", "disabled","Stop-Process","terminate","suspend") and
-    process.args : ("elasticendpoint", "Elastic Agent","elastic-agent","elastic-endpoint")
-  ) or
-
-  /* service or systemctl used to stop Elastic Agent on Linux */
-  (
-    process.name in ("systemctl", "service", "chkconfig", "update-rc.d") and
-    process.args : ("elastic-agent", "elastic-agent.service", "ElasticEndpoint") and
-    process.args : ("stop", "disable", "remove", "off", "kill", "mask") and
-    not (
-      process.parent.executable : "/opt/Elastic/Agent/data/elastic-agent-*/components/previous/elastic-endpoint" and
-      process.parent.args : "uninstall" and
-      process.parent.args : "--keepstate"
-    )
-  ) or
-
-  /* pkill, killall used to stop Elastic Agent or Endpoint on Linux */
-  (process.name in ("pkill", "killall", "kill") and process.args : ("elastic-agent", "elastic-endpoint")) or
-
-  /* Unload Elastic Defend extension on MacOS */
-  (process.name : "kextunload" and process.args : "com.apple.iokit.EndpointSecurity")
-)
-```
-
-
-
 ### Emond Rules Creation or Modification
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0489
+Index: geneve-ut-0492
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -6355,7 +6385,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0490
+Index: geneve-ut-0493
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6369,7 +6399,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0491
+Index: geneve-ut-0494
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6391,7 +6421,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0492
+Index: geneve-ut-0495
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6426,7 +6456,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0493
+Index: geneve-ut-0496
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6438,7 +6468,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0541
+Index: geneve-ut-0544
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6450,7 +6480,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0567
+Index: geneve-ut-0570
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6464,7 +6494,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0570
+Index: geneve-ut-0573
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6491,7 +6521,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0573
+Index: geneve-ut-0576
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6512,7 +6542,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0574
+Index: geneve-ut-0577
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6542,7 +6572,7 @@ container.id like "*"
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0577
+Index: geneve-ut-0580
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6560,7 +6590,7 @@ container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0578
+Index: geneve-ut-0581
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6593,7 +6623,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0580
+Index: geneve-ut-0583
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6610,7 +6640,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0581
+Index: geneve-ut-0584
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6638,7 +6668,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0582
+Index: geneve-ut-0585
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6651,7 +6681,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0584
+Index: geneve-ut-0587
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6671,7 +6701,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0585
+Index: geneve-ut-0588
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6697,7 +6727,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0586
+Index: geneve-ut-0589
 
 ```python
 sequence with maxspan=2h
@@ -6719,7 +6749,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0587
+Index: geneve-ut-0590
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6748,7 +6778,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0590
+Index: geneve-ut-0593
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6761,7 +6791,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0594
+Index: geneve-ut-0597
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6776,7 +6806,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0595
+Index: geneve-ut-0598
 
 ```python
 process where event.type == "start" and
@@ -6798,7 +6828,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0596
+Index: geneve-ut-0599
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6810,7 +6840,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0597
+Index: geneve-ut-0600
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6832,7 +6862,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0599
+Index: geneve-ut-0602
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6849,7 +6879,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0600
+Index: geneve-ut-0603
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6863,7 +6893,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0601
+Index: geneve-ut-0604
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6876,7 +6906,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0602
+Index: geneve-ut-0605
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6888,7 +6918,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0603
+Index: geneve-ut-0606
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6900,7 +6930,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0604
+Index: geneve-ut-0607
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6914,7 +6944,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0605
+Index: geneve-ut-0608
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6926,7 +6956,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0606
+Index: geneve-ut-0609
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -6948,7 +6978,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0609
+Index: geneve-ut-0612
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6997,7 +7027,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0610
+Index: geneve-ut-0613
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -7014,7 +7044,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0611
+Index: geneve-ut-0614
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7034,7 +7064,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0616
+Index: geneve-ut-0619
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7056,7 +7086,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0619
+Index: geneve-ut-0623
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7071,7 +7101,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0620
+Index: geneve-ut-0624
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7085,7 +7115,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0622
+Index: geneve-ut-0626
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7107,7 +7137,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0623
+Index: geneve-ut-0627
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -7128,7 +7158,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0624
+Index: geneve-ut-0628
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7154,7 +7184,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0625
+Index: geneve-ut-0629
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -7182,7 +7212,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0628
+Index: geneve-ut-0632
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -7196,7 +7226,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0667
+Index: geneve-ut-0672
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -7213,7 +7243,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0668
+Index: geneve-ut-0673
 
 ```python
 registry where host.os.type == "windows" and
@@ -7231,7 +7261,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0737
+Index: geneve-ut-0742
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7300,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0738
+Index: geneve-ut-0743
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7327,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0739
+Index: geneve-ut-0744
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7342,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0740
+Index: geneve-ut-0745
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7429,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0748
+Index: geneve-ut-0753
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7447,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0749
+Index: geneve-ut-0754
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7478,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0750
+Index: geneve-ut-0755
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7505,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0751
+Index: geneve-ut-0756
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7525,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0755
+Index: geneve-ut-0760
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7538,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0758
+Index: geneve-ut-0763
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7550,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0761
+Index: geneve-ut-0766
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7562,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0765
+Index: geneve-ut-0770
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7574,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0767
+Index: geneve-ut-0772
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7591,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0791
+Index: geneve-ut-0796
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7604,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0793
+Index: geneve-ut-0798
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7628,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0794
+Index: geneve-ut-0799
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7640,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0807
+Index: geneve-ut-0812
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7658,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0808
+Index: geneve-ut-0813
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7707,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0809
+Index: geneve-ut-0814
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7721,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0813
+Index: geneve-ut-0818
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7736,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0818
+Index: geneve-ut-0822
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7753,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0820
+Index: geneve-ut-0824
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7772,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0821
+Index: geneve-ut-0825
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7790,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0822
+Index: geneve-ut-0826
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7809,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0823
+Index: geneve-ut-0827
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7825,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0824
+Index: geneve-ut-0828
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7841,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0825
+Index: geneve-ut-0829
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0830
+Index: geneve-ut-0834
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7871,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0832
+Index: geneve-ut-0836
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7884,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0833
+Index: geneve-ut-0837
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7900,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0834
+Index: geneve-ut-0838
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7888,7 +7918,9 @@ registry where host.os.type == "windows" and event.type == "change" and
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\SAP\\SAPsetup\\setup\\NwSapSetup.exe",
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\SAP\\SapSetup\\OnRebootSvc\\NWSAPSetupOnRebootInstSvc.exe",
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\Kaspersky Lab\\Kaspersky Security for Windows Server\\kavfs.exe"
-  )
+  ) and
+  /* Microsoft Cloud AppCompat SDB test registrations */
+  not registry.path : "*\\AppCompatFlags\\Custom\\*\\{22221111-1111-1111-1111-111111111111}.sdb"
 ```
 
 
@@ -7897,7 +7929,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0835
+Index: geneve-ut-0839
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7953,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0840
+Index: geneve-ut-0844
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7977,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0842
+Index: geneve-ut-0846
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +8013,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0843
+Index: geneve-ut-0847
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +8025,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0844
+Index: geneve-ut-0848
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8039,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0845
+Index: geneve-ut-0849
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8052,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0846
+Index: geneve-ut-0850
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8111,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0847
+Index: geneve-ut-0851
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8124,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0848
+Index: geneve-ut-0852
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8137,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0849
+Index: geneve-ut-0853
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8158,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0850
+Index: geneve-ut-0854
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8176,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0851
+Index: geneve-ut-0855
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8210,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0853
+Index: geneve-ut-0857
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8232,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0855
+Index: geneve-ut-0859
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8259,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0856
+Index: geneve-ut-0860
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8285,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0857
+Index: geneve-ut-0861
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8301,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0858
+Index: geneve-ut-0862
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8317,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0860
+Index: geneve-ut-0864
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8329,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0861
+Index: geneve-ut-0865
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8357,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0863
+Index: geneve-ut-0867
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8373,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0865
+Index: geneve-ut-0869
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8398,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0866
+Index: geneve-ut-0870
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8412,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0868
+Index: geneve-ut-0872
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8435,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0869
+Index: geneve-ut-0873
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8468,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0870
+Index: geneve-ut-0874
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8495,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0873
+Index: geneve-ut-0877
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8516,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0874
+Index: geneve-ut-0878
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8543,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0884
+Index: geneve-ut-0887
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8565,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0910
+Index: geneve-ut-0913
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8584,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0913
+Index: geneve-ut-0916
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8628,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0915
+Index: geneve-ut-0918
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8653,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0927
+Index: geneve-ut-0929
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8691,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0932
+Index: geneve-ut-0934
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8709,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0933
+Index: geneve-ut-0935
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8723,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0938
+Index: geneve-ut-0940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8738,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0939
+Index: geneve-ut-0941
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8752,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0942
+Index: geneve-ut-0944
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8766,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0944
+Index: geneve-ut-0946
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8787,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-0945
+Index: geneve-ut-0947
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8817,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0949
+Index: geneve-ut-0951
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8864,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0950
+Index: geneve-ut-0952
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8895,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0953
+Index: geneve-ut-0955
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8908,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0955
+Index: geneve-ut-0957
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8921,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0956
+Index: geneve-ut-0958
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8933,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0992
+Index: geneve-ut-0994
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8946,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-0993
+Index: geneve-ut-0995
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8959,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0994
+Index: geneve-ut-0996
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8971,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0995
+Index: geneve-ut-0997
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8983,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0996
+Index: geneve-ut-0998
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8996,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1004
+Index: geneve-ut-1006
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +9009,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1007
+Index: geneve-ut-1009
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +9029,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1008
+Index: geneve-ut-1010
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9041,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1009
+Index: geneve-ut-1011
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9053,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1013
+Index: geneve-ut-1015
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9065,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1014
+Index: geneve-ut-1016
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9077,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1015
+Index: geneve-ut-1017
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9089,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1016
+Index: geneve-ut-1018
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9101,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1017
+Index: geneve-ut-1019
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9126,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1018
+Index: geneve-ut-1020
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9146,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1019
+Index: geneve-ut-1021
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9159,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1020
+Index: geneve-ut-1022
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9174,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1021
+Index: geneve-ut-1023
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9199,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1023
+Index: geneve-ut-1025
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9211,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1026
+Index: geneve-ut-1028
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9223,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1027
+Index: geneve-ut-1029
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9235,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1028
+Index: geneve-ut-1030
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9269,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1031
+Index: geneve-ut-1033
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9283,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1032
+Index: geneve-ut-1034
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9304,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1033
+Index: geneve-ut-1035
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9318,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1036
+Index: geneve-ut-1038
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9353,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1037
+Index: geneve-ut-1039
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9378,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1038
+Index: geneve-ut-1040
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9395,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1042
+Index: geneve-ut-1044
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9409,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1044
+Index: geneve-ut-1046
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9440,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1046
+Index: geneve-ut-1048
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9494,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1047
+Index: geneve-ut-1049
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9506,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1048
+Index: geneve-ut-1050
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9524,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1049
+Index: geneve-ut-1051
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9541,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1051
+Index: geneve-ut-1053
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9556,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1052
+Index: geneve-ut-1054
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9606,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1054
+Index: geneve-ut-1056
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9622,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1055
+Index: geneve-ut-1057
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9636,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1057
+Index: geneve-ut-1059
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1058
+Index: geneve-ut-1060
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9693,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1059
+Index: geneve-ut-1061
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9715,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1060
+Index: geneve-ut-1062
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9734,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1061
+Index: geneve-ut-1063
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9767,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1062
+Index: geneve-ut-1064
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9785,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1063
+Index: geneve-ut-1065
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9826,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1075
+Index: geneve-ut-1077
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9852,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1084
+Index: geneve-ut-1086
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9876,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1088
+Index: geneve-ut-1090
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1089
+Index: geneve-ut-1091
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9909,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1090
+Index: geneve-ut-1092
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9929,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1091
+Index: geneve-ut-1093
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9952,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1092
+Index: geneve-ut-1094
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9973,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1094
+Index: geneve-ut-1096
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9988,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1095
+Index: geneve-ut-1097
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +10005,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1097
+Index: geneve-ut-1099
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +10029,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1099
+Index: geneve-ut-1101
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10075,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1100
+Index: geneve-ut-1102
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10117,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1101
+Index: geneve-ut-1103
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10134,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1103
+Index: geneve-ut-1105
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10149,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1104
+Index: geneve-ut-1106
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10168,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1105
+Index: geneve-ut-1107
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10188,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1106
+Index: geneve-ut-1108
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10207,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1107
+Index: geneve-ut-1109
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10236,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1108
+Index: geneve-ut-1110
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10261,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1109
+Index: geneve-ut-1111
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10283,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1110
+Index: geneve-ut-1112
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10316,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1111
+Index: geneve-ut-1113
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10346,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1114
+Index: geneve-ut-1116
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10363,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1115
+Index: geneve-ut-1117
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10400,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1116
+Index: geneve-ut-1118
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10413,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1121
+Index: geneve-ut-1123
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10425,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1124
+Index: geneve-ut-1126
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10437,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1133
+Index: geneve-ut-1136
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10451,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1134
+Index: geneve-ut-1137
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10465,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1135
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10479,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1136
+Index: geneve-ut-1139
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10499,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1138
+Index: geneve-ut-1141
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10512,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1139
+Index: geneve-ut-1142
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10527,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1141
+Index: geneve-ut-1144
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10549,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1150
+Index: geneve-ut-1153
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10576,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1151
+Index: geneve-ut-1154
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10596,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1152
+Index: geneve-ut-1155
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10611,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1153
+Index: geneve-ut-1156
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10638,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1154
+Index: geneve-ut-1157
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10653,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1155
+Index: geneve-ut-1158
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10669,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1156
+Index: geneve-ut-1159
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10683,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1157
+Index: geneve-ut-1160
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10670,7 +10702,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1158
+Index: geneve-ut-1161
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -10690,7 +10722,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1164
+Index: geneve-ut-1167
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10705,7 +10737,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1165
+Index: geneve-ut-1168
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10719,7 +10751,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1166
+Index: geneve-ut-1169
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10738,7 +10770,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1167
+Index: geneve-ut-1170
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10750,7 +10782,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1168
+Index: geneve-ut-1171
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10762,7 +10794,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1169
+Index: geneve-ut-1172
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10780,7 +10812,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1170
+Index: geneve-ut-1173
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10793,7 +10825,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1171
+Index: geneve-ut-1174
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10808,7 +10840,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1172
+Index: geneve-ut-1175
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10823,7 +10855,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1174
+Index: geneve-ut-1177
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10843,7 +10875,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1175
+Index: geneve-ut-1178
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10867,7 +10899,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1176
+Index: geneve-ut-1179
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10881,7 +10913,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1177
+Index: geneve-ut-1180
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10900,7 +10932,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1178
+Index: geneve-ut-1181
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10928,7 +10960,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1179
+Index: geneve-ut-1182
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10957,7 +10989,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1180
+Index: geneve-ut-1183
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10976,7 +11008,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1181
+Index: geneve-ut-1184
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11004,7 +11036,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1182
+Index: geneve-ut-1185
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11019,7 +11051,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1183
+Index: geneve-ut-1186
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11082,7 +11114,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1184
+Index: geneve-ut-1187
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11103,7 +11135,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1185
+Index: geneve-ut-1188
 
 ```python
 any where host.os.type == "windows" and
@@ -11165,7 +11197,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1187
+Index: geneve-ut-1190
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11194,7 +11226,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1188
+Index: geneve-ut-1191
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11208,7 +11240,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1189
+Index: geneve-ut-1192
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11241,7 +11273,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1192
+Index: geneve-ut-1195
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11288,7 +11320,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1193
+Index: geneve-ut-1196
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11315,7 +11347,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1194
+Index: geneve-ut-1197
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11328,7 +11360,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1205
+Index: geneve-ut-1208
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11345,7 +11377,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1207
+Index: geneve-ut-1210
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11353,6 +11385,8 @@ process where host.os.type == "windows" and event.type == "start" and process.na
   not (process.args : "-m" and process.args : "-bg") and
   not process.args : (
     "-mm",
+    "?:\\Windows\\appcompat\\cloudsdb\\apppatch.sdb",
+    "\"?:\\Windows\\appcompat\\cloudsdb\\apppatch.sdb\"",
     "?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\sysMergeInboxStoreApp.sdb",
     "\"?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\sysMergeInboxStoreApp.sdb\"",
     "?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\msiMergeInboxStoreApp.sdb",
@@ -11370,7 +11404,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1212
+Index: geneve-ut-1215
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11386,7 +11420,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1213
+Index: geneve-ut-1216
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11407,7 +11441,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1215
+Index: geneve-ut-1218
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11424,7 +11458,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1216
+Index: geneve-ut-1219
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11437,7 +11471,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1217
+Index: geneve-ut-1220
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11461,7 +11495,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1219
+Index: geneve-ut-1222
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11490,7 +11524,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1221
+Index: geneve-ut-1224
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11517,7 +11551,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1222
+Index: geneve-ut-1225
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11541,7 +11575,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1225
+Index: geneve-ut-1228
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11559,7 +11593,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1226
+Index: geneve-ut-1229
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11582,7 +11616,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1227
+Index: geneve-ut-1230
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11639,7 +11673,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1228
+Index: geneve-ut-1231
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11656,7 +11690,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1229
+Index: geneve-ut-1232
 
 ```python
 sequence by process.entity_id
@@ -11670,7 +11704,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1243
+Index: geneve-ut-1248
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11685,7 +11719,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1244
+Index: geneve-ut-1249
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11716,7 +11750,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1245
+Index: geneve-ut-1250
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11730,7 +11764,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1246
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11743,7 +11777,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1247
+Index: geneve-ut-1252
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11755,7 +11789,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1248
+Index: geneve-ut-1253
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11768,7 +11802,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1250
+Index: geneve-ut-1255
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11787,7 +11821,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1251
+Index: geneve-ut-1256
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11800,7 +11834,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1252
+Index: geneve-ut-1257
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11821,7 +11855,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1253
+Index: geneve-ut-1258
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11835,7 +11869,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1256
+Index: geneve-ut-1261
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11855,7 +11889,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1257
+Index: geneve-ut-1262
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11879,7 +11913,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1258
+Index: geneve-ut-1263
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11895,7 +11929,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1259
+Index: geneve-ut-1264
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11912,7 +11946,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1260
+Index: geneve-ut-1266
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11933,7 +11967,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1262
+Index: geneve-ut-1268
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11946,7 +11980,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1264
+Index: geneve-ut-1270
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11974,7 +12008,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1267
+Index: geneve-ut-1273
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11990,7 +12024,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1268
+Index: geneve-ut-1274
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12013,7 +12047,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1269
+Index: geneve-ut-1275
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12026,7 +12060,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1271
+Index: geneve-ut-1277
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12039,7 +12073,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1276
+Index: geneve-ut-1282
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12053,7 +12087,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1277
+Index: geneve-ut-1283
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12064,11 +12098,37 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 
 
+### Potential IIS Web Shell File Creation
+
+Branch count: 165  
+Document count: 165  
+Index: geneve-ut-1285
+
+```python
+file where host.os.type == "windows" and event.type != "deletion" and file.extension : ("aspx", "ashx", "asmx") and
+ process.name : ("w3wp.exe", "MSExchangeMailboxReplication.exe", "EdgeTransport.exe", "Microsoft.Exchange.*.exe", "UMWorkerProcess.exe", "umservice.exe", "cmd.exe", "powershell.exe", "pwsh.exe", "certutil.exe", "xcopy.exe") and 
+  (
+   (file.path : ("?:\\Program Files\\Common Files\\microsoft shared\\Web Server Extensions\\*\\TEMPLATE\\LAYOUTS\\*",
+                 "?:\\inetpub\\wwwroot\\aspnet_client\\system_web\\*", 
+                 "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\owa\\auth\\*", 
+                 "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\ecp\\auth\\*") and 
+    /* not sub-dirs */
+    not file.path : ("?:\\inetpub\\wwwroot\\aspnet_client\\system_web\\*\\*", 
+                     "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\*\\auth\\*\\*", 
+                     "?:\\Program Files\\Common Files\\microsoft shared\\Web Server Extensions\\*\\TEMPLATE\\LAYOUTS\\*\\*")) or 
+
+    /* not sub-dirs */
+   (file.path : "?:\\inetpub\\wwwroot\\aspnet_client\\*" and not file.path : "?:\\inetpub\\wwwroot\\aspnet_client\\*\\*")
+  )
+```
+
+
+
 ### Potential Impersonation Attempt via Kubectl
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1279
+Index: geneve-ut-1286
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12087,38 +12147,28 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 
 
-### Potential JAVA/JNDI Exploitation Attempt
+### Potential Java Service Exploitation via Suspicious Child Process
 
-Branch count: 60  
-Document count: 120  
-Index: geneve-ut-1282
+Branch count: 30  
+Document count: 60  
+Index: geneve-ut-1289
 
 ```python
-sequence by host.id with maxspan=1m
- [network where event.action == "connection_attempted" and
+sequence by host.id with maxspan=5s
+ [network where event.action == "connection_accepted" and network.direction == "ingress" and
+
   process.name : "java" and
-  /*
-     outbound connection attempt to
-     LDAP, RMI or DNS standard ports
-     by JAVA process
-   */
-  destination.port in (1389, 389, 1099, 53, 5353)] by process.pid
+  destination.port < 49152  and source.port >= 32768] by process.pid
  [process where event.type == "start" and
 
   /* Suspicious JAVA child process */
   process.parent.name : "java" and
-   process.name : ("sh",
-                   "bash",
-                   "dash",
-                   "ksh",
-                   "tcsh",
-                   "zsh",
-                   "curl",
-                   "perl*",
-                   "python*",
-                   "ruby*",
-                   "php*",
-                   "wget") and
+  process.name : (
+    "sh", "bash", "dash", "ksh", "tcsh", "zsh", "ash",  "mksh", "busybox",
+    "curl", "wget", "perl*", "python*", "ruby*", "php*", "lua*", "socat",
+    "nc", "ncat", "netcat", "netcat.openbsd", "netcat.traditional", "nc.openbsd",
+    "nc.traditional", "nohup", "setsid", "disown", "hostname", "whoami", "id"
+  ) and
     not process.command_line like~ (
       "bash -c ulimit -u",
       "bash /opt/flutter/bin/flutter*",
@@ -12134,7 +12184,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1283
+Index: geneve-ut-1290
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12152,7 +12202,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1284
+Index: geneve-ut-1291
 
 ```python
 host.os.type:"windows" and
@@ -12168,7 +12218,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1286
+Index: geneve-ut-1293
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12180,7 +12230,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1288
+Index: geneve-ut-1295
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12196,7 +12246,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1289
+Index: geneve-ut-1296
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12212,7 +12262,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1290
+Index: geneve-ut-1297
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12230,7 +12280,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1291
+Index: geneve-ut-1298
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12244,7 +12294,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1293
+Index: geneve-ut-1300
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12267,7 +12317,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1295
+Index: geneve-ut-1302
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12283,7 +12333,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1296
+Index: geneve-ut-1303
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12296,7 +12346,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1297
+Index: geneve-ut-1304
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12326,7 +12376,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1302
+Index: geneve-ut-1309
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12349,7 +12399,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1303
+Index: geneve-ut-1310
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12368,7 +12418,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1308
+Index: geneve-ut-1315
 
 ```python
 process where host.os.type == "windows" and 
@@ -12510,7 +12560,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1309
+Index: geneve-ut-1316
 
 ```python
 process where host.os.type == "windows" and
@@ -12587,7 +12637,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1313
+Index: geneve-ut-1320
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12604,7 +12654,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1314
+Index: geneve-ut-1321
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12638,7 +12688,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1316
+Index: geneve-ut-1323
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12650,7 +12700,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1317
+Index: geneve-ut-1324
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12689,7 +12739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1319
+Index: geneve-ut-1326
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12702,7 +12752,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1324
+Index: geneve-ut-1331
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12716,7 +12766,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1331
+Index: geneve-ut-1338
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12754,7 +12804,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1332
+Index: geneve-ut-1339
 
 ```python
 network where host.os.type == "windows" and
@@ -12780,7 +12830,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1335
+Index: geneve-ut-1342
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12795,7 +12845,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1337
+Index: geneve-ut-1344
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12809,7 +12859,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1338
+Index: geneve-ut-1345
 
 ```python
 file where host.os.type == "windows" and
@@ -12823,7 +12873,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1339
+Index: geneve-ut-1346
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12836,7 +12886,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1340
+Index: geneve-ut-1347
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12906,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1341
+Index: geneve-ut-1348
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12876,7 +12926,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1343
+Index: geneve-ut-1350
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12915,7 +12965,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1344
+Index: geneve-ut-1351
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13110,7 +13160,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1357
+Index: geneve-ut-1364
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13126,7 +13176,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1358
+Index: geneve-ut-1365
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13140,7 +13190,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1359
+Index: geneve-ut-1366
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13154,7 +13204,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1360
+Index: geneve-ut-1367
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13171,7 +13221,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1361
+Index: geneve-ut-1368
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13185,7 +13235,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1362
+Index: geneve-ut-1369
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13201,7 +13251,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1366
+Index: geneve-ut-1373
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13213,7 +13263,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1367
+Index: geneve-ut-1374
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13229,7 +13279,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1368
+Index: geneve-ut-1375
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13249,7 +13299,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1370
+Index: geneve-ut-1377
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13289,7 +13339,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1372
+Index: geneve-ut-1379
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13301,7 +13351,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1373
+Index: geneve-ut-1380
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13322,7 +13372,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1374
+Index: geneve-ut-1381
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13343,7 +13393,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1375
+Index: geneve-ut-1382
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13364,7 +13414,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1376
+Index: geneve-ut-1383
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13390,7 +13440,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1377
+Index: geneve-ut-1384
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13406,7 +13456,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1378
+Index: geneve-ut-1385
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13420,7 +13470,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1379
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13443,7 +13493,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1381
+Index: geneve-ut-1388
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13460,7 +13510,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1382
+Index: geneve-ut-1389
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13483,7 +13533,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1383
+Index: geneve-ut-1390
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13496,7 +13546,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1384
+Index: geneve-ut-1391
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13510,7 +13560,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1385
+Index: geneve-ut-1392
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13527,7 +13577,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1386
+Index: geneve-ut-1393
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13581,7 +13631,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1387
+Index: geneve-ut-1394
 
 ```python
 any where host.os.type == "windows" and
@@ -13608,7 +13658,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1393
+Index: geneve-ut-1400
 
 ```python
 file where host.os.type == "windows" and
@@ -13623,7 +13673,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1394
+Index: geneve-ut-1401
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13654,7 +13704,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1395
+Index: geneve-ut-1402
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13668,7 +13718,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1396
+Index: geneve-ut-1403
 
 ```python
 sequence with maxspan=1m
@@ -13710,7 +13760,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1397
+Index: geneve-ut-1404
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13735,7 +13785,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1398
+Index: geneve-ut-1405
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13789,7 +13839,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1399
+Index: geneve-ut-1406
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13809,7 +13859,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1400
+Index: geneve-ut-1407
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13830,7 +13880,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1401
+Index: geneve-ut-1408
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13845,7 +13895,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1402
+Index: geneve-ut-1409
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13865,7 +13915,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1403
+Index: geneve-ut-1410
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13907,7 +13957,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1407
+Index: geneve-ut-1414
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13922,7 +13972,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1408
+Index: geneve-ut-1415
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13957,7 +14007,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1409
+Index: geneve-ut-1416
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13974,7 +14024,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1411
+Index: geneve-ut-1418
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13988,7 +14038,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1414
+Index: geneve-ut-1421
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -14001,7 +14051,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1415
+Index: geneve-ut-1422
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -14013,7 +14063,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1416
+Index: geneve-ut-1424
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14028,7 +14078,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1418
+Index: geneve-ut-1426
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14056,7 +14106,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1419
+Index: geneve-ut-1427
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14081,7 +14131,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1423
+Index: geneve-ut-1431
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14118,7 +14168,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1424
+Index: geneve-ut-1432
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14132,7 +14182,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1425
+Index: geneve-ut-1433
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14148,7 +14198,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1426
+Index: geneve-ut-1434
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14162,7 +14212,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1427
+Index: geneve-ut-1435
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14192,7 +14242,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1428
+Index: geneve-ut-1436
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14221,7 +14271,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1429
+Index: geneve-ut-1437
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14237,7 +14287,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1430
+Index: geneve-ut-1438
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14251,7 +14301,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1431
+Index: geneve-ut-1439
 
 ```python
 file where host.os.type == "windows" and
@@ -14270,12 +14320,26 @@ file where host.os.type == "windows" and
   not process.executable : (
     "?:\\Program Files\\*",
     "?:\\Program Files (x86)\\*",
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\*",
     "?:\\Windows\\system32\\cleanmgr.exe",
     "?:\\Windows\\system32\\msiexec.exe",
     "?:\\Windows\\syswow64\\msiexec.exe",
     "?:\\Windows\\system32\\svchost.exe",
     "?:\\Windows\\System32\\Robocopy.exe",
-    "?:\\Windows\\SysWOW64\\Robocopy.exe"
+    "?:\\Windows\\SysWOW64\\Robocopy.exe",
+    "?:\\Windows\\explorer.exe",
+    "?:\\Windows\\system32\\Dism.exe",
+    "?:\\Windows\\system32\\DFSRs.exe",
+    "?:\\Windows\\system32\\wbengine.exe",
+    "?:\\Windows\\system32\\CompatTelRunner.exe",
+    "?:\\Windows\\system32\\SearchIndexer.exe",
+    "?:\\Windows\\system32\\wuauclt.exe",
+    "?:\\Windows\\servicing\\TrustedInstaller.exe",
+    "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+    "?:\\Windows\\Microsoft.NET\\*",
+    "?:\\Windows\\SystemApps\\*",
+    "?:\\Windows\\uus\\*\\wuaucltcore.exe",
+    "?:\\$WINDOWS.~BT\\Sources\\mighost.exe"
   ) and
   not (process.executable : "?:\\Windows\\System32\\spoolsv.exe" and file.path : "?:\\Windows\\System32\\spool\\*") and
   not user.name : ("SYSTEM", "Local Service", "Network Service")
@@ -14287,7 +14351,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1434
+Index: geneve-ut-1442
 
 ```python
 process where event.type == "start" and
@@ -14301,7 +14365,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1435
+Index: geneve-ut-1443
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14379,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1436
+Index: geneve-ut-1444
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14335,7 +14399,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1438
+Index: geneve-ut-1446
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14352,7 +14416,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1439
+Index: geneve-ut-1447
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14364,7 +14428,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1440
+Index: geneve-ut-1448
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14377,29 +14441,11 @@ process.executable : (
 
 
 
-### Potential Web Shell ASPX File Creation
-
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-1441
-
-```python
-file where host.os.type == "windows" and event.type != "deletion" and
-  file.extension : "aspx" and
-  file.path : "?:\\Program Files\\Common Files\\Microsoft Shared\\Web Server Extensions\\*" and
-  not process.executable: (
-        "?:\\Windows\\System32\\msiexec.exe",
-        "?:\\Program Files\\Common Files\\Microsoft Shared\\Web Server Extensions\\16\\BIN\\psconfigui.exe"
-  )
-```
-
-
-
 ### Potential notify_on_release Container Escape Detected via Defend for Containers
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1448
+Index: geneve-ut-1455
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14412,7 +14458,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1449
+Index: geneve-ut-1456
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14439,7 +14485,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1450
+Index: geneve-ut-1457
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14452,7 +14498,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1451
+Index: geneve-ut-1458
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14466,7 +14512,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1453
+Index: geneve-ut-1460
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14483,7 +14529,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1454
+Index: geneve-ut-1461
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14506,7 +14552,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1456
+Index: geneve-ut-1463
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14523,7 +14569,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1459
+Index: geneve-ut-1466
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14536,7 +14582,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1461
+Index: geneve-ut-1468
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14560,7 +14606,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1462
+Index: geneve-ut-1469
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14588,7 +14634,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1477
+Index: geneve-ut-1484
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14609,7 +14655,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1479
+Index: geneve-ut-1486
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14637,7 +14683,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1481
+Index: geneve-ut-1488
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14677,7 +14723,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1482
+Index: geneve-ut-1489
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14694,7 +14740,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1483
+Index: geneve-ut-1490
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14708,7 +14754,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1484
+Index: geneve-ut-1491
 
 ```python
 file where host.os.type == "windows" and
@@ -14727,7 +14773,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1485
+Index: geneve-ut-1492
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14741,7 +14787,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1487
+Index: geneve-ut-1494
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14759,7 +14805,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1489
+Index: geneve-ut-1496
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14777,7 +14823,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1492
+Index: geneve-ut-1499
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14791,7 +14837,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1494
+Index: geneve-ut-1501
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14806,7 +14852,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1495
+Index: geneve-ut-1502
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14829,7 +14875,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1497
+Index: geneve-ut-1504
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14911,7 +14957,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1498
+Index: geneve-ut-1505
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14932,7 +14978,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1499
+Index: geneve-ut-1506
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14954,11 +15000,29 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 
 
+### Process Execution Followed by Self-Deletion
+
+Branch count: 9  
+Document count: 18  
+Index: geneve-ut-1508
+
+```python
+sequence by process.entity_id, host.id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
+  process.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/*", "/var/run/*", "/var/www/*",
+    "/proc/*/fd/*", "?memfd:*", "memfd:*"
+  )] by process.executable
+  [file where host.os.type == "linux" and event.action == "deletion"] by file.path
+```
+
+
+
 ### Process Execution from an Unusual Directory
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1501
+Index: geneve-ut-1509
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15011,7 +15075,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1502
+Index: geneve-ut-1510
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15023,7 +15087,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1503
+Index: geneve-ut-1511
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15035,7 +15099,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1504
+Index: geneve-ut-1512
 
 ```python
 process where host.os.type == "windows" and
@@ -15050,7 +15114,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1505
+Index: geneve-ut-1513
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15080,7 +15144,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1506
+Index: geneve-ut-1514
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15140,7 +15204,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1509
+Index: geneve-ut-1517
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15153,7 +15217,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1510
+Index: geneve-ut-1518
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15185,7 +15249,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1511
+Index: geneve-ut-1519
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15209,7 +15273,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1513
+Index: geneve-ut-1521
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15242,7 +15306,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1514
+Index: geneve-ut-1522
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15259,7 +15323,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1515
+Index: geneve-ut-1523
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15288,7 +15352,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1516
+Index: geneve-ut-1524
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15302,7 +15366,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1517
+Index: geneve-ut-1525
 
 ```python
 sequence by process.entity_id
@@ -15327,7 +15391,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1518
+Index: geneve-ut-1526
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15361,7 +15425,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1519
+Index: geneve-ut-1527
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15389,7 +15453,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1520
+Index: geneve-ut-1528
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15408,7 +15472,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1524
+Index: geneve-ut-1532
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15436,7 +15500,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1525
+Index: geneve-ut-1533
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15455,7 +15519,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1529
+Index: geneve-ut-1537
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15467,7 +15531,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1530
+Index: geneve-ut-1538
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15479,7 +15543,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1531
+Index: geneve-ut-1539
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15491,7 +15555,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1532
+Index: geneve-ut-1540
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15503,7 +15567,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1542
+Index: geneve-ut-1550
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15516,7 +15580,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1543
+Index: geneve-ut-1551
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15554,7 +15618,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1545
+Index: geneve-ut-1553
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15569,7 +15633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1546
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15588,7 +15652,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1547
+Index: geneve-ut-1555
 
 ```python
 sequence with maxspan=1m
@@ -15636,7 +15700,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1549
+Index: geneve-ut-1557
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15659,7 +15723,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1551
+Index: geneve-ut-1559
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15673,7 +15737,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1552
+Index: geneve-ut-1560
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15687,7 +15751,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1554
+Index: geneve-ut-1562
 
 ```python
 sequence by host.id, process.entity_id
@@ -15704,7 +15768,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1555
+Index: geneve-ut-1563
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15718,7 +15782,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1556
+Index: geneve-ut-1564
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15738,7 +15802,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1557
+Index: geneve-ut-1565
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15767,7 +15831,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1558
+Index: geneve-ut-1566
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15787,7 +15851,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1559
+Index: geneve-ut-1567
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15800,7 +15864,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1561
+Index: geneve-ut-1569
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15842,7 +15906,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1562
+Index: geneve-ut-1570
 
 ```python
 sequence with maxspan=1m
@@ -15865,7 +15929,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1563
+Index: geneve-ut-1571
 
 ```python
 sequence with maxspan=1s
@@ -15913,7 +15977,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1564
+Index: geneve-ut-1572
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15930,7 +15994,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1566
+Index: geneve-ut-1574
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15959,7 +16023,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1568
+Index: geneve-ut-1576
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15987,7 +16051,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1569
+Index: geneve-ut-1577
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -16004,7 +16068,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1571
+Index: geneve-ut-1579
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16023,7 +16087,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1572
+Index: geneve-ut-1580
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16044,7 +16108,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1577
+Index: geneve-ut-1587
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16058,7 +16122,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1579
+Index: geneve-ut-1589
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16077,7 +16141,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1580
+Index: geneve-ut-1590
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16091,7 +16155,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1581
+Index: geneve-ut-1591
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16111,7 +16175,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1583
+Index: geneve-ut-1593
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16129,7 +16193,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1584
+Index: geneve-ut-1594
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16150,7 +16214,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1586
+Index: geneve-ut-1596
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16164,7 +16228,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1587
+Index: geneve-ut-1597
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16179,7 +16243,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1588
+Index: geneve-ut-1598
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16220,7 +16284,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1590
+Index: geneve-ut-1600
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16245,7 +16309,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1591
+Index: geneve-ut-1601
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16284,7 +16348,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1592
+Index: geneve-ut-1602
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16298,7 +16362,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1593
+Index: geneve-ut-1603
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16337,7 +16401,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1594
+Index: geneve-ut-1604
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16351,7 +16415,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1595
+Index: geneve-ut-1605
 
 ```python
 process where event.type == "start" and
@@ -16423,7 +16487,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1599
+Index: geneve-ut-1609
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16444,7 +16508,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1602
+Index: geneve-ut-1612
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16461,7 +16525,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1605
+Index: geneve-ut-1615
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16479,7 +16543,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1606
+Index: geneve-ut-1616
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16491,7 +16555,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1607
+Index: geneve-ut-1617
 
 ```python
 file where host.os.type == "windows" and
@@ -16524,7 +16588,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1610
+Index: geneve-ut-1620
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16556,7 +16620,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1612
+Index: geneve-ut-1622
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16592,7 +16656,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1613
+Index: geneve-ut-1623
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16609,7 +16673,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1614
+Index: geneve-ut-1624
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16629,7 +16693,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1616
+Index: geneve-ut-1626
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16644,7 +16708,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1617
+Index: geneve-ut-1627
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16665,7 +16729,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1618
+Index: geneve-ut-1628
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16688,7 +16752,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1619
+Index: geneve-ut-1629
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16701,7 +16765,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1620
+Index: geneve-ut-1630
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16718,7 +16782,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1622
+Index: geneve-ut-1632
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16743,7 +16807,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1625
+Index: geneve-ut-1635
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16774,7 +16838,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1626
+Index: geneve-ut-1636
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16823,7 +16887,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1627
+Index: geneve-ut-1637
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16837,7 +16901,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1628
+Index: geneve-ut-1638
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16852,7 +16916,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1629
+Index: geneve-ut-1639
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16867,7 +16931,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1630
+Index: geneve-ut-1640
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16889,7 +16953,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1631
+Index: geneve-ut-1641
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16910,7 +16974,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1634
+Index: geneve-ut-1644
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16924,7 +16988,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1635
+Index: geneve-ut-1645
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16947,7 +17011,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1665
+Index: geneve-ut-1675
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16972,7 +17036,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1666
+Index: geneve-ut-1676
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -17005,7 +17069,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1667
+Index: geneve-ut-1677
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17064,7 +17128,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1669
+Index: geneve-ut-1679
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17082,7 +17146,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1670
+Index: geneve-ut-1680
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17094,7 +17158,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1672
+Index: geneve-ut-1682
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17119,7 +17183,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1678
+Index: geneve-ut-1688
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17134,7 +17198,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1679
+Index: geneve-ut-1689
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17157,7 +17221,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1682
+Index: geneve-ut-1692
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17169,9 +17233,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### Suspicious /proc/maps Discovery
 
-Branch count: 48  
-Document count: 48  
-Index: geneve-ut-1684
+Branch count: 96  
+Document count: 96  
+Index: geneve-ut-1694
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17183,7 +17247,9 @@ not (
   ?process.parent.name == "uac" or
   ?process.parent.executable in ("/opt/secl/linux-ir-scripts-v3/thieves.sh", "/opt/traps/rpm-installer/setup.sh") or
   ?process.working_directory like ("/opt/traps/deb-installer", "/opt/Tanium/TaniumClient/*") or
-  ?process.parent.executable like ("/home/*/sunlight/thieves.sh")
+  ?process.parent.executable like ("/home/*/sunlight/thieves.sh") or
+  (?process.parent.executable == "/usr/lib/systemd/systemd" and ?process.parent.command_line == "/sbin/init") or
+  ?process.group_leader.executable in ("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/opt/traps/bin/cytool")
 )
 ```
 
@@ -17193,7 +17259,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1686
+Index: geneve-ut-1696
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17220,7 +17286,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1690
+Index: geneve-ut-1700
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17259,7 +17325,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1691
+Index: geneve-ut-1701
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17282,7 +17348,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1692
+Index: geneve-ut-1702
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17296,7 +17362,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1693
+Index: geneve-ut-1703
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17312,7 +17378,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1694
+Index: geneve-ut-1704
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17328,7 +17394,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1695
+Index: geneve-ut-1705
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17342,7 +17408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1697
+Index: geneve-ut-1707
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17361,11 +17427,76 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 
 
+### Suspicious Child Process of PaperCut Server Component
+
+Branch count: 92  
+Document count: 92  
+Index: geneve-ut-1708
+
+```python
+process where host.os.type == "windows" and event.type == "start" and
+  process.parent.name : ("pc-app.exe", "pc-printjob-spooler.exe") and
+  (
+    process.name : (
+      "cmd.exe",
+      "powershell.exe",
+      "pwsh.exe",
+      "powershell_ise.exe",
+      "wscript.exe",
+      "cscript.exe",
+      "mshta.exe",
+      "rundll32.exe",
+      "regsvr32.exe",
+      "bitsadmin.exe",
+      "certutil.exe",
+      "curl.exe",
+      "wget.exe",
+      "net.exe",
+      "net1.exe",
+      "whoami.exe",
+      "tasklist.exe",
+      "ipconfig.exe",
+      "nltest.exe",
+      "systeminfo.exe",
+      "charmap.exe",
+      "calc.exe",
+      "mspaint.exe"
+    ) or
+    ?process.pe.original_file_name : (
+      "Cmd.Exe",
+      "PowerShell.EXE",
+      "pwsh.dll",
+      "powershell_ise.EXE",
+      "wscript.exe",
+      "cscript.exe",
+      "MSHTA.EXE",
+      "RUNDLL32.EXE",
+      "REGSVR32.EXE",
+      "bitsadmin.exe",
+      "CertUtil.exe",
+      "curl.exe",
+      "wget.exe",
+      "net.exe",
+      "net1.exe",
+      "whoami.exe",
+      "tasklist.exe",
+      "ipconfig.exe",
+      "nltest.exe",
+      "systeminfo.exe",
+      "charmap.exe",
+      "CALC.EXE",
+      "mspaint.exe"
+    )
+  )
+```
+
+
+
 ### Suspicious Child Process via Azure VM CustomScript Extension
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1698
+Index: geneve-ut-1709
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17393,7 +17524,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1699
+Index: geneve-ut-1710
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17408,7 +17539,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1702
+Index: geneve-ut-1713
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17435,7 +17566,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1704
+Index: geneve-ut-1715
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17466,7 +17597,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1705
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17482,7 +17613,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1706
+Index: geneve-ut-1717
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17495,7 +17626,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1708
+Index: geneve-ut-1719
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17511,7 +17642,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1709
+Index: geneve-ut-1720
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17527,7 +17658,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1710
+Index: geneve-ut-1721
 
 ```python
 any where host.os.type == "windows" and 
@@ -17594,7 +17725,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1712
+Index: geneve-ut-1723
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17610,7 +17741,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1714
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17646,7 +17777,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1715
+Index: geneve-ut-1726
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17684,7 +17815,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1716
+Index: geneve-ut-1727
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17719,7 +17850,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1717
+Index: geneve-ut-1728
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17753,7 +17884,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1719
+Index: geneve-ut-1730
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17774,7 +17905,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1724
+Index: geneve-ut-1735
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17851,7 +17982,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1725
+Index: geneve-ut-1736
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17873,7 +18004,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1726
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17897,7 +18028,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1727
+Index: geneve-ut-1738
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17918,7 +18049,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1730
+Index: geneve-ut-1741
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17933,7 +18064,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1733
+Index: geneve-ut-1744
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17946,7 +18077,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1734
+Index: geneve-ut-1745
 
 ```python
 any where host.os.type == "windows" and
@@ -17961,7 +18092,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1735
+Index: geneve-ut-1746
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17977,7 +18108,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1736
+Index: geneve-ut-1747
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17991,7 +18122,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1740
+Index: geneve-ut-1751
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18044,11 +18175,32 @@ process.parent.executable != null and (
 
 
 
+### Suspicious Java Class File Created in PaperCut Server Library
+
+Branch count: 30  
+Document count: 30  
+Index: geneve-ut-1752
+
+```python
+file where host.os.type in ("windows", "linux", "macos") and
+  event.action in ("creation", "overwrite") and
+  file.extension : "class" and
+  file.path : (
+    "?:\\Program Files\\PaperCut*\\server\\lib\\*",
+    "?:\\Program Files (x86)\\PaperCut*\\server\\lib\\*",
+    "/opt/papercut/server/lib/*",
+    "/usr/local/papercut/server/lib/*",
+    "/Applications/PaperCut*/server/lib/*"
+  )
+```
+
+
+
 ### Suspicious JavaScript Execution via Deno
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1741
+Index: geneve-ut-1753
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18062,7 +18214,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1743
+Index: geneve-ut-1755
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18094,7 +18246,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1745
+Index: geneve-ut-1757
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18107,7 +18259,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1746
+Index: geneve-ut-1758
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18126,7 +18278,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1747
+Index: geneve-ut-1759
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18172,7 +18324,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1749
+Index: geneve-ut-1761
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18193,7 +18345,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1750
+Index: geneve-ut-1762
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18213,7 +18365,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1751
+Index: geneve-ut-1763
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18227,7 +18379,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1752
+Index: geneve-ut-1764
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18259,7 +18411,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1755
+Index: geneve-ut-1767
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18280,7 +18432,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1757
+Index: geneve-ut-1769
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18381,7 +18533,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1760
+Index: geneve-ut-1772
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18429,7 +18581,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1763
+Index: geneve-ut-1775
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18455,7 +18607,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1764
+Index: geneve-ut-1776
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18500,7 +18652,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1765
+Index: geneve-ut-1777
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18524,7 +18676,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1766
+Index: geneve-ut-1778
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18540,7 +18692,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1768
+Index: geneve-ut-1780
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18565,7 +18717,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1769
+Index: geneve-ut-1781
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18580,7 +18732,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1772
+Index: geneve-ut-1784
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18594,7 +18746,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1773
+Index: geneve-ut-1785
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18614,7 +18766,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1774
+Index: geneve-ut-1786
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18649,7 +18801,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1778
+Index: geneve-ut-1790
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18667,7 +18819,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1779
+Index: geneve-ut-1792
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18680,7 +18832,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1781
+Index: geneve-ut-1794
 
 ```python
 any where host.os.type == "windows" and
@@ -18709,11 +18861,41 @@ any where host.os.type == "windows" and
 
 
 
+### Suspicious Reading of procfs Syscall File
+
+Branch count: 120  
+Document count: 120  
+Index: geneve-ut-1796
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+(
+  process.name in (
+    "cat", "less", "more", "head", "tail", "nano", "vi", "vim", "strings", "nvim", "vim.basic",
+    "vim.tiny", "od", "hexdump", "xxd", "hx", "hexedit", "pager", "tr"
+  ) or
+  (
+    process.name in (
+      "find", "awk", "gawk", "mawk", "nawk", "grep", "fgrep", "rgrep", "xargs", "sed", "tee"
+    ) and
+    process.args_count <= 20
+  )
+) and
+process.command_line like "*/proc/*/syscall*" and
+not (
+  process.command_line like ("*/proc/self/syscall*", "*/proc/thread-self/syscall*") or
+  process.args like "/proc/*/syscall/comm"
+)
+```
+
+
+
 ### Suspicious Remote Registry Access via SeBackupPrivilege
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1783
+Index: geneve-ut-1797
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18731,7 +18913,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1784
+Index: geneve-ut-1798
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18753,7 +18935,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1787
+Index: geneve-ut-1801
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18792,7 +18974,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1788
+Index: geneve-ut-1802
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18822,7 +19004,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1789
+Index: geneve-ut-1803
 
 ```python
 any where host.os.type == "windows" and
@@ -18856,7 +19038,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1790
+Index: geneve-ut-1804
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18870,7 +19052,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1793
+Index: geneve-ut-1807
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18901,7 +19083,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1794
+Index: geneve-ut-1808
 
 ```python
 any where host.os.type == "windows" and
@@ -18921,7 +19103,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1795
+Index: geneve-ut-1809
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18962,7 +19144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1796
+Index: geneve-ut-1810
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18978,7 +19160,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1797
+Index: geneve-ut-1811
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -19008,7 +19190,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1801
+Index: geneve-ut-1815
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19021,7 +19203,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1802
+Index: geneve-ut-1816
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19045,7 +19227,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1805
+Index: geneve-ut-1819
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19063,7 +19245,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1807
+Index: geneve-ut-1821
 
 ```python
 any where host.os.type == "windows" and
@@ -19078,7 +19260,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1808
+Index: geneve-ut-1822
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19096,7 +19278,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1809
+Index: geneve-ut-1823
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19117,7 +19299,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1810
+Index: geneve-ut-1824
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19136,7 +19318,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1813
+Index: geneve-ut-1827
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19161,7 +19343,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1814
+Index: geneve-ut-1828
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19174,7 +19356,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1816
+Index: geneve-ut-1830
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19187,7 +19369,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1818
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19210,7 +19392,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1820
+Index: geneve-ut-1834
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19229,7 +19411,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1821
+Index: geneve-ut-1835
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19251,7 +19433,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1822
+Index: geneve-ut-1836
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19284,7 +19466,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1824
+Index: geneve-ut-1838
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19302,7 +19484,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1825
+Index: geneve-ut-1839
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19316,7 +19498,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1826
+Index: geneve-ut-1840
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19340,7 +19522,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1827
+Index: geneve-ut-1841
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19363,7 +19545,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1828
+Index: geneve-ut-1842
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19382,7 +19564,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1831
+Index: geneve-ut-1845
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19401,7 +19583,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1833
+Index: geneve-ut-1847
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19436,7 +19618,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1834
+Index: geneve-ut-1848
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19635,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1835
+Index: geneve-ut-1849
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19473,7 +19655,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1836
+Index: geneve-ut-1850
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19513,7 +19695,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1837
+Index: geneve-ut-1851
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19529,7 +19711,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1838
+Index: geneve-ut-1852
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19543,7 +19725,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1839
+Index: geneve-ut-1853
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19581,7 +19763,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1840
+Index: geneve-ut-1854
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19635,7 +19817,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1841
+Index: geneve-ut-1855
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19663,7 +19845,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1843
+Index: geneve-ut-1857
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19677,7 +19859,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1844
+Index: geneve-ut-1858
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19723,7 +19905,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1845
+Index: geneve-ut-1859
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19762,7 +19944,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1846
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19775,7 +19957,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1849
+Index: geneve-ut-1863
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19808,7 +19990,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1850
+Index: geneve-ut-1864
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19822,7 +20004,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1851
+Index: geneve-ut-1865
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19836,7 +20018,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1852
+Index: geneve-ut-1866
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19850,7 +20032,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1853
+Index: geneve-ut-1867
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19889,7 +20071,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1860
+Index: geneve-ut-1874
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19931,7 +20113,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1862
+Index: geneve-ut-1876
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19953,7 +20135,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1863
+Index: geneve-ut-1877
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19966,7 +20148,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1865
+Index: geneve-ut-1879
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19983,7 +20165,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1866
+Index: geneve-ut-1880
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19999,7 +20181,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1867
+Index: geneve-ut-1881
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20012,7 +20194,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1868
+Index: geneve-ut-1882
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20027,7 +20209,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1869
+Index: geneve-ut-1883
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20050,7 +20232,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1870
+Index: geneve-ut-1884
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20066,7 +20248,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1871
+Index: geneve-ut-1885
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20082,7 +20264,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1877
+Index: geneve-ut-1891
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20094,7 +20276,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1878
+Index: geneve-ut-1892
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20123,7 +20305,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1880
+Index: geneve-ut-1894
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20137,7 +20319,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1885
+Index: geneve-ut-1899
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20157,7 +20339,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1886
+Index: geneve-ut-1900
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20182,7 +20364,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1893
+Index: geneve-ut-1907
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20196,7 +20378,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1894
+Index: geneve-ut-1908
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20219,7 +20401,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1903
+Index: geneve-ut-1917
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20253,7 +20435,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1905
+Index: geneve-ut-1919
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20272,7 +20454,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-1912
+Index: geneve-ut-1926
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20291,7 +20473,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1927
+Index: geneve-ut-1941
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20308,7 +20490,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1930
+Index: geneve-ut-1944
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20325,7 +20507,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1946
+Index: geneve-ut-1960
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20344,7 +20526,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1950
+Index: geneve-ut-1964
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20386,7 +20568,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1951
+Index: geneve-ut-1965
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20431,7 +20613,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1954
+Index: geneve-ut-1968
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20473,7 +20655,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1956
+Index: geneve-ut-1970
 
 ```python
 host.os.type:"linux" and 
@@ -20501,7 +20683,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1959
+Index: geneve-ut-1973
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20525,7 +20707,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-1960
+Index: geneve-ut-1974
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20565,7 +20747,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-1961
+Index: geneve-ut-1975
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20612,7 +20794,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1965
+Index: geneve-ut-1979
 
 ```python
 sequence by process.entity_id
@@ -20649,7 +20831,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1997
+Index: geneve-ut-2011
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20663,7 +20845,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1998
+Index: geneve-ut-2012
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20706,7 +20888,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1999
+Index: geneve-ut-2013
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20719,7 +20901,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2001
+Index: geneve-ut-2015
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20733,7 +20915,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2002
+Index: geneve-ut-2016
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20746,7 +20928,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2006
+Index: geneve-ut-2020
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20771,7 +20953,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2007
+Index: geneve-ut-2021
 
 ```python
 process where event.type == "start" and
@@ -20786,7 +20968,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2008
+Index: geneve-ut-2022
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20803,7 +20985,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2009
+Index: geneve-ut-2023
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20817,7 +20999,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2010
+Index: geneve-ut-2024
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20833,7 +21015,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2011
+Index: geneve-ut-2025
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20847,7 +21029,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2012
+Index: geneve-ut-2026
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20874,7 +21056,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2014
+Index: geneve-ut-2028
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20886,7 +21068,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2015
+Index: geneve-ut-2029
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20902,7 +21084,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2016
+Index: geneve-ut-2030
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20925,7 +21107,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2017
+Index: geneve-ut-2031
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20938,7 +21120,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2018
+Index: geneve-ut-2032
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20950,7 +21132,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2019
+Index: geneve-ut-2033
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20962,7 +21144,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2020
+Index: geneve-ut-2034
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20974,7 +21156,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2021
+Index: geneve-ut-2035
 
 ```python
 web where (
@@ -21002,7 +21184,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2027
+Index: geneve-ut-2041
 
 ```python
 any where (
@@ -21065,6 +21247,11 @@ url.original like~ (
     "*select @@version*", "*select user()*", "*select current_user()*", "*select database()*",
     "*sp_executesql*exec*", "*xp_dirtree*"
   )
+) and
+not user_agent.original like~ (
+    "*Nessus*", "*Qualys*", "*Acunetix*",  "*Tenable*", "*CensysInspect*", "*Detectify*",
+    "*Assetnote*", "*ExposureScan*", "*RecordedFuture*", "*AppSpider*", "*WebInspect*",
+    "*Rapid7*", "*InsightVM*", "*Probely*"
 )
 ```
 
@@ -21074,7 +21261,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2029
+Index: geneve-ut-2043
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21095,7 +21282,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2032
+Index: geneve-ut-2046
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21109,7 +21296,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2033
+Index: geneve-ut-2047
 
 ```python
 file where event.type == "deletion" and
@@ -21126,7 +21313,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2034
+Index: geneve-ut-2048
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21144,7 +21331,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2036
+Index: geneve-ut-2050
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21182,7 +21369,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2038
+Index: geneve-ut-2052
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21219,7 +21406,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2039
+Index: geneve-ut-2053
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21234,7 +21421,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2040
+Index: geneve-ut-2054
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21247,7 +21434,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2041
+Index: geneve-ut-2055
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21266,7 +21453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2042
+Index: geneve-ut-2056
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21291,7 +21478,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2043
+Index: geneve-ut-2057
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21317,7 +21504,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2044
+Index: geneve-ut-2058
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21339,7 +21526,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2045
+Index: geneve-ut-2059
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21356,7 +21543,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2047
+Index: geneve-ut-2061
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21375,7 +21562,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2048
+Index: geneve-ut-2062
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21415,7 +21602,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2049
+Index: geneve-ut-2063
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21432,7 +21619,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2051
+Index: geneve-ut-2065
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21445,7 +21632,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2052
+Index: geneve-ut-2066
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21459,7 +21646,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2053
+Index: geneve-ut-2067
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21487,7 +21674,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2054
+Index: geneve-ut-2068
 
 ```python
 process where event.type == "start" and
@@ -21512,7 +21699,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2055
+Index: geneve-ut-2069
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21526,7 +21713,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2056
+Index: geneve-ut-2070
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21542,7 +21729,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2057
+Index: geneve-ut-2071
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21577,7 +21764,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2058
+Index: geneve-ut-2072
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21595,7 +21782,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2061
+Index: geneve-ut-2075
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.4.md
+++ b/tests/reports/alerts_from_rules-9.4.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.11
+Rules version: 9.4.12
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
    1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
-   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
+   1. [Rules with the correct signals (810)](#rules-with-the-correct-signals-810)
 
 ## Failed rules (24)
 
@@ -20,7 +20,7 @@ Rules version: 9.4.11
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0368  
+Index: geneve-ut-0378  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0379  
+Index: geneve-ut-0389  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -190,7 +190,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0647  
+Index: geneve-ut-0656  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0672  
+Index: geneve-ut-0681  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0808  
+Index: geneve-ut-0820  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1001  
+Index: geneve-ut-1012  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1146  
+Index: geneve-ut-1158  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1176  
+Index: geneve-ut-1188  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1250  
+Index: geneve-ut-1263  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1279  
+Index: geneve-ut-1292  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1297  
+Index: geneve-ut-1310  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1362  
+Index: geneve-ut-1378  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1377  
+Index: geneve-ut-1394  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1467  
+Index: geneve-ut-1484  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1712  
+Index: geneve-ut-1732  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1716  
+Index: geneve-ut-1736  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1800  
+Index: geneve-ut-1820  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1815  
+Index: geneve-ut-1836  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1828  
+Index: geneve-ut-1849  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1838  
+Index: geneve-ut-1859  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1844  
+Index: geneve-ut-1865  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1853  
+Index: geneve-ut-1874  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1950  
+Index: geneve-ut-1974  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1981  
+Index: geneve-ut-2005  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1123,7 +1123,7 @@ container.id like "*"
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0368
+Index: geneve-ut-0378
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1175,7 +1175,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0379
+Index: geneve-ut-0389
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -1287,7 +1287,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0647
+Index: geneve-ut-0656
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1353,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0672
+Index: geneve-ut-0681
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0808
+Index: geneve-ut-0820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1001
+Index: geneve-ut-1012
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1146
+Index: geneve-ut-1158
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1176
+Index: geneve-ut-1188
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1250
+Index: geneve-ut-1263
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1279
+Index: geneve-ut-1292
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1297
+Index: geneve-ut-1310
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1362
+Index: geneve-ut-1378
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1377
+Index: geneve-ut-1394
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1467
+Index: geneve-ut-1484
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1712
+Index: geneve-ut-1732
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1716
+Index: geneve-ut-1736
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1800
+Index: geneve-ut-1820
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1815
+Index: geneve-ut-1836
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1828
+Index: geneve-ut-1849
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1838
+Index: geneve-ut-1859
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1844
+Index: geneve-ut-1865
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1853
+Index: geneve-ut-1874
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1950
+Index: geneve-ut-1974
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1981
+Index: geneve-ut-2005
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2154,7 +2154,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0239
+Index: geneve-ut-0247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1002
+Index: geneve-ut-1013
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1022
+Index: geneve-ut-1033
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1414
+Index: geneve-ut-1431
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1615
+Index: geneve-ut-1633
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2227,7 +2227,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0368  
+Index: geneve-ut-0378  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2281,7 +2281,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0379  
+Index: geneve-ut-0389  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -2395,7 +2395,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0647  
+Index: geneve-ut-0656  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2463,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0672  
+Index: geneve-ut-0681  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0808  
+Index: geneve-ut-0820  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0974  
+Index: geneve-ut-0985  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2530,8 +2530,8 @@ event.dataset:"kubernetes.audit_logs" and event.action:list and
 kubernetes.audit.objectRef.resource:secrets and 
 kubernetes.audit.requestURI :(/api/v1/secrets or /api/v1/secrets?limit* or /api/v1/namespaces/kube-system/secrets or /api/v1/namespaces/kube-system/secrets?limit* or /api/v1/namespaces/default/secrets or /api/v1/namespaces/default/secrets?limit*) and 
 source.ip:(* and not ("::1" or "127.0.0.1")) and 
-not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator) and 
-not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
+not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator or "system:serviceaccount:argocd:argocd-application-controller" or "system:serviceaccount:elastic:kube-state-metrics" or "system:serviceaccount:cert-manager:cert-manager-cainjector" or "system:serviceaccount:elastic-system:elastic-agent" or "system:serviceaccount:longhorn-system:longhorn-service-account") and 
+not kubernetes.audit.user.groups:("system:serviceaccounts:ibm-csi" or "system:serviceaccounts:argocd" or "system:serviceaccounts:elastic")
 ```
 
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1001  
+Index: geneve-ut-1012  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1124  
+Index: geneve-ut-1136  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1146  
+Index: geneve-ut-1158  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1176  
+Index: geneve-ut-1188  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1250  
+Index: geneve-ut-1263  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1279  
+Index: geneve-ut-1292  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1297  
+Index: geneve-ut-1310  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1362  
+Index: geneve-ut-1378  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1377  
+Index: geneve-ut-1394  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1458  
+Index: geneve-ut-1475  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1467  
+Index: geneve-ut-1484  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1582  
+Index: geneve-ut-1599  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1712  
+Index: geneve-ut-1732  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1716  
+Index: geneve-ut-1736  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1800  
+Index: geneve-ut-1820  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1815  
+Index: geneve-ut-1836  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1828  
+Index: geneve-ut-1849  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1838  
+Index: geneve-ut-1859  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1844  
+Index: geneve-ut-1865  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1853  
+Index: geneve-ut-1874  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1950  
+Index: geneve-ut-1974  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1981  
+Index: geneve-ut-2005  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3381,7 +3381,7 @@ container.id like "*"
 
 
 
-## Rules with the correct signals (805)
+## Rules with the correct signals (810)
 
 ### A scheduled task was created
 
@@ -3470,11 +3470,33 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 
 
+### AWS Bedrock AgentCore Resource Created with IAM Execution Role
+
+Branch count: 8  
+Document count: 8  
+Index: geneve-ut-0016
+
+```python
+event.dataset: "aws.cloudtrail" and
+  event.provider: "bedrock-agentcore.amazonaws.com" and
+  event.action: (
+    "CreateCodeInterpreter" or
+    "CreateAgentRuntime" or
+    "CreateBrowser" or
+    "CreateHarness"
+  ) and
+  event.outcome: "success" and
+  aws.cloudtrail.request_parameters: (*executionRoleArn* or *roleArn*) and
+  not aws.cloudtrail.user_identity.invoked_by: ("bedrock-agentcore.amazonaws.com" or "cloudformation.amazonaws.com")
+```
+
+
+
 ### AWS Credentials Searched For Inside A Container
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0052
+Index: geneve-ut-0053
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -3492,7 +3514,7 @@ process.command_line like~ (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0069
+Index: geneve-ut-0071
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3505,11 +3527,32 @@ event.dataset: "aws.cloudtrail"
 
 
 
+### AWS GetFederationToken Followed by Console Login via Federation Exchange
+
+Branch count: 1  
+Document count: 3  
+Index: geneve-ut-0093
+
+```python
+sequence by source.ip with maxspan=2m
+  [any where event.provider == "sts.amazonaws.com"
+   and event.action == "GetFederationToken"
+   and event.outcome == "success"]
+  [any where event.provider == "signin.amazonaws.com"
+   and event.action == "GetSigninToken"
+   and event.outcome == "success"]
+  [any where event.provider == "signin.amazonaws.com"
+   and event.action == "ConsoleLogin"
+   and event.outcome == "success"]
+```
+
+
+
 ### AWS IAM Customer Managed Policy Version Created or Default Version Set
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0102
+Index: geneve-ut-0108
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3520,6 +3563,7 @@ event.dataset: "aws.cloudtrail"
     and not aws.cloudtrail.user_identity.arn:arn*/terraform 
     and not source.as.organization.name:(Amazon* or AMAZON* or "Google LLC" or "MongoDB, Inc.")
     and not source.address: ( "cloudformation.amazonaws.com" or "servicecatalog.amazonaws.com")
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3528,11 +3572,12 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0109
+Index: geneve-ut-0115
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
     and event.action: "CreateLoginProfile" and event.outcome: success
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3541,7 +3586,7 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0121
+Index: geneve-ut-0127
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3573,7 +3618,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0130
+Index: geneve-ut-0136
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3581,6 +3626,7 @@ event.dataset: "aws.cloudtrail"
     and event.action: "PutKeyPolicy"
     and event.outcome: "success"
     and not aws.cloudtrail.user_identity.type: "AWSService"
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3589,13 +3635,14 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0132
+Index: geneve-ut-0138
 
 ```python
 event.dataset: "aws.cloudtrail"
     and event.provider: "lambda.amazonaws.com"
     and event.outcome: "success"
     and event.action: (CreateFunction* or UpdateFunctionCode*)
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3604,11 +3651,12 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0152
+Index: geneve-ut-0158
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
-    and event.action: ("CreateDBSnapshot" or "CreateDBClusterSnapshot") and event.outcome: "success"
+    and event.action: ("CreateDBSnapshot" or "CreateDBClusterSnapshot") and event.outcome: "success" 
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3617,7 +3665,7 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0189
+Index: geneve-ut-0197
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3633,7 +3681,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0190
+Index: geneve-ut-0198
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -3648,7 +3696,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0201
+Index: geneve-ut-0209
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -3663,7 +3711,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0210
+Index: geneve-ut-0218
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3687,7 +3735,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0211
+Index: geneve-ut-0219
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -3722,7 +3770,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0212
+Index: geneve-ut-0220
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -3739,7 +3787,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0213
+Index: geneve-ut-0221
 
 ```python
 any where host.os.type == "windows" and
@@ -3764,7 +3812,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0215
+Index: geneve-ut-0223
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -3792,7 +3840,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0217
+Index: geneve-ut-0225
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3805,7 +3853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0219
+Index: geneve-ut-0227
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -3821,7 +3869,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0220
+Index: geneve-ut-0228
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3841,7 +3889,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0221
+Index: geneve-ut-0229
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3862,7 +3910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0222
+Index: geneve-ut-0230
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3874,7 +3922,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0225
+Index: geneve-ut-0233
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3886,7 +3934,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0237
+Index: geneve-ut-0245
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3903,7 +3951,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0238
+Index: geneve-ut-0246
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3915,7 +3963,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0240
+Index: geneve-ut-0248
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3935,7 +3983,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0241
+Index: geneve-ut-0249
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3949,7 +3997,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0245
+Index: geneve-ut-0253
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3980,7 +4028,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0246
+Index: geneve-ut-0254
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3992,7 +4040,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0247
+Index: geneve-ut-0255
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4006,7 +4054,7 @@ process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clea
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0248
+Index: geneve-ut-0256
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4021,7 +4069,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0258
+Index: geneve-ut-0266
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -4040,7 +4088,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0259
+Index: geneve-ut-0267
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4054,7 +4102,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0261
+Index: geneve-ut-0269
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -4085,7 +4133,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0262
+Index: geneve-ut-0270
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4108,7 +4156,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0263
+Index: geneve-ut-0271
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4122,7 +4170,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0264
+Index: geneve-ut-0272
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4141,7 +4189,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0265
+Index: geneve-ut-0273
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4155,7 +4203,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0266
+Index: geneve-ut-0274
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4180,7 +4228,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0271
+Index: geneve-ut-0279
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4199,7 +4247,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0274
+Index: geneve-ut-0282
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4212,7 +4260,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0276
+Index: geneve-ut-0284
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4254,7 +4302,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0283
+Index: geneve-ut-0291
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -4269,7 +4317,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0324
+Index: geneve-ut-0332
 
 ```python
 event.dataset:azure.activitylogs and
@@ -4283,7 +4331,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0327
+Index: geneve-ut-0335
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -4301,7 +4349,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0345
+Index: geneve-ut-0353
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4319,7 +4367,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0346
+Index: geneve-ut-0354
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4337,7 +4385,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0347
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4352,7 +4400,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0348
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4366,7 +4414,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0349
+Index: geneve-ut-0357
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4381,7 +4429,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0352
+Index: geneve-ut-0360
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4398,7 +4446,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0353
+Index: geneve-ut-0361
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4410,7 +4458,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0354
+Index: geneve-ut-0362
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4422,7 +4470,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0355
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4437,7 +4485,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0356
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4453,11 +4501,34 @@ not (
 
 
 
+### Binfmt Configuration File Creation
+
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0365
+
+```python
+file where host.os.type == "linux" and event.action != "deletion" and process.executable != null and
+file.path like (
+  "/etc/binfmt.d/*.conf", "/run/binfmt.d/*.conf", "/usr/local/lib/binfmt.d/*.conf", "/usr/lib/binfmt.d/*.conf",
+  "/proc/sys/fs/binfmt_misc/register", "/proc/sys/fs/binfmt_misc/*"
+) and
+not (
+  file.path like (
+    "/usr/lib/binfmt.d/python3.*.conf", "/usr/lib/binfmt.d/qemu-*-static.conf",
+    "/proc/sys/fs/binfmt_misc/status"
+  ) or
+  process.executable == "/usr/lib/systemd/systemd-binfmt"
+)
+```
+
+
+
 ### Bitsadmin Activity
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0357
+Index: geneve-ut-0366
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4479,7 +4550,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0359
+Index: geneve-ut-0368
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4525,7 +4596,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0360
+Index: geneve-ut-0369
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4559,7 +4630,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0361
+Index: geneve-ut-0370
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4582,7 +4653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0363
+Index: geneve-ut-0372
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4604,7 +4675,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0364
+Index: geneve-ut-0373
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4632,7 +4703,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0365
+Index: geneve-ut-0374
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4644,11 +4715,43 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 
 
+### Claude Cowork VM Boot Image Tamper
+
+Branch count: 320  
+Document count: 320  
+Index: geneve-ut-0375
+
+```python
+file where host.os.type in ("windows", "macos") and
+  event.action in ("creation", "modification", "overwrite", "rename") and
+  event.outcome == "success" and
+  file.path : (
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/initrd",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/initrd.zst",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/vmlinuz",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/vmlinuz.zst",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/rootfs.img",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\initrd",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\initrd.zst",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\vmlinuz",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\rootfs.vhdx",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\smol-bin.vhdx"
+  ) and
+  not (
+    (process.name : "claude.exe" and
+     process.executable : "?:\\Program Files\\WindowsApps\\Claude_*\\app\\claude.exe") or
+    (process.name : ("Claude", "Claude Helper") and
+     process.executable like "/Applications/Claude.app/*")
+  )
+```
+
+
+
 ### Clearing Windows Event Logs
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0367
+Index: geneve-ut-0377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4673,7 +4776,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0369
+Index: geneve-ut-0379
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4703,7 +4806,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0371
+Index: geneve-ut-0381
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4717,7 +4820,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0372
+Index: geneve-ut-0382
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4739,7 +4842,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0373
+Index: geneve-ut-0383
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4753,7 +4856,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0374
+Index: geneve-ut-0384
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4773,7 +4876,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0377
+Index: geneve-ut-0387
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4790,7 +4893,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0380
+Index: geneve-ut-0390
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4820,7 +4923,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0383
+Index: geneve-ut-0393
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4845,7 +4948,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0385
+Index: geneve-ut-0395
 
 ```python
 sequence by process.entity_id
@@ -4866,7 +4969,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0386
+Index: geneve-ut-0396
 
 ```python
 sequence by process.entity_id
@@ -4887,7 +4990,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0389
+Index: geneve-ut-0399
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4918,7 +5021,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0390
+Index: geneve-ut-0400
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4930,7 +5033,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0391
+Index: geneve-ut-0401
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4953,7 +5056,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0394
+Index: geneve-ut-0404
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4966,7 +5069,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0395
+Index: geneve-ut-0405
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4979,7 +5082,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0397
+Index: geneve-ut-0407
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4996,7 +5099,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0398
+Index: geneve-ut-0408
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -5009,7 +5112,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0399
+Index: geneve-ut-0409
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -5026,7 +5129,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0400
+Index: geneve-ut-0410
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -5038,7 +5141,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0401
+Index: geneve-ut-0411
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -5106,7 +5209,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0402
+Index: geneve-ut-0412
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -5124,7 +5227,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0403
+Index: geneve-ut-0413
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -5137,7 +5240,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0404
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5155,7 +5258,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0405
+Index: geneve-ut-0415
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5167,7 +5270,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0406
+Index: geneve-ut-0416
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5179,7 +5282,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0407
+Index: geneve-ut-0417
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5191,7 +5294,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0408
+Index: geneve-ut-0418
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5203,7 +5306,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0409
+Index: geneve-ut-0419
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -5248,7 +5351,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0411
+Index: geneve-ut-0421
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5268,7 +5371,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0412
+Index: geneve-ut-0422
 
 ```python
 sequence with maxspan=10s
@@ -5288,7 +5391,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0413
+Index: geneve-ut-0423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5315,7 +5418,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0414
+Index: geneve-ut-0424
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5329,7 +5432,7 @@ container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0417
+Index: geneve-ut-0427
 
 ```python
 process where event.type == "start" and
@@ -5354,7 +5457,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0420
+Index: geneve-ut-0430
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5398,7 +5501,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0421
+Index: geneve-ut-0431
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5432,7 +5535,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0423
+Index: geneve-ut-0433
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5477,7 +5580,7 @@ container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0424
+Index: geneve-ut-0434
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5493,7 +5596,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0425
+Index: geneve-ut-0435
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5518,7 +5621,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0426
+Index: geneve-ut-0436
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5537,7 +5640,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0428
+Index: geneve-ut-0438
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5664,7 +5767,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0429
+Index: geneve-ut-0439
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5682,7 +5785,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0431
+Index: geneve-ut-0441
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5695,7 +5798,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0432
+Index: geneve-ut-0442
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5725,7 +5828,7 @@ container.security_context.privileged == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0438
+Index: geneve-ut-0448
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5735,46 +5838,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Deprecated - Adobe Hijack Persistence
-
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-0450
-
-```python
-file where host.os.type == "windows" and event.type == "creation" and
-  file.path : (
-    "?:\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-    "?:\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-
-    /* Crowdstrike specific condition as it uses NT Object paths */
-    "\\Device\\HarddiskVolume*\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-    "\\Device\\HarddiskVolume*\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe"
-  ) and
-  not process.name : ("msiexec.exe", "AdobeARM.exe")
-```
-
-
-
-### Deprecated - Encoded Executable Stored in the Registry
-
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-0457
-
-```python
-registry where host.os.type == "windows" and
-/* update here with encoding combinations */
- registry.data.strings : "TVqQAAMAAAAEAAAA*"
-```
-
-
-
 ### Deprecated - Microsoft Exchange Transport Agent Install Script
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0469
+Index: geneve-ut-0478
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5798,7 +5866,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0508
+Index: geneve-ut-0517
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5852,7 +5920,7 @@ container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0510
+Index: geneve-ut-0519
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5868,7 +5936,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0511
+Index: geneve-ut-0520
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5896,7 +5964,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0512
+Index: geneve-ut-0521
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5913,7 +5981,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0513
+Index: geneve-ut-0522
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5930,7 +5998,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0514
+Index: geneve-ut-0523
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5951,7 +6019,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0516
+Index: geneve-ut-0525
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5971,7 +6039,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0517
+Index: geneve-ut-0526
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5986,7 +6054,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0519
+Index: geneve-ut-0528
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5999,7 +6067,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0520
+Index: geneve-ut-0529
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6019,7 +6087,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0523
+Index: geneve-ut-0532
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -6032,7 +6100,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0524
+Index: geneve-ut-0533
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6070,7 +6138,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0525
+Index: geneve-ut-0534
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -6090,7 +6158,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0526
+Index: geneve-ut-0535
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6103,7 +6171,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0527
+Index: geneve-ut-0536
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -6126,7 +6194,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0529
+Index: geneve-ut-0538
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6157,7 +6225,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0530
+Index: geneve-ut-0539
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -6176,7 +6244,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0531
+Index: geneve-ut-0540
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6219,7 +6287,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0532
+Index: geneve-ut-0541
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -6233,7 +6301,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0534
+Index: geneve-ut-0543
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6248,7 +6316,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0535
+Index: geneve-ut-0544
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6264,7 +6332,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0536
+Index: geneve-ut-0545
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6278,7 +6346,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0537
+Index: geneve-ut-0546
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6300,49 +6368,11 @@ sequence by host.id with maxspan=3s
 
 
 
-### Elastic Agent Service Terminated
-
-Branch count: 419  
-Document count: 419  
-Index: geneve-ut-0538
-
-```python
-process where event.type == "start" and
-(
-  /* net, sc or wmic stopping or deleting Elastic Agent on Windows */
-  (
-    process.name : ("net.exe", "sc.exe", "wmic.exe","powershell.exe","taskkill.exe","PsKill.exe","ProcessHacker.exe") and
-    process.args : ("stopservice","uninstall", "stop", "disabled","Stop-Process","terminate","suspend") and
-    process.args : ("elasticendpoint", "Elastic Agent","elastic-agent","elastic-endpoint")
-  ) or
-
-  /* service or systemctl used to stop Elastic Agent on Linux */
-  (
-    process.name in ("systemctl", "service", "chkconfig", "update-rc.d") and
-    process.args : ("elastic-agent", "elastic-agent.service", "ElasticEndpoint") and
-    process.args : ("stop", "disable", "remove", "off", "kill", "mask") and
-    not (
-      process.parent.executable : "/opt/Elastic/Agent/data/elastic-agent-*/components/previous/elastic-endpoint" and
-      process.parent.args : "uninstall" and
-      process.parent.args : "--keepstate"
-    )
-  ) or
-
-  /* pkill, killall used to stop Elastic Agent or Endpoint on Linux */
-  (process.name in ("pkill", "killall", "kill") and process.args : ("elastic-agent", "elastic-endpoint")) or
-
-  /* Unload Elastic Defend extension on MacOS */
-  (process.name : "kextunload" and process.args : "com.apple.iokit.EndpointSecurity")
-)
-```
-
-
-
 ### Emond Rules Creation or Modification
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0545
+Index: geneve-ut-0554
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -6355,7 +6385,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0546
+Index: geneve-ut-0555
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6369,7 +6399,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0547
+Index: geneve-ut-0556
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6391,7 +6421,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0548
+Index: geneve-ut-0557
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6426,7 +6456,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0549
+Index: geneve-ut-0558
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6438,7 +6468,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0597
+Index: geneve-ut-0606
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6450,7 +6480,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0623
+Index: geneve-ut-0632
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6464,7 +6494,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0626
+Index: geneve-ut-0635
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6491,7 +6521,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0629
+Index: geneve-ut-0638
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6512,7 +6542,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0630
+Index: geneve-ut-0639
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6542,7 +6572,7 @@ container.id like "*"
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0633
+Index: geneve-ut-0642
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6560,7 +6590,7 @@ container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0634
+Index: geneve-ut-0643
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6593,7 +6623,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0636
+Index: geneve-ut-0645
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6610,7 +6640,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0637
+Index: geneve-ut-0646
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6638,7 +6668,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0638
+Index: geneve-ut-0647
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6651,7 +6681,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0640
+Index: geneve-ut-0649
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6671,7 +6701,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0641
+Index: geneve-ut-0650
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6697,7 +6727,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0642
+Index: geneve-ut-0651
 
 ```python
 sequence with maxspan=2h
@@ -6719,7 +6749,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0643
+Index: geneve-ut-0652
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6748,7 +6778,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0646
+Index: geneve-ut-0655
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6761,7 +6791,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0650
+Index: geneve-ut-0659
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6776,7 +6806,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0651
+Index: geneve-ut-0660
 
 ```python
 process where event.type == "start" and
@@ -6798,7 +6828,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0653
+Index: geneve-ut-0662
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6810,7 +6840,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0654
+Index: geneve-ut-0663
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6832,7 +6862,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0656
+Index: geneve-ut-0665
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6849,7 +6879,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0657
+Index: geneve-ut-0666
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6863,7 +6893,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0658
+Index: geneve-ut-0667
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6876,7 +6906,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0659
+Index: geneve-ut-0668
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6888,7 +6918,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0660
+Index: geneve-ut-0669
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6900,7 +6930,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0661
+Index: geneve-ut-0670
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6914,7 +6944,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0662
+Index: geneve-ut-0671
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6926,7 +6956,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0663
+Index: geneve-ut-0672
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -6948,7 +6978,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0667
+Index: geneve-ut-0676
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6997,7 +7027,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0668
+Index: geneve-ut-0677
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -7014,7 +7044,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0669
+Index: geneve-ut-0678
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7034,7 +7064,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0674
+Index: geneve-ut-0683
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7056,7 +7086,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0677
+Index: geneve-ut-0687
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7071,7 +7101,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0678
+Index: geneve-ut-0688
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7085,7 +7115,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0680
+Index: geneve-ut-0690
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7107,7 +7137,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0682
+Index: geneve-ut-0692
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -7128,7 +7158,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0683
+Index: geneve-ut-0693
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7154,7 +7184,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0684
+Index: geneve-ut-0694
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -7182,7 +7212,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0687
+Index: geneve-ut-0697
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -7196,7 +7226,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0726
+Index: geneve-ut-0737
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -7213,7 +7243,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0727
+Index: geneve-ut-0738
 
 ```python
 registry where host.os.type == "windows" and
@@ -7231,7 +7261,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0798
+Index: geneve-ut-0810
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7300,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0799
+Index: geneve-ut-0811
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7327,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0800
+Index: geneve-ut-0812
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7342,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0801
+Index: geneve-ut-0813
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7429,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0809
+Index: geneve-ut-0821
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7447,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0810
+Index: geneve-ut-0822
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7478,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0811
+Index: geneve-ut-0823
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7505,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0812
+Index: geneve-ut-0824
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7525,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0816
+Index: geneve-ut-0828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7538,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0819
+Index: geneve-ut-0831
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7550,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0822
+Index: geneve-ut-0834
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7562,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0826
+Index: geneve-ut-0838
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7574,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0828
+Index: geneve-ut-0840
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7591,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0854
+Index: geneve-ut-0866
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7604,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0857
+Index: geneve-ut-0869
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7628,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0858
+Index: geneve-ut-0870
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7640,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0871
+Index: geneve-ut-0883
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7658,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0872
+Index: geneve-ut-0884
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7707,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0873
+Index: geneve-ut-0885
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7721,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0877
+Index: geneve-ut-0889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7736,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0883
+Index: geneve-ut-0894
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7753,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0885
+Index: geneve-ut-0896
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7772,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0886
+Index: geneve-ut-0897
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7790,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0887
+Index: geneve-ut-0898
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7809,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0888
+Index: geneve-ut-0899
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7825,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0889
+Index: geneve-ut-0900
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7841,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0890
+Index: geneve-ut-0901
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0895
+Index: geneve-ut-0906
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7871,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0897
+Index: geneve-ut-0908
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7884,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0898
+Index: geneve-ut-0909
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7900,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0899
+Index: geneve-ut-0910
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7888,7 +7918,9 @@ registry where host.os.type == "windows" and event.type == "change" and
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\SAP\\SAPsetup\\setup\\NwSapSetup.exe",
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\SAP\\SapSetup\\OnRebootSvc\\NWSAPSetupOnRebootInstSvc.exe",
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\Kaspersky Lab\\Kaspersky Security for Windows Server\\kavfs.exe"
-  )
+  ) and
+  /* Microsoft Cloud AppCompat SDB test registrations */
+  not registry.path : "*\\AppCompatFlags\\Custom\\*\\{22221111-1111-1111-1111-111111111111}.sdb"
 ```
 
 
@@ -7897,7 +7929,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0900
+Index: geneve-ut-0911
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7953,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0905
+Index: geneve-ut-0916
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7977,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0907
+Index: geneve-ut-0918
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +8013,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0908
+Index: geneve-ut-0919
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +8025,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0909
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8039,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0910
+Index: geneve-ut-0921
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8052,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0911
+Index: geneve-ut-0922
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8111,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0912
+Index: geneve-ut-0923
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8124,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0913
+Index: geneve-ut-0924
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8137,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0914
+Index: geneve-ut-0925
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8158,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0915
+Index: geneve-ut-0926
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8176,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0916
+Index: geneve-ut-0927
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8178,7 +8210,7 @@ not (
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0918
+Index: geneve-ut-0929
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8232,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0920
+Index: geneve-ut-0931
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8259,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0921
+Index: geneve-ut-0932
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8285,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0922
+Index: geneve-ut-0933
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8301,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0923
+Index: geneve-ut-0934
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8317,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0925
+Index: geneve-ut-0936
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8329,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0926
+Index: geneve-ut-0937
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8357,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0928
+Index: geneve-ut-0939
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8373,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0930
+Index: geneve-ut-0941
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8398,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0931
+Index: geneve-ut-0942
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8412,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0933
+Index: geneve-ut-0944
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8435,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0934
+Index: geneve-ut-0945
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8468,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0935
+Index: geneve-ut-0946
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8495,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0938
+Index: geneve-ut-0949
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8516,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0939
+Index: geneve-ut-0950
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8543,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0949
+Index: geneve-ut-0960
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8565,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0975
+Index: geneve-ut-0986
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8584,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0978
+Index: geneve-ut-0989
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8628,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0980
+Index: geneve-ut-0991
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8653,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0992
+Index: geneve-ut-1003
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8691,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0997
+Index: geneve-ut-1008
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8709,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0998
+Index: geneve-ut-1009
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8723,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1003
+Index: geneve-ut-1014
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8738,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1018
+Index: geneve-ut-1029
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8752,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1021
+Index: geneve-ut-1032
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8766,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1023
+Index: geneve-ut-1034
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8787,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1024
+Index: geneve-ut-1035
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8817,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1028
+Index: geneve-ut-1039
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8864,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1029
+Index: geneve-ut-1040
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8895,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1032
+Index: geneve-ut-1043
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8908,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1034
+Index: geneve-ut-1045
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8921,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1035
+Index: geneve-ut-1046
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8933,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1071
+Index: geneve-ut-1082
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8946,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1072
+Index: geneve-ut-1083
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8959,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1073
+Index: geneve-ut-1084
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8971,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1074
+Index: geneve-ut-1085
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8983,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1075
+Index: geneve-ut-1086
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +8996,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1083
+Index: geneve-ut-1094
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +9009,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1086
+Index: geneve-ut-1098
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +9029,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1087
+Index: geneve-ut-1099
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9041,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1088
+Index: geneve-ut-1100
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9053,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1092
+Index: geneve-ut-1104
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9065,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1093
+Index: geneve-ut-1105
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9077,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1095
+Index: geneve-ut-1107
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9089,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1096
+Index: geneve-ut-1108
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9101,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1097
+Index: geneve-ut-1109
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9126,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1098
+Index: geneve-ut-1110
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9146,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1099
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9159,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1100
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9174,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1101
+Index: geneve-ut-1113
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9199,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1103
+Index: geneve-ut-1115
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9211,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1106
+Index: geneve-ut-1118
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9223,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1107
+Index: geneve-ut-1119
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9235,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1108
+Index: geneve-ut-1120
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9269,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1111
+Index: geneve-ut-1123
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9283,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1112
+Index: geneve-ut-1124
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9304,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1113
+Index: geneve-ut-1125
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9318,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1117
+Index: geneve-ut-1129
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9353,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1118
+Index: geneve-ut-1130
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9378,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1119
+Index: geneve-ut-1131
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9395,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1123
+Index: geneve-ut-1135
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9409,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1125
+Index: geneve-ut-1137
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9440,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1127
+Index: geneve-ut-1139
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9494,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1128
+Index: geneve-ut-1140
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9506,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1142
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9524,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1131
+Index: geneve-ut-1143
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9541,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1133
+Index: geneve-ut-1145
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9556,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1134
+Index: geneve-ut-1146
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9606,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1136
+Index: geneve-ut-1148
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9622,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1137
+Index: geneve-ut-1149
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9636,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1139
+Index: geneve-ut-1151
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1140
+Index: geneve-ut-1152
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9693,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1141
+Index: geneve-ut-1153
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9715,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1142
+Index: geneve-ut-1154
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9734,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1143
+Index: geneve-ut-1155
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9767,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1144
+Index: geneve-ut-1156
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9785,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1145
+Index: geneve-ut-1157
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9826,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1158
+Index: geneve-ut-1170
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9852,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1167
+Index: geneve-ut-1179
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9876,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1171
+Index: geneve-ut-1183
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9890,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1172
+Index: geneve-ut-1184
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9909,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1173
+Index: geneve-ut-1185
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9929,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1174
+Index: geneve-ut-1186
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9952,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1175
+Index: geneve-ut-1187
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9973,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1177
+Index: geneve-ut-1189
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +9988,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1178
+Index: geneve-ut-1190
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +10005,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1180
+Index: geneve-ut-1192
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +10029,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1182
+Index: geneve-ut-1194
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10075,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1183
+Index: geneve-ut-1195
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10117,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1184
+Index: geneve-ut-1196
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10134,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1186
+Index: geneve-ut-1198
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10149,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1187
+Index: geneve-ut-1199
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10168,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1188
+Index: geneve-ut-1200
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10188,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1189
+Index: geneve-ut-1201
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10207,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1191
+Index: geneve-ut-1203
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10236,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1192
+Index: geneve-ut-1204
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10261,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1193
+Index: geneve-ut-1205
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10283,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1194
+Index: geneve-ut-1206
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10316,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1195
+Index: geneve-ut-1207
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10346,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1199
+Index: geneve-ut-1211
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10363,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1200
+Index: geneve-ut-1212
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10400,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1201
+Index: geneve-ut-1213
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10413,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1206
+Index: geneve-ut-1218
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10425,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1209
+Index: geneve-ut-1221
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10437,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1219
+Index: geneve-ut-1232
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10451,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1220
+Index: geneve-ut-1233
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10465,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1221
+Index: geneve-ut-1234
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10479,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1222
+Index: geneve-ut-1235
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10499,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1224
+Index: geneve-ut-1237
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10512,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1225
+Index: geneve-ut-1238
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10527,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1227
+Index: geneve-ut-1240
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10549,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1236
+Index: geneve-ut-1249
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10576,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1237
+Index: geneve-ut-1250
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10596,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1238
+Index: geneve-ut-1251
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10611,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1239
+Index: geneve-ut-1252
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10638,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1240
+Index: geneve-ut-1253
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10653,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1241
+Index: geneve-ut-1254
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10669,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1242
+Index: geneve-ut-1255
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10683,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1243
+Index: geneve-ut-1256
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10670,7 +10702,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1244
+Index: geneve-ut-1257
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -10690,7 +10722,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1251
+Index: geneve-ut-1264
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10705,7 +10737,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1252
+Index: geneve-ut-1265
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10719,7 +10751,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1253
+Index: geneve-ut-1266
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10738,7 +10770,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1254
+Index: geneve-ut-1267
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10750,7 +10782,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1255
+Index: geneve-ut-1268
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10762,7 +10794,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1256
+Index: geneve-ut-1269
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10780,7 +10812,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1257
+Index: geneve-ut-1270
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10793,7 +10825,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1258
+Index: geneve-ut-1271
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10808,7 +10840,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1259
+Index: geneve-ut-1272
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10823,7 +10855,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1262
+Index: geneve-ut-1275
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10843,7 +10875,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1263
+Index: geneve-ut-1276
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10867,7 +10899,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1264
+Index: geneve-ut-1277
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10881,7 +10913,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1265
+Index: geneve-ut-1278
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10900,7 +10932,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1266
+Index: geneve-ut-1279
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10928,7 +10960,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1267
+Index: geneve-ut-1280
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10957,7 +10989,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1268
+Index: geneve-ut-1281
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10976,7 +11008,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1269
+Index: geneve-ut-1282
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11004,7 +11036,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1270
+Index: geneve-ut-1283
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11019,7 +11051,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1271
+Index: geneve-ut-1284
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11082,7 +11114,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1272
+Index: geneve-ut-1285
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11103,7 +11135,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1273
+Index: geneve-ut-1286
 
 ```python
 any where host.os.type == "windows" and
@@ -11165,7 +11197,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1275
+Index: geneve-ut-1288
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11194,7 +11226,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1276
+Index: geneve-ut-1289
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11208,7 +11240,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1277
+Index: geneve-ut-1290
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11241,7 +11273,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1280
+Index: geneve-ut-1293
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11288,7 +11320,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1281
+Index: geneve-ut-1294
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11315,7 +11347,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1282
+Index: geneve-ut-1295
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11328,7 +11360,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1293
+Index: geneve-ut-1306
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11345,7 +11377,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1295
+Index: geneve-ut-1308
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11353,6 +11385,8 @@ process where host.os.type == "windows" and event.type == "start" and process.na
   not (process.args : "-m" and process.args : "-bg") and
   not process.args : (
     "-mm",
+    "?:\\Windows\\appcompat\\cloudsdb\\apppatch.sdb",
+    "\"?:\\Windows\\appcompat\\cloudsdb\\apppatch.sdb\"",
     "?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\sysMergeInboxStoreApp.sdb",
     "\"?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\sysMergeInboxStoreApp.sdb\"",
     "?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\msiMergeInboxStoreApp.sdb",
@@ -11370,7 +11404,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1300
+Index: geneve-ut-1313
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11386,7 +11420,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1301
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11407,7 +11441,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1304
+Index: geneve-ut-1317
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11424,7 +11458,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1305
+Index: geneve-ut-1318
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11437,7 +11471,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1306
+Index: geneve-ut-1319
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11461,7 +11495,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1308
+Index: geneve-ut-1321
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11490,7 +11524,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1310
+Index: geneve-ut-1323
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11517,7 +11551,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1311
+Index: geneve-ut-1324
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11541,7 +11575,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1314
+Index: geneve-ut-1327
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11559,7 +11593,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1315
+Index: geneve-ut-1328
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11582,7 +11616,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1316
+Index: geneve-ut-1329
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11639,7 +11673,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1317
+Index: geneve-ut-1330
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11656,7 +11690,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1318
+Index: geneve-ut-1331
 
 ```python
 sequence by process.entity_id
@@ -11670,7 +11704,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1333
+Index: geneve-ut-1348
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11685,7 +11719,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1334
+Index: geneve-ut-1349
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11716,7 +11750,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1335
+Index: geneve-ut-1350
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11730,7 +11764,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1336
+Index: geneve-ut-1351
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11743,7 +11777,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1337
+Index: geneve-ut-1352
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11755,7 +11789,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1338
+Index: geneve-ut-1353
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11768,7 +11802,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1340
+Index: geneve-ut-1355
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11787,7 +11821,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1341
+Index: geneve-ut-1356
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11800,7 +11834,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1342
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11821,7 +11855,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1343
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11835,7 +11869,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1346
+Index: geneve-ut-1361
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11855,7 +11889,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1347
+Index: geneve-ut-1362
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11879,7 +11913,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1348
+Index: geneve-ut-1363
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11895,7 +11929,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1349
+Index: geneve-ut-1364
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11912,7 +11946,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1350
+Index: geneve-ut-1366
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11933,7 +11967,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1352
+Index: geneve-ut-1368
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11946,7 +11980,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1354
+Index: geneve-ut-1370
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11974,7 +12008,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1357
+Index: geneve-ut-1373
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11990,7 +12024,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1358
+Index: geneve-ut-1374
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12013,7 +12047,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1359
+Index: geneve-ut-1375
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12026,7 +12060,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1361
+Index: geneve-ut-1377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12039,7 +12073,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1366
+Index: geneve-ut-1382
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12053,7 +12087,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1367
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12064,11 +12098,37 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 
 
+### Potential IIS Web Shell File Creation
+
+Branch count: 165  
+Document count: 165  
+Index: geneve-ut-1385
+
+```python
+file where host.os.type == "windows" and event.type != "deletion" and file.extension : ("aspx", "ashx", "asmx") and
+ process.name : ("w3wp.exe", "MSExchangeMailboxReplication.exe", "EdgeTransport.exe", "Microsoft.Exchange.*.exe", "UMWorkerProcess.exe", "umservice.exe", "cmd.exe", "powershell.exe", "pwsh.exe", "certutil.exe", "xcopy.exe") and 
+  (
+   (file.path : ("?:\\Program Files\\Common Files\\microsoft shared\\Web Server Extensions\\*\\TEMPLATE\\LAYOUTS\\*",
+                 "?:\\inetpub\\wwwroot\\aspnet_client\\system_web\\*", 
+                 "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\owa\\auth\\*", 
+                 "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\ecp\\auth\\*") and 
+    /* not sub-dirs */
+    not file.path : ("?:\\inetpub\\wwwroot\\aspnet_client\\system_web\\*\\*", 
+                     "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\*\\auth\\*\\*", 
+                     "?:\\Program Files\\Common Files\\microsoft shared\\Web Server Extensions\\*\\TEMPLATE\\LAYOUTS\\*\\*")) or 
+
+    /* not sub-dirs */
+   (file.path : "?:\\inetpub\\wwwroot\\aspnet_client\\*" and not file.path : "?:\\inetpub\\wwwroot\\aspnet_client\\*\\*")
+  )
+```
+
+
+
 ### Potential Impersonation Attempt via Kubectl
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1369
+Index: geneve-ut-1386
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12087,38 +12147,28 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 
 
-### Potential JAVA/JNDI Exploitation Attempt
+### Potential Java Service Exploitation via Suspicious Child Process
 
-Branch count: 60  
-Document count: 120  
-Index: geneve-ut-1372
+Branch count: 30  
+Document count: 60  
+Index: geneve-ut-1389
 
 ```python
-sequence by host.id with maxspan=1m
- [network where event.action == "connection_attempted" and
+sequence by host.id with maxspan=5s
+ [network where event.action == "connection_accepted" and network.direction == "ingress" and
+
   process.name : "java" and
-  /*
-     outbound connection attempt to
-     LDAP, RMI or DNS standard ports
-     by JAVA process
-   */
-  destination.port in (1389, 389, 1099, 53, 5353)] by process.pid
+  destination.port < 49152  and source.port >= 32768] by process.pid
  [process where event.type == "start" and
 
   /* Suspicious JAVA child process */
   process.parent.name : "java" and
-   process.name : ("sh",
-                   "bash",
-                   "dash",
-                   "ksh",
-                   "tcsh",
-                   "zsh",
-                   "curl",
-                   "perl*",
-                   "python*",
-                   "ruby*",
-                   "php*",
-                   "wget") and
+  process.name : (
+    "sh", "bash", "dash", "ksh", "tcsh", "zsh", "ash",  "mksh", "busybox",
+    "curl", "wget", "perl*", "python*", "ruby*", "php*", "lua*", "socat",
+    "nc", "ncat", "netcat", "netcat.openbsd", "netcat.traditional", "nc.openbsd",
+    "nc.traditional", "nohup", "setsid", "disown", "hostname", "whoami", "id"
+  ) and
     not process.command_line like~ (
       "bash -c ulimit -u",
       "bash /opt/flutter/bin/flutter*",
@@ -12134,7 +12184,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1373
+Index: geneve-ut-1390
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12152,7 +12202,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1374
+Index: geneve-ut-1391
 
 ```python
 host.os.type:"windows" and
@@ -12168,7 +12218,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1376
+Index: geneve-ut-1393
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12180,7 +12230,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1378
+Index: geneve-ut-1395
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12196,7 +12246,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1379
+Index: geneve-ut-1396
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12212,7 +12262,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1380
+Index: geneve-ut-1397
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12230,7 +12280,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1381
+Index: geneve-ut-1398
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12244,7 +12294,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1383
+Index: geneve-ut-1400
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12267,7 +12317,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1385
+Index: geneve-ut-1402
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12283,7 +12333,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1386
+Index: geneve-ut-1403
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12296,7 +12346,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1387
+Index: geneve-ut-1404
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12326,7 +12376,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1393
+Index: geneve-ut-1410
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12349,7 +12399,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1394
+Index: geneve-ut-1411
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12368,7 +12418,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1399
+Index: geneve-ut-1416
 
 ```python
 process where host.os.type == "windows" and 
@@ -12510,7 +12560,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1400
+Index: geneve-ut-1417
 
 ```python
 process where host.os.type == "windows" and
@@ -12587,7 +12637,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1404
+Index: geneve-ut-1421
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12604,7 +12654,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1405
+Index: geneve-ut-1422
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12638,7 +12688,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1407
+Index: geneve-ut-1424
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12650,7 +12700,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1408
+Index: geneve-ut-1425
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12689,7 +12739,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1411
+Index: geneve-ut-1428
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12702,7 +12752,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1416
+Index: geneve-ut-1433
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12716,7 +12766,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1423
+Index: geneve-ut-1440
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12754,7 +12804,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1424
+Index: geneve-ut-1441
 
 ```python
 network where host.os.type == "windows" and
@@ -12780,7 +12830,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1427
+Index: geneve-ut-1444
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12795,7 +12845,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1430
+Index: geneve-ut-1447
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12809,7 +12859,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1431
+Index: geneve-ut-1448
 
 ```python
 file where host.os.type == "windows" and
@@ -12823,7 +12873,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1432
+Index: geneve-ut-1449
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12836,7 +12886,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1433
+Index: geneve-ut-1450
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12906,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1434
+Index: geneve-ut-1451
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12876,7 +12926,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1436
+Index: geneve-ut-1453
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12915,7 +12965,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1437
+Index: geneve-ut-1454
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13110,7 +13160,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1452
+Index: geneve-ut-1469
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13126,7 +13176,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1453
+Index: geneve-ut-1470
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13140,7 +13190,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1454
+Index: geneve-ut-1471
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13154,7 +13204,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1455
+Index: geneve-ut-1472
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13171,7 +13221,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1456
+Index: geneve-ut-1473
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13185,7 +13235,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1457
+Index: geneve-ut-1474
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13201,7 +13251,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1462
+Index: geneve-ut-1479
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13213,7 +13263,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1463
+Index: geneve-ut-1480
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13229,7 +13279,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1464
+Index: geneve-ut-1481
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13249,7 +13299,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1466
+Index: geneve-ut-1483
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13289,7 +13339,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1468
+Index: geneve-ut-1485
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13301,7 +13351,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1469
+Index: geneve-ut-1486
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13322,7 +13372,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1470
+Index: geneve-ut-1487
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13343,7 +13393,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1471
+Index: geneve-ut-1488
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13364,7 +13414,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1472
+Index: geneve-ut-1489
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13390,7 +13440,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1473
+Index: geneve-ut-1490
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13406,7 +13456,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1474
+Index: geneve-ut-1491
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13420,7 +13470,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1476
+Index: geneve-ut-1493
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13443,7 +13493,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1478
+Index: geneve-ut-1495
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13460,7 +13510,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1479
+Index: geneve-ut-1496
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13483,7 +13533,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1480
+Index: geneve-ut-1497
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13496,7 +13546,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1481
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13510,7 +13560,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1482
+Index: geneve-ut-1499
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13527,7 +13577,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1483
+Index: geneve-ut-1500
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13581,7 +13631,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1484
+Index: geneve-ut-1501
 
 ```python
 any where host.os.type == "windows" and
@@ -13608,7 +13658,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1490
+Index: geneve-ut-1507
 
 ```python
 file where host.os.type == "windows" and
@@ -13623,7 +13673,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1491
+Index: geneve-ut-1508
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13654,7 +13704,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1492
+Index: geneve-ut-1509
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13668,7 +13718,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1493
+Index: geneve-ut-1510
 
 ```python
 sequence with maxspan=1m
@@ -13710,7 +13760,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1494
+Index: geneve-ut-1511
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13735,7 +13785,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1495
+Index: geneve-ut-1512
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13789,7 +13839,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1496
+Index: geneve-ut-1513
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13809,7 +13859,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1497
+Index: geneve-ut-1514
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13830,7 +13880,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1498
+Index: geneve-ut-1515
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13845,7 +13895,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1499
+Index: geneve-ut-1516
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13865,7 +13915,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1500
+Index: geneve-ut-1517
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13907,7 +13957,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1504
+Index: geneve-ut-1521
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13922,7 +13972,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1505
+Index: geneve-ut-1522
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13957,7 +14007,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1506
+Index: geneve-ut-1523
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13974,7 +14024,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1511
+Index: geneve-ut-1528
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13988,7 +14038,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1514
+Index: geneve-ut-1531
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -14001,7 +14051,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1515
+Index: geneve-ut-1532
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -14013,7 +14063,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1516
+Index: geneve-ut-1534
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14028,7 +14078,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1518
+Index: geneve-ut-1536
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14056,7 +14106,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1520
+Index: geneve-ut-1538
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14081,7 +14131,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1524
+Index: geneve-ut-1542
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14118,7 +14168,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1525
+Index: geneve-ut-1543
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14132,7 +14182,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1526
+Index: geneve-ut-1544
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14148,7 +14198,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1527
+Index: geneve-ut-1545
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14162,7 +14212,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1528
+Index: geneve-ut-1546
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14192,7 +14242,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1529
+Index: geneve-ut-1547
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14221,7 +14271,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1530
+Index: geneve-ut-1548
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14237,7 +14287,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1531
+Index: geneve-ut-1549
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14251,7 +14301,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1532
+Index: geneve-ut-1550
 
 ```python
 file where host.os.type == "windows" and
@@ -14270,12 +14320,26 @@ file where host.os.type == "windows" and
   not process.executable : (
     "?:\\Program Files\\*",
     "?:\\Program Files (x86)\\*",
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\*",
     "?:\\Windows\\system32\\cleanmgr.exe",
     "?:\\Windows\\system32\\msiexec.exe",
     "?:\\Windows\\syswow64\\msiexec.exe",
     "?:\\Windows\\system32\\svchost.exe",
     "?:\\Windows\\System32\\Robocopy.exe",
-    "?:\\Windows\\SysWOW64\\Robocopy.exe"
+    "?:\\Windows\\SysWOW64\\Robocopy.exe",
+    "?:\\Windows\\explorer.exe",
+    "?:\\Windows\\system32\\Dism.exe",
+    "?:\\Windows\\system32\\DFSRs.exe",
+    "?:\\Windows\\system32\\wbengine.exe",
+    "?:\\Windows\\system32\\CompatTelRunner.exe",
+    "?:\\Windows\\system32\\SearchIndexer.exe",
+    "?:\\Windows\\system32\\wuauclt.exe",
+    "?:\\Windows\\servicing\\TrustedInstaller.exe",
+    "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+    "?:\\Windows\\Microsoft.NET\\*",
+    "?:\\Windows\\SystemApps\\*",
+    "?:\\Windows\\uus\\*\\wuaucltcore.exe",
+    "?:\\$WINDOWS.~BT\\Sources\\mighost.exe"
   ) and
   not (process.executable : "?:\\Windows\\System32\\spoolsv.exe" and file.path : "?:\\Windows\\System32\\spool\\*") and
   not user.name : ("SYSTEM", "Local Service", "Network Service")
@@ -14287,7 +14351,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1535
+Index: geneve-ut-1553
 
 ```python
 process where event.type == "start" and
@@ -14301,7 +14365,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1536
+Index: geneve-ut-1554
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14379,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1537
+Index: geneve-ut-1555
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14335,7 +14399,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1539
+Index: geneve-ut-1557
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14352,7 +14416,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1540
+Index: geneve-ut-1558
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14364,7 +14428,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1541
+Index: geneve-ut-1559
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14377,29 +14441,11 @@ process.executable : (
 
 
 
-### Potential Web Shell ASPX File Creation
-
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-1542
-
-```python
-file where host.os.type == "windows" and event.type != "deletion" and
-  file.extension : "aspx" and
-  file.path : "?:\\Program Files\\Common Files\\Microsoft Shared\\Web Server Extensions\\*" and
-  not process.executable: (
-        "?:\\Windows\\System32\\msiexec.exe",
-        "?:\\Program Files\\Common Files\\Microsoft Shared\\Web Server Extensions\\16\\BIN\\psconfigui.exe"
-  )
-```
-
-
-
 ### Potential notify_on_release Container Escape Detected via Defend for Containers
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1549
+Index: geneve-ut-1566
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14412,7 +14458,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1550
+Index: geneve-ut-1567
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14439,7 +14485,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1551
+Index: geneve-ut-1568
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14452,7 +14498,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1552
+Index: geneve-ut-1569
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14466,7 +14512,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1554
+Index: geneve-ut-1571
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14483,7 +14529,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1555
+Index: geneve-ut-1572
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14506,7 +14552,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1557
+Index: geneve-ut-1574
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14523,7 +14569,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1560
+Index: geneve-ut-1577
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14536,7 +14582,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1562
+Index: geneve-ut-1579
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14560,7 +14606,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1563
+Index: geneve-ut-1580
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14588,7 +14634,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1579
+Index: geneve-ut-1596
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14609,7 +14655,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1581
+Index: geneve-ut-1598
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14637,7 +14683,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1583
+Index: geneve-ut-1600
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14677,7 +14723,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1584
+Index: geneve-ut-1601
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14694,7 +14740,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1585
+Index: geneve-ut-1602
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14708,7 +14754,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1586
+Index: geneve-ut-1603
 
 ```python
 file where host.os.type == "windows" and
@@ -14727,7 +14773,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1587
+Index: geneve-ut-1604
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14741,7 +14787,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1589
+Index: geneve-ut-1606
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14759,7 +14805,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1591
+Index: geneve-ut-1608
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14777,7 +14823,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1594
+Index: geneve-ut-1611
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14791,7 +14837,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1596
+Index: geneve-ut-1613
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14806,7 +14852,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1597
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14829,7 +14875,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1599
+Index: geneve-ut-1616
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14911,7 +14957,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1600
+Index: geneve-ut-1617
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14932,7 +14978,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1601
+Index: geneve-ut-1618
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14954,11 +15000,29 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 
 
+### Process Execution Followed by Self-Deletion
+
+Branch count: 9  
+Document count: 18  
+Index: geneve-ut-1621
+
+```python
+sequence by process.entity_id, host.id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
+  process.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/*", "/var/run/*", "/var/www/*",
+    "/proc/*/fd/*", "?memfd:*", "memfd:*"
+  )] by process.executable
+  [file where host.os.type == "linux" and event.action == "deletion"] by file.path
+```
+
+
+
 ### Process Execution from an Unusual Directory
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1604
+Index: geneve-ut-1622
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15011,7 +15075,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1605
+Index: geneve-ut-1623
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15023,7 +15087,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1606
+Index: geneve-ut-1624
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15035,7 +15099,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1607
+Index: geneve-ut-1625
 
 ```python
 process where host.os.type == "windows" and
@@ -15050,7 +15114,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1608
+Index: geneve-ut-1626
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15080,7 +15144,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1609
+Index: geneve-ut-1627
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15140,7 +15204,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1612
+Index: geneve-ut-1630
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15153,7 +15217,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1613
+Index: geneve-ut-1631
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15185,7 +15249,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1614
+Index: geneve-ut-1632
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15209,7 +15273,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1616
+Index: geneve-ut-1634
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15242,7 +15306,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1617
+Index: geneve-ut-1635
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15259,7 +15323,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1619
+Index: geneve-ut-1637
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15288,7 +15352,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1620
+Index: geneve-ut-1638
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15302,7 +15366,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1621
+Index: geneve-ut-1639
 
 ```python
 sequence by process.entity_id
@@ -15327,7 +15391,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1622
+Index: geneve-ut-1640
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15361,7 +15425,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1623
+Index: geneve-ut-1641
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15389,7 +15453,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1624
+Index: geneve-ut-1642
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15408,7 +15472,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1630
+Index: geneve-ut-1648
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15436,7 +15500,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1631
+Index: geneve-ut-1649
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15455,7 +15519,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1635
+Index: geneve-ut-1653
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15467,7 +15531,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1636
+Index: geneve-ut-1654
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15479,7 +15543,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1637
+Index: geneve-ut-1655
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15491,7 +15555,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1638
+Index: geneve-ut-1656
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15503,7 +15567,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1649
+Index: geneve-ut-1667
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15516,7 +15580,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1650
+Index: geneve-ut-1668
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15554,7 +15618,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1652
+Index: geneve-ut-1670
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15569,7 +15633,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1653
+Index: geneve-ut-1671
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15588,7 +15652,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1654
+Index: geneve-ut-1672
 
 ```python
 sequence with maxspan=1m
@@ -15636,7 +15700,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1656
+Index: geneve-ut-1674
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15659,7 +15723,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1658
+Index: geneve-ut-1676
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15673,7 +15737,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1659
+Index: geneve-ut-1677
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15687,7 +15751,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1661
+Index: geneve-ut-1679
 
 ```python
 sequence by host.id, process.entity_id
@@ -15704,7 +15768,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1662
+Index: geneve-ut-1680
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15718,7 +15782,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1663
+Index: geneve-ut-1681
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15738,7 +15802,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1664
+Index: geneve-ut-1682
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15767,7 +15831,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1665
+Index: geneve-ut-1683
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15787,7 +15851,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1666
+Index: geneve-ut-1684
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15800,7 +15864,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1668
+Index: geneve-ut-1686
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15842,7 +15906,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1669
+Index: geneve-ut-1687
 
 ```python
 sequence with maxspan=1m
@@ -15865,7 +15929,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1670
+Index: geneve-ut-1688
 
 ```python
 sequence with maxspan=1s
@@ -15913,7 +15977,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1671
+Index: geneve-ut-1689
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15930,7 +15994,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1673
+Index: geneve-ut-1691
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15959,7 +16023,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1676
+Index: geneve-ut-1694
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15987,7 +16051,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1677
+Index: geneve-ut-1695
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -16004,7 +16068,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1679
+Index: geneve-ut-1697
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16023,7 +16087,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1680
+Index: geneve-ut-1698
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16044,7 +16108,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1689
+Index: geneve-ut-1709
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16058,7 +16122,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1691
+Index: geneve-ut-1711
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16077,7 +16141,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1692
+Index: geneve-ut-1712
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16091,7 +16155,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1693
+Index: geneve-ut-1713
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16111,7 +16175,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1695
+Index: geneve-ut-1715
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16129,7 +16193,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1696
+Index: geneve-ut-1716
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16150,7 +16214,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1698
+Index: geneve-ut-1718
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16164,7 +16228,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1699
+Index: geneve-ut-1719
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16179,7 +16243,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1700
+Index: geneve-ut-1720
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16220,7 +16284,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1702
+Index: geneve-ut-1722
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16245,7 +16309,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1703
+Index: geneve-ut-1723
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16284,7 +16348,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1704
+Index: geneve-ut-1724
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16298,7 +16362,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1705
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16337,7 +16401,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1706
+Index: geneve-ut-1726
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16351,7 +16415,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1707
+Index: geneve-ut-1727
 
 ```python
 process where event.type == "start" and
@@ -16423,7 +16487,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1711
+Index: geneve-ut-1731
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16444,7 +16508,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1714
+Index: geneve-ut-1734
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16461,7 +16525,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1717
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16479,7 +16543,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1718
+Index: geneve-ut-1738
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16491,7 +16555,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1719
+Index: geneve-ut-1739
 
 ```python
 file where host.os.type == "windows" and
@@ -16524,7 +16588,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1722
+Index: geneve-ut-1742
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16556,7 +16620,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1724
+Index: geneve-ut-1744
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16592,7 +16656,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1725
+Index: geneve-ut-1745
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16609,7 +16673,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1726
+Index: geneve-ut-1746
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16629,7 +16693,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1728
+Index: geneve-ut-1748
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16644,7 +16708,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1729
+Index: geneve-ut-1749
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16665,7 +16729,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1730
+Index: geneve-ut-1750
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16688,7 +16752,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1731
+Index: geneve-ut-1751
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16701,7 +16765,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1732
+Index: geneve-ut-1752
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16718,7 +16782,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1735
+Index: geneve-ut-1755
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16743,7 +16807,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1738
+Index: geneve-ut-1758
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16774,7 +16838,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1739
+Index: geneve-ut-1759
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16823,7 +16887,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1740
+Index: geneve-ut-1760
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16837,7 +16901,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1741
+Index: geneve-ut-1761
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16852,7 +16916,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1742
+Index: geneve-ut-1762
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16867,7 +16931,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1743
+Index: geneve-ut-1763
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16889,7 +16953,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1744
+Index: geneve-ut-1764
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16910,7 +16974,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1748
+Index: geneve-ut-1768
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16924,7 +16988,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1749
+Index: geneve-ut-1769
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16947,7 +17011,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1779
+Index: geneve-ut-1799
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16972,7 +17036,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1780
+Index: geneve-ut-1800
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -17005,7 +17069,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1781
+Index: geneve-ut-1801
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17064,7 +17128,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1783
+Index: geneve-ut-1803
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17082,7 +17146,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1784
+Index: geneve-ut-1804
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17094,7 +17158,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1787
+Index: geneve-ut-1807
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17119,7 +17183,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1793
+Index: geneve-ut-1813
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17134,7 +17198,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1794
+Index: geneve-ut-1814
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17157,7 +17221,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1797
+Index: geneve-ut-1817
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17169,9 +17233,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### Suspicious /proc/maps Discovery
 
-Branch count: 48  
-Document count: 48  
-Index: geneve-ut-1799
+Branch count: 96  
+Document count: 96  
+Index: geneve-ut-1819
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17183,7 +17247,9 @@ not (
   ?process.parent.name == "uac" or
   ?process.parent.executable in ("/opt/secl/linux-ir-scripts-v3/thieves.sh", "/opt/traps/rpm-installer/setup.sh") or
   ?process.working_directory like ("/opt/traps/deb-installer", "/opt/Tanium/TaniumClient/*") or
-  ?process.parent.executable like ("/home/*/sunlight/thieves.sh")
+  ?process.parent.executable like ("/home/*/sunlight/thieves.sh") or
+  (?process.parent.executable == "/usr/lib/systemd/systemd" and ?process.parent.command_line == "/sbin/init") or
+  ?process.group_leader.executable in ("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/opt/traps/bin/cytool")
 )
 ```
 
@@ -17193,7 +17259,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1801
+Index: geneve-ut-1821
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17220,7 +17286,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1805
+Index: geneve-ut-1825
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17259,7 +17325,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1806
+Index: geneve-ut-1826
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17282,7 +17348,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1807
+Index: geneve-ut-1827
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17296,7 +17362,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1808
+Index: geneve-ut-1828
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17312,7 +17378,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1809
+Index: geneve-ut-1829
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17328,7 +17394,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1810
+Index: geneve-ut-1830
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17342,7 +17408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1812
+Index: geneve-ut-1832
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17361,11 +17427,76 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 
 
+### Suspicious Child Process of PaperCut Server Component
+
+Branch count: 92  
+Document count: 92  
+Index: geneve-ut-1833
+
+```python
+process where host.os.type == "windows" and event.type == "start" and
+  process.parent.name : ("pc-app.exe", "pc-printjob-spooler.exe") and
+  (
+    process.name : (
+      "cmd.exe",
+      "powershell.exe",
+      "pwsh.exe",
+      "powershell_ise.exe",
+      "wscript.exe",
+      "cscript.exe",
+      "mshta.exe",
+      "rundll32.exe",
+      "regsvr32.exe",
+      "bitsadmin.exe",
+      "certutil.exe",
+      "curl.exe",
+      "wget.exe",
+      "net.exe",
+      "net1.exe",
+      "whoami.exe",
+      "tasklist.exe",
+      "ipconfig.exe",
+      "nltest.exe",
+      "systeminfo.exe",
+      "charmap.exe",
+      "calc.exe",
+      "mspaint.exe"
+    ) or
+    ?process.pe.original_file_name : (
+      "Cmd.Exe",
+      "PowerShell.EXE",
+      "pwsh.dll",
+      "powershell_ise.EXE",
+      "wscript.exe",
+      "cscript.exe",
+      "MSHTA.EXE",
+      "RUNDLL32.EXE",
+      "REGSVR32.EXE",
+      "bitsadmin.exe",
+      "CertUtil.exe",
+      "curl.exe",
+      "wget.exe",
+      "net.exe",
+      "net1.exe",
+      "whoami.exe",
+      "tasklist.exe",
+      "ipconfig.exe",
+      "nltest.exe",
+      "systeminfo.exe",
+      "charmap.exe",
+      "CALC.EXE",
+      "mspaint.exe"
+    )
+  )
+```
+
+
+
 ### Suspicious Child Process via Azure VM CustomScript Extension
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1813
+Index: geneve-ut-1834
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17393,7 +17524,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1814
+Index: geneve-ut-1835
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17408,7 +17539,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1817
+Index: geneve-ut-1838
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17435,7 +17566,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1819
+Index: geneve-ut-1840
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17466,7 +17597,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1820
+Index: geneve-ut-1841
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17482,7 +17613,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1821
+Index: geneve-ut-1842
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17495,7 +17626,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1823
+Index: geneve-ut-1844
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17511,7 +17642,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1824
+Index: geneve-ut-1845
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17527,7 +17658,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1825
+Index: geneve-ut-1846
 
 ```python
 any where host.os.type == "windows" and 
@@ -17594,7 +17725,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1827
+Index: geneve-ut-1848
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17610,7 +17741,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1829
+Index: geneve-ut-1850
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17646,7 +17777,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1830
+Index: geneve-ut-1851
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17684,7 +17815,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1831
+Index: geneve-ut-1852
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17719,7 +17850,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1832
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17753,7 +17884,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1834
+Index: geneve-ut-1855
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17774,7 +17905,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1839
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17851,7 +17982,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1840
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17873,7 +18004,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1841
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17897,7 +18028,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1843
+Index: geneve-ut-1864
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17918,7 +18049,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1846
+Index: geneve-ut-1867
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17933,7 +18064,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1849
+Index: geneve-ut-1870
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17946,7 +18077,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1850
+Index: geneve-ut-1871
 
 ```python
 any where host.os.type == "windows" and
@@ -17961,7 +18092,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1851
+Index: geneve-ut-1872
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17977,7 +18108,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1852
+Index: geneve-ut-1873
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17991,7 +18122,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1856
+Index: geneve-ut-1877
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18044,11 +18175,32 @@ process.parent.executable != null and (
 
 
 
+### Suspicious Java Class File Created in PaperCut Server Library
+
+Branch count: 30  
+Document count: 30  
+Index: geneve-ut-1878
+
+```python
+file where host.os.type in ("windows", "linux", "macos") and
+  event.action in ("creation", "overwrite") and
+  file.extension : "class" and
+  file.path : (
+    "?:\\Program Files\\PaperCut*\\server\\lib\\*",
+    "?:\\Program Files (x86)\\PaperCut*\\server\\lib\\*",
+    "/opt/papercut/server/lib/*",
+    "/usr/local/papercut/server/lib/*",
+    "/Applications/PaperCut*/server/lib/*"
+  )
+```
+
+
+
 ### Suspicious JavaScript Execution via Deno
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1857
+Index: geneve-ut-1879
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18062,7 +18214,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1859
+Index: geneve-ut-1881
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18094,7 +18246,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1861
+Index: geneve-ut-1883
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18107,7 +18259,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1862
+Index: geneve-ut-1884
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18126,7 +18278,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1863
+Index: geneve-ut-1885
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18172,7 +18324,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1865
+Index: geneve-ut-1887
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18193,7 +18345,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1866
+Index: geneve-ut-1888
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18213,7 +18365,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1867
+Index: geneve-ut-1889
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18227,7 +18379,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1868
+Index: geneve-ut-1890
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18259,7 +18411,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1871
+Index: geneve-ut-1893
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18280,7 +18432,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1873
+Index: geneve-ut-1895
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18381,7 +18533,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1877
+Index: geneve-ut-1899
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18429,7 +18581,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1880
+Index: geneve-ut-1902
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18455,7 +18607,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1881
+Index: geneve-ut-1903
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18500,7 +18652,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1882
+Index: geneve-ut-1904
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18524,7 +18676,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1883
+Index: geneve-ut-1905
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18540,7 +18692,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1885
+Index: geneve-ut-1907
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18565,7 +18717,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1886
+Index: geneve-ut-1908
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18580,7 +18732,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1889
+Index: geneve-ut-1911
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18594,7 +18746,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1890
+Index: geneve-ut-1912
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18614,7 +18766,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1891
+Index: geneve-ut-1913
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18649,7 +18801,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1895
+Index: geneve-ut-1917
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18667,7 +18819,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1896
+Index: geneve-ut-1919
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18680,7 +18832,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1899
+Index: geneve-ut-1922
 
 ```python
 any where host.os.type == "windows" and
@@ -18709,11 +18861,41 @@ any where host.os.type == "windows" and
 
 
 
+### Suspicious Reading of procfs Syscall File
+
+Branch count: 120  
+Document count: 120  
+Index: geneve-ut-1924
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+(
+  process.name in (
+    "cat", "less", "more", "head", "tail", "nano", "vi", "vim", "strings", "nvim", "vim.basic",
+    "vim.tiny", "od", "hexdump", "xxd", "hx", "hexedit", "pager", "tr"
+  ) or
+  (
+    process.name in (
+      "find", "awk", "gawk", "mawk", "nawk", "grep", "fgrep", "rgrep", "xargs", "sed", "tee"
+    ) and
+    process.args_count <= 20
+  )
+) and
+process.command_line like "*/proc/*/syscall*" and
+not (
+  process.command_line like ("*/proc/self/syscall*", "*/proc/thread-self/syscall*") or
+  process.args like "/proc/*/syscall/comm"
+)
+```
+
+
+
 ### Suspicious Remote Registry Access via SeBackupPrivilege
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1901
+Index: geneve-ut-1925
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18731,7 +18913,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1902
+Index: geneve-ut-1926
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18753,7 +18935,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1905
+Index: geneve-ut-1929
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18792,7 +18974,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1906
+Index: geneve-ut-1930
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18822,7 +19004,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1907
+Index: geneve-ut-1931
 
 ```python
 any where host.os.type == "windows" and
@@ -18856,7 +19038,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1908
+Index: geneve-ut-1932
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18870,7 +19052,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1911
+Index: geneve-ut-1935
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18901,7 +19083,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1912
+Index: geneve-ut-1936
 
 ```python
 any where host.os.type == "windows" and
@@ -18921,7 +19103,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1913
+Index: geneve-ut-1937
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18962,7 +19144,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1914
+Index: geneve-ut-1938
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18978,7 +19160,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1915
+Index: geneve-ut-1939
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -19008,7 +19190,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1919
+Index: geneve-ut-1943
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19021,7 +19203,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1920
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19045,7 +19227,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1923
+Index: geneve-ut-1947
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19063,7 +19245,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1925
+Index: geneve-ut-1949
 
 ```python
 any where host.os.type == "windows" and
@@ -19078,7 +19260,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1926
+Index: geneve-ut-1950
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19096,7 +19278,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1927
+Index: geneve-ut-1951
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19117,7 +19299,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1928
+Index: geneve-ut-1952
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19136,7 +19318,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1931
+Index: geneve-ut-1955
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19161,7 +19343,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1932
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19174,7 +19356,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1934
+Index: geneve-ut-1958
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19187,7 +19369,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1936
+Index: geneve-ut-1960
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19210,7 +19392,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1938
+Index: geneve-ut-1962
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19229,7 +19411,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1939
+Index: geneve-ut-1963
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19251,7 +19433,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1940
+Index: geneve-ut-1964
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19284,7 +19466,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1942
+Index: geneve-ut-1966
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19302,7 +19484,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1943
+Index: geneve-ut-1967
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19316,7 +19498,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1944
+Index: geneve-ut-1968
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19340,7 +19522,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1945
+Index: geneve-ut-1969
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19363,7 +19545,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1946
+Index: geneve-ut-1970
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19382,7 +19564,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1949
+Index: geneve-ut-1973
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19401,7 +19583,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1951
+Index: geneve-ut-1975
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19436,7 +19618,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1952
+Index: geneve-ut-1976
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19635,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1953
+Index: geneve-ut-1977
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19473,7 +19655,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1954
+Index: geneve-ut-1978
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19513,7 +19695,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1955
+Index: geneve-ut-1979
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19529,7 +19711,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1956
+Index: geneve-ut-1980
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19543,7 +19725,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1957
+Index: geneve-ut-1981
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19581,7 +19763,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1958
+Index: geneve-ut-1982
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19635,7 +19817,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1959
+Index: geneve-ut-1983
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19663,7 +19845,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1961
+Index: geneve-ut-1985
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19677,7 +19859,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1962
+Index: geneve-ut-1986
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19723,7 +19905,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1963
+Index: geneve-ut-1987
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19762,7 +19944,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1964
+Index: geneve-ut-1988
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19775,7 +19957,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1968
+Index: geneve-ut-1992
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19808,7 +19990,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1969
+Index: geneve-ut-1993
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19822,7 +20004,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1970
+Index: geneve-ut-1994
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19836,7 +20018,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1971
+Index: geneve-ut-1995
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19850,7 +20032,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1972
+Index: geneve-ut-1996
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19889,7 +20071,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1980
+Index: geneve-ut-2004
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19931,7 +20113,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1982
+Index: geneve-ut-2006
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19953,7 +20135,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1984
+Index: geneve-ut-2008
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19966,7 +20148,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1987
+Index: geneve-ut-2011
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19983,7 +20165,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1988
+Index: geneve-ut-2012
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19999,7 +20181,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1989
+Index: geneve-ut-2013
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20012,7 +20194,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1990
+Index: geneve-ut-2014
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20027,7 +20209,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1991
+Index: geneve-ut-2015
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20050,7 +20232,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1992
+Index: geneve-ut-2016
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20066,7 +20248,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1993
+Index: geneve-ut-2017
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20082,7 +20264,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1999
+Index: geneve-ut-2023
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20094,7 +20276,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-2000
+Index: geneve-ut-2024
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20123,7 +20305,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2002
+Index: geneve-ut-2026
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20137,7 +20319,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2007
+Index: geneve-ut-2031
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20157,7 +20339,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2008
+Index: geneve-ut-2032
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20182,7 +20364,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2015
+Index: geneve-ut-2039
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20196,7 +20378,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2016
+Index: geneve-ut-2040
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20219,7 +20401,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2025
+Index: geneve-ut-2049
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20253,7 +20435,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2027
+Index: geneve-ut-2051
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20272,7 +20454,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2034
+Index: geneve-ut-2058
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20291,7 +20473,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2049
+Index: geneve-ut-2073
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20308,7 +20490,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2052
+Index: geneve-ut-2076
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20325,7 +20507,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2068
+Index: geneve-ut-2092
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20344,7 +20526,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2072
+Index: geneve-ut-2096
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20386,7 +20568,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2073
+Index: geneve-ut-2097
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20431,7 +20613,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2076
+Index: geneve-ut-2100
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20473,7 +20655,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2078
+Index: geneve-ut-2102
 
 ```python
 host.os.type:"linux" and 
@@ -20501,7 +20683,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2082
+Index: geneve-ut-2106
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20525,7 +20707,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2083
+Index: geneve-ut-2107
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20565,7 +20747,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2084
+Index: geneve-ut-2108
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20612,7 +20794,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2088
+Index: geneve-ut-2112
 
 ```python
 sequence by process.entity_id
@@ -20649,7 +20831,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2120
+Index: geneve-ut-2144
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20663,7 +20845,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2121
+Index: geneve-ut-2145
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20706,7 +20888,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2122
+Index: geneve-ut-2146
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20719,7 +20901,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2125
+Index: geneve-ut-2149
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20733,7 +20915,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2126
+Index: geneve-ut-2150
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20746,7 +20928,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2130
+Index: geneve-ut-2154
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20771,7 +20953,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2131
+Index: geneve-ut-2155
 
 ```python
 process where event.type == "start" and
@@ -20786,7 +20968,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2132
+Index: geneve-ut-2156
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20803,7 +20985,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2133
+Index: geneve-ut-2157
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20817,7 +20999,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2134
+Index: geneve-ut-2158
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20833,7 +21015,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2135
+Index: geneve-ut-2159
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20847,7 +21029,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2136
+Index: geneve-ut-2160
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20874,7 +21056,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2138
+Index: geneve-ut-2162
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20886,7 +21068,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2139
+Index: geneve-ut-2163
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20902,7 +21084,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2140
+Index: geneve-ut-2164
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20925,7 +21107,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2141
+Index: geneve-ut-2165
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20938,7 +21120,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2143
+Index: geneve-ut-2167
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20950,7 +21132,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2144
+Index: geneve-ut-2168
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20962,7 +21144,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2145
+Index: geneve-ut-2169
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20974,7 +21156,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2146
+Index: geneve-ut-2170
 
 ```python
 web where (
@@ -21002,7 +21184,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2152
+Index: geneve-ut-2176
 
 ```python
 any where (
@@ -21065,6 +21247,11 @@ url.original like~ (
     "*select @@version*", "*select user()*", "*select current_user()*", "*select database()*",
     "*sp_executesql*exec*", "*xp_dirtree*"
   )
+) and
+not user_agent.original like~ (
+    "*Nessus*", "*Qualys*", "*Acunetix*",  "*Tenable*", "*CensysInspect*", "*Detectify*",
+    "*Assetnote*", "*ExposureScan*", "*RecordedFuture*", "*AppSpider*", "*WebInspect*",
+    "*Rapid7*", "*InsightVM*", "*Probely*"
 )
 ```
 
@@ -21074,7 +21261,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2154
+Index: geneve-ut-2178
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21095,7 +21282,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2157
+Index: geneve-ut-2181
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21109,7 +21296,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2158
+Index: geneve-ut-2182
 
 ```python
 file where event.type == "deletion" and
@@ -21126,7 +21313,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2159
+Index: geneve-ut-2183
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21144,7 +21331,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2162
+Index: geneve-ut-2186
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21182,7 +21369,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2164
+Index: geneve-ut-2188
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21219,7 +21406,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2165
+Index: geneve-ut-2189
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21234,7 +21421,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2166
+Index: geneve-ut-2190
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21247,7 +21434,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2167
+Index: geneve-ut-2191
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21266,7 +21453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2168
+Index: geneve-ut-2192
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21291,7 +21478,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2169
+Index: geneve-ut-2193
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21317,7 +21504,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2170
+Index: geneve-ut-2194
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21339,7 +21526,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2171
+Index: geneve-ut-2195
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21356,7 +21543,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2173
+Index: geneve-ut-2197
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21375,7 +21562,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2174
+Index: geneve-ut-2198
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21415,7 +21602,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2175
+Index: geneve-ut-2199
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21432,7 +21619,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2177
+Index: geneve-ut-2201
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21445,7 +21632,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2178
+Index: geneve-ut-2202
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21459,7 +21646,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2179
+Index: geneve-ut-2203
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21487,7 +21674,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2180
+Index: geneve-ut-2204
 
 ```python
 process where event.type == "start" and
@@ -21512,7 +21699,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2181
+Index: geneve-ut-2205
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21526,7 +21713,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2182
+Index: geneve-ut-2206
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21542,7 +21729,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2183
+Index: geneve-ut-2207
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21577,7 +21764,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2184
+Index: geneve-ut-2208
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21595,7 +21782,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2187
+Index: geneve-ut-2211
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-9.5.md
+++ b/tests/reports/alerts_from_rules-9.5.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.4
+Rules version: 9.5.5
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
    1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
-   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
+   1. [Rules with the correct signals (811)](#rules-with-the-correct-signals-811)
 
 ## Failed rules (24)
 
@@ -20,7 +20,7 @@ Rules version: 9.5.4
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0368  
+Index: geneve-ut-0378  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0379  
+Index: geneve-ut-0389  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -190,7 +190,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0647  
+Index: geneve-ut-0656  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0672  
+Index: geneve-ut-0681  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0808  
+Index: geneve-ut-0820  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1001  
+Index: geneve-ut-1013  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1146  
+Index: geneve-ut-1159  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1176  
+Index: geneve-ut-1189  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1250  
+Index: geneve-ut-1264  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1279  
+Index: geneve-ut-1293  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1297  
+Index: geneve-ut-1311  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1362  
+Index: geneve-ut-1379  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1377  
+Index: geneve-ut-1395  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1467  
+Index: geneve-ut-1485  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1712  
+Index: geneve-ut-1733  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1716  
+Index: geneve-ut-1737  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1800  
+Index: geneve-ut-1821  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1815  
+Index: geneve-ut-1837  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1828  
+Index: geneve-ut-1850  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1838  
+Index: geneve-ut-1860  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1844  
+Index: geneve-ut-1866  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1853  
+Index: geneve-ut-1875  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1950  
+Index: geneve-ut-1975  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1981  
+Index: geneve-ut-2006  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1123,7 +1123,7 @@ container.id like "*"
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0368
+Index: geneve-ut-0378
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1175,7 +1175,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0379
+Index: geneve-ut-0389
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -1287,7 +1287,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0647
+Index: geneve-ut-0656
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1353,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0672
+Index: geneve-ut-0681
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0808
+Index: geneve-ut-0820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1001
+Index: geneve-ut-1013
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1146
+Index: geneve-ut-1159
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1176
+Index: geneve-ut-1189
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1250
+Index: geneve-ut-1264
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1279
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1297
+Index: geneve-ut-1311
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1362
+Index: geneve-ut-1379
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1377
+Index: geneve-ut-1395
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1467
+Index: geneve-ut-1485
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1712
+Index: geneve-ut-1733
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1716
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1800
+Index: geneve-ut-1821
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1815
+Index: geneve-ut-1837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1828
+Index: geneve-ut-1850
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1838
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1844
+Index: geneve-ut-1866
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1853
+Index: geneve-ut-1875
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1950
+Index: geneve-ut-1975
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1981
+Index: geneve-ut-2006
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2154,7 +2154,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0239
+Index: geneve-ut-0247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1002
+Index: geneve-ut-1014
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1022
+Index: geneve-ut-1034
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1414
+Index: geneve-ut-1432
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1615
+Index: geneve-ut-1634
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2227,7 +2227,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0368  
+Index: geneve-ut-0378  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2281,7 +2281,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0379  
+Index: geneve-ut-0389  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -2395,7 +2395,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0647  
+Index: geneve-ut-0656  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2463,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0672  
+Index: geneve-ut-0681  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0808  
+Index: geneve-ut-0820  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0974  
+Index: geneve-ut-0986  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2530,8 +2530,8 @@ event.dataset:"kubernetes.audit_logs" and event.action:list and
 kubernetes.audit.objectRef.resource:secrets and 
 kubernetes.audit.requestURI :(/api/v1/secrets or /api/v1/secrets?limit* or /api/v1/namespaces/kube-system/secrets or /api/v1/namespaces/kube-system/secrets?limit* or /api/v1/namespaces/default/secrets or /api/v1/namespaces/default/secrets?limit*) and 
 source.ip:(* and not ("::1" or "127.0.0.1")) and 
-not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator) and 
-not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
+not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator or "system:serviceaccount:argocd:argocd-application-controller" or "system:serviceaccount:elastic:kube-state-metrics" or "system:serviceaccount:cert-manager:cert-manager-cainjector" or "system:serviceaccount:elastic-system:elastic-agent" or "system:serviceaccount:longhorn-system:longhorn-service-account") and 
+not kubernetes.audit.user.groups:("system:serviceaccounts:ibm-csi" or "system:serviceaccounts:argocd" or "system:serviceaccounts:elastic")
 ```
 
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1001  
+Index: geneve-ut-1013  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1124  
+Index: geneve-ut-1137  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1146  
+Index: geneve-ut-1159  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1176  
+Index: geneve-ut-1189  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1250  
+Index: geneve-ut-1264  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1279  
+Index: geneve-ut-1293  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1297  
+Index: geneve-ut-1311  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1362  
+Index: geneve-ut-1379  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1377  
+Index: geneve-ut-1395  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1458  
+Index: geneve-ut-1476  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1467  
+Index: geneve-ut-1485  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1582  
+Index: geneve-ut-1600  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1712  
+Index: geneve-ut-1733  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1716  
+Index: geneve-ut-1737  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1800  
+Index: geneve-ut-1821  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1815  
+Index: geneve-ut-1837  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1828  
+Index: geneve-ut-1850  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1838  
+Index: geneve-ut-1860  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1844  
+Index: geneve-ut-1866  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1853  
+Index: geneve-ut-1875  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1950  
+Index: geneve-ut-1975  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1981  
+Index: geneve-ut-2006  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3381,7 +3381,7 @@ container.id like "*"
 
 
 
-## Rules with the correct signals (805)
+## Rules with the correct signals (811)
 
 ### A scheduled task was created
 
@@ -3470,11 +3470,33 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 
 
+### AWS Bedrock AgentCore Resource Created with IAM Execution Role
+
+Branch count: 8  
+Document count: 8  
+Index: geneve-ut-0016
+
+```python
+event.dataset: "aws.cloudtrail" and
+  event.provider: "bedrock-agentcore.amazonaws.com" and
+  event.action: (
+    "CreateCodeInterpreter" or
+    "CreateAgentRuntime" or
+    "CreateBrowser" or
+    "CreateHarness"
+  ) and
+  event.outcome: "success" and
+  aws.cloudtrail.request_parameters: (*executionRoleArn* or *roleArn*) and
+  not aws.cloudtrail.user_identity.invoked_by: ("bedrock-agentcore.amazonaws.com" or "cloudformation.amazonaws.com")
+```
+
+
+
 ### AWS Credentials Searched For Inside A Container
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0052
+Index: geneve-ut-0053
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -3492,7 +3514,7 @@ process.command_line like~ (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0069
+Index: geneve-ut-0071
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3505,11 +3527,32 @@ event.dataset: "aws.cloudtrail"
 
 
 
+### AWS GetFederationToken Followed by Console Login via Federation Exchange
+
+Branch count: 1  
+Document count: 3  
+Index: geneve-ut-0093
+
+```python
+sequence by source.ip with maxspan=2m
+  [any where event.provider == "sts.amazonaws.com"
+   and event.action == "GetFederationToken"
+   and event.outcome == "success"]
+  [any where event.provider == "signin.amazonaws.com"
+   and event.action == "GetSigninToken"
+   and event.outcome == "success"]
+  [any where event.provider == "signin.amazonaws.com"
+   and event.action == "ConsoleLogin"
+   and event.outcome == "success"]
+```
+
+
+
 ### AWS IAM Customer Managed Policy Version Created or Default Version Set
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0102
+Index: geneve-ut-0108
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3520,6 +3563,7 @@ event.dataset: "aws.cloudtrail"
     and not aws.cloudtrail.user_identity.arn:arn*/terraform 
     and not source.as.organization.name:(Amazon* or AMAZON* or "Google LLC" or "MongoDB, Inc.")
     and not source.address: ( "cloudformation.amazonaws.com" or "servicecatalog.amazonaws.com")
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3528,11 +3572,12 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0109
+Index: geneve-ut-0115
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
     and event.action: "CreateLoginProfile" and event.outcome: success
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3541,7 +3586,7 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0121
+Index: geneve-ut-0127
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3573,7 +3618,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0130
+Index: geneve-ut-0136
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3581,6 +3626,7 @@ event.dataset: "aws.cloudtrail"
     and event.action: "PutKeyPolicy"
     and event.outcome: "success"
     and not aws.cloudtrail.user_identity.type: "AWSService"
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3589,13 +3635,14 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0132
+Index: geneve-ut-0138
 
 ```python
 event.dataset: "aws.cloudtrail"
     and event.provider: "lambda.amazonaws.com"
     and event.outcome: "success"
     and event.action: (CreateFunction* or UpdateFunctionCode*)
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3604,11 +3651,12 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0152
+Index: geneve-ut-0158
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
-    and event.action: ("CreateDBSnapshot" or "CreateDBClusterSnapshot") and event.outcome: "success"
+    and event.action: ("CreateDBSnapshot" or "CreateDBClusterSnapshot") and event.outcome: "success" 
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3617,7 +3665,7 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0189
+Index: geneve-ut-0197
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3633,7 +3681,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0190
+Index: geneve-ut-0198
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -3648,7 +3696,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0201
+Index: geneve-ut-0209
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -3663,7 +3711,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0210
+Index: geneve-ut-0218
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3687,7 +3735,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0211
+Index: geneve-ut-0219
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -3722,7 +3770,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0212
+Index: geneve-ut-0220
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -3739,7 +3787,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0213
+Index: geneve-ut-0221
 
 ```python
 any where host.os.type == "windows" and
@@ -3764,7 +3812,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0215
+Index: geneve-ut-0223
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -3792,7 +3840,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0217
+Index: geneve-ut-0225
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3805,7 +3853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0219
+Index: geneve-ut-0227
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -3821,7 +3869,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0220
+Index: geneve-ut-0228
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3841,7 +3889,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0221
+Index: geneve-ut-0229
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3862,7 +3910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0222
+Index: geneve-ut-0230
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3874,7 +3922,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0225
+Index: geneve-ut-0233
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3886,7 +3934,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0237
+Index: geneve-ut-0245
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3903,7 +3951,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0238
+Index: geneve-ut-0246
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3915,7 +3963,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0240
+Index: geneve-ut-0248
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3935,7 +3983,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0241
+Index: geneve-ut-0249
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3949,7 +3997,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0245
+Index: geneve-ut-0253
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3980,7 +4028,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0246
+Index: geneve-ut-0254
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3992,7 +4040,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0247
+Index: geneve-ut-0255
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4006,7 +4054,7 @@ process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clea
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0248
+Index: geneve-ut-0256
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4021,7 +4069,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0258
+Index: geneve-ut-0266
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -4040,7 +4088,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0259
+Index: geneve-ut-0267
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4054,7 +4102,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0261
+Index: geneve-ut-0269
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -4085,7 +4133,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0262
+Index: geneve-ut-0270
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4108,7 +4156,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0263
+Index: geneve-ut-0271
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4122,7 +4170,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0264
+Index: geneve-ut-0272
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4141,7 +4189,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0265
+Index: geneve-ut-0273
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4155,7 +4203,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0266
+Index: geneve-ut-0274
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4180,7 +4228,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0271
+Index: geneve-ut-0279
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4199,7 +4247,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0274
+Index: geneve-ut-0282
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4212,7 +4260,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0276
+Index: geneve-ut-0284
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4254,7 +4302,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0283
+Index: geneve-ut-0291
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -4269,7 +4317,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0324
+Index: geneve-ut-0332
 
 ```python
 event.dataset:azure.activitylogs and
@@ -4283,7 +4331,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0327
+Index: geneve-ut-0335
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -4301,7 +4349,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0345
+Index: geneve-ut-0353
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4319,7 +4367,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0346
+Index: geneve-ut-0354
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4337,7 +4385,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0347
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4352,7 +4400,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0348
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4366,7 +4414,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0349
+Index: geneve-ut-0357
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4381,7 +4429,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0352
+Index: geneve-ut-0360
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4398,7 +4446,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0353
+Index: geneve-ut-0361
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4410,7 +4458,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0354
+Index: geneve-ut-0362
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4422,7 +4470,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0355
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4437,7 +4485,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0356
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4453,11 +4501,34 @@ not (
 
 
 
+### Binfmt Configuration File Creation
+
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0365
+
+```python
+file where host.os.type == "linux" and event.action != "deletion" and process.executable != null and
+file.path like (
+  "/etc/binfmt.d/*.conf", "/run/binfmt.d/*.conf", "/usr/local/lib/binfmt.d/*.conf", "/usr/lib/binfmt.d/*.conf",
+  "/proc/sys/fs/binfmt_misc/register", "/proc/sys/fs/binfmt_misc/*"
+) and
+not (
+  file.path like (
+    "/usr/lib/binfmt.d/python3.*.conf", "/usr/lib/binfmt.d/qemu-*-static.conf",
+    "/proc/sys/fs/binfmt_misc/status"
+  ) or
+  process.executable == "/usr/lib/systemd/systemd-binfmt"
+)
+```
+
+
+
 ### Bitsadmin Activity
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0357
+Index: geneve-ut-0366
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4479,7 +4550,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0359
+Index: geneve-ut-0368
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4525,7 +4596,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0360
+Index: geneve-ut-0369
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4559,7 +4630,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0361
+Index: geneve-ut-0370
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4582,7 +4653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0363
+Index: geneve-ut-0372
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4604,7 +4675,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0364
+Index: geneve-ut-0373
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4632,7 +4703,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0365
+Index: geneve-ut-0374
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4644,11 +4715,43 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 
 
+### Claude Cowork VM Boot Image Tamper
+
+Branch count: 320  
+Document count: 320  
+Index: geneve-ut-0375
+
+```python
+file where host.os.type in ("windows", "macos") and
+  event.action in ("creation", "modification", "overwrite", "rename") and
+  event.outcome == "success" and
+  file.path : (
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/initrd",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/initrd.zst",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/vmlinuz",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/vmlinuz.zst",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/rootfs.img",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\initrd",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\initrd.zst",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\vmlinuz",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\rootfs.vhdx",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\smol-bin.vhdx"
+  ) and
+  not (
+    (process.name : "claude.exe" and
+     process.executable : "?:\\Program Files\\WindowsApps\\Claude_*\\app\\claude.exe") or
+    (process.name : ("Claude", "Claude Helper") and
+     process.executable like "/Applications/Claude.app/*")
+  )
+```
+
+
+
 ### Clearing Windows Event Logs
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0367
+Index: geneve-ut-0377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4673,7 +4776,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0369
+Index: geneve-ut-0379
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4703,7 +4806,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0371
+Index: geneve-ut-0381
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4717,7 +4820,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0372
+Index: geneve-ut-0382
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4739,7 +4842,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0373
+Index: geneve-ut-0383
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4753,7 +4856,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0374
+Index: geneve-ut-0384
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4773,7 +4876,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0377
+Index: geneve-ut-0387
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4790,7 +4893,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0380
+Index: geneve-ut-0390
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4820,7 +4923,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0383
+Index: geneve-ut-0393
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4845,7 +4948,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0385
+Index: geneve-ut-0395
 
 ```python
 sequence by process.entity_id
@@ -4866,7 +4969,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0386
+Index: geneve-ut-0396
 
 ```python
 sequence by process.entity_id
@@ -4887,7 +4990,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0389
+Index: geneve-ut-0399
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4918,7 +5021,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0390
+Index: geneve-ut-0400
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4930,7 +5033,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0391
+Index: geneve-ut-0401
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4953,7 +5056,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0394
+Index: geneve-ut-0404
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4966,7 +5069,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0395
+Index: geneve-ut-0405
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4979,7 +5082,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0397
+Index: geneve-ut-0407
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4996,7 +5099,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0398
+Index: geneve-ut-0408
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -5009,7 +5112,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0399
+Index: geneve-ut-0409
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -5026,7 +5129,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0400
+Index: geneve-ut-0410
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -5038,7 +5141,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0401
+Index: geneve-ut-0411
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -5106,7 +5209,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0402
+Index: geneve-ut-0412
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -5124,7 +5227,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0403
+Index: geneve-ut-0413
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -5137,7 +5240,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0404
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5155,7 +5258,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0405
+Index: geneve-ut-0415
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5167,7 +5270,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0406
+Index: geneve-ut-0416
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5179,7 +5282,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0407
+Index: geneve-ut-0417
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5191,7 +5294,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0408
+Index: geneve-ut-0418
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5203,7 +5306,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0409
+Index: geneve-ut-0419
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -5248,7 +5351,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0411
+Index: geneve-ut-0421
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5268,7 +5371,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0412
+Index: geneve-ut-0422
 
 ```python
 sequence with maxspan=10s
@@ -5288,7 +5391,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0413
+Index: geneve-ut-0423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5315,7 +5418,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0414
+Index: geneve-ut-0424
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5329,7 +5432,7 @@ container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0417
+Index: geneve-ut-0427
 
 ```python
 process where event.type == "start" and
@@ -5354,7 +5457,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0420
+Index: geneve-ut-0430
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5398,7 +5501,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0421
+Index: geneve-ut-0431
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5432,7 +5535,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0423
+Index: geneve-ut-0433
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5477,7 +5580,7 @@ container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0424
+Index: geneve-ut-0434
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5493,7 +5596,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0425
+Index: geneve-ut-0435
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5518,7 +5621,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0426
+Index: geneve-ut-0436
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5537,7 +5640,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0428
+Index: geneve-ut-0438
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5664,7 +5767,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0429
+Index: geneve-ut-0439
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5682,7 +5785,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0431
+Index: geneve-ut-0441
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5695,7 +5798,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0432
+Index: geneve-ut-0442
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5725,7 +5828,7 @@ container.security_context.privileged == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0438
+Index: geneve-ut-0448
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5735,46 +5838,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Deprecated - Adobe Hijack Persistence
-
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-0450
-
-```python
-file where host.os.type == "windows" and event.type == "creation" and
-  file.path : (
-    "?:\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-    "?:\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-
-    /* Crowdstrike specific condition as it uses NT Object paths */
-    "\\Device\\HarddiskVolume*\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-    "\\Device\\HarddiskVolume*\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe"
-  ) and
-  not process.name : ("msiexec.exe", "AdobeARM.exe")
-```
-
-
-
-### Deprecated - Encoded Executable Stored in the Registry
-
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-0457
-
-```python
-registry where host.os.type == "windows" and
-/* update here with encoding combinations */
- registry.data.strings : "TVqQAAMAAAAEAAAA*"
-```
-
-
-
 ### Deprecated - Microsoft Exchange Transport Agent Install Script
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0469
+Index: geneve-ut-0478
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5798,7 +5866,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0508
+Index: geneve-ut-0517
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5852,7 +5920,7 @@ container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0510
+Index: geneve-ut-0519
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5868,7 +5936,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0511
+Index: geneve-ut-0520
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5896,7 +5964,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0512
+Index: geneve-ut-0521
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5913,7 +5981,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0513
+Index: geneve-ut-0522
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5930,7 +5998,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0514
+Index: geneve-ut-0523
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5951,7 +6019,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0516
+Index: geneve-ut-0525
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5971,7 +6039,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0517
+Index: geneve-ut-0526
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5986,7 +6054,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0519
+Index: geneve-ut-0528
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5999,7 +6067,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0520
+Index: geneve-ut-0529
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6019,7 +6087,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0523
+Index: geneve-ut-0532
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -6032,7 +6100,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0524
+Index: geneve-ut-0533
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6070,7 +6138,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0525
+Index: geneve-ut-0534
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -6090,7 +6158,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0526
+Index: geneve-ut-0535
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6103,7 +6171,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0527
+Index: geneve-ut-0536
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -6126,7 +6194,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0529
+Index: geneve-ut-0538
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6157,7 +6225,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0530
+Index: geneve-ut-0539
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -6176,7 +6244,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0531
+Index: geneve-ut-0540
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6219,7 +6287,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0532
+Index: geneve-ut-0541
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -6233,7 +6301,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0534
+Index: geneve-ut-0543
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6248,7 +6316,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0535
+Index: geneve-ut-0544
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6264,7 +6332,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0536
+Index: geneve-ut-0545
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6278,7 +6346,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0537
+Index: geneve-ut-0546
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6300,49 +6368,11 @@ sequence by host.id with maxspan=3s
 
 
 
-### Elastic Agent Service Terminated
-
-Branch count: 419  
-Document count: 419  
-Index: geneve-ut-0538
-
-```python
-process where event.type == "start" and
-(
-  /* net, sc or wmic stopping or deleting Elastic Agent on Windows */
-  (
-    process.name : ("net.exe", "sc.exe", "wmic.exe","powershell.exe","taskkill.exe","PsKill.exe","ProcessHacker.exe") and
-    process.args : ("stopservice","uninstall", "stop", "disabled","Stop-Process","terminate","suspend") and
-    process.args : ("elasticendpoint", "Elastic Agent","elastic-agent","elastic-endpoint")
-  ) or
-
-  /* service or systemctl used to stop Elastic Agent on Linux */
-  (
-    process.name in ("systemctl", "service", "chkconfig", "update-rc.d") and
-    process.args : ("elastic-agent", "elastic-agent.service", "ElasticEndpoint") and
-    process.args : ("stop", "disable", "remove", "off", "kill", "mask") and
-    not (
-      process.parent.executable : "/opt/Elastic/Agent/data/elastic-agent-*/components/previous/elastic-endpoint" and
-      process.parent.args : "uninstall" and
-      process.parent.args : "--keepstate"
-    )
-  ) or
-
-  /* pkill, killall used to stop Elastic Agent or Endpoint on Linux */
-  (process.name in ("pkill", "killall", "kill") and process.args : ("elastic-agent", "elastic-endpoint")) or
-
-  /* Unload Elastic Defend extension on MacOS */
-  (process.name : "kextunload" and process.args : "com.apple.iokit.EndpointSecurity")
-)
-```
-
-
-
 ### Emond Rules Creation or Modification
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0545
+Index: geneve-ut-0554
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -6355,7 +6385,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0546
+Index: geneve-ut-0555
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6369,7 +6399,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0547
+Index: geneve-ut-0556
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6391,7 +6421,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0548
+Index: geneve-ut-0557
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6426,7 +6456,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0549
+Index: geneve-ut-0558
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6438,7 +6468,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0597
+Index: geneve-ut-0606
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6450,7 +6480,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0623
+Index: geneve-ut-0632
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6464,7 +6494,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0626
+Index: geneve-ut-0635
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6491,7 +6521,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0629
+Index: geneve-ut-0638
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6512,7 +6542,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0630
+Index: geneve-ut-0639
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6542,7 +6572,7 @@ container.id like "*"
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0633
+Index: geneve-ut-0642
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6560,7 +6590,7 @@ container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0634
+Index: geneve-ut-0643
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6593,7 +6623,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0636
+Index: geneve-ut-0645
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6610,7 +6640,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0637
+Index: geneve-ut-0646
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6638,7 +6668,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0638
+Index: geneve-ut-0647
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6651,7 +6681,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0640
+Index: geneve-ut-0649
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6671,7 +6701,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0641
+Index: geneve-ut-0650
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6697,7 +6727,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0642
+Index: geneve-ut-0651
 
 ```python
 sequence with maxspan=2h
@@ -6719,7 +6749,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0643
+Index: geneve-ut-0652
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6748,7 +6778,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0646
+Index: geneve-ut-0655
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6761,7 +6791,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0650
+Index: geneve-ut-0659
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6776,7 +6806,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0651
+Index: geneve-ut-0660
 
 ```python
 process where event.type == "start" and
@@ -6798,7 +6828,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0653
+Index: geneve-ut-0662
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6810,7 +6840,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0654
+Index: geneve-ut-0663
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6832,7 +6862,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0656
+Index: geneve-ut-0665
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6849,7 +6879,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0657
+Index: geneve-ut-0666
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6863,7 +6893,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0658
+Index: geneve-ut-0667
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6876,7 +6906,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0659
+Index: geneve-ut-0668
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6888,7 +6918,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0660
+Index: geneve-ut-0669
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6900,7 +6930,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0661
+Index: geneve-ut-0670
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6914,7 +6944,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0662
+Index: geneve-ut-0671
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6926,7 +6956,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0663
+Index: geneve-ut-0672
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -6948,7 +6978,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0667
+Index: geneve-ut-0676
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6997,7 +7027,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0668
+Index: geneve-ut-0677
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -7014,7 +7044,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0669
+Index: geneve-ut-0678
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7034,7 +7064,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0674
+Index: geneve-ut-0683
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7056,7 +7086,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0677
+Index: geneve-ut-0687
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7071,7 +7101,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0678
+Index: geneve-ut-0688
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7085,7 +7115,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0680
+Index: geneve-ut-0690
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7107,7 +7137,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0682
+Index: geneve-ut-0692
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -7128,7 +7158,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0683
+Index: geneve-ut-0693
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7154,7 +7184,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0684
+Index: geneve-ut-0694
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -7182,7 +7212,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0687
+Index: geneve-ut-0697
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -7196,7 +7226,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0726
+Index: geneve-ut-0737
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -7213,7 +7243,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0727
+Index: geneve-ut-0738
 
 ```python
 registry where host.os.type == "windows" and
@@ -7231,7 +7261,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0798
+Index: geneve-ut-0810
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7300,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0799
+Index: geneve-ut-0811
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7327,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0800
+Index: geneve-ut-0812
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7342,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0801
+Index: geneve-ut-0813
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7429,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0809
+Index: geneve-ut-0821
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7447,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0810
+Index: geneve-ut-0822
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7478,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0811
+Index: geneve-ut-0823
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7505,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0812
+Index: geneve-ut-0824
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7525,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0816
+Index: geneve-ut-0828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7538,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0819
+Index: geneve-ut-0831
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7550,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0822
+Index: geneve-ut-0834
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7562,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0826
+Index: geneve-ut-0838
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7574,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0828
+Index: geneve-ut-0840
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7591,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0854
+Index: geneve-ut-0866
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7604,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0857
+Index: geneve-ut-0869
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7628,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0858
+Index: geneve-ut-0870
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7640,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0871
+Index: geneve-ut-0883
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7658,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0872
+Index: geneve-ut-0884
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7707,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0873
+Index: geneve-ut-0885
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7721,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0877
+Index: geneve-ut-0889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7736,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0883
+Index: geneve-ut-0894
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7753,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0885
+Index: geneve-ut-0896
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7772,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0886
+Index: geneve-ut-0897
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7790,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0887
+Index: geneve-ut-0898
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7809,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0888
+Index: geneve-ut-0899
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7825,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0889
+Index: geneve-ut-0900
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7841,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0890
+Index: geneve-ut-0901
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0895
+Index: geneve-ut-0906
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7871,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0897
+Index: geneve-ut-0908
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7884,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0898
+Index: geneve-ut-0909
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7900,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0899
+Index: geneve-ut-0910
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7888,7 +7918,9 @@ registry where host.os.type == "windows" and event.type == "change" and
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\SAP\\SAPsetup\\setup\\NwSapSetup.exe",
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\SAP\\SapSetup\\OnRebootSvc\\NWSAPSetupOnRebootInstSvc.exe",
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\Kaspersky Lab\\Kaspersky Security for Windows Server\\kavfs.exe"
-  )
+  ) and
+  /* Microsoft Cloud AppCompat SDB test registrations */
+  not registry.path : "*\\AppCompatFlags\\Custom\\*\\{22221111-1111-1111-1111-111111111111}.sdb"
 ```
 
 
@@ -7897,7 +7929,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0900
+Index: geneve-ut-0911
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7953,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0905
+Index: geneve-ut-0916
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7977,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0907
+Index: geneve-ut-0918
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +8013,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0908
+Index: geneve-ut-0919
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +8025,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0909
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8039,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0910
+Index: geneve-ut-0921
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8052,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0911
+Index: geneve-ut-0922
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8111,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0912
+Index: geneve-ut-0923
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8124,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0913
+Index: geneve-ut-0924
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8137,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0914
+Index: geneve-ut-0925
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8158,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0915
+Index: geneve-ut-0926
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8176,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0916
+Index: geneve-ut-0927
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8174,11 +8206,24 @@ not (
 
 
 
+### Kernel Module Loaded with Tainting Flags
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0929
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "load_module" and
+process.Ext.load_module.taint_flags != null
+```
+
+
+
 ### Kernel Module Removal
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0918
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8245,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0920
+Index: geneve-ut-0932
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8272,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0921
+Index: geneve-ut-0933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8298,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0922
+Index: geneve-ut-0934
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8314,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0923
+Index: geneve-ut-0935
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8330,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0925
+Index: geneve-ut-0937
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8342,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0926
+Index: geneve-ut-0938
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8370,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0928
+Index: geneve-ut-0940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8386,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0930
+Index: geneve-ut-0942
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8411,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0931
+Index: geneve-ut-0943
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8425,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0933
+Index: geneve-ut-0945
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8448,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0934
+Index: geneve-ut-0946
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8481,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0935
+Index: geneve-ut-0947
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8508,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0938
+Index: geneve-ut-0950
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8529,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0939
+Index: geneve-ut-0951
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8556,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0949
+Index: geneve-ut-0961
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8578,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0975
+Index: geneve-ut-0987
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8597,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0978
+Index: geneve-ut-0990
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8641,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0980
+Index: geneve-ut-0992
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8666,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0992
+Index: geneve-ut-1004
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8704,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0997
+Index: geneve-ut-1009
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8722,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0998
+Index: geneve-ut-1010
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8736,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1003
+Index: geneve-ut-1015
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8751,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1018
+Index: geneve-ut-1030
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8765,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1021
+Index: geneve-ut-1033
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8779,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1023
+Index: geneve-ut-1035
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8800,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1024
+Index: geneve-ut-1036
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8830,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1028
+Index: geneve-ut-1040
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8877,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1029
+Index: geneve-ut-1041
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8908,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1032
+Index: geneve-ut-1044
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8921,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1034
+Index: geneve-ut-1046
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8934,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1035
+Index: geneve-ut-1047
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8946,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1071
+Index: geneve-ut-1083
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8959,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1072
+Index: geneve-ut-1084
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8972,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1073
+Index: geneve-ut-1085
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8984,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1074
+Index: geneve-ut-1086
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8996,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1075
+Index: geneve-ut-1087
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +9009,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1083
+Index: geneve-ut-1095
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +9022,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1086
+Index: geneve-ut-1099
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +9042,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1087
+Index: geneve-ut-1100
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9054,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1088
+Index: geneve-ut-1101
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9066,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1092
+Index: geneve-ut-1105
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9078,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1093
+Index: geneve-ut-1106
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9090,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1095
+Index: geneve-ut-1108
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9102,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1096
+Index: geneve-ut-1109
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9114,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1097
+Index: geneve-ut-1110
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9139,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1098
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9159,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1099
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9172,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1100
+Index: geneve-ut-1113
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9187,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1101
+Index: geneve-ut-1114
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9212,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1103
+Index: geneve-ut-1116
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9224,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1106
+Index: geneve-ut-1119
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9236,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1107
+Index: geneve-ut-1120
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9248,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1108
+Index: geneve-ut-1121
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9282,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1111
+Index: geneve-ut-1124
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9296,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1112
+Index: geneve-ut-1125
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9317,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1113
+Index: geneve-ut-1126
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9331,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1117
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1118
+Index: geneve-ut-1131
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9391,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1119
+Index: geneve-ut-1132
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1123
+Index: geneve-ut-1136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9422,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1125
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1127
+Index: geneve-ut-1140
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9507,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1128
+Index: geneve-ut-1141
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9519,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1143
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9537,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1131
+Index: geneve-ut-1144
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9554,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1133
+Index: geneve-ut-1146
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9569,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1134
+Index: geneve-ut-1147
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9619,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1136
+Index: geneve-ut-1149
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9635,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1137
+Index: geneve-ut-1150
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9649,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1139
+Index: geneve-ut-1152
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9678,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1140
+Index: geneve-ut-1153
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9706,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1141
+Index: geneve-ut-1154
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9728,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1142
+Index: geneve-ut-1155
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9747,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1143
+Index: geneve-ut-1156
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9780,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1144
+Index: geneve-ut-1157
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9798,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1145
+Index: geneve-ut-1158
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9839,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1158
+Index: geneve-ut-1171
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9865,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1167
+Index: geneve-ut-1180
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9889,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1171
+Index: geneve-ut-1184
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9903,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1172
+Index: geneve-ut-1185
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9922,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1173
+Index: geneve-ut-1186
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9942,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1174
+Index: geneve-ut-1187
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9965,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1175
+Index: geneve-ut-1188
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9986,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1177
+Index: geneve-ut-1190
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +10001,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1178
+Index: geneve-ut-1191
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +10018,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1180
+Index: geneve-ut-1193
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +10042,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1182
+Index: geneve-ut-1195
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10088,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1183
+Index: geneve-ut-1196
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10130,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1184
+Index: geneve-ut-1197
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10147,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1186
+Index: geneve-ut-1199
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10162,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1187
+Index: geneve-ut-1200
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10181,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1188
+Index: geneve-ut-1201
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10201,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1189
+Index: geneve-ut-1202
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10220,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1191
+Index: geneve-ut-1204
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10249,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1192
+Index: geneve-ut-1205
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10274,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1193
+Index: geneve-ut-1206
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10296,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1194
+Index: geneve-ut-1207
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10329,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1195
+Index: geneve-ut-1208
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10359,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1199
+Index: geneve-ut-1212
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10376,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1200
+Index: geneve-ut-1213
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10413,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1201
+Index: geneve-ut-1214
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1206
+Index: geneve-ut-1219
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10438,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1209
+Index: geneve-ut-1222
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10450,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1219
+Index: geneve-ut-1233
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10464,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1220
+Index: geneve-ut-1234
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10478,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1221
+Index: geneve-ut-1235
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10492,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1222
+Index: geneve-ut-1236
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10512,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1224
+Index: geneve-ut-1238
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10525,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1225
+Index: geneve-ut-1239
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10540,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1227
+Index: geneve-ut-1241
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10562,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1236
+Index: geneve-ut-1250
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10589,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1237
+Index: geneve-ut-1251
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10609,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1238
+Index: geneve-ut-1252
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10624,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1239
+Index: geneve-ut-1253
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10651,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1240
+Index: geneve-ut-1254
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10666,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1241
+Index: geneve-ut-1255
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10682,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1242
+Index: geneve-ut-1256
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10696,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1243
+Index: geneve-ut-1257
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10670,7 +10715,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1244
+Index: geneve-ut-1258
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -10690,7 +10735,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1251
+Index: geneve-ut-1265
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10705,7 +10750,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1252
+Index: geneve-ut-1266
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10719,7 +10764,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1253
+Index: geneve-ut-1267
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10738,7 +10783,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1254
+Index: geneve-ut-1268
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10750,7 +10795,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1255
+Index: geneve-ut-1269
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10762,7 +10807,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1256
+Index: geneve-ut-1270
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10780,7 +10825,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1257
+Index: geneve-ut-1271
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10793,7 +10838,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1258
+Index: geneve-ut-1272
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10808,7 +10853,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1259
+Index: geneve-ut-1273
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10823,7 +10868,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1262
+Index: geneve-ut-1276
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10843,7 +10888,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1263
+Index: geneve-ut-1277
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10867,7 +10912,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1264
+Index: geneve-ut-1278
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10881,7 +10926,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1265
+Index: geneve-ut-1279
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10900,7 +10945,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1266
+Index: geneve-ut-1280
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10928,7 +10973,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1267
+Index: geneve-ut-1281
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10957,7 +11002,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1268
+Index: geneve-ut-1282
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10976,7 +11021,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1269
+Index: geneve-ut-1283
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11004,7 +11049,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1270
+Index: geneve-ut-1284
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11019,7 +11064,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1271
+Index: geneve-ut-1285
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11082,7 +11127,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1272
+Index: geneve-ut-1286
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11103,7 +11148,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1273
+Index: geneve-ut-1287
 
 ```python
 any where host.os.type == "windows" and
@@ -11165,7 +11210,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1275
+Index: geneve-ut-1289
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11194,7 +11239,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1276
+Index: geneve-ut-1290
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11208,7 +11253,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1277
+Index: geneve-ut-1291
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11241,7 +11286,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1280
+Index: geneve-ut-1294
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11288,7 +11333,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1281
+Index: geneve-ut-1295
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11315,7 +11360,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1282
+Index: geneve-ut-1296
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11328,7 +11373,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1293
+Index: geneve-ut-1307
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11345,7 +11390,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1295
+Index: geneve-ut-1309
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11353,6 +11398,8 @@ process where host.os.type == "windows" and event.type == "start" and process.na
   not (process.args : "-m" and process.args : "-bg") and
   not process.args : (
     "-mm",
+    "?:\\Windows\\appcompat\\cloudsdb\\apppatch.sdb",
+    "\"?:\\Windows\\appcompat\\cloudsdb\\apppatch.sdb\"",
     "?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\sysMergeInboxStoreApp.sdb",
     "\"?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\sysMergeInboxStoreApp.sdb\"",
     "?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\msiMergeInboxStoreApp.sdb",
@@ -11370,7 +11417,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1300
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11386,7 +11433,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1301
+Index: geneve-ut-1315
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11407,7 +11454,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1304
+Index: geneve-ut-1318
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11424,7 +11471,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1305
+Index: geneve-ut-1319
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11437,7 +11484,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1306
+Index: geneve-ut-1320
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11461,7 +11508,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1308
+Index: geneve-ut-1322
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11490,7 +11537,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1310
+Index: geneve-ut-1324
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11517,7 +11564,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1311
+Index: geneve-ut-1325
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11541,7 +11588,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1314
+Index: geneve-ut-1328
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11559,7 +11606,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1315
+Index: geneve-ut-1329
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11582,7 +11629,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1316
+Index: geneve-ut-1330
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11639,7 +11686,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1317
+Index: geneve-ut-1331
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11656,7 +11703,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1318
+Index: geneve-ut-1332
 
 ```python
 sequence by process.entity_id
@@ -11670,7 +11717,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1333
+Index: geneve-ut-1349
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11685,7 +11732,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1334
+Index: geneve-ut-1350
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11716,7 +11763,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1335
+Index: geneve-ut-1351
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11730,7 +11777,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1336
+Index: geneve-ut-1352
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11743,7 +11790,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1337
+Index: geneve-ut-1353
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11755,7 +11802,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1338
+Index: geneve-ut-1354
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11768,7 +11815,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1340
+Index: geneve-ut-1356
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11787,7 +11834,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1341
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11800,7 +11847,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1342
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11821,7 +11868,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1343
+Index: geneve-ut-1359
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11835,7 +11882,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1346
+Index: geneve-ut-1362
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11855,7 +11902,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1347
+Index: geneve-ut-1363
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11879,7 +11926,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1348
+Index: geneve-ut-1364
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11895,7 +11942,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1349
+Index: geneve-ut-1365
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11912,7 +11959,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1350
+Index: geneve-ut-1367
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11933,7 +11980,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1352
+Index: geneve-ut-1369
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11946,7 +11993,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1354
+Index: geneve-ut-1371
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11974,7 +12021,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1357
+Index: geneve-ut-1374
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11990,7 +12037,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1358
+Index: geneve-ut-1375
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12013,7 +12060,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1359
+Index: geneve-ut-1376
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12026,7 +12073,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1361
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12039,7 +12086,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1366
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12053,7 +12100,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1367
+Index: geneve-ut-1384
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12064,11 +12111,37 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 
 
+### Potential IIS Web Shell File Creation
+
+Branch count: 165  
+Document count: 165  
+Index: geneve-ut-1386
+
+```python
+file where host.os.type == "windows" and event.type != "deletion" and file.extension : ("aspx", "ashx", "asmx") and
+ process.name : ("w3wp.exe", "MSExchangeMailboxReplication.exe", "EdgeTransport.exe", "Microsoft.Exchange.*.exe", "UMWorkerProcess.exe", "umservice.exe", "cmd.exe", "powershell.exe", "pwsh.exe", "certutil.exe", "xcopy.exe") and 
+  (
+   (file.path : ("?:\\Program Files\\Common Files\\microsoft shared\\Web Server Extensions\\*\\TEMPLATE\\LAYOUTS\\*",
+                 "?:\\inetpub\\wwwroot\\aspnet_client\\system_web\\*", 
+                 "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\owa\\auth\\*", 
+                 "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\ecp\\auth\\*") and 
+    /* not sub-dirs */
+    not file.path : ("?:\\inetpub\\wwwroot\\aspnet_client\\system_web\\*\\*", 
+                     "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\*\\auth\\*\\*", 
+                     "?:\\Program Files\\Common Files\\microsoft shared\\Web Server Extensions\\*\\TEMPLATE\\LAYOUTS\\*\\*")) or 
+
+    /* not sub-dirs */
+   (file.path : "?:\\inetpub\\wwwroot\\aspnet_client\\*" and not file.path : "?:\\inetpub\\wwwroot\\aspnet_client\\*\\*")
+  )
+```
+
+
+
 ### Potential Impersonation Attempt via Kubectl
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1369
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12087,38 +12160,28 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 
 
-### Potential JAVA/JNDI Exploitation Attempt
+### Potential Java Service Exploitation via Suspicious Child Process
 
-Branch count: 60  
-Document count: 120  
-Index: geneve-ut-1372
+Branch count: 30  
+Document count: 60  
+Index: geneve-ut-1390
 
 ```python
-sequence by host.id with maxspan=1m
- [network where event.action == "connection_attempted" and
+sequence by host.id with maxspan=5s
+ [network where event.action == "connection_accepted" and network.direction == "ingress" and
+
   process.name : "java" and
-  /*
-     outbound connection attempt to
-     LDAP, RMI or DNS standard ports
-     by JAVA process
-   */
-  destination.port in (1389, 389, 1099, 53, 5353)] by process.pid
+  destination.port < 49152  and source.port >= 32768] by process.pid
  [process where event.type == "start" and
 
   /* Suspicious JAVA child process */
   process.parent.name : "java" and
-   process.name : ("sh",
-                   "bash",
-                   "dash",
-                   "ksh",
-                   "tcsh",
-                   "zsh",
-                   "curl",
-                   "perl*",
-                   "python*",
-                   "ruby*",
-                   "php*",
-                   "wget") and
+  process.name : (
+    "sh", "bash", "dash", "ksh", "tcsh", "zsh", "ash",  "mksh", "busybox",
+    "curl", "wget", "perl*", "python*", "ruby*", "php*", "lua*", "socat",
+    "nc", "ncat", "netcat", "netcat.openbsd", "netcat.traditional", "nc.openbsd",
+    "nc.traditional", "nohup", "setsid", "disown", "hostname", "whoami", "id"
+  ) and
     not process.command_line like~ (
       "bash -c ulimit -u",
       "bash /opt/flutter/bin/flutter*",
@@ -12134,7 +12197,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1373
+Index: geneve-ut-1391
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12152,7 +12215,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1374
+Index: geneve-ut-1392
 
 ```python
 host.os.type:"windows" and
@@ -12168,7 +12231,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1376
+Index: geneve-ut-1394
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12180,7 +12243,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1378
+Index: geneve-ut-1396
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12196,7 +12259,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1379
+Index: geneve-ut-1397
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12212,7 +12275,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1380
+Index: geneve-ut-1398
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12230,7 +12293,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1381
+Index: geneve-ut-1399
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12244,7 +12307,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1383
+Index: geneve-ut-1401
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12267,7 +12330,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1385
+Index: geneve-ut-1403
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12283,7 +12346,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1386
+Index: geneve-ut-1404
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12296,7 +12359,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1387
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12326,7 +12389,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1393
+Index: geneve-ut-1411
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12349,7 +12412,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1394
+Index: geneve-ut-1412
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12368,7 +12431,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1399
+Index: geneve-ut-1417
 
 ```python
 process where host.os.type == "windows" and 
@@ -12510,7 +12573,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1400
+Index: geneve-ut-1418
 
 ```python
 process where host.os.type == "windows" and
@@ -12587,7 +12650,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1404
+Index: geneve-ut-1422
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12604,7 +12667,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1405
+Index: geneve-ut-1423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12638,7 +12701,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1407
+Index: geneve-ut-1425
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12650,7 +12713,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1408
+Index: geneve-ut-1426
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12689,7 +12752,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1411
+Index: geneve-ut-1429
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12702,7 +12765,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1416
+Index: geneve-ut-1434
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12716,7 +12779,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1423
+Index: geneve-ut-1441
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12754,7 +12817,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1424
+Index: geneve-ut-1442
 
 ```python
 network where host.os.type == "windows" and
@@ -12780,7 +12843,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1427
+Index: geneve-ut-1445
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12795,7 +12858,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1430
+Index: geneve-ut-1448
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12809,7 +12872,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1431
+Index: geneve-ut-1449
 
 ```python
 file where host.os.type == "windows" and
@@ -12823,7 +12886,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1432
+Index: geneve-ut-1450
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12836,7 +12899,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1433
+Index: geneve-ut-1451
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12919,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1434
+Index: geneve-ut-1452
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12876,7 +12939,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1436
+Index: geneve-ut-1454
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12915,7 +12978,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1437
+Index: geneve-ut-1455
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13110,7 +13173,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1452
+Index: geneve-ut-1470
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13126,7 +13189,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1453
+Index: geneve-ut-1471
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13140,7 +13203,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1454
+Index: geneve-ut-1472
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13154,7 +13217,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1455
+Index: geneve-ut-1473
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13171,7 +13234,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1456
+Index: geneve-ut-1474
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13185,7 +13248,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1457
+Index: geneve-ut-1475
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13201,7 +13264,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1462
+Index: geneve-ut-1480
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13213,7 +13276,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1463
+Index: geneve-ut-1481
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13229,7 +13292,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1464
+Index: geneve-ut-1482
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13249,7 +13312,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1466
+Index: geneve-ut-1484
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13289,7 +13352,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1468
+Index: geneve-ut-1486
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13301,7 +13364,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1469
+Index: geneve-ut-1487
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13322,7 +13385,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1470
+Index: geneve-ut-1488
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13343,7 +13406,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1471
+Index: geneve-ut-1489
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13364,7 +13427,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1472
+Index: geneve-ut-1490
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13390,7 +13453,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1473
+Index: geneve-ut-1491
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13406,7 +13469,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1474
+Index: geneve-ut-1492
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13420,7 +13483,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1476
+Index: geneve-ut-1494
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13443,7 +13506,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1478
+Index: geneve-ut-1496
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13460,7 +13523,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1479
+Index: geneve-ut-1497
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13483,7 +13546,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1480
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13496,7 +13559,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1481
+Index: geneve-ut-1499
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13510,7 +13573,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1482
+Index: geneve-ut-1500
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13527,7 +13590,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1483
+Index: geneve-ut-1501
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13581,7 +13644,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1484
+Index: geneve-ut-1502
 
 ```python
 any where host.os.type == "windows" and
@@ -13608,7 +13671,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1490
+Index: geneve-ut-1508
 
 ```python
 file where host.os.type == "windows" and
@@ -13623,7 +13686,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1491
+Index: geneve-ut-1509
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13654,7 +13717,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1492
+Index: geneve-ut-1510
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13668,7 +13731,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1493
+Index: geneve-ut-1511
 
 ```python
 sequence with maxspan=1m
@@ -13710,7 +13773,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1494
+Index: geneve-ut-1512
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13735,7 +13798,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1495
+Index: geneve-ut-1513
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13789,7 +13852,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1496
+Index: geneve-ut-1514
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13809,7 +13872,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1497
+Index: geneve-ut-1515
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13830,7 +13893,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1498
+Index: geneve-ut-1516
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13845,7 +13908,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1499
+Index: geneve-ut-1517
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13865,7 +13928,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1500
+Index: geneve-ut-1518
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13907,7 +13970,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1504
+Index: geneve-ut-1522
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13922,7 +13985,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1505
+Index: geneve-ut-1523
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13957,7 +14020,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1506
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13974,7 +14037,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1511
+Index: geneve-ut-1529
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13988,7 +14051,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1514
+Index: geneve-ut-1532
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -14001,7 +14064,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1515
+Index: geneve-ut-1533
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -14013,7 +14076,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1516
+Index: geneve-ut-1535
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14028,7 +14091,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1518
+Index: geneve-ut-1537
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14056,7 +14119,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1520
+Index: geneve-ut-1539
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14081,7 +14144,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1524
+Index: geneve-ut-1543
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14118,7 +14181,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1525
+Index: geneve-ut-1544
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14132,7 +14195,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1526
+Index: geneve-ut-1545
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14148,7 +14211,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1527
+Index: geneve-ut-1546
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14162,7 +14225,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1528
+Index: geneve-ut-1547
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14192,7 +14255,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1529
+Index: geneve-ut-1548
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14221,7 +14284,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1530
+Index: geneve-ut-1549
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14237,7 +14300,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1531
+Index: geneve-ut-1550
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14251,7 +14314,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1532
+Index: geneve-ut-1551
 
 ```python
 file where host.os.type == "windows" and
@@ -14270,12 +14333,26 @@ file where host.os.type == "windows" and
   not process.executable : (
     "?:\\Program Files\\*",
     "?:\\Program Files (x86)\\*",
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\*",
     "?:\\Windows\\system32\\cleanmgr.exe",
     "?:\\Windows\\system32\\msiexec.exe",
     "?:\\Windows\\syswow64\\msiexec.exe",
     "?:\\Windows\\system32\\svchost.exe",
     "?:\\Windows\\System32\\Robocopy.exe",
-    "?:\\Windows\\SysWOW64\\Robocopy.exe"
+    "?:\\Windows\\SysWOW64\\Robocopy.exe",
+    "?:\\Windows\\explorer.exe",
+    "?:\\Windows\\system32\\Dism.exe",
+    "?:\\Windows\\system32\\DFSRs.exe",
+    "?:\\Windows\\system32\\wbengine.exe",
+    "?:\\Windows\\system32\\CompatTelRunner.exe",
+    "?:\\Windows\\system32\\SearchIndexer.exe",
+    "?:\\Windows\\system32\\wuauclt.exe",
+    "?:\\Windows\\servicing\\TrustedInstaller.exe",
+    "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+    "?:\\Windows\\Microsoft.NET\\*",
+    "?:\\Windows\\SystemApps\\*",
+    "?:\\Windows\\uus\\*\\wuaucltcore.exe",
+    "?:\\$WINDOWS.~BT\\Sources\\mighost.exe"
   ) and
   not (process.executable : "?:\\Windows\\System32\\spoolsv.exe" and file.path : "?:\\Windows\\System32\\spool\\*") and
   not user.name : ("SYSTEM", "Local Service", "Network Service")
@@ -14287,7 +14364,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1535
+Index: geneve-ut-1554
 
 ```python
 process where event.type == "start" and
@@ -14301,7 +14378,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1536
+Index: geneve-ut-1555
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14392,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1537
+Index: geneve-ut-1556
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14335,7 +14412,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1539
+Index: geneve-ut-1558
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14352,7 +14429,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1540
+Index: geneve-ut-1559
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14364,7 +14441,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1541
+Index: geneve-ut-1560
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14377,29 +14454,11 @@ process.executable : (
 
 
 
-### Potential Web Shell ASPX File Creation
-
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-1542
-
-```python
-file where host.os.type == "windows" and event.type != "deletion" and
-  file.extension : "aspx" and
-  file.path : "?:\\Program Files\\Common Files\\Microsoft Shared\\Web Server Extensions\\*" and
-  not process.executable: (
-        "?:\\Windows\\System32\\msiexec.exe",
-        "?:\\Program Files\\Common Files\\Microsoft Shared\\Web Server Extensions\\16\\BIN\\psconfigui.exe"
-  )
-```
-
-
-
 ### Potential notify_on_release Container Escape Detected via Defend for Containers
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1549
+Index: geneve-ut-1567
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14412,7 +14471,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1550
+Index: geneve-ut-1568
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14439,7 +14498,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1551
+Index: geneve-ut-1569
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14452,7 +14511,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1552
+Index: geneve-ut-1570
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14466,7 +14525,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1554
+Index: geneve-ut-1572
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14483,7 +14542,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1555
+Index: geneve-ut-1573
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14506,7 +14565,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1557
+Index: geneve-ut-1575
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14523,7 +14582,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1560
+Index: geneve-ut-1578
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14536,7 +14595,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1562
+Index: geneve-ut-1580
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14560,7 +14619,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1563
+Index: geneve-ut-1581
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14588,7 +14647,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1579
+Index: geneve-ut-1597
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14609,7 +14668,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1581
+Index: geneve-ut-1599
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14637,7 +14696,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1583
+Index: geneve-ut-1601
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14677,7 +14736,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1584
+Index: geneve-ut-1602
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14694,7 +14753,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1585
+Index: geneve-ut-1603
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14708,7 +14767,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1586
+Index: geneve-ut-1604
 
 ```python
 file where host.os.type == "windows" and
@@ -14727,7 +14786,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1587
+Index: geneve-ut-1605
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14741,7 +14800,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1589
+Index: geneve-ut-1607
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14759,7 +14818,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1591
+Index: geneve-ut-1609
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14777,7 +14836,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1594
+Index: geneve-ut-1612
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14791,7 +14850,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1596
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14806,7 +14865,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1597
+Index: geneve-ut-1615
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14829,7 +14888,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1599
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14911,7 +14970,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1600
+Index: geneve-ut-1618
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14932,7 +14991,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1601
+Index: geneve-ut-1619
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14954,11 +15013,29 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 
 
+### Process Execution Followed by Self-Deletion
+
+Branch count: 9  
+Document count: 18  
+Index: geneve-ut-1622
+
+```python
+sequence by process.entity_id, host.id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
+  process.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/*", "/var/run/*", "/var/www/*",
+    "/proc/*/fd/*", "?memfd:*", "memfd:*"
+  )] by process.executable
+  [file where host.os.type == "linux" and event.action == "deletion"] by file.path
+```
+
+
+
 ### Process Execution from an Unusual Directory
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1604
+Index: geneve-ut-1623
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15011,7 +15088,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1605
+Index: geneve-ut-1624
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15023,7 +15100,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1606
+Index: geneve-ut-1625
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15035,7 +15112,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1607
+Index: geneve-ut-1626
 
 ```python
 process where host.os.type == "windows" and
@@ -15050,7 +15127,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1608
+Index: geneve-ut-1627
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15080,7 +15157,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1609
+Index: geneve-ut-1628
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15140,7 +15217,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1612
+Index: geneve-ut-1631
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15153,7 +15230,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1613
+Index: geneve-ut-1632
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15185,7 +15262,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1614
+Index: geneve-ut-1633
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15209,7 +15286,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1616
+Index: geneve-ut-1635
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15242,7 +15319,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1617
+Index: geneve-ut-1636
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15259,7 +15336,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1619
+Index: geneve-ut-1638
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15288,7 +15365,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1620
+Index: geneve-ut-1639
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15302,7 +15379,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1621
+Index: geneve-ut-1640
 
 ```python
 sequence by process.entity_id
@@ -15327,7 +15404,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1622
+Index: geneve-ut-1641
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15361,7 +15438,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1623
+Index: geneve-ut-1642
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15389,7 +15466,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1624
+Index: geneve-ut-1643
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15408,7 +15485,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1630
+Index: geneve-ut-1649
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15436,7 +15513,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1631
+Index: geneve-ut-1650
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15455,7 +15532,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1635
+Index: geneve-ut-1654
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15467,7 +15544,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1636
+Index: geneve-ut-1655
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15479,7 +15556,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1637
+Index: geneve-ut-1656
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15491,7 +15568,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1638
+Index: geneve-ut-1657
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15503,7 +15580,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1649
+Index: geneve-ut-1668
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15516,7 +15593,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1650
+Index: geneve-ut-1669
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15554,7 +15631,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1652
+Index: geneve-ut-1671
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15569,7 +15646,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1653
+Index: geneve-ut-1672
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15588,7 +15665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1654
+Index: geneve-ut-1673
 
 ```python
 sequence with maxspan=1m
@@ -15636,7 +15713,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1656
+Index: geneve-ut-1675
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15659,7 +15736,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1658
+Index: geneve-ut-1677
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15673,7 +15750,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1659
+Index: geneve-ut-1678
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15687,7 +15764,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1661
+Index: geneve-ut-1680
 
 ```python
 sequence by host.id, process.entity_id
@@ -15704,7 +15781,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1662
+Index: geneve-ut-1681
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15718,7 +15795,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1663
+Index: geneve-ut-1682
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15738,7 +15815,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1664
+Index: geneve-ut-1683
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15767,7 +15844,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1665
+Index: geneve-ut-1684
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15787,7 +15864,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1666
+Index: geneve-ut-1685
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15800,7 +15877,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1668
+Index: geneve-ut-1687
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15842,7 +15919,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1669
+Index: geneve-ut-1688
 
 ```python
 sequence with maxspan=1m
@@ -15865,7 +15942,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1670
+Index: geneve-ut-1689
 
 ```python
 sequence with maxspan=1s
@@ -15913,7 +15990,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1671
+Index: geneve-ut-1690
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15930,7 +16007,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1673
+Index: geneve-ut-1692
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15959,7 +16036,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1676
+Index: geneve-ut-1695
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15987,7 +16064,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1677
+Index: geneve-ut-1696
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -16004,7 +16081,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1679
+Index: geneve-ut-1698
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16023,7 +16100,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1680
+Index: geneve-ut-1699
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16044,7 +16121,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1689
+Index: geneve-ut-1710
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16058,7 +16135,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1691
+Index: geneve-ut-1712
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16077,7 +16154,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1692
+Index: geneve-ut-1713
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16091,7 +16168,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1693
+Index: geneve-ut-1714
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16111,7 +16188,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1695
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16129,7 +16206,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1696
+Index: geneve-ut-1717
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16150,7 +16227,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1698
+Index: geneve-ut-1719
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16164,7 +16241,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1699
+Index: geneve-ut-1720
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16179,7 +16256,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1700
+Index: geneve-ut-1721
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16220,7 +16297,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1702
+Index: geneve-ut-1723
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16245,7 +16322,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1703
+Index: geneve-ut-1724
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16284,7 +16361,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1704
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16298,7 +16375,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1705
+Index: geneve-ut-1726
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16337,7 +16414,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1706
+Index: geneve-ut-1727
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16351,7 +16428,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1707
+Index: geneve-ut-1728
 
 ```python
 process where event.type == "start" and
@@ -16423,7 +16500,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1711
+Index: geneve-ut-1732
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16444,7 +16521,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1714
+Index: geneve-ut-1735
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16461,7 +16538,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1717
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16479,7 +16556,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1718
+Index: geneve-ut-1739
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16491,7 +16568,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1719
+Index: geneve-ut-1740
 
 ```python
 file where host.os.type == "windows" and
@@ -16524,7 +16601,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1722
+Index: geneve-ut-1743
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16556,7 +16633,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1724
+Index: geneve-ut-1745
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16592,7 +16669,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1725
+Index: geneve-ut-1746
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16609,7 +16686,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1726
+Index: geneve-ut-1747
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16629,7 +16706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1728
+Index: geneve-ut-1749
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16644,7 +16721,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1729
+Index: geneve-ut-1750
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16665,7 +16742,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1730
+Index: geneve-ut-1751
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16688,7 +16765,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1731
+Index: geneve-ut-1752
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16701,7 +16778,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1732
+Index: geneve-ut-1753
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16718,7 +16795,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1735
+Index: geneve-ut-1756
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16743,7 +16820,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1738
+Index: geneve-ut-1759
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16774,7 +16851,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1739
+Index: geneve-ut-1760
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16823,7 +16900,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1740
+Index: geneve-ut-1761
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16837,7 +16914,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1741
+Index: geneve-ut-1762
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16852,7 +16929,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1742
+Index: geneve-ut-1763
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16867,7 +16944,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1743
+Index: geneve-ut-1764
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16889,7 +16966,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1744
+Index: geneve-ut-1765
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16910,7 +16987,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1748
+Index: geneve-ut-1769
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16924,7 +17001,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1749
+Index: geneve-ut-1770
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16947,7 +17024,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1779
+Index: geneve-ut-1800
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16972,7 +17049,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1780
+Index: geneve-ut-1801
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -17005,7 +17082,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1781
+Index: geneve-ut-1802
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17064,7 +17141,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1783
+Index: geneve-ut-1804
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17082,7 +17159,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1784
+Index: geneve-ut-1805
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17094,7 +17171,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1787
+Index: geneve-ut-1808
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17119,7 +17196,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1793
+Index: geneve-ut-1814
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17134,7 +17211,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1794
+Index: geneve-ut-1815
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17157,7 +17234,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1797
+Index: geneve-ut-1818
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17169,9 +17246,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### Suspicious /proc/maps Discovery
 
-Branch count: 48  
-Document count: 48  
-Index: geneve-ut-1799
+Branch count: 96  
+Document count: 96  
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17183,7 +17260,9 @@ not (
   ?process.parent.name == "uac" or
   ?process.parent.executable in ("/opt/secl/linux-ir-scripts-v3/thieves.sh", "/opt/traps/rpm-installer/setup.sh") or
   ?process.working_directory like ("/opt/traps/deb-installer", "/opt/Tanium/TaniumClient/*") or
-  ?process.parent.executable like ("/home/*/sunlight/thieves.sh")
+  ?process.parent.executable like ("/home/*/sunlight/thieves.sh") or
+  (?process.parent.executable == "/usr/lib/systemd/systemd" and ?process.parent.command_line == "/sbin/init") or
+  ?process.group_leader.executable in ("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/opt/traps/bin/cytool")
 )
 ```
 
@@ -17193,7 +17272,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1801
+Index: geneve-ut-1822
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17220,7 +17299,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1805
+Index: geneve-ut-1826
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17259,7 +17338,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1806
+Index: geneve-ut-1827
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17282,7 +17361,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1807
+Index: geneve-ut-1828
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17296,7 +17375,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1808
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17312,7 +17391,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1809
+Index: geneve-ut-1830
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17328,7 +17407,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1810
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17342,7 +17421,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1812
+Index: geneve-ut-1833
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17361,11 +17440,76 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 
 
+### Suspicious Child Process of PaperCut Server Component
+
+Branch count: 92  
+Document count: 92  
+Index: geneve-ut-1834
+
+```python
+process where host.os.type == "windows" and event.type == "start" and
+  process.parent.name : ("pc-app.exe", "pc-printjob-spooler.exe") and
+  (
+    process.name : (
+      "cmd.exe",
+      "powershell.exe",
+      "pwsh.exe",
+      "powershell_ise.exe",
+      "wscript.exe",
+      "cscript.exe",
+      "mshta.exe",
+      "rundll32.exe",
+      "regsvr32.exe",
+      "bitsadmin.exe",
+      "certutil.exe",
+      "curl.exe",
+      "wget.exe",
+      "net.exe",
+      "net1.exe",
+      "whoami.exe",
+      "tasklist.exe",
+      "ipconfig.exe",
+      "nltest.exe",
+      "systeminfo.exe",
+      "charmap.exe",
+      "calc.exe",
+      "mspaint.exe"
+    ) or
+    ?process.pe.original_file_name : (
+      "Cmd.Exe",
+      "PowerShell.EXE",
+      "pwsh.dll",
+      "powershell_ise.EXE",
+      "wscript.exe",
+      "cscript.exe",
+      "MSHTA.EXE",
+      "RUNDLL32.EXE",
+      "REGSVR32.EXE",
+      "bitsadmin.exe",
+      "CertUtil.exe",
+      "curl.exe",
+      "wget.exe",
+      "net.exe",
+      "net1.exe",
+      "whoami.exe",
+      "tasklist.exe",
+      "ipconfig.exe",
+      "nltest.exe",
+      "systeminfo.exe",
+      "charmap.exe",
+      "CALC.EXE",
+      "mspaint.exe"
+    )
+  )
+```
+
+
+
 ### Suspicious Child Process via Azure VM CustomScript Extension
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1813
+Index: geneve-ut-1835
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17393,7 +17537,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1814
+Index: geneve-ut-1836
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17408,7 +17552,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1817
+Index: geneve-ut-1839
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17435,7 +17579,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1819
+Index: geneve-ut-1841
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17466,7 +17610,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1820
+Index: geneve-ut-1842
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17482,7 +17626,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1821
+Index: geneve-ut-1843
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17495,7 +17639,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1823
+Index: geneve-ut-1845
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17511,7 +17655,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1824
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17527,7 +17671,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1825
+Index: geneve-ut-1847
 
 ```python
 any where host.os.type == "windows" and 
@@ -17594,7 +17738,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1827
+Index: geneve-ut-1849
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17610,7 +17754,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1829
+Index: geneve-ut-1851
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17646,7 +17790,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1830
+Index: geneve-ut-1852
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17684,7 +17828,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1831
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17719,7 +17863,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1832
+Index: geneve-ut-1854
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17753,7 +17897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1834
+Index: geneve-ut-1856
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17774,7 +17918,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1839
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17851,7 +17995,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1840
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17873,7 +18017,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1841
+Index: geneve-ut-1863
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17897,7 +18041,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1843
+Index: geneve-ut-1865
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17918,7 +18062,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1846
+Index: geneve-ut-1868
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17933,7 +18077,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1849
+Index: geneve-ut-1871
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17946,7 +18090,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1850
+Index: geneve-ut-1872
 
 ```python
 any where host.os.type == "windows" and
@@ -17961,7 +18105,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1851
+Index: geneve-ut-1873
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17977,7 +18121,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1852
+Index: geneve-ut-1874
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17991,7 +18135,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1856
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18044,11 +18188,32 @@ process.parent.executable != null and (
 
 
 
+### Suspicious Java Class File Created in PaperCut Server Library
+
+Branch count: 30  
+Document count: 30  
+Index: geneve-ut-1879
+
+```python
+file where host.os.type in ("windows", "linux", "macos") and
+  event.action in ("creation", "overwrite") and
+  file.extension : "class" and
+  file.path : (
+    "?:\\Program Files\\PaperCut*\\server\\lib\\*",
+    "?:\\Program Files (x86)\\PaperCut*\\server\\lib\\*",
+    "/opt/papercut/server/lib/*",
+    "/usr/local/papercut/server/lib/*",
+    "/Applications/PaperCut*/server/lib/*"
+  )
+```
+
+
+
 ### Suspicious JavaScript Execution via Deno
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1857
+Index: geneve-ut-1880
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18062,7 +18227,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1859
+Index: geneve-ut-1882
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18094,7 +18259,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1861
+Index: geneve-ut-1884
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18107,7 +18272,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1862
+Index: geneve-ut-1885
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18126,7 +18291,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1863
+Index: geneve-ut-1886
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18172,7 +18337,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1865
+Index: geneve-ut-1888
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18193,7 +18358,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1866
+Index: geneve-ut-1889
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18213,7 +18378,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1867
+Index: geneve-ut-1890
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18227,7 +18392,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1868
+Index: geneve-ut-1891
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18259,7 +18424,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1871
+Index: geneve-ut-1894
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18280,7 +18445,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1873
+Index: geneve-ut-1896
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18381,7 +18546,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1877
+Index: geneve-ut-1900
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18429,7 +18594,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1880
+Index: geneve-ut-1903
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18455,7 +18620,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1881
+Index: geneve-ut-1904
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18500,7 +18665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1882
+Index: geneve-ut-1905
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18524,7 +18689,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1883
+Index: geneve-ut-1906
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18540,7 +18705,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1885
+Index: geneve-ut-1908
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18565,7 +18730,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1886
+Index: geneve-ut-1909
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18580,7 +18745,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1889
+Index: geneve-ut-1912
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18594,7 +18759,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1890
+Index: geneve-ut-1913
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18614,7 +18779,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1891
+Index: geneve-ut-1914
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18649,7 +18814,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1895
+Index: geneve-ut-1918
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18667,7 +18832,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1896
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18680,7 +18845,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1899
+Index: geneve-ut-1923
 
 ```python
 any where host.os.type == "windows" and
@@ -18709,11 +18874,41 @@ any where host.os.type == "windows" and
 
 
 
+### Suspicious Reading of procfs Syscall File
+
+Branch count: 120  
+Document count: 120  
+Index: geneve-ut-1925
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+(
+  process.name in (
+    "cat", "less", "more", "head", "tail", "nano", "vi", "vim", "strings", "nvim", "vim.basic",
+    "vim.tiny", "od", "hexdump", "xxd", "hx", "hexedit", "pager", "tr"
+  ) or
+  (
+    process.name in (
+      "find", "awk", "gawk", "mawk", "nawk", "grep", "fgrep", "rgrep", "xargs", "sed", "tee"
+    ) and
+    process.args_count <= 20
+  )
+) and
+process.command_line like "*/proc/*/syscall*" and
+not (
+  process.command_line like ("*/proc/self/syscall*", "*/proc/thread-self/syscall*") or
+  process.args like "/proc/*/syscall/comm"
+)
+```
+
+
+
 ### Suspicious Remote Registry Access via SeBackupPrivilege
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1901
+Index: geneve-ut-1926
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18731,7 +18926,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1902
+Index: geneve-ut-1927
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18753,7 +18948,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1905
+Index: geneve-ut-1930
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18792,7 +18987,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1906
+Index: geneve-ut-1931
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18822,7 +19017,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1907
+Index: geneve-ut-1932
 
 ```python
 any where host.os.type == "windows" and
@@ -18856,7 +19051,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1908
+Index: geneve-ut-1933
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18870,7 +19065,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1911
+Index: geneve-ut-1936
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18901,7 +19096,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1912
+Index: geneve-ut-1937
 
 ```python
 any where host.os.type == "windows" and
@@ -18921,7 +19116,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1913
+Index: geneve-ut-1938
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18962,7 +19157,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1914
+Index: geneve-ut-1939
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18978,7 +19173,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1915
+Index: geneve-ut-1940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -19008,7 +19203,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1919
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19021,7 +19216,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1920
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19045,7 +19240,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1923
+Index: geneve-ut-1948
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19063,7 +19258,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1925
+Index: geneve-ut-1950
 
 ```python
 any where host.os.type == "windows" and
@@ -19078,7 +19273,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1926
+Index: geneve-ut-1951
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19096,7 +19291,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1927
+Index: geneve-ut-1952
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19117,7 +19312,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1928
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19136,7 +19331,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1931
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19161,7 +19356,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1932
+Index: geneve-ut-1957
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19174,7 +19369,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1934
+Index: geneve-ut-1959
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19187,7 +19382,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1936
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19210,7 +19405,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1938
+Index: geneve-ut-1963
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19229,7 +19424,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1939
+Index: geneve-ut-1964
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19251,7 +19446,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1940
+Index: geneve-ut-1965
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19284,7 +19479,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1942
+Index: geneve-ut-1967
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19302,7 +19497,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1943
+Index: geneve-ut-1968
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19316,7 +19511,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1944
+Index: geneve-ut-1969
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19340,7 +19535,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1945
+Index: geneve-ut-1970
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19363,7 +19558,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1946
+Index: geneve-ut-1971
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19382,7 +19577,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1949
+Index: geneve-ut-1974
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19401,7 +19596,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1951
+Index: geneve-ut-1976
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19436,7 +19631,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1952
+Index: geneve-ut-1977
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19648,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1953
+Index: geneve-ut-1978
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19473,7 +19668,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1954
+Index: geneve-ut-1979
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19513,7 +19708,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1955
+Index: geneve-ut-1980
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19529,7 +19724,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1956
+Index: geneve-ut-1981
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19543,7 +19738,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1957
+Index: geneve-ut-1982
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19581,7 +19776,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1958
+Index: geneve-ut-1983
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19635,7 +19830,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1959
+Index: geneve-ut-1984
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19663,7 +19858,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1961
+Index: geneve-ut-1986
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19677,7 +19872,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1962
+Index: geneve-ut-1987
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19723,7 +19918,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1963
+Index: geneve-ut-1988
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19762,7 +19957,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1964
+Index: geneve-ut-1989
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19775,7 +19970,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1968
+Index: geneve-ut-1993
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19808,7 +20003,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1969
+Index: geneve-ut-1994
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19822,7 +20017,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1970
+Index: geneve-ut-1995
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19836,7 +20031,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1971
+Index: geneve-ut-1996
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19850,7 +20045,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1972
+Index: geneve-ut-1997
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19889,7 +20084,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1980
+Index: geneve-ut-2005
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19931,7 +20126,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1982
+Index: geneve-ut-2007
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19953,7 +20148,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1984
+Index: geneve-ut-2009
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19966,7 +20161,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1987
+Index: geneve-ut-2012
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19983,7 +20178,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1988
+Index: geneve-ut-2013
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19999,7 +20194,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1989
+Index: geneve-ut-2014
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20012,7 +20207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1990
+Index: geneve-ut-2015
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20027,7 +20222,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1991
+Index: geneve-ut-2016
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20050,7 +20245,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1992
+Index: geneve-ut-2017
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20066,7 +20261,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1993
+Index: geneve-ut-2018
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20082,7 +20277,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1999
+Index: geneve-ut-2024
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20094,7 +20289,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-2000
+Index: geneve-ut-2025
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20123,7 +20318,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2002
+Index: geneve-ut-2027
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20137,7 +20332,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2007
+Index: geneve-ut-2032
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20157,7 +20352,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2008
+Index: geneve-ut-2033
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20182,7 +20377,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2015
+Index: geneve-ut-2040
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20196,7 +20391,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2016
+Index: geneve-ut-2041
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20219,7 +20414,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2025
+Index: geneve-ut-2050
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20253,7 +20448,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2027
+Index: geneve-ut-2052
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20272,7 +20467,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2034
+Index: geneve-ut-2059
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20291,7 +20486,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2049
+Index: geneve-ut-2074
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20308,7 +20503,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2052
+Index: geneve-ut-2077
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20325,7 +20520,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2068
+Index: geneve-ut-2093
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20344,7 +20539,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2072
+Index: geneve-ut-2097
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20386,7 +20581,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2073
+Index: geneve-ut-2098
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20431,7 +20626,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2076
+Index: geneve-ut-2101
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20473,7 +20668,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2078
+Index: geneve-ut-2103
 
 ```python
 host.os.type:"linux" and 
@@ -20501,7 +20696,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2082
+Index: geneve-ut-2107
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20525,7 +20720,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2083
+Index: geneve-ut-2108
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20565,7 +20760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2084
+Index: geneve-ut-2109
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20612,7 +20807,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2088
+Index: geneve-ut-2113
 
 ```python
 sequence by process.entity_id
@@ -20649,7 +20844,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2120
+Index: geneve-ut-2145
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20663,7 +20858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2121
+Index: geneve-ut-2146
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20706,7 +20901,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2122
+Index: geneve-ut-2147
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20719,7 +20914,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2125
+Index: geneve-ut-2150
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20733,7 +20928,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2126
+Index: geneve-ut-2151
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20746,7 +20941,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2130
+Index: geneve-ut-2155
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20771,7 +20966,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2131
+Index: geneve-ut-2156
 
 ```python
 process where event.type == "start" and
@@ -20786,7 +20981,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2132
+Index: geneve-ut-2157
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20803,7 +20998,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2133
+Index: geneve-ut-2158
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20817,7 +21012,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2134
+Index: geneve-ut-2159
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20833,7 +21028,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2135
+Index: geneve-ut-2160
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20847,7 +21042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2136
+Index: geneve-ut-2161
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20874,7 +21069,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2138
+Index: geneve-ut-2163
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20886,7 +21081,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2139
+Index: geneve-ut-2164
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20902,7 +21097,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2140
+Index: geneve-ut-2165
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20925,7 +21120,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2141
+Index: geneve-ut-2166
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20938,7 +21133,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2143
+Index: geneve-ut-2168
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20950,7 +21145,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2144
+Index: geneve-ut-2169
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20962,7 +21157,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2145
+Index: geneve-ut-2170
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20974,7 +21169,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2146
+Index: geneve-ut-2171
 
 ```python
 web where (
@@ -21002,7 +21197,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2152
+Index: geneve-ut-2177
 
 ```python
 any where (
@@ -21065,6 +21260,11 @@ url.original like~ (
     "*select @@version*", "*select user()*", "*select current_user()*", "*select database()*",
     "*sp_executesql*exec*", "*xp_dirtree*"
   )
+) and
+not user_agent.original like~ (
+    "*Nessus*", "*Qualys*", "*Acunetix*",  "*Tenable*", "*CensysInspect*", "*Detectify*",
+    "*Assetnote*", "*ExposureScan*", "*RecordedFuture*", "*AppSpider*", "*WebInspect*",
+    "*Rapid7*", "*InsightVM*", "*Probely*"
 )
 ```
 
@@ -21074,7 +21274,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2154
+Index: geneve-ut-2179
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21095,7 +21295,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2157
+Index: geneve-ut-2182
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21109,7 +21309,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2158
+Index: geneve-ut-2183
 
 ```python
 file where event.type == "deletion" and
@@ -21126,7 +21326,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2159
+Index: geneve-ut-2184
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21144,7 +21344,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2162
+Index: geneve-ut-2187
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21182,7 +21382,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2164
+Index: geneve-ut-2189
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21219,7 +21419,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2165
+Index: geneve-ut-2190
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21234,7 +21434,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2166
+Index: geneve-ut-2191
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21247,7 +21447,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2167
+Index: geneve-ut-2192
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21266,7 +21466,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2168
+Index: geneve-ut-2193
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21291,7 +21491,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2169
+Index: geneve-ut-2194
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21317,7 +21517,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2170
+Index: geneve-ut-2195
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21339,7 +21539,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2171
+Index: geneve-ut-2196
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21356,7 +21556,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2173
+Index: geneve-ut-2198
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21375,7 +21575,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2174
+Index: geneve-ut-2199
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21415,7 +21615,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2175
+Index: geneve-ut-2200
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21432,7 +21632,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2177
+Index: geneve-ut-2202
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21445,7 +21645,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2178
+Index: geneve-ut-2203
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21459,7 +21659,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2179
+Index: geneve-ut-2204
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21487,7 +21687,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2180
+Index: geneve-ut-2205
 
 ```python
 process where event.type == "start" and
@@ -21512,7 +21712,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2181
+Index: geneve-ut-2206
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21526,7 +21726,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2182
+Index: geneve-ut-2207
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21542,7 +21742,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2183
+Index: geneve-ut-2208
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21577,7 +21777,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2184
+Index: geneve-ut-2209
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21595,7 +21795,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2187
+Index: geneve-ut-2212
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/alerts_from_rules-serverless.md
+++ b/tests/reports/alerts_from_rules-serverless.md
@@ -5,14 +5,14 @@ learn what rules are supported and what not and why.
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.4
+Rules version: 9.5.5
 
 ## Table of contents
    1. [Failed rules (24)](#failed-rules-24)
    1. [Unsuccessful rules with signals (24)](#unsuccessful-rules-with-signals-24)
    1. [Rules with no signals (5)](#rules-with-no-signals-5)
    1. [Rules with too few signals (28)](#rules-with-too-few-signals-28)
-   1. [Rules with the correct signals (805)](#rules-with-the-correct-signals-805)
+   1. [Rules with the correct signals (811)](#rules-with-the-correct-signals-811)
 
 ## Failed rules (24)
 
@@ -20,7 +20,7 @@ Rules version: 9.5.4
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0368  
+Index: geneve-ut-0378  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -75,7 +75,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0379  
+Index: geneve-ut-0389  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -190,7 +190,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0647  
+Index: geneve-ut-0656  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -259,7 +259,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0672  
+Index: geneve-ut-0681  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -288,7 +288,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0808  
+Index: geneve-ut-0820  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -319,7 +319,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1001  
+Index: geneve-ut-1013  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -372,7 +372,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1146  
+Index: geneve-ut-1159  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -405,7 +405,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1176  
+Index: geneve-ut-1189  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -448,7 +448,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1250  
+Index: geneve-ut-1264  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -489,7 +489,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1279  
+Index: geneve-ut-1293  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -515,7 +515,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1297  
+Index: geneve-ut-1311  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -553,7 +553,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1362  
+Index: geneve-ut-1379  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -575,7 +575,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1377  
+Index: geneve-ut-1395  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -616,7 +616,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1467  
+Index: geneve-ut-1485  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -679,7 +679,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1712  
+Index: geneve-ut-1733  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -725,7 +725,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1716  
+Index: geneve-ut-1737  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -768,7 +768,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1800  
+Index: geneve-ut-1821  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -816,7 +816,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1815  
+Index: geneve-ut-1837  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -851,7 +851,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1828  
+Index: geneve-ut-1850  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -876,7 +876,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1838  
+Index: geneve-ut-1860  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -939,7 +939,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1844  
+Index: geneve-ut-1866  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -967,7 +967,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1853  
+Index: geneve-ut-1875  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -999,7 +999,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1950  
+Index: geneve-ut-1975  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1074,7 +1074,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1981  
+Index: geneve-ut-2006  
 Failure message(s):  
   SDE says:
 > This rule reached the maximum alert limit for the rule execution. Some alerts were not created.  
@@ -1123,7 +1123,7 @@ container.id like "*"
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0368
+Index: geneve-ut-0378
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1175,7 +1175,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0379
+Index: geneve-ut-0389
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -1287,7 +1287,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0647
+Index: geneve-ut-0656
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -1353,7 +1353,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0672
+Index: geneve-ut-0681
 
 ```python
 sequence by host.id, user.id with maxspan=1m
@@ -1379,7 +1379,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0808
+Index: geneve-ut-0820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -1407,7 +1407,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1001
+Index: geneve-ut-1013
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1457,7 +1457,7 @@ not (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1146
+Index: geneve-ut-1159
 
 ```python
 sequence by process.parent.entity_id with maxspan=3s
@@ -1487,7 +1487,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1176
+Index: geneve-ut-1189
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1527,7 +1527,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1250
+Index: geneve-ut-1264
 
 ```python
 sequence by process.parent.entity_id, container.id with maxspan=1s
@@ -1565,7 +1565,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1279
+Index: geneve-ut-1293
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and (
@@ -1588,7 +1588,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1297
+Index: geneve-ut-1311
 
 ```python
 sequence by process.entity_id with maxspan=3s
@@ -1623,7 +1623,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1362
+Index: geneve-ut-1379
 
 ```python
 sequence by host.id with maxspan=1m
@@ -1642,7 +1642,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1377
+Index: geneve-ut-1395
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -1680,7 +1680,7 @@ process.args like~ (
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1467
+Index: geneve-ut-1485
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -1740,7 +1740,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1712
+Index: geneve-ut-1733
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1783,7 +1783,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1716
+Index: geneve-ut-1737
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -1823,7 +1823,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1800
+Index: geneve-ut-1821
 
 ```python
 sequence by host.id with maxspan=5s
@@ -1868,7 +1868,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1815
+Index: geneve-ut-1837
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -1900,7 +1900,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1828
+Index: geneve-ut-1850
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -1922,7 +1922,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1838
+Index: geneve-ut-1860
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -1982,7 +1982,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1844
+Index: geneve-ut-1866
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -2007,7 +2007,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1853
+Index: geneve-ut-1875
 
 ```python
 process where host.os.type in ("linux", "macos", "windows") and event.type == "start" and
@@ -2036,7 +2036,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1950
+Index: geneve-ut-1975
 
 ```python
 network where host.os.type == "windows" and dns.question.name != null and process.name != null and
@@ -2108,7 +2108,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1981
+Index: geneve-ut-2006
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -2154,7 +2154,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0239
+Index: geneve-ut-0247
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -2168,7 +2168,7 @@ process.name == "apparmor_parser" and process.args in ("--ofile*", "-o*", "--out
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1002
+Index: geneve-ut-1014
 
 ```python
 iam where host.os.type == "linux" and event.type == "group" and event.type == "creation" and event.outcome == "success"
@@ -2180,7 +2180,7 @@ iam where host.os.type == "linux" and event.type == "group" and event.type == "c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1022
+Index: geneve-ut-1034
 
 ```python
 iam where host.os.type == "linux" and event.type == "user" and event.type == "creation" and event.outcome == "success"
@@ -2192,7 +2192,7 @@ iam where host.os.type == "linux" and event.type == "user" and event.type == "cr
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1414
+Index: geneve-ut-1432
 
 ```python
 sequence by user.name, source.port, source.ip with maxspan=15s 
@@ -2210,7 +2210,7 @@ sequence by user.name, source.port, source.ip with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1615
+Index: geneve-ut-1634
 
 ```python
 host.os.type:windows and event.category:file and event.code:5145 and
@@ -2227,7 +2227,7 @@ host.os.type:windows and event.category:file and event.code:5145 and
 
 Branch count: 8325  
 Document count: 8325  
-Index: geneve-ut-0368  
+Index: geneve-ut-0378  
 Failure message(s):  
   got 1000 signals, expected 8325  
 
@@ -2281,7 +2281,7 @@ process.args like~ (
 
 Branch count: 1680  
 Document count: 1680  
-Index: geneve-ut-0379  
+Index: geneve-ut-0389  
 Failure message(s):  
   got 1000 signals, expected 1680  
 
@@ -2395,7 +2395,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2640  
 Document count: 2640  
-Index: geneve-ut-0647  
+Index: geneve-ut-0656  
 Failure message(s):  
   got 1000 signals, expected 2640  
 
@@ -2463,7 +2463,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 4608  
 Document count: 13824  
-Index: geneve-ut-0672  
+Index: geneve-ut-0681  
 Failure message(s):  
   got 1000 signals, expected 4608  
 
@@ -2491,7 +2491,7 @@ sequence by host.id, user.id with maxspan=1m
 
 Branch count: 2300  
 Document count: 2300  
-Index: geneve-ut-0808  
+Index: geneve-ut-0820  
 Failure message(s):  
   got 1000 signals, expected 2300  
 
@@ -2521,7 +2521,7 @@ not process.name in ("git", "dirname")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0974  
+Index: geneve-ut-0986  
 Failure message(s):  
   got 3 signals, expected 6  
 
@@ -2530,8 +2530,8 @@ event.dataset:"kubernetes.audit_logs" and event.action:list and
 kubernetes.audit.objectRef.resource:secrets and 
 kubernetes.audit.requestURI :(/api/v1/secrets or /api/v1/secrets?limit* or /api/v1/namespaces/kube-system/secrets or /api/v1/namespaces/kube-system/secrets?limit* or /api/v1/namespaces/default/secrets or /api/v1/namespaces/default/secrets?limit*) and 
 source.ip:(* and not ("::1" or "127.0.0.1")) and 
-not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator) and 
-not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
+not user.name: (system\:kube-controller-manager or eks\:cloud-controller-manager or eks\:kms-storage-migrator or "system:serviceaccount:argocd:argocd-application-controller" or "system:serviceaccount:elastic:kube-state-metrics" or "system:serviceaccount:cert-manager:cert-manager-cainjector" or "system:serviceaccount:elastic-system:elastic-agent" or "system:serviceaccount:longhorn-system:longhorn-service-account") and 
+not kubernetes.audit.user.groups:("system:serviceaccounts:ibm-csi" or "system:serviceaccounts:argocd" or "system:serviceaccounts:elastic")
 ```
 
 
@@ -2540,7 +2540,7 @@ not kubernetes.audit.user.groups:"system:serviceaccounts:ibm-csi"
 
 Branch count: 6552  
 Document count: 6552  
-Index: geneve-ut-1001  
+Index: geneve-ut-1013  
 Failure message(s):  
   got 1000 signals, expected 6552  
 
@@ -2592,7 +2592,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1124  
+Index: geneve-ut-1137  
 Failure message(s):  
   got 10 signals, expected 12  
 
@@ -2612,7 +2612,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1146  
+Index: geneve-ut-1159  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2644,7 +2644,7 @@ sequence by process.parent.entity_id with maxspan=3s
 
 Branch count: 1110  
 Document count: 1110  
-Index: geneve-ut-1176  
+Index: geneve-ut-1189  
 Failure message(s):  
   got 1000 signals, expected 1110  
 
@@ -2686,7 +2686,7 @@ process.args like~ (
 
 Branch count: 2352  
 Document count: 4704  
-Index: geneve-ut-1250  
+Index: geneve-ut-1264  
 Failure message(s):  
   got 1000 signals, expected 2352  
 
@@ -2726,7 +2726,7 @@ sequence by process.parent.entity_id, container.id with maxspan=1s
 
 Branch count: 8448  
 Document count: 8448  
-Index: geneve-ut-1279  
+Index: geneve-ut-1293  
 Failure message(s):  
   got 1000 signals, expected 8448  
 
@@ -2751,7 +2751,7 @@ process.command_line like~ (
 
 Branch count: 3600  
 Document count: 7200  
-Index: geneve-ut-1297  
+Index: geneve-ut-1311  
 Failure message(s):  
   got 1000 signals, expected 3600  
 
@@ -2788,7 +2788,7 @@ sequence by process.entity_id with maxspan=3s
 
 Branch count: 2500  
 Document count: 5000  
-Index: geneve-ut-1362  
+Index: geneve-ut-1379  
 Failure message(s):  
   got 1000 signals, expected 2500  
 
@@ -2809,7 +2809,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 3410  
 Document count: 3410  
-Index: geneve-ut-1377  
+Index: geneve-ut-1395  
 Failure message(s):  
   got 1000 signals, expected 3410  
 
@@ -2849,7 +2849,7 @@ process.args like~ (
 
 Branch count: 6  
 Document count: 12  
-Index: geneve-ut-1458  
+Index: geneve-ut-1476  
 Failure message(s):  
   got 5 signals, expected 6  
 
@@ -2866,7 +2866,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5s
 
 Branch count: 1794  
 Document count: 1794  
-Index: geneve-ut-1467  
+Index: geneve-ut-1485  
 Failure message(s):  
   got 1000 signals, expected 1794  
 
@@ -2928,7 +2928,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 32  
 Document count: 64  
-Index: geneve-ut-1582  
+Index: geneve-ut-1600  
 Failure message(s):  
   got 24 signals, expected 32  
 
@@ -2953,7 +2953,7 @@ sequence by host.id, process.pid with maxspan=1s
 
 Branch count: 8880  
 Document count: 8880  
-Index: geneve-ut-1712  
+Index: geneve-ut-1733  
 Failure message(s):  
   got 1000 signals, expected 8880  
 
@@ -2998,7 +2998,7 @@ process.args like~ (
 
 Branch count: 2997  
 Document count: 2997  
-Index: geneve-ut-1716  
+Index: geneve-ut-1737  
 Failure message(s):  
   got 1000 signals, expected 2997  
 
@@ -3040,7 +3040,7 @@ process.args like~ (
 
 Branch count: 1368  
 Document count: 2736  
-Index: geneve-ut-1800  
+Index: geneve-ut-1821  
 Failure message(s):  
   got 1000 signals, expected 1368  
 
@@ -3087,7 +3087,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 5280  
 Document count: 5280  
-Index: geneve-ut-1815  
+Index: geneve-ut-1837  
 Failure message(s):  
   got 1000 signals, expected 5280  
 
@@ -3121,7 +3121,7 @@ process.name == "busybox" and (
 
 Branch count: 1728  
 Document count: 1728  
-Index: geneve-ut-1828  
+Index: geneve-ut-1850  
 Failure message(s):  
   got 1000 signals, expected 1728  
 
@@ -3145,7 +3145,7 @@ process.args like (
 
 Branch count: 6144  
 Document count: 6144  
-Index: geneve-ut-1838  
+Index: geneve-ut-1860  
 Failure message(s):  
   got 1000 signals, expected 6144  
 
@@ -3207,7 +3207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4032  
 Document count: 8064  
-Index: geneve-ut-1844  
+Index: geneve-ut-1866  
 Failure message(s):  
   got 1000 signals, expected 4032  
 
@@ -3234,7 +3234,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2457  
 Document count: 2457  
-Index: geneve-ut-1853  
+Index: geneve-ut-1875  
 Failure message(s):  
   got 1000 signals, expected 2457  
 
@@ -3265,7 +3265,7 @@ process.args like~ (
 
 Branch count: 2442  
 Document count: 2442  
-Index: geneve-ut-1950  
+Index: geneve-ut-1975  
 Failure message(s):  
   got 1000 signals, expected 2442  
 
@@ -3339,7 +3339,7 @@ not (
 
 Branch count: 2035  
 Document count: 2035  
-Index: geneve-ut-1981  
+Index: geneve-ut-2006  
 Failure message(s):  
   got 1000 signals, expected 2035  
 
@@ -3381,7 +3381,7 @@ container.id like "*"
 
 
 
-## Rules with the correct signals (805)
+## Rules with the correct signals (811)
 
 ### A scheduled task was created
 
@@ -3470,11 +3470,33 @@ file.path : "/etc/apt/apt.conf.d/*" and not (
 
 
 
+### AWS Bedrock AgentCore Resource Created with IAM Execution Role
+
+Branch count: 8  
+Document count: 8  
+Index: geneve-ut-0016
+
+```python
+event.dataset: "aws.cloudtrail" and
+  event.provider: "bedrock-agentcore.amazonaws.com" and
+  event.action: (
+    "CreateCodeInterpreter" or
+    "CreateAgentRuntime" or
+    "CreateBrowser" or
+    "CreateHarness"
+  ) and
+  event.outcome: "success" and
+  aws.cloudtrail.request_parameters: (*executionRoleArn* or *roleArn*) and
+  not aws.cloudtrail.user_identity.invoked_by: ("bedrock-agentcore.amazonaws.com" or "cloudformation.amazonaws.com")
+```
+
+
+
 ### AWS Credentials Searched For Inside A Container
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-0052
+Index: geneve-ut-0053
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -3492,7 +3514,7 @@ process.command_line like~ (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0069
+Index: geneve-ut-0071
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3505,11 +3527,32 @@ event.dataset: "aws.cloudtrail"
 
 
 
+### AWS GetFederationToken Followed by Console Login via Federation Exchange
+
+Branch count: 1  
+Document count: 3  
+Index: geneve-ut-0093
+
+```python
+sequence by source.ip with maxspan=2m
+  [any where event.provider == "sts.amazonaws.com"
+   and event.action == "GetFederationToken"
+   and event.outcome == "success"]
+  [any where event.provider == "signin.amazonaws.com"
+   and event.action == "GetSigninToken"
+   and event.outcome == "success"]
+  [any where event.provider == "signin.amazonaws.com"
+   and event.action == "ConsoleLogin"
+   and event.outcome == "success"]
+```
+
+
+
 ### AWS IAM Customer Managed Policy Version Created or Default Version Set
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0102
+Index: geneve-ut-0108
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3520,6 +3563,7 @@ event.dataset: "aws.cloudtrail"
     and not aws.cloudtrail.user_identity.arn:arn*/terraform 
     and not source.as.organization.name:(Amazon* or AMAZON* or "Google LLC" or "MongoDB, Inc.")
     and not source.address: ( "cloudformation.amazonaws.com" or "servicecatalog.amazonaws.com")
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3528,11 +3572,12 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0109
+Index: geneve-ut-0115
 
 ```python
 event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
     and event.action: "CreateLoginProfile" and event.outcome: success
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3541,7 +3586,7 @@ event.dataset: aws.cloudtrail and event.provider: "iam.amazonaws.com"
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0121
+Index: geneve-ut-0127
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3573,7 +3618,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0130
+Index: geneve-ut-0136
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3581,6 +3626,7 @@ event.dataset: "aws.cloudtrail"
     and event.action: "PutKeyPolicy"
     and event.outcome: "success"
     and not aws.cloudtrail.user_identity.type: "AWSService"
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3589,13 +3635,14 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0132
+Index: geneve-ut-0138
 
 ```python
 event.dataset: "aws.cloudtrail"
     and event.provider: "lambda.amazonaws.com"
     and event.outcome: "success"
     and event.action: (CreateFunction* or UpdateFunctionCode*)
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3604,11 +3651,12 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0152
+Index: geneve-ut-0158
 
 ```python
 event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com" 
-    and event.action: ("CreateDBSnapshot" or "CreateDBClusterSnapshot") and event.outcome: "success"
+    and event.action: ("CreateDBSnapshot" or "CreateDBClusterSnapshot") and event.outcome: "success" 
+    and not user_agent.original: (*Terraform* or *Pulumi*)
 ```
 
 
@@ -3617,7 +3665,7 @@ event.dataset: "aws.cloudtrail" and event.provider: "rds.amazonaws.com"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0189
+Index: geneve-ut-0197
 
 ```python
 event.dataset: "aws.cloudtrail"
@@ -3633,7 +3681,7 @@ event.dataset: "aws.cloudtrail"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0190
+Index: geneve-ut-0198
 
 ```python
 event.dataset: aws.cloudtrail 
@@ -3648,7 +3696,7 @@ event.dataset: aws.cloudtrail
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0201
+Index: geneve-ut-0209
 
 ```python
 event.dataset: "aws.cloudtrail" and 
@@ -3663,7 +3711,7 @@ event.dataset: "aws.cloudtrail" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0210
+Index: geneve-ut-0218
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -3687,7 +3735,7 @@ process.name == "setfacl" and not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0211
+Index: geneve-ut-0219
 
 ```python
 any where host.os.type == "windows" and event.code == "4662" and
@@ -3722,7 +3770,7 @@ any where host.os.type == "windows" and event.code == "4662" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0212
+Index: geneve-ut-0220
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args : ("*.ost", "*.pst") and
@@ -3739,7 +3787,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0213
+Index: geneve-ut-0221
 
 ```python
 any where host.os.type == "windows" and
@@ -3764,7 +3812,7 @@ any where host.os.type == "windows" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0215
+Index: geneve-ut-0223
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -3792,7 +3840,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0217
+Index: geneve-ut-0225
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3805,7 +3853,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0219
+Index: geneve-ut-0227
 
 ```python
 iam where host.os.type == "windows" and event.code == "4728" and
@@ -3821,7 +3869,7 @@ not group.id : "S-1-5-21-*-513"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0220
+Index: geneve-ut-0228
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3841,7 +3889,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0221
+Index: geneve-ut-0229
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -3862,7 +3910,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0222
+Index: geneve-ut-0230
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=AdminSDHolder,CN=System*
@@ -3874,7 +3922,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.ObjectDN:CN=Adm
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0225
+Index: geneve-ut-0233
 
 ```python
 event.kind:alert and event.module:endgame and (event.action:behavior_protection_event or endgame.event_subtype_full:behavior_protection_event)
@@ -3886,7 +3934,7 @@ event.kind:alert and event.module:endgame and (event.action:behavior_protection_
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0237
+Index: geneve-ut-0245
 
 ```python
 file where host.os.type == "linux" and event.action in ("opened-file", "wrote-to-file", "deleted") and
@@ -3903,7 +3951,7 @@ file.path in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0238
+Index: geneve-ut-0246
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "violated-apparmor-policy"
@@ -3915,7 +3963,7 @@ file where host.os.type == "linux" and event.type == "change" and event.action =
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0240
+Index: geneve-ut-0248
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -3935,7 +3983,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0241
+Index: geneve-ut-0249
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -3949,7 +3997,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0245
+Index: geneve-ut-0253
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -3980,7 +4028,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0246
+Index: geneve-ut-0254
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "at.exe" and process.args : "\\\\*"
@@ -3992,7 +4040,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0247
+Index: geneve-ut-0255
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4006,7 +4054,7 @@ process.name == "dmesg" and process.args in ("-c", "-C", "--clear", "--read-clea
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0248
+Index: geneve-ut-0256
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4021,7 +4069,7 @@ not process.parent.args == "/etc/cron.daily/clean-journal-logs"
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0258
+Index: geneve-ut-0266
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and (
@@ -4040,7 +4088,7 @@ not ?process.parent.name == "auditd.prerm"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0259
+Index: geneve-ut-0267
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4054,7 +4102,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 165  
 Document count: 165  
-Index: geneve-ut-0261
+Index: geneve-ut-0269
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -4085,7 +4133,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 192  
 Document count: 192  
-Index: geneve-ut-0262
+Index: geneve-ut-0270
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4108,7 +4156,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0263
+Index: geneve-ut-0271
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4122,7 +4170,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-0264
+Index: geneve-ut-0272
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4141,7 +4189,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0265
+Index: geneve-ut-0273
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4155,7 +4203,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0266
+Index: geneve-ut-0274
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4180,7 +4228,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0271
+Index: geneve-ut-0279
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4199,7 +4247,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0274
+Index: geneve-ut-0282
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -4212,7 +4260,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0276
+Index: geneve-ut-0284
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4254,7 +4302,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0283
+Index: geneve-ut-0291
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -4269,7 +4317,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0324
+Index: geneve-ut-0332
 
 ```python
 event.dataset:azure.activitylogs and
@@ -4283,7 +4331,7 @@ event.dataset:azure.activitylogs and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0327
+Index: geneve-ut-0335
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -4301,7 +4349,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0345
+Index: geneve-ut-0353
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4319,7 +4367,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0346
+Index: geneve-ut-0354
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4337,7 +4385,7 @@ process.name == "bpftool" and (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0347
+Index: geneve-ut-0355
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4352,7 +4400,7 @@ not ?process.parent.executable == "/usr/sbin/libvirtd"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0348
+Index: geneve-ut-0356
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4366,7 +4414,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0349
+Index: geneve-ut-0357
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -4381,7 +4429,7 @@ not process.args in ("--help", "--version")
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0352
+Index: geneve-ut-0360
 
 ```python
 event.category:file and host.os.type:(linux or macos) and event.type:change and not event.action:("rename" or "extended_attributes_delete") and
@@ -4398,7 +4446,7 @@ event.category:file and host.os.type:(linux or macos) and event.type:change and 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0353
+Index: geneve-ut-0361
 
 ```python
 event.kind : alert and event.code : behavior and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -4410,7 +4458,7 @@ event.kind : alert and event.code : behavior and (event.type : allowed or (event
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0354
+Index: geneve-ut-0362
 
 ```python
 event.kind : alert and event.code : behavior and event.type : denied and event.outcome : success
@@ -4422,7 +4470,7 @@ event.kind : alert and event.code : behavior and event.type : denied and event.o
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0355
+Index: geneve-ut-0363
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4437,7 +4485,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0356
+Index: geneve-ut-0364
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and
@@ -4453,11 +4501,34 @@ not (
 
 
 
+### Binfmt Configuration File Creation
+
+Branch count: 6  
+Document count: 6  
+Index: geneve-ut-0365
+
+```python
+file where host.os.type == "linux" and event.action != "deletion" and process.executable != null and
+file.path like (
+  "/etc/binfmt.d/*.conf", "/run/binfmt.d/*.conf", "/usr/local/lib/binfmt.d/*.conf", "/usr/lib/binfmt.d/*.conf",
+  "/proc/sys/fs/binfmt_misc/register", "/proc/sys/fs/binfmt_misc/*"
+) and
+not (
+  file.path like (
+    "/usr/lib/binfmt.d/python3.*.conf", "/usr/lib/binfmt.d/qemu-*-static.conf",
+    "/proc/sys/fs/binfmt_misc/status"
+  ) or
+  process.executable == "/usr/lib/systemd/systemd-binfmt"
+)
+```
+
+
+
 ### Bitsadmin Activity
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-0357
+Index: geneve-ut-0366
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4479,7 +4550,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0359
+Index: geneve-ut-0368
 
 ```python
 file where host.os.type == "windows" and event.type : "creation" and
@@ -4525,7 +4596,7 @@ file where host.os.type == "windows" and event.type : "creation" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0360
+Index: geneve-ut-0369
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4559,7 +4630,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0361
+Index: geneve-ut-0370
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4582,7 +4653,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0363
+Index: geneve-ut-0372
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -4604,7 +4675,7 @@ process.executable != null and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0364
+Index: geneve-ut-0373
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -4632,7 +4703,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0365
+Index: geneve-ut-0374
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -4644,11 +4715,43 @@ not process.args:(apt-get or add-apt-repository or apt-cache* or */var/lib/ranch
 
 
 
+### Claude Cowork VM Boot Image Tamper
+
+Branch count: 320  
+Document count: 320  
+Index: geneve-ut-0375
+
+```python
+file where host.os.type in ("windows", "macos") and
+  event.action in ("creation", "modification", "overwrite", "rename") and
+  event.outcome == "success" and
+  file.path : (
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/initrd",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/initrd.zst",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/vmlinuz",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/vmlinuz.zst",
+    "/Users/*/Library/Application Support/Claude/vm_bundles/claudevm.bundle/rootfs.img",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\initrd",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\initrd.zst",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\vmlinuz",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\rootfs.vhdx",
+    "?:\\Users\\*\\AppData\\Local\\Packages\\Claude_*\\LocalCache\\Roaming\\Claude\\vm_bundles\\claudevm.bundle\\smol-bin.vhdx"
+  ) and
+  not (
+    (process.name : "claude.exe" and
+     process.executable : "?:\\Program Files\\WindowsApps\\Claude_*\\app\\claude.exe") or
+    (process.name : ("Claude", "Claude Helper") and
+     process.executable like "/Applications/Claude.app/*")
+  )
+```
+
+
+
 ### Clearing Windows Event Logs
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0367
+Index: geneve-ut-0377
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4673,7 +4776,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 219  
 Document count: 219  
-Index: geneve-ut-0369
+Index: geneve-ut-0379
 
 ```python
 network where event.module == "network_traffic" and destination.ip == "169.254.169.254" and destination.port == 80 and
@@ -4703,7 +4806,7 @@ http.request.method == "GET" and url.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0371
+Index: geneve-ut-0381
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4717,7 +4820,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0372
+Index: geneve-ut-0382
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -4739,7 +4842,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0373
+Index: geneve-ut-0383
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and user.id != "S-1-5-18" and
@@ -4753,7 +4856,7 @@ process where host.os.type == "windows" and event.type == "start" and user.id !=
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0374
+Index: geneve-ut-0384
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name: ("cmd.exe", "powershell.exe") and
@@ -4773,7 +4876,7 @@ process.parent.name: (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0377
+Index: geneve-ut-0387
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4790,7 +4893,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0380
+Index: geneve-ut-0390
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -4820,7 +4923,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0383
+Index: geneve-ut-0393
 
 ```python
 network where host.os.type == "windows" and network.protocol == "dns" and
@@ -4845,7 +4948,7 @@ network where host.os.type == "windows" and network.protocol == "dns" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0385
+Index: geneve-ut-0395
 
 ```python
 sequence by process.entity_id
@@ -4866,7 +4969,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0386
+Index: geneve-ut-0396
 
 ```python
 sequence by process.entity_id
@@ -4887,7 +4990,7 @@ sequence by process.entity_id
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0389
+Index: geneve-ut-0399
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -4918,7 +5021,7 @@ not process.parent.executable in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0390
+Index: geneve-ut-0400
 
 ```python
 event.kind:alert and event.module:cloud_defend
@@ -4930,7 +5033,7 @@ event.kind:alert and event.module:cloud_defend
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0391
+Index: geneve-ut-0401
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -4953,7 +5056,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0394
+Index: geneve-ut-0404
 
 ```python
 file where host.os.type == "macos" and event.action == "launch_daemon" and
@@ -4966,7 +5069,7 @@ file where host.os.type == "macos" and event.action == "launch_daemon" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0395
+Index: geneve-ut-0405
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "osascript" and
@@ -4979,7 +5082,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0397
+Index: geneve-ut-0407
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -4996,7 +5099,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0398
+Index: geneve-ut-0408
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectClass == "dnsNode" and
@@ -5009,7 +5112,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0399
+Index: geneve-ut-0409
 
 ```python
 registry where host.os.type == "windows" and event.type in ("change", "creation") and
@@ -5026,7 +5129,7 @@ registry where host.os.type == "windows" and event.type in ("change", "creation"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0400
+Index: geneve-ut-0410
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.name : ("ntds_capi_*.pfx", "ntds_capi_*.pvk")
@@ -5038,7 +5141,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.name 
 
 Branch count: 156  
 Document count: 156  
-Index: geneve-ut-0401
+Index: geneve-ut-0411
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Blob" and
@@ -5106,7 +5209,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0402
+Index: geneve-ut-0412
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and event.action != "open" and
@@ -5124,7 +5227,7 @@ file where host.os.type == "windows" and event.type != "deletion" and event.acti
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0403
+Index: geneve-ut-0413
 
 ```python
 process where event.type == "start" and process.name : ("trufflehog.exe", "trufflehog") and
@@ -5137,7 +5240,7 @@ process.args == "--json" and process.args == "filesystem"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0404
+Index: geneve-ut-0414
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5155,7 +5258,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0405
+Index: geneve-ut-0415
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5167,7 +5270,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0406
+Index: geneve-ut-0416
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:cred_theft_event or endgame.event_subtype_full:cred_theft_event)
@@ -5179,7 +5282,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0407
+Index: geneve-ut-0417
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5191,7 +5294,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0408
+Index: geneve-ut-0418
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_manipulation_event or endgame.event_subtype_full:token_manipulation_event)
@@ -5203,7 +5306,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-0409
+Index: geneve-ut-0419
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path like (
@@ -5248,7 +5351,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0411
+Index: geneve-ut-0421
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5268,7 +5371,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0412
+Index: geneve-ut-0422
 
 ```python
 sequence with maxspan=10s
@@ -5288,7 +5391,7 @@ sequence with maxspan=10s
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-0413
+Index: geneve-ut-0423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5315,7 +5418,7 @@ process.name == "curl" and (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0414
+Index: geneve-ut-0424
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5329,7 +5432,7 @@ container.id like "?*"
 
 Branch count: 624  
 Document count: 624  
-Index: geneve-ut-0417
+Index: geneve-ut-0427
 
 ```python
 process where event.type == "start" and
@@ -5354,7 +5457,7 @@ process.parent.name in ("node", "bun", "node.exe", "bun.exe") and (
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0420
+Index: geneve-ut-0430
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -5398,7 +5501,7 @@ file.extension in ("service", "conf") and file.path like (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0421
+Index: geneve-ut-0431
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -5432,7 +5535,7 @@ file.path like ("/usr/lib/python*/site-packages/dnf-plugins/*", "/etc/dnf/plugin
 
 Branch count: 556  
 Document count: 556  
-Index: geneve-ut-0423
+Index: geneve-ut-0433
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -5477,7 +5580,7 @@ container.id like "*" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0424
+Index: geneve-ut-0434
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.data.strings != null and
@@ -5493,7 +5596,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 86  
 Document count: 86  
-Index: geneve-ut-0425
+Index: geneve-ut-0435
 
 ```python
 network where host.os.type == "macos" and event.action == "lookup_result" and 
@@ -5518,7 +5621,7 @@ network where host.os.type == "macos" and event.action == "lookup_result" and
 
 Branch count: 50  
 Document count: 50  
-Index: geneve-ut-0426
+Index: geneve-ut-0436
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5537,7 +5640,7 @@ dns.question.name like~ (
 
 Branch count: 218  
 Document count: 218  
-Index: geneve-ut-0428
+Index: geneve-ut-0438
 
 ```python
 network where host.os.type == "linux" and dns.question.name != null and process.name != null and
@@ -5664,7 +5767,7 @@ not process.executable like (
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0429
+Index: geneve-ut-0439
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5682,7 +5785,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0431
+Index: geneve-ut-0441
 
 ```python
 process where event.type == "start" and event.action in ("start", "exec", "executed", "exec_event", "ProcessRollup2") and
@@ -5695,7 +5798,7 @@ process.name : "openssl*" and process.args : "enc" and process.args : "-in" and 
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-0432
+Index: geneve-ut-0442
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5725,7 +5828,7 @@ container.security_context.privileged == true and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0438
+Index: geneve-ut-0448
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5735,46 +5838,11 @@ process where host.os.type == "windows" and event.type == "start" and
 
 
 
-### Deprecated - Adobe Hijack Persistence
-
-Branch count: 4  
-Document count: 4  
-Index: geneve-ut-0450
-
-```python
-file where host.os.type == "windows" and event.type == "creation" and
-  file.path : (
-    "?:\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-    "?:\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-
-    /* Crowdstrike specific condition as it uses NT Object paths */
-    "\\Device\\HarddiskVolume*\\Program Files (x86)\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe",
-    "\\Device\\HarddiskVolume*\\Program Files\\Adobe\\Acrobat Reader DC\\Reader\\AcroCEF\\RdrCEF.exe"
-  ) and
-  not process.name : ("msiexec.exe", "AdobeARM.exe")
-```
-
-
-
-### Deprecated - Encoded Executable Stored in the Registry
-
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-0457
-
-```python
-registry where host.os.type == "windows" and
-/* update here with encoding combinations */
- registry.data.strings : "TVqQAAMAAAAEAAAA*"
-```
-
-
-
 ### Deprecated - Microsoft Exchange Transport Agent Install Script
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0469
+Index: geneve-ut-0478
 
 ```python
 event.category: "process" and host.os.type:windows and
@@ -5798,7 +5866,7 @@ event.category: "process" and host.os.type:windows and
 
 Branch count: 56  
 Document count: 56  
-Index: geneve-ut-0508
+Index: geneve-ut-0517
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -5852,7 +5920,7 @@ container.id like "*"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0510
+Index: geneve-ut-0519
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -5868,7 +5936,7 @@ not process.parent.executable in ("/usr/bin/make", "/bin/make")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0511
+Index: geneve-ut-0520
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5896,7 +5964,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0512
+Index: geneve-ut-0521
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -5913,7 +5981,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0513
+Index: geneve-ut-0522
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5930,7 +5998,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0514
+Index: geneve-ut-0523
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -5951,7 +6019,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-0516
+Index: geneve-ut-0525
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -5971,7 +6039,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-0517
+Index: geneve-ut-0526
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRollup2")
@@ -5986,7 +6054,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0519
+Index: geneve-ut-0528
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name in ("release_agent", "notify_on_release") and
@@ -5999,7 +6067,7 @@ not process.executable in ("/usr/bin/podman", "/sbin/sos", "/sbin/sosreport", "/
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0520
+Index: geneve-ut-0529
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6019,7 +6087,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0523
+Index: geneve-ut-0532
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension == "url"
@@ -6032,7 +6100,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0524
+Index: geneve-ut-0533
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6070,7 +6138,7 @@ file.path like~ ("/lib/dracut/modules.d/*", "/usr/lib/dracut/modules.d/*") and n
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0525
+Index: geneve-ut-0534
 
 ```python
 process where host.os.type == "macos" and event.type in ("start","process_started") and (
@@ -6090,7 +6158,7 @@ process where host.os.type == "macos" and event.type in ("start","process_starte
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0526
+Index: geneve-ut-0535
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6103,7 +6171,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0527
+Index: geneve-ut-0536
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -6126,7 +6194,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0529
+Index: geneve-ut-0538
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -6157,7 +6225,7 @@ not (
 
 Branch count: 30  
 Document count: 60  
-Index: geneve-ut-0530
+Index: geneve-ut-0539
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -6176,7 +6244,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0531
+Index: geneve-ut-0540
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -6219,7 +6287,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0532
+Index: geneve-ut-0541
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and
@@ -6233,7 +6301,7 @@ container.id like "*"
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0534
+Index: geneve-ut-0543
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6248,7 +6316,7 @@ not ?process.parent.executable == "/usr/lib/vmware/viewagent/bin/uninstall_viewa
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-0535
+Index: geneve-ut-0544
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6264,7 +6332,7 @@ not ?process.parent.executable in ("/usr/share/qemu/init/qemu-kvm-init", "/etc/s
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0536
+Index: geneve-ut-0545
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -6278,7 +6346,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0537
+Index: geneve-ut-0546
 
 ```python
 sequence by host.id with maxspan=3s
@@ -6300,49 +6368,11 @@ sequence by host.id with maxspan=3s
 
 
 
-### Elastic Agent Service Terminated
-
-Branch count: 419  
-Document count: 419  
-Index: geneve-ut-0538
-
-```python
-process where event.type == "start" and
-(
-  /* net, sc or wmic stopping or deleting Elastic Agent on Windows */
-  (
-    process.name : ("net.exe", "sc.exe", "wmic.exe","powershell.exe","taskkill.exe","PsKill.exe","ProcessHacker.exe") and
-    process.args : ("stopservice","uninstall", "stop", "disabled","Stop-Process","terminate","suspend") and
-    process.args : ("elasticendpoint", "Elastic Agent","elastic-agent","elastic-endpoint")
-  ) or
-
-  /* service or systemctl used to stop Elastic Agent on Linux */
-  (
-    process.name in ("systemctl", "service", "chkconfig", "update-rc.d") and
-    process.args : ("elastic-agent", "elastic-agent.service", "ElasticEndpoint") and
-    process.args : ("stop", "disable", "remove", "off", "kill", "mask") and
-    not (
-      process.parent.executable : "/opt/Elastic/Agent/data/elastic-agent-*/components/previous/elastic-endpoint" and
-      process.parent.args : "uninstall" and
-      process.parent.args : "--keepstate"
-    )
-  ) or
-
-  /* pkill, killall used to stop Elastic Agent or Endpoint on Linux */
-  (process.name in ("pkill", "killall", "kill") and process.args : ("elastic-agent", "elastic-endpoint")) or
-
-  /* Unload Elastic Defend extension on MacOS */
-  (process.name : "kextunload" and process.args : "com.apple.iokit.EndpointSecurity")
-)
-```
-
-
-
 ### Emond Rules Creation or Modification
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-0545
+Index: geneve-ut-0554
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -6355,7 +6385,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0546
+Index: geneve-ut-0555
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6369,7 +6399,7 @@ process.args : ("firewall", "advfirewall") and process.args : "group=Network Dis
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0547
+Index: geneve-ut-0556
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6391,7 +6421,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0548
+Index: geneve-ut-0557
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6426,7 +6456,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0549
+Index: geneve-ut-0558
 
 ```python
 event.kind:alert and event.module:(endpoint and not endgame)
@@ -6438,7 +6468,7 @@ event.kind:alert and event.module:(endpoint and not endgame)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0597
+Index: geneve-ut-0606
 
 ```python
 event.dataset: "azure.identity_protection"
@@ -6450,7 +6480,7 @@ event.dataset: "azure.identity_protection"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0623
+Index: geneve-ut-0632
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6464,7 +6494,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0626
+Index: geneve-ut-0635
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6491,7 +6521,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 276  
 Document count: 276  
-Index: geneve-ut-0629
+Index: geneve-ut-0638
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6512,7 +6542,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-0630
+Index: geneve-ut-0639
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -6542,7 +6572,7 @@ container.id like "*"
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-0633
+Index: geneve-ut-0642
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -6560,7 +6590,7 @@ container.id like "*"
 
 Branch count: 648  
 Document count: 648  
-Index: geneve-ut-0634
+Index: geneve-ut-0643
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -6593,7 +6623,7 @@ process.args : (
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-0636
+Index: geneve-ut-0645
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -6610,7 +6640,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-0637
+Index: geneve-ut-0646
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -6638,7 +6668,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0638
+Index: geneve-ut-0647
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -6651,7 +6681,7 @@ process.name : ("kworker*", "kthread*") and process.executable != null
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0640
+Index: geneve-ut-0649
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -6671,7 +6701,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0641
+Index: geneve-ut-0650
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6697,7 +6727,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-0642
+Index: geneve-ut-0651
 
 ```python
 sequence with maxspan=2h
@@ -6719,7 +6749,7 @@ sequence with maxspan=2h
 
 Branch count: 54  
 Document count: 162  
-Index: geneve-ut-0643
+Index: geneve-ut-0652
 
 ```python
 /* userinit followed by explorer followed by early child process of explorer (unlikely to be launched interactively) within 1m */
@@ -6748,7 +6778,7 @@ sequence by host.id, user.name with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0646
+Index: geneve-ut-0655
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and 
@@ -6761,7 +6791,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0650
+Index: geneve-ut-0659
 
 ```python
 sequence by user.id with maxspan=5s
@@ -6776,7 +6806,7 @@ sequence by user.id with maxspan=5s
 
 Branch count: 90  
 Document count: 90  
-Index: geneve-ut-0651
+Index: geneve-ut-0660
 
 ```python
 process where event.type == "start" and
@@ -6798,7 +6828,7 @@ process where event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0653
+Index: geneve-ut-0662
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "\\Device\\Mup\\tsclient\\*.exe"
@@ -6810,7 +6840,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0654
+Index: geneve-ut-0663
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6832,7 +6862,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0656
+Index: geneve-ut-0665
 
 ```python
 file where host.os.type == "windows" and file.extension : "dll" and
@@ -6849,7 +6879,7 @@ file where host.os.type == "windows" and file.extension : "dll" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-0657
+Index: geneve-ut-0666
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -6863,7 +6893,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0658
+Index: geneve-ut-0667
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -6876,7 +6906,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0659
+Index: geneve-ut-0668
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6888,7 +6918,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0660
+Index: geneve-ut-0669
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:exploit_event or endgame.event_subtype_full:exploit_event)
@@ -6900,7 +6930,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0661
+Index: geneve-ut-0670
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -6914,7 +6944,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0662
+Index: geneve-ut-0671
 
 ```python
 event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
@@ -6926,7 +6956,7 @@ event.kind:alert and not event.module:(endgame or endpoint or cloud_defend)
 
 Branch count: 342  
 Document count: 342  
-Index: geneve-ut-0663
+Index: geneve-ut-0672
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -6948,7 +6978,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 62  
 Document count: 62  
-Index: geneve-ut-0667
+Index: geneve-ut-0676
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -6997,7 +7027,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0668
+Index: geneve-ut-0677
 
 ```python
 sequence by container.id, user.id with maxspan=3s
@@ -7014,7 +7044,7 @@ sequence by container.id, user.id with maxspan=3s
 
 Branch count: 64  
 Document count: 128  
-Index: geneve-ut-0669
+Index: geneve-ut-0678
 
 ```python
 sequence by host.id with maxspan=10s
@@ -7034,7 +7064,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-0674
+Index: geneve-ut-0683
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -7056,7 +7086,7 @@ and container.id like "?*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0677
+Index: geneve-ut-0687
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -7071,7 +7101,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0678
+Index: geneve-ut-0688
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -7085,7 +7115,7 @@ process.command_line like~ "/dev/sd*" and not process.args == "-R"
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-0680
+Index: geneve-ut-0690
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7107,7 +7137,7 @@ process.args like~ (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0682
+Index: geneve-ut-0692
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -7128,7 +7158,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0683
+Index: geneve-ut-0693
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7154,7 +7184,7 @@ not (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-0684
+Index: geneve-ut-0694
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and 
@@ -7182,7 +7212,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0687
+Index: geneve-ut-0697
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "pluginkit" and
@@ -7196,7 +7226,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-0726
+Index: geneve-ut-0737
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and
@@ -7213,7 +7243,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0727
+Index: geneve-ut-0738
 
 ```python
 registry where host.os.type == "windows" and
@@ -7231,7 +7261,7 @@ registry where host.os.type == "windows" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-0798
+Index: geneve-ut-0810
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and file.path like~ (
@@ -7270,7 +7300,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.exec
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0799
+Index: geneve-ut-0811
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7297,7 +7327,7 @@ process.parent.executable != null and process.name in ("grub-mkconfig", "grub2-m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-0800
+Index: geneve-ut-0812
 
 ```python
 configuration where host.os.type == "macos" and event.action == "gatekeeper_override" and
@@ -7312,7 +7342,7 @@ configuration where host.os.type == "macos" and event.action == "gatekeeper_over
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-0801
+Index: geneve-ut-0813
 
 ```python
 process where event.type == "start" and event.action in ("exec", "start") and
@@ -7399,7 +7429,7 @@ process where event.type == "start" and event.action in ("exec", "start") and
 
 Branch count: 576  
 Document count: 1152  
-Index: geneve-ut-0809
+Index: geneve-ut-0821
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7417,7 +7447,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-0810
+Index: geneve-ut-0822
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "*.git/hooks/*" and
@@ -7448,7 +7478,7 @@ file.extension == null and process.executable != null and not (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-0811
+Index: geneve-ut-0823
 
 ```python
 sequence by host.id with maxspan=3s
@@ -7475,7 +7505,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-0812
+Index: geneve-ut-0824
 
 ```python
 sequence by process.entity_id, host.id with maxspan=10s
@@ -7495,7 +7525,7 @@ sequence by process.entity_id, host.id with maxspan=10s
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-0816
+Index: geneve-ut-0828
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2", "exec_event") and process.parent.name == "node" and
@@ -7508,7 +7538,7 @@ process.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish") and 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0819
+Index: geneve-ut-0831
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "personal_access_token.access_revoked"
@@ -7520,7 +7550,7 @@ configuration where event.dataset == "github.audit" and event.action == "persona
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0822
+Index: geneve-ut-0834
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "repo.create"
@@ -7532,7 +7562,7 @@ configuration where event.dataset == "github.audit" and event.action == "repo.cr
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0826
+Index: geneve-ut-0838
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.block_user"
@@ -7544,7 +7574,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.blo
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-0828
+Index: geneve-ut-0840
 
 ```python
 sequence by process.entity_id with maxspan=20s
@@ -7561,7 +7591,7 @@ sequence by process.entity_id with maxspan=20s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0854
+Index: geneve-ut-0866
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7574,7 +7604,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-0857
+Index: geneve-ut-0869
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start", "exec_event") and
@@ -7598,7 +7628,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0858
+Index: geneve-ut-0870
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name == "chflags"
@@ -7610,7 +7640,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-0871
+Index: geneve-ut-0883
 
 ```python
 sequence by process.entity_id with maxspan=5m
@@ -7628,7 +7658,7 @@ sequence by process.entity_id with maxspan=5m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0872
+Index: geneve-ut-0884
 
 ```python
 any where process.executable != null and
@@ -7677,7 +7707,7 @@ any where process.executable != null and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-0873
+Index: geneve-ut-0885
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7691,7 +7721,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0877
+Index: geneve-ut-0889
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7706,7 +7736,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0883
+Index: geneve-ut-0894
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7723,7 +7753,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0885
+Index: geneve-ut-0896
 
 ```python
 sequence with maxspan=1m
@@ -7742,7 +7772,7 @@ sequence with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0886
+Index: geneve-ut-0897
 
 ```python
 sequence by host.id with maxspan=1m
@@ -7760,7 +7790,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0887
+Index: geneve-ut-0898
 
 ```python
 sequence by host.id with maxspan=5s
@@ -7779,7 +7809,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0888
+Index: geneve-ut-0899
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -7795,7 +7825,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-0889
+Index: geneve-ut-0900
 
 ```python
 sequence by host.id with maxspan=30s
@@ -7811,7 +7841,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0890
+Index: geneve-ut-0901
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7824,7 +7854,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-0895
+Index: geneve-ut-0906
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -7841,7 +7871,7 @@ process.name == "unmkinitramfs" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0897
+Index: geneve-ut-0908
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -7854,7 +7884,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0898
+Index: geneve-ut-0909
 
 ```python
 /* the benefit of doing this as an eql sequence vs kql is this will limit to alerting only on the first network connection */
@@ -7870,7 +7900,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0899
+Index: geneve-ut-0910
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7888,7 +7918,9 @@ registry where host.os.type == "windows" and event.type == "change" and
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\SAP\\SAPsetup\\setup\\NwSapSetup.exe",
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\SAP\\SapSetup\\OnRebootSvc\\NWSAPSetupOnRebootInstSvc.exe",
         "\\Device\\HarddiskVolume*\\Program Files (x86)\\Kaspersky Lab\\Kaspersky Security for Windows Server\\kavfs.exe"
-  )
+  ) and
+  /* Microsoft Cloud AppCompat SDB test registrations */
+  not registry.path : "*\\AppCompatFlags\\Custom\\*\\{22221111-1111-1111-1111-111111111111}.sdb"
 ```
 
 
@@ -7897,7 +7929,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0900
+Index: geneve-ut-0911
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -7921,7 +7953,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 459  
 Document count: 459  
-Index: geneve-ut-0905
+Index: geneve-ut-0916
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -7945,7 +7977,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-0907
+Index: geneve-ut-0918
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -7981,7 +8013,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0908
+Index: geneve-ut-0919
 
 ```python
 iam where host.os.type == "windows" and event.code == "4738" and winlog.event_data.AllowedToDelegateTo : "*krbtgt*"
@@ -7993,7 +8025,7 @@ iam where host.os.type == "windows" and event.code == "4738" and winlog.event_da
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0909
+Index: geneve-ut-0920
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -8007,7 +8039,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0910
+Index: geneve-ut-0921
 
 ```python
 any where host.os.type == "windows" and event.code == "4738" and
@@ -8020,7 +8052,7 @@ any where host.os.type == "windows" and event.code == "4738" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0911
+Index: geneve-ut-0922
 
 ```python
 network where host.os.type == "windows" and event.type == "start" and network.direction == "egress" and
@@ -8079,7 +8111,7 @@ network where host.os.type == "windows" and event.type == "start" and network.di
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0912
+Index: geneve-ut-0923
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8092,7 +8124,7 @@ auditd.data.syscall in ("init_module", "finit_module")
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-0913
+Index: geneve-ut-0924
 
 ```python
 driver where host.os.type == "linux" and event.action == "loaded-kernel-module" and
@@ -8105,7 +8137,7 @@ auditd.data.syscall in ("init_module", "finit_module") and user.id != "0"
 
 Branch count: 450  
 Document count: 450  
-Index: geneve-ut-0914
+Index: geneve-ut-0925
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8126,7 +8158,7 @@ process.args like ("/sys/kernel/debug/kprobes/*", "/sys/kernel/debug/tracing/*",
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0915
+Index: geneve-ut-0926
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8144,7 +8176,7 @@ not (
 
 Branch count: 148  
 Document count: 148  
-Index: geneve-ut-0916
+Index: geneve-ut-0927
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8174,11 +8206,24 @@ not (
 
 
 
+### Kernel Module Loaded with Tainting Flags
+
+Branch count: 1  
+Document count: 1  
+Index: geneve-ut-0929
+
+```python
+process where host.os.type == "linux" and event.type == "start" and event.action == "load_module" and
+process.Ext.load_module.taint_flags != null
+```
+
+
+
 ### Kernel Module Removal
 
 Branch count: 120  
 Document count: 120  
-Index: geneve-ut-0918
+Index: geneve-ut-0930
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8200,7 +8245,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0920
+Index: geneve-ut-0932
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8227,7 +8272,7 @@ not (
 
 Branch count: 26  
 Document count: 26  
-Index: geneve-ut-0921
+Index: geneve-ut-0933
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8253,7 +8298,7 @@ not (
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-0922
+Index: geneve-ut-0934
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -8269,7 +8314,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-0923
+Index: geneve-ut-0935
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -8285,7 +8330,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0925
+Index: geneve-ut-0937
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and file.extension : "kirbi"
@@ -8297,7 +8342,7 @@ file where host.os.type == "windows" and event.type == "creation" and file.exten
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0926
+Index: geneve-ut-0938
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8325,7 +8370,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0928
+Index: geneve-ut-0940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8341,7 +8386,7 @@ not process.args like~ ("*download.elastic.co*", "*github.com/kubernetes-sigs/*"
 
 Branch count: 456  
 Document count: 456  
-Index: geneve-ut-0930
+Index: geneve-ut-0942
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8366,7 +8411,7 @@ process.name == "kubectl" and (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-0931
+Index: geneve-ut-0943
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -8380,7 +8425,7 @@ process.name == "kubectl" and process.args == "auth" and process.args == "can-i"
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0933
+Index: geneve-ut-0945
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8403,7 +8448,7 @@ process.name == "kubectl" and (
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-0934
+Index: geneve-ut-0946
 
 ```python
 network where host.os.type == "linux" and event.type == "start" and event.category == "network" and network.direction == "egress" and 
@@ -8436,7 +8481,7 @@ network where host.os.type == "linux" and event.type == "start" and event.catego
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-0935
+Index: geneve-ut-0947
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -8463,7 +8508,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-0938
+Index: geneve-ut-0950
 
 ```python
 kubernetes.audit.objectRef.subresource:"proxy" and
@@ -8484,7 +8529,7 @@ not user.name:(
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-0939
+Index: geneve-ut-0951
 
 ```python
 kubernetes.audit.objectRef.resource:("mutatingwebhookconfigurations" or "validatingwebhookconfigurations") and
@@ -8511,7 +8556,7 @@ not (kubernetes.audit.user.groups:"system:serviceaccounts:flux-system" and kuber
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-0949
+Index: geneve-ut-0961
 
 ```python
 process where event.type == "start" and
@@ -8533,7 +8578,7 @@ process.name : ("curl", "wget", "curl.exe", "wget.exe") and process.command_line
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-0975
+Index: geneve-ut-0987
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path like (
@@ -8552,7 +8597,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path li
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-0978
+Index: geneve-ut-0990
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -8596,7 +8641,7 @@ not (
 
 Branch count: 116  
 Document count: 116  
-Index: geneve-ut-0980
+Index: geneve-ut-0992
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and 
@@ -8621,7 +8666,7 @@ process.name:(
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-0992
+Index: geneve-ut-1004
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -8659,7 +8704,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-0997
+Index: geneve-ut-1009
 
 ```python
 file where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -8677,7 +8722,7 @@ file where host.os.type == "windows" and event.type in ("creation", "change") an
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-0998
+Index: geneve-ut-1010
 
 ```python
 sequence by host.id with maxspan=30s
@@ -8691,7 +8736,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1003
+Index: geneve-ut-1015
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -8706,7 +8751,7 @@ process.args != "1"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1018
+Index: geneve-ut-1030
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -8720,7 +8765,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1021
+Index: geneve-ut-1033
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8734,7 +8779,7 @@ process.name in ("curl", "wget") and process.command_line like "*api.telegram.or
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1023
+Index: geneve-ut-1035
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -8755,7 +8800,7 @@ not (
 
 Branch count: 720  
 Document count: 720  
-Index: geneve-ut-1024
+Index: geneve-ut-1036
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -8785,7 +8830,7 @@ not (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1028
+Index: geneve-ut-1040
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and process.executable != null and
@@ -8832,7 +8877,7 @@ file.path like (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1029
+Index: geneve-ut-1041
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8863,7 +8908,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1032
+Index: geneve-ut-1044
 
 ```python
 event.dataset:o365.audit and
@@ -8876,7 +8921,7 @@ event.dataset:o365.audit and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1034
+Index: geneve-ut-1046
 
 ```python
 event.dataset:o365.audit and
@@ -8889,7 +8934,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1035
+Index: geneve-ut-1047
 
 ```python
 event.dataset:o365.audit and event.code:AadRiskDetection
@@ -8901,7 +8946,7 @@ event.dataset:o365.audit and event.code:AadRiskDetection
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1071
+Index: geneve-ut-1083
 
 ```python
 event.dataset:o365.audit and
@@ -8914,7 +8959,7 @@ event.dataset:o365.audit and
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1072
+Index: geneve-ut-1084
 
 ```python
 event.dataset:o365.audit and
@@ -8927,7 +8972,7 @@ event.dataset:o365.audit and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1073
+Index: geneve-ut-1085
 
 ```python
 event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.code:SecurityComplianceAlerts
@@ -8939,7 +8984,7 @@ event.dataset:o365.audit and event.provider:SecurityComplianceCenter and event.c
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1074
+Index: geneve-ut-1086
 
 ```python
 event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmission)
@@ -8951,7 +8996,7 @@ event.dataset:o365.audit and event.code:(Quarantine or HygieneEvent or MailSubmi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1075
+Index: geneve-ut-1087
 
 ```python
 event.dataset:o365.audit and
@@ -8964,7 +9009,7 @@ event.dataset:o365.audit and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1083
+Index: geneve-ut-1095
 
 ```python
 event.dataset: "o365.audit" and
@@ -8977,7 +9022,7 @@ event.dataset: "o365.audit" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1086
+Index: geneve-ut-1099
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -8997,7 +9042,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1087
+Index: geneve-ut-1100
 
 ```python
 ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.com
@@ -9009,7 +9054,7 @@ ml_is_dga.malicious_prediction:1 and dns.question.registered_domain:avsvmcloud.c
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1088
+Index: geneve-ut-1101
 
 ```python
 ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmcloud.com
@@ -9021,7 +9066,7 @@ ml_is_dga.malicious_prediction:1 and not dns.question.registered_domain:avsvmclo
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1092
+Index: geneve-ut-1105
 
 ```python
 event.kind : alert and event.code : malicious_file and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9033,7 +9078,7 @@ event.kind : alert and event.code : malicious_file and (event.type : allowed or 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1093
+Index: geneve-ut-1106
 
 ```python
 event.kind : alert and event.code : malicious_file and event.type : denied and event.outcome : success
@@ -9045,7 +9090,7 @@ event.kind : alert and event.code : malicious_file and event.type : denied and e
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1095
+Index: geneve-ut-1108
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9057,7 +9102,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1096
+Index: geneve-ut-1109
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:file_classification_event or endgame.event_subtype_full:file_classification_event)
@@ -9069,7 +9114,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1097
+Index: geneve-ut-1110
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9094,7 +9139,7 @@ process.name == "dracut" and process.parent.executable != null and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1098
+Index: geneve-ut-1111
 
 ```python
 process where host.os.type == "macos" and event.action == "exec" and
@@ -9114,7 +9159,7 @@ process where host.os.type == "macos" and event.action == "exec" and
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1099
+Index: geneve-ut-1112
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -9127,7 +9172,7 @@ process.name in ("cat", "grep", "tail", "less", "more", "egrep", "fgrep") and pr
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1100
+Index: geneve-ut-1113
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9142,7 +9187,7 @@ process.command_line like ("/etc/exports", "/etc/fstab")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1101
+Index: geneve-ut-1114
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -9167,7 +9212,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1103
+Index: geneve-ut-1116
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.remove_member"
@@ -9179,7 +9224,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.rem
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1106
+Index: geneve-ut-1119
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -9191,7 +9236,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1107
+Index: geneve-ut-1120
 
 ```python
 event.kind : alert and event.code : (memory_signature or shellcode_thread) and event.type : denied and event.outcome : success
@@ -9203,7 +9248,7 @@ event.kind : alert and event.code : (memory_signature or shellcode_thread) and e
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1108
+Index: geneve-ut-1121
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path like "/etc/update-motd.d/*" and
@@ -9237,7 +9282,7 @@ not (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1111
+Index: geneve-ut-1124
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9251,7 +9296,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1112
+Index: geneve-ut-1125
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9272,7 +9317,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1113
+Index: geneve-ut-1126
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9286,7 +9331,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1117
+Index: geneve-ut-1130
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9321,7 +9366,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1118
+Index: geneve-ut-1131
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -9346,7 +9391,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1119
+Index: geneve-ut-1132
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9363,7 +9408,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1123
+Index: geneve-ut-1136
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9377,7 +9422,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1125
+Index: geneve-ut-1138
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9408,7 +9453,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1127
+Index: geneve-ut-1140
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and process.executable != null and
@@ -9462,7 +9507,7 @@ registry where host.os.type == "windows" and event.type == "change" and process.
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1128
+Index: geneve-ut-1141
 
 ```python
 file where host.os.type == "windows" and file.name : "mimilsa.log" and process.name : "lsass.exe"
@@ -9474,7 +9519,7 @@ file where host.os.type == "windows" and file.name : "mimilsa.log" and process.n
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1130
+Index: geneve-ut-1143
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9492,7 +9537,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1131
+Index: geneve-ut-1144
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9509,7 +9554,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1133
+Index: geneve-ut-1146
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -9524,7 +9569,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 267  
 Document count: 267  
-Index: geneve-ut-1134
+Index: geneve-ut-1147
 
 ```python
 file where event.type != "deletion" and
@@ -9574,7 +9619,7 @@ not process.name in ("apt", "apt-get", "dnf", "microdnf", "yum", "zypper", "tdnf
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1136
+Index: geneve-ut-1149
 
 ```python
 registry where host.os.type == "windows" and event.type in ("creation", "change") and
@@ -9590,7 +9635,7 @@ registry where host.os.type == "windows" and event.type in ("creation", "change"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1137
+Index: geneve-ut-1150
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msPKIAccountCredentials" and
@@ -9604,7 +9649,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1139
+Index: geneve-ut-1152
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9633,7 +9678,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1140
+Index: geneve-ut-1153
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -9661,7 +9706,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1141
+Index: geneve-ut-1154
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -9683,7 +9728,7 @@ process.entry_leader.entry_meta.type == "container" and process.name == "mount" 
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1142
+Index: geneve-ut-1155
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9702,7 +9747,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1143
+Index: geneve-ut-1156
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -9735,7 +9780,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1144
+Index: geneve-ut-1157
 
 ```python
 sequence by process.entity_id with maxspan=10m
@@ -9753,7 +9798,7 @@ sequence by process.entity_id with maxspan=10m
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1145
+Index: geneve-ut-1158
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -9794,7 +9839,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 6  
-Index: geneve-ut-1158
+Index: geneve-ut-1171
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -9820,7 +9865,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1167
+Index: geneve-ut-1180
 
 ```python
 sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
@@ -9844,7 +9889,7 @@ sequence by winlog.computer_name, winlog.process.pid with maxspan=1s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1171
+Index: geneve-ut-1184
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9858,7 +9903,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 168  
 Document count: 168  
-Index: geneve-ut-1172
+Index: geneve-ut-1185
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9877,7 +9922,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1173
+Index: geneve-ut-1186
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "executed") and
@@ -9897,7 +9942,7 @@ process.name == "unshare" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1174
+Index: geneve-ut-1187
 
 ```python
 process where event.type == "start" and event.action == "exec" and
@@ -9920,7 +9965,7 @@ process.name == "unshare" and container.id like "?*" and not (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1175
+Index: geneve-ut-1188
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -9941,7 +9986,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1177
+Index: geneve-ut-1190
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -9956,7 +10001,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1178
+Index: geneve-ut-1191
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -9973,7 +10018,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1180
+Index: geneve-ut-1193
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -9997,7 +10042,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 112  
 Document count: 224  
-Index: geneve-ut-1182
+Index: geneve-ut-1195
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -10043,7 +10088,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 35  
 Document count: 70  
-Index: geneve-ut-1183
+Index: geneve-ut-1196
 
 ```python
 sequence by host.id with maxspan=1s
@@ -10085,7 +10130,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1184
+Index: geneve-ut-1197
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10102,7 +10147,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1186
+Index: geneve-ut-1199
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -10117,7 +10162,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1187
+Index: geneve-ut-1200
 
 ```python
 network where host.os.type == "windows" and process.name : "certutil.exe" and
@@ -10136,7 +10181,7 @@ network where host.os.type == "windows" and process.name : "certutil.exe" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1188
+Index: geneve-ut-1201
 
 ```python
 sequence by process.entity_id
@@ -10156,7 +10201,7 @@ sequence by process.entity_id
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1189
+Index: geneve-ut-1202
 
 ```python
 sequence by process.entity_id
@@ -10175,7 +10220,7 @@ sequence by process.entity_id
 
 Branch count: 152  
 Document count: 608  
-Index: geneve-ut-1191
+Index: geneve-ut-1204
 
 ```python
 sequence by host.id with maxspan=1m
@@ -10204,7 +10249,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 18  
 Document count: 36  
-Index: geneve-ut-1192
+Index: geneve-ut-1205
 
 ```python
 sequence by process.entity_id
@@ -10229,7 +10274,7 @@ sequence by process.entity_id
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1193
+Index: geneve-ut-1206
 
 ```python
 sequence by process.entity_id
@@ -10251,7 +10296,7 @@ sequence by process.entity_id
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1194
+Index: geneve-ut-1207
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -10284,7 +10329,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1195
+Index: geneve-ut-1208
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -10314,7 +10359,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1199
+Index: geneve-ut-1212
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "UserAuthentication" and
@@ -10331,7 +10376,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1200
+Index: geneve-ut-1213
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.path like "/etc/NetworkManager/dispatcher.d/*" and
@@ -10368,7 +10413,7 @@ not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1201
+Index: geneve-ut-1214
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10381,7 +10426,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1206
+Index: geneve-ut-1219
 
 ```python
 event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
@@ -10393,7 +10438,7 @@ event.dataset:okta.system and okta.debug_context.debug_data.risk_behaviors:*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1209
+Index: geneve-ut-1222
 
 ```python
 configuration where event.dataset == "github.audit" and event.action == "org.add_member"
@@ -10405,7 +10450,7 @@ configuration where event.dataset == "github.audit" and event.action == "org.add
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1219
+Index: geneve-ut-1233
 
 ```python
 sequence by host.id with maxspan=10s
@@ -10419,7 +10464,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1220
+Index: geneve-ut-1234
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10433,7 +10478,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1221
+Index: geneve-ut-1235
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -10447,7 +10492,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1222
+Index: geneve-ut-1236
 
 ```python
 host.os.type:linux and event.category:process and event.action:(exec or executed) and
@@ -10467,7 +10512,7 @@ process.args:(
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1224
+Index: geneve-ut-1238
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -10480,7 +10525,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1225
+Index: geneve-ut-1239
 
 ```python
 event.dataset: "okta.system"
@@ -10495,7 +10540,7 @@ event.dataset: "okta.system"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1227
+Index: geneve-ut-1241
 
 ```python
 sequence by user.name with maxspan=30m
@@ -10517,7 +10562,7 @@ sequence by user.name with maxspan=30m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1236
+Index: geneve-ut-1250
 
 ```python
 network where event.action == "connection_accepted" and
@@ -10544,7 +10589,7 @@ network where event.action == "connection_accepted" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1237
+Index: geneve-ut-1251
 
 ```python
 network where event.action == "lookup_requested" and
@@ -10564,7 +10609,7 @@ network where event.action == "lookup_requested" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1238
+Index: geneve-ut-1252
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -10579,7 +10624,7 @@ not process.args in ("-help", "--help", "-h")
 
 Branch count: 99  
 Document count: 99  
-Index: geneve-ut-1239
+Index: geneve-ut-1253
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -10606,7 +10651,7 @@ not process.parent.executable in (
 
 Branch count: 36  
 Document count: 72  
-Index: geneve-ut-1240
+Index: geneve-ut-1254
 
 ```python
 sequence by host.id, process.entity_id with maxspan = 5s
@@ -10621,7 +10666,7 @@ sequence by host.id, process.entity_id with maxspan = 5s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1241
+Index: geneve-ut-1255
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and registry.value : "URL" and
@@ -10637,7 +10682,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and regi
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1242
+Index: geneve-ut-1256
 
 ```python
 sequence by source.port, source.ip, destination.ip with maxspan=1m
@@ -10651,7 +10696,7 @@ sequence by source.port, source.ip, destination.ip with maxspan=1m
 
 Branch count: 46  
 Document count: 46  
-Index: geneve-ut-1243
+Index: geneve-ut-1257
 
 ```python
 file where host.os.type == "linux" and event.type in ("creation", "change") and (
@@ -10670,7 +10715,7 @@ file.path like~ "*/wp-content/plugins/*"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1244
+Index: geneve-ut-1258
 
 ```python
 sequence by winlog.computer_name, source.ip with maxspan=5s
@@ -10690,7 +10735,7 @@ sequence by winlog.computer_name, source.ip with maxspan=5s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1251
+Index: geneve-ut-1265
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -10705,7 +10750,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1252
+Index: geneve-ut-1266
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10719,7 +10764,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1253
+Index: geneve-ut-1267
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -10738,7 +10783,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1254
+Index: geneve-ut-1268
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10750,7 +10795,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1255
+Index: geneve-ut-1269
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:token_protection_event or endgame.event_subtype_full:token_protection_event)
@@ -10762,7 +10807,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1256
+Index: geneve-ut-1270
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10780,7 +10825,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1257
+Index: geneve-ut-1271
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10793,7 +10838,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1258
+Index: geneve-ut-1272
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -10808,7 +10853,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 22  
 Document count: 22  
-Index: geneve-ut-1259
+Index: geneve-ut-1273
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.parent.name == "com.apple.foundation.UserScriptService" and 
@@ -10823,7 +10868,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1262
+Index: geneve-ut-1276
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and
@@ -10843,7 +10888,7 @@ process where host.os.type == "macos" and event.type == "start" and
 
 Branch count: 108  
 Document count: 108  
-Index: geneve-ut-1263
+Index: geneve-ut-1277
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10867,7 +10912,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1264
+Index: geneve-ut-1278
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10881,7 +10926,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1265
+Index: geneve-ut-1279
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10900,7 +10945,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1266
+Index: geneve-ut-1280
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -10928,7 +10973,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 380  
 Document count: 380  
-Index: geneve-ut-1267
+Index: geneve-ut-1281
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -10957,7 +11002,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1268
+Index: geneve-ut-1282
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -10976,7 +11021,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1269
+Index: geneve-ut-1283
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11004,7 +11049,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1270
+Index: geneve-ut-1284
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11019,7 +11064,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1271
+Index: geneve-ut-1285
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -11082,7 +11127,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1272
+Index: geneve-ut-1286
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -11103,7 +11148,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1273
+Index: geneve-ut-1287
 
 ```python
 any where host.os.type == "windows" and
@@ -11165,7 +11210,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1275
+Index: geneve-ut-1289
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and file.name like "pam_*.so" and not file.path like (
@@ -11194,7 +11239,7 @@ file where host.os.type == "linux" and event.type == "creation" and file.name li
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1276
+Index: geneve-ut-1290
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "ProcessRollup2") and
@@ -11208,7 +11253,7 @@ process.args like~ "https://github.com/linux-pam/linux-pam/releases/download/v*/
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1277
+Index: geneve-ut-1291
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11241,7 +11286,7 @@ not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1280
+Index: geneve-ut-1294
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -11288,7 +11333,7 @@ file.extension in ("rules", "pkla", "policy") and file.path like~ (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1281
+Index: geneve-ut-1295
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11315,7 +11360,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1282
+Index: geneve-ut-1296
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -11328,7 +11373,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1293
+Index: geneve-ut-1307
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -11345,7 +11390,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1295
+Index: geneve-ut-1309
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "sdbinst.exe" and
@@ -11353,6 +11398,8 @@ process where host.os.type == "windows" and event.type == "start" and process.na
   not (process.args : "-m" and process.args : "-bg") and
   not process.args : (
     "-mm",
+    "?:\\Windows\\appcompat\\cloudsdb\\apppatch.sdb",
+    "\"?:\\Windows\\appcompat\\cloudsdb\\apppatch.sdb\"",
     "?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\sysMergeInboxStoreApp.sdb",
     "\"?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\sysMergeInboxStoreApp.sdb\"",
     "?:\\Program Files\\WindowsApps\\Microsoft.ApplicationCompatibilityEnhancements_*\\sdb\\msiMergeInboxStoreApp.sdb",
@@ -11370,7 +11417,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1300
+Index: geneve-ut-1314
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11386,7 +11433,7 @@ process.command_line like ("*sudo -R*", "*sudo --chroot*")
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1301
+Index: geneve-ut-1315
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11407,7 +11454,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 72  
 Document count: 144  
-Index: geneve-ut-1304
+Index: geneve-ut-1318
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=5m
@@ -11424,7 +11471,7 @@ sequence by host.id, process.parent.entity_id with maxspan=5m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1305
+Index: geneve-ut-1319
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "jq" and
@@ -11437,7 +11484,7 @@ container.id like "?*"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1306
+Index: geneve-ut-1320
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11461,7 +11508,7 @@ event.action in ("exec", "exec_event", "fork", "fork_event") and user.name == "p
 
 Branch count: 2  
 Document count: 6  
-Index: geneve-ut-1308
+Index: geneve-ut-1322
 
 ```python
 sequence by host.id, user.name with maxspan = 5s
@@ -11490,7 +11537,7 @@ sequence by host.id, user.name with maxspan = 5s
 
 Branch count: 288  
 Document count: 288  
-Index: geneve-ut-1310
+Index: geneve-ut-1324
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11517,7 +11564,7 @@ not ?process.parent.executable in ("/usr/lib/systemd/systemd", "/usr/bin/kdumpct
 
 Branch count: 63  
 Document count: 63  
-Index: geneve-ut-1311
+Index: geneve-ut-1325
 
 ```python
 process where event.type in ("start", "process_started", "info") and
@@ -11541,7 +11588,7 @@ process where event.type in ("start", "process_started", "info") and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1314
+Index: geneve-ut-1328
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11559,7 +11606,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1315
+Index: geneve-ut-1329
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -11582,7 +11629,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1316
+Index: geneve-ut-1330
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -11639,7 +11686,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1317
+Index: geneve-ut-1331
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -11656,7 +11703,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1318
+Index: geneve-ut-1332
 
 ```python
 sequence by process.entity_id
@@ -11670,7 +11717,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1333
+Index: geneve-ut-1349
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11685,7 +11732,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1334
+Index: geneve-ut-1350
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11716,7 +11763,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1335
+Index: geneve-ut-1351
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11730,7 +11777,7 @@ process.name in ("pg_dump", "pg_dumpall", "mysqldump", "mariadb-dump", "mongodum
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1336
+Index: geneve-ut-1352
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11743,7 +11790,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1337
+Index: geneve-ut-1353
 
 ```python
 file where host.os.type == "linux" and event.type != "deletion" and file.path == "/etc/doas.conf"
@@ -11755,7 +11802,7 @@ file where host.os.type == "linux" and event.type != "deletion" and file.path ==
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1338
+Index: geneve-ut-1354
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -11768,7 +11815,7 @@ process.parent.name == "proot"
 
 Branch count: 136  
 Document count: 136  
-Index: geneve-ut-1340
+Index: geneve-ut-1356
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and
@@ -11787,7 +11834,7 @@ process.args like ("http*:10250/*", "http*:10255/*", "wss:*:10250/*", "wss:*:102
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1341
+Index: geneve-ut-1357
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -11800,7 +11847,7 @@ process.args like ("http*:10250*", "http*:10255*", "wss:*:10250*", "wss:*:10255*
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1342
+Index: geneve-ut-1358
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11821,7 +11868,7 @@ not ?process.parent.executable == "/opt/puppetlabs/puppet/bin/ruby"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1343
+Index: geneve-ut-1359
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -11835,7 +11882,7 @@ process.name == "setenforce" and process.args == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1346
+Index: geneve-ut-1362
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11855,7 +11902,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1347
+Index: geneve-ut-1363
 
 ```python
 sequence by process.entity_id with maxspan=3m
@@ -11879,7 +11926,7 @@ sequence by process.entity_id with maxspan=3m
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1348
+Index: geneve-ut-1364
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -11895,7 +11942,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 90  
 Document count: 180  
-Index: geneve-ut-1349
+Index: geneve-ut-1365
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -11912,7 +11959,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1350
+Index: geneve-ut-1367
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11933,7 +11980,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1352
+Index: geneve-ut-1369
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -11946,7 +11993,7 @@ process.parent.args == "/etc/rc.local" and process.parent.args == "start"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1354
+Index: geneve-ut-1371
 
 ```python
 sequence by host.id with maxspan=1m
@@ -11974,7 +12021,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-1357
+Index: geneve-ut-1374
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -11990,7 +12037,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 306  
 Document count: 306  
-Index: geneve-ut-1358
+Index: geneve-ut-1375
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12013,7 +12060,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1359
+Index: geneve-ut-1376
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12026,7 +12073,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1361
+Index: geneve-ut-1378
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12039,7 +12086,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1366
+Index: geneve-ut-1383
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12053,7 +12100,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1367
+Index: geneve-ut-1384
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12064,11 +12111,37 @@ not process.parent.command_line like "/opt/cloudlinux/*"
 
 
 
+### Potential IIS Web Shell File Creation
+
+Branch count: 165  
+Document count: 165  
+Index: geneve-ut-1386
+
+```python
+file where host.os.type == "windows" and event.type != "deletion" and file.extension : ("aspx", "ashx", "asmx") and
+ process.name : ("w3wp.exe", "MSExchangeMailboxReplication.exe", "EdgeTransport.exe", "Microsoft.Exchange.*.exe", "UMWorkerProcess.exe", "umservice.exe", "cmd.exe", "powershell.exe", "pwsh.exe", "certutil.exe", "xcopy.exe") and 
+  (
+   (file.path : ("?:\\Program Files\\Common Files\\microsoft shared\\Web Server Extensions\\*\\TEMPLATE\\LAYOUTS\\*",
+                 "?:\\inetpub\\wwwroot\\aspnet_client\\system_web\\*", 
+                 "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\owa\\auth\\*", 
+                 "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\ecp\\auth\\*") and 
+    /* not sub-dirs */
+    not file.path : ("?:\\inetpub\\wwwroot\\aspnet_client\\system_web\\*\\*", 
+                     "?:\\Program Files\\Microsoft\\Exchange Server\\V*\\FrontEnd\\HttpProxy\\*\\auth\\*\\*", 
+                     "?:\\Program Files\\Common Files\\microsoft shared\\Web Server Extensions\\*\\TEMPLATE\\LAYOUTS\\*\\*")) or 
+
+    /* not sub-dirs */
+   (file.path : "?:\\inetpub\\wwwroot\\aspnet_client\\*" and not file.path : "?:\\inetpub\\wwwroot\\aspnet_client\\*\\*")
+  )
+```
+
+
+
 ### Potential Impersonation Attempt via Kubectl
 
 Branch count: 950  
 Document count: 950  
-Index: geneve-ut-1369
+Index: geneve-ut-1387
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and
@@ -12087,38 +12160,28 @@ not process.parent.args like ("/snap/microk8s/*/apiservice-kicker", "/snap/micro
 
 
 
-### Potential JAVA/JNDI Exploitation Attempt
+### Potential Java Service Exploitation via Suspicious Child Process
 
-Branch count: 60  
-Document count: 120  
-Index: geneve-ut-1372
+Branch count: 30  
+Document count: 60  
+Index: geneve-ut-1390
 
 ```python
-sequence by host.id with maxspan=1m
- [network where event.action == "connection_attempted" and
+sequence by host.id with maxspan=5s
+ [network where event.action == "connection_accepted" and network.direction == "ingress" and
+
   process.name : "java" and
-  /*
-     outbound connection attempt to
-     LDAP, RMI or DNS standard ports
-     by JAVA process
-   */
-  destination.port in (1389, 389, 1099, 53, 5353)] by process.pid
+  destination.port < 49152  and source.port >= 32768] by process.pid
  [process where event.type == "start" and
 
   /* Suspicious JAVA child process */
   process.parent.name : "java" and
-   process.name : ("sh",
-                   "bash",
-                   "dash",
-                   "ksh",
-                   "tcsh",
-                   "zsh",
-                   "curl",
-                   "perl*",
-                   "python*",
-                   "ruby*",
-                   "php*",
-                   "wget") and
+  process.name : (
+    "sh", "bash", "dash", "ksh", "tcsh", "zsh", "ash",  "mksh", "busybox",
+    "curl", "wget", "perl*", "python*", "ruby*", "php*", "lua*", "socat",
+    "nc", "ncat", "netcat", "netcat.openbsd", "netcat.traditional", "nc.openbsd",
+    "nc.traditional", "nohup", "setsid", "disown", "hostname", "whoami", "id"
+  ) and
     not process.command_line like~ (
       "bash -c ulimit -u",
       "bash /opt/flutter/bin/flutter*",
@@ -12134,7 +12197,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1373
+Index: geneve-ut-1391
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -12152,7 +12215,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1374
+Index: geneve-ut-1392
 
 ```python
 host.os.type:"windows" and
@@ -12168,7 +12231,7 @@ host.os.type:"windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1376
+Index: geneve-ut-1394
 
 ```python
 network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
@@ -12180,7 +12243,7 @@ network where host.os.type == "windows" and dns.question.name : "*UWhRC*BAAAA*"
 
 Branch count: 38  
 Document count: 38  
-Index: geneve-ut-1378
+Index: geneve-ut-1396
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "executed") and 
@@ -12196,7 +12259,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1379
+Index: geneve-ut-1397
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -12212,7 +12275,7 @@ container.id like "?*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1380
+Index: geneve-ut-1398
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12230,7 +12293,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1381
+Index: geneve-ut-1399
 
 ```python
 process where host.os.type == "windows" and event.code:"4688" and
@@ -12244,7 +12307,7 @@ process where host.os.type == "windows" and event.code:"4688" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-1383
+Index: geneve-ut-1401
 
 ```python
 sequence by host.id with maxspan=30s
@@ -12267,7 +12330,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1385
+Index: geneve-ut-1403
 
 ```python
 sequence by host.id, process.parent.name with maxspan=1m
@@ -12283,7 +12346,7 @@ sequence by host.id, process.parent.name with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1386
+Index: geneve-ut-1404
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12296,7 +12359,7 @@ process.name == "unshadow" and process.args_count >= 3
 
 Branch count: 252  
 Document count: 252  
-Index: geneve-ut-1387
+Index: geneve-ut-1405
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -12326,7 +12389,7 @@ process.name in~ (
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1393
+Index: geneve-ut-1411
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -12349,7 +12412,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1394
+Index: geneve-ut-1412
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12368,7 +12431,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1399
+Index: geneve-ut-1417
 
 ```python
 process where host.os.type == "windows" and 
@@ -12510,7 +12573,7 @@ process where host.os.type == "windows" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-1400
+Index: geneve-ut-1418
 
 ```python
 process where host.os.type == "windows" and
@@ -12587,7 +12650,7 @@ process where host.os.type == "windows" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1404
+Index: geneve-ut-1422
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -12604,7 +12667,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 28  
 Document count: 28  
-Index: geneve-ut-1405
+Index: geneve-ut-1423
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event") and (
@@ -12638,7 +12701,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1407
+Index: geneve-ut-1425
 
 ```python
 file where host.os.type == "macos" and event.action in ("modification", "rename") and file.name like~ "~$*.zip"
@@ -12650,7 +12713,7 @@ file where host.os.type == "macos" and event.action in ("modification", "rename"
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1408
+Index: geneve-ut-1426
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12689,7 +12752,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1411
+Index: geneve-ut-1429
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -12702,7 +12765,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1416
+Index: geneve-ut-1434
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -12716,7 +12779,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1423
+Index: geneve-ut-1441
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.name in ("ssh", "sshd") and
@@ -12754,7 +12817,7 @@ file where host.os.type == "linux" and event.type == "creation" and process.name
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1424
+Index: geneve-ut-1442
 
 ```python
 network where host.os.type == "windows" and
@@ -12780,7 +12843,7 @@ network where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1427
+Index: geneve-ut-1445
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12795,7 +12858,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1430
+Index: geneve-ut-1448
 
 ```python
 event.category:file and host.os.type:macos and not event.type:"deletion" and
@@ -12809,7 +12872,7 @@ event.category:file and host.os.type:macos and not event.type:"deletion" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1431
+Index: geneve-ut-1449
 
 ```python
 file where host.os.type == "windows" and
@@ -12823,7 +12886,7 @@ file where host.os.type == "windows" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1432
+Index: geneve-ut-1450
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -12836,7 +12899,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1433
+Index: geneve-ut-1451
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12856,7 +12919,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1434
+Index: geneve-ut-1452
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -12876,7 +12939,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1436
+Index: geneve-ut-1454
 
 ```python
 host.os.type:windows and event.category:process and
@@ -12915,7 +12978,7 @@ host.os.type:windows and event.category:process and
 
 Branch count: 702  
 Document count: 702  
-Index: geneve-ut-1437
+Index: geneve-ut-1455
 
 ```python
 event.category:process and host.os.type:windows and
@@ -13110,7 +13173,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1452
+Index: geneve-ut-1470
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -13126,7 +13189,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1453
+Index: geneve-ut-1471
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name like~ "sqlite*" and
@@ -13140,7 +13203,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1454
+Index: geneve-ut-1472
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13154,7 +13217,7 @@ process.title:"runc init" and user.effective.id:0 and user.id:(* and not 0)
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1455
+Index: geneve-ut-1473
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "ProcessRollup2") and
@@ -13171,7 +13234,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1456
+Index: geneve-ut-1474
 
 ```python
 sequence by host.id, process.parent.entity_id, process.executable with maxspan=5s
@@ -13185,7 +13248,7 @@ sequence by host.id, process.parent.entity_id, process.executable with maxspan=5
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1457
+Index: geneve-ut-1475
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13201,7 +13264,7 @@ process.interactive == true and process.parent.interactive == true
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1462
+Index: geneve-ut-1480
 
 ```python
 file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
@@ -13213,7 +13276,7 @@ file where host.os.type == "linux" and file.path : "/*GCONV_PATH*"
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1463
+Index: geneve-ut-1481
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -13229,7 +13292,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 6  
 Document count: 24  
-Index: geneve-ut-1464
+Index: geneve-ut-1482
 
 ```python
 sequence by host.id with maxspan=1m
@@ -13249,7 +13312,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1466
+Index: geneve-ut-1484
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -13289,7 +13352,7 @@ not process.parent.executable like (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1468
+Index: geneve-ut-1486
 
 ```python
 event.category:process and event.type:start and process.args:(echo and *NOPASSWD*ALL*)
@@ -13301,7 +13364,7 @@ event.category:process and event.type:start and process.args:(echo and *NOPASSWD
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1469
+Index: geneve-ut-1487
 
 ```python
 sequence by host.id, process.parent.entity_id with maxspan=15s
@@ -13322,7 +13385,7 @@ sequence by host.id, process.parent.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1470
+Index: geneve-ut-1488
 
 ```python
 sequence by host.id with maxspan=15s
@@ -13343,7 +13406,7 @@ sequence by host.id with maxspan=15s
 
 Branch count: 14  
 Document count: 28  
-Index: geneve-ut-1471
+Index: geneve-ut-1489
 
 ```python
 sequence by host.id, process.entity_id with maxspan=30s
@@ -13364,7 +13427,7 @@ sequence by host.id, process.entity_id with maxspan=30s
 
 Branch count: 341  
 Document count: 682  
-Index: geneve-ut-1472
+Index: geneve-ut-1490
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=30s
@@ -13390,7 +13453,7 @@ sequence by host.id, process.parent.pid with maxspan=30s
 
 Branch count: 5  
 Document count: 10  
-Index: geneve-ut-1473
+Index: geneve-ut-1491
 
 ```python
 sequence by process.parent.entity_id, host.id with maxspan=60s
@@ -13406,7 +13469,7 @@ sequence by process.parent.entity_id, host.id with maxspan=60s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1474
+Index: geneve-ut-1492
 
 ```python
 iam where host.os.type == "windows" and event.action == "renamed-user-account" and
@@ -13420,7 +13483,7 @@ iam where host.os.type == "windows" and event.action == "renamed-user-account" a
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1476
+Index: geneve-ut-1494
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -13443,7 +13506,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 13  
 Document count: 13  
-Index: geneve-ut-1478
+Index: geneve-ut-1496
 
 ```python
 process where host.os.type == "linux" and auditd.data.syscall == "prctl" and auditd.data.a0 == "f" and
@@ -13460,7 +13523,7 @@ not process.executable like ("/home/*/.vscode-server/*", "/tmp/VeeamAgent*", "/h
 
 Branch count: 27  
 Document count: 54  
-Index: geneve-ut-1479
+Index: geneve-ut-1497
 
 ```python
 sequence by host.id, process.entity_id with maxspan=3s
@@ -13483,7 +13546,7 @@ sequence by host.id, process.entity_id with maxspan=3s
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1480
+Index: geneve-ut-1498
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13496,7 +13559,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1481
+Index: geneve-ut-1499
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13510,7 +13573,7 @@ process.args : "-s" and process.args : "-d" and process.args : "rssocks"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1482
+Index: geneve-ut-1500
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13527,7 +13590,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1483
+Index: geneve-ut-1501
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13581,7 +13644,7 @@ not (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1484
+Index: geneve-ut-1502
 
 ```python
 any where host.os.type == "windows" and
@@ -13608,7 +13671,7 @@ any where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1490
+Index: geneve-ut-1508
 
 ```python
 file where host.os.type == "windows" and
@@ -13623,7 +13686,7 @@ file where host.os.type == "windows" and
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1491
+Index: geneve-ut-1509
 
 ```python
 /* Identifies the modification of RDP Shadow registry or
@@ -13654,7 +13717,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1492
+Index: geneve-ut-1510
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13668,7 +13731,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 144  
-Index: geneve-ut-1493
+Index: geneve-ut-1511
 
 ```python
 sequence with maxspan=1m
@@ -13710,7 +13773,7 @@ sequence with maxspan=1m
 
 Branch count: 400  
 Document count: 400  
-Index: geneve-ut-1494
+Index: geneve-ut-1512
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -13735,7 +13798,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1495
+Index: geneve-ut-1513
 
 ```python
 registry where host.os.type == "windows" and event.action != "deletion" and
@@ -13789,7 +13852,7 @@ registry where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 864  
 Document count: 1728  
-Index: geneve-ut-1496
+Index: geneve-ut-1514
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13809,7 +13872,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1497
+Index: geneve-ut-1515
 
 ```python
 process where event.type in ("start", "process_started") and
@@ -13830,7 +13893,7 @@ process where event.type in ("start", "process_started") and
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1498
+Index: geneve-ut-1516
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -13845,7 +13908,7 @@ process.parent.name in ("bash", "dash", "sh", "tcsh", "csh", "zsh", "ksh", "fish
 
 Branch count: 432  
 Document count: 864  
-Index: geneve-ut-1499
+Index: geneve-ut-1517
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -13865,7 +13928,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 288  
 Document count: 576  
-Index: geneve-ut-1500
+Index: geneve-ut-1518
 
 ```python
 sequence by host.id with maxspan=5s
@@ -13907,7 +13970,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1504
+Index: geneve-ut-1522
 
 ```python
 host.os.type:linux and event.category:process and 
@@ -13922,7 +13985,7 @@ user.effective.id:0 and process.args:-p
 
 Branch count: 216  
 Document count: 216  
-Index: geneve-ut-1505
+Index: geneve-ut-1523
 
 ```python
 process where event.type == "start" and host.os.type in ("linux", "windows") and
@@ -13957,7 +14020,7 @@ process where event.type == "start" and host.os.type in ("linux", "windows") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1506
+Index: geneve-ut-1524
 
 ```python
 file where host.os.type in ("linux", "windows") and event.action == "creation" and
@@ -13974,7 +14037,7 @@ file where host.os.type in ("linux", "windows") and event.action == "creation" a
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1511
+Index: geneve-ut-1529
 
 ```python
 sequence by host.id with maxspan=3s
@@ -13988,7 +14051,7 @@ sequence by host.id with maxspan=3s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1514
+Index: geneve-ut-1532
 
 ```python
 process where event.type == "start" and event.action like ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started", "Process Create*") and
@@ -14001,7 +14064,7 @@ process.name : ("gitleaks.exe", "gitleaks")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1515
+Index: geneve-ut-1533
 
 ```python
 file where host.os.type == "windows" and event.type == "change" and file.name : "*AAA.AAA"
@@ -14013,7 +14076,7 @@ file where host.os.type == "windows" and event.type == "change" and file.name : 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1516
+Index: geneve-ut-1535
 
 ```python
 event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAPDisplayName:"msDS-KeyCredentialLink" and
@@ -14028,7 +14091,7 @@ event.code:"5136" and host.os.type:"windows" and winlog.event_data.AttributeLDAP
 
 Branch count: 32  
 Document count: 96  
-Index: geneve-ut-1518
+Index: geneve-ut-1537
 
 ```python
 /* Incoming RDP followed by a new RunMRU string value set to cmd, powershell, taskmgr or tsclient, followed by process execution within 1m */
@@ -14056,7 +14119,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 648  
 Document count: 1296  
-Index: geneve-ut-1520
+Index: geneve-ut-1539
 
 ```python
 sequence by host.id with maxspan=1s
@@ -14081,7 +14144,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1524
+Index: geneve-ut-1543
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "rename") and
@@ -14118,7 +14181,7 @@ file.path in ("/usr/bin/sudo", "/bin/sudo") and not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1525
+Index: geneve-ut-1544
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14132,7 +14195,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1526
+Index: geneve-ut-1545
 
 ```python
 sequence by host.id, process.session_leader.entity_id with maxspan=15s
@@ -14148,7 +14211,7 @@ sequence by host.id, process.session_leader.entity_id with maxspan=15s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1527
+Index: geneve-ut-1546
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -14162,7 +14225,7 @@ not user.Ext.real.id == "0" and not group.Ext.real.id == "0"
 
 Branch count: 94  
 Document count: 94  
-Index: geneve-ut-1528
+Index: geneve-ut-1547
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and file.extension == "swp" and
@@ -14192,7 +14255,7 @@ file.path : (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1529
+Index: geneve-ut-1548
 
 ```python
 file where host.os.type == "windows" and event.type in ("change", "deletion") and
@@ -14221,7 +14284,7 @@ file where host.os.type == "windows" and event.type in ("change", "deletion") an
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1530
+Index: geneve-ut-1549
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14237,7 +14300,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1531
+Index: geneve-ut-1550
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14251,7 +14314,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1532
+Index: geneve-ut-1551
 
 ```python
 file where host.os.type == "windows" and
@@ -14270,12 +14333,26 @@ file where host.os.type == "windows" and
   not process.executable : (
     "?:\\Program Files\\*",
     "?:\\Program Files (x86)\\*",
+    "?:\\ProgramData\\Microsoft\\Windows Defender\\*",
     "?:\\Windows\\system32\\cleanmgr.exe",
     "?:\\Windows\\system32\\msiexec.exe",
     "?:\\Windows\\syswow64\\msiexec.exe",
     "?:\\Windows\\system32\\svchost.exe",
     "?:\\Windows\\System32\\Robocopy.exe",
-    "?:\\Windows\\SysWOW64\\Robocopy.exe"
+    "?:\\Windows\\SysWOW64\\Robocopy.exe",
+    "?:\\Windows\\explorer.exe",
+    "?:\\Windows\\system32\\Dism.exe",
+    "?:\\Windows\\system32\\DFSRs.exe",
+    "?:\\Windows\\system32\\wbengine.exe",
+    "?:\\Windows\\system32\\CompatTelRunner.exe",
+    "?:\\Windows\\system32\\SearchIndexer.exe",
+    "?:\\Windows\\system32\\wuauclt.exe",
+    "?:\\Windows\\servicing\\TrustedInstaller.exe",
+    "?:\\Windows\\WinSxS\\*\\TiWorker.exe",
+    "?:\\Windows\\Microsoft.NET\\*",
+    "?:\\Windows\\SystemApps\\*",
+    "?:\\Windows\\uus\\*\\wuaucltcore.exe",
+    "?:\\$WINDOWS.~BT\\Sources\\mighost.exe"
   ) and
   not (process.executable : "?:\\Windows\\System32\\spoolsv.exe" and file.path : "?:\\Windows\\System32\\spool\\*") and
   not user.name : ("SYSTEM", "Local Service", "Network Service")
@@ -14287,7 +14364,7 @@ file where host.os.type == "windows" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1535
+Index: geneve-ut-1554
 
 ```python
 process where event.type == "start" and
@@ -14301,7 +14378,7 @@ process.args like~ ("*--socks5-server*", "*--outbound-http-proxy-listen*")
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1536
+Index: geneve-ut-1555
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14315,7 +14392,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1537
+Index: geneve-ut-1556
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14335,7 +14412,7 @@ not process.parent.command_line like ("linode-longview", "*bootstrap*", "*homebr
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1539
+Index: geneve-ut-1558
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14352,7 +14429,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1540
+Index: geneve-ut-1559
 
 ```python
 any where host.os.type == "windows" and event.code == "5137" and winlog.event_data.ObjectDN : "DC=wpad,*"
@@ -14364,7 +14441,7 @@ any where host.os.type == "windows" and event.code == "5137" and winlog.event_da
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1541
+Index: geneve-ut-1560
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.name : "wuauclt.exe" and
@@ -14377,29 +14454,11 @@ process.executable : (
 
 
 
-### Potential Web Shell ASPX File Creation
-
-Branch count: 1  
-Document count: 1  
-Index: geneve-ut-1542
-
-```python
-file where host.os.type == "windows" and event.type != "deletion" and
-  file.extension : "aspx" and
-  file.path : "?:\\Program Files\\Common Files\\Microsoft Shared\\Web Server Extensions\\*" and
-  not process.executable: (
-        "?:\\Windows\\System32\\msiexec.exe",
-        "?:\\Program Files\\Common Files\\Microsoft Shared\\Web Server Extensions\\16\\BIN\\psconfigui.exe"
-  )
-```
-
-
-
 ### Potential notify_on_release Container Escape Detected via Defend for Containers
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1549
+Index: geneve-ut-1567
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14412,7 +14471,7 @@ file.name == "notify_on_release" and container.id like "*"
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1550
+Index: geneve-ut-1568
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -14439,7 +14498,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1551
+Index: geneve-ut-1569
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "open" and
@@ -14452,7 +14511,7 @@ file.name == "release_agent" and container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1552
+Index: geneve-ut-1570
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -14466,7 +14525,7 @@ user.id != "0"
 
 Branch count: 144  
 Document count: 144  
-Index: geneve-ut-1554
+Index: geneve-ut-1572
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14483,7 +14542,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1555
+Index: geneve-ut-1573
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14506,7 +14565,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1557
+Index: geneve-ut-1575
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14523,7 +14582,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1560
+Index: geneve-ut-1578
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14536,7 +14595,7 @@ powershell.file.script_block_text:(MiniDumpWriteDump or MiniDumpWithFullMemory o
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1562
+Index: geneve-ut-1580
 
 ```python
 event.category:process and host.os.type:windows and
@@ -14560,7 +14619,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1563
+Index: geneve-ut-1581
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14588,7 +14647,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 240  
 Document count: 240  
-Index: geneve-ut-1579
+Index: geneve-ut-1597
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14609,7 +14668,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-1581
+Index: geneve-ut-1599
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -14637,7 +14696,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1583
+Index: geneve-ut-1601
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1s
@@ -14677,7 +14736,7 @@ sequence by host.id, process.entity_id with maxspan=1s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1584
+Index: geneve-ut-1602
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=1m
@@ -14694,7 +14753,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1585
+Index: geneve-ut-1603
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14708,7 +14767,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1586
+Index: geneve-ut-1604
 
 ```python
 file where host.os.type == "windows" and
@@ -14727,7 +14786,7 @@ file where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1587
+Index: geneve-ut-1605
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -14741,7 +14800,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1589
+Index: geneve-ut-1607
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -14759,7 +14818,7 @@ registry.path : (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1591
+Index: geneve-ut-1609
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -14777,7 +14836,7 @@ not (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1594
+Index: geneve-ut-1612
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -14791,7 +14850,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1596
+Index: geneve-ut-1614
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -14806,7 +14865,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1597
+Index: geneve-ut-1615
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -14829,7 +14888,7 @@ process.name == "setcap" and not (
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1599
+Index: geneve-ut-1617
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -14911,7 +14970,7 @@ not (process.parent.executable : ("?:\\Windows\\System32\\spoolsv.exe", "?:\\Win
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1600
+Index: geneve-ut-1618
 
 ```python
 sequence by winlog.computer_name with maxspan=1m
@@ -14932,7 +14991,7 @@ sequence by winlog.computer_name with maxspan=1m
 
 Branch count: 11  
 Document count: 11  
-Index: geneve-ut-1601
+Index: geneve-ut-1619
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.args != null and 
@@ -14954,11 +15013,29 @@ process where host.os.type == "windows" and event.type == "start" and process.ar
 
 
 
+### Process Execution Followed by Self-Deletion
+
+Branch count: 9  
+Document count: 18  
+Index: geneve-ut-1622
+
+```python
+sequence by process.entity_id, host.id with maxspan=30s
+  [process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and 
+  process.executable like (
+    "/tmp/*", "/var/tmp/*", "/dev/shm/*", "/run/*", "/var/run/*", "/var/www/*",
+    "/proc/*/fd/*", "?memfd:*", "memfd:*"
+  )] by process.executable
+  [file where host.os.type == "linux" and event.action == "deletion"] by file.path
+```
+
+
+
 ### Process Execution from an Unusual Directory
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-1604
+Index: geneve-ut-1623
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15011,7 +15088,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1605
+Index: geneve-ut-1624
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15023,7 +15100,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1606
+Index: geneve-ut-1625
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:kernel_shellcode_event or endgame.event_subtype_full:kernel_shellcode_event)
@@ -15035,7 +15112,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1607
+Index: geneve-ut-1626
 
 ```python
 process where host.os.type == "windows" and
@@ -15050,7 +15127,7 @@ process where host.os.type == "windows" and
 
 Branch count: 111  
 Document count: 111  
-Index: geneve-ut-1608
+Index: geneve-ut-1627
 
 ```python
 process where event.type == "start" and event.action == "exec" and container.id like "*?" and 
@@ -15080,7 +15157,7 @@ process where event.type == "start" and event.action == "exec" and container.id 
 
 Branch count: 171  
 Document count: 171  
-Index: geneve-ut-1609
+Index: geneve-ut-1628
 
 ```python
 process where event.type == "start" and host.os.type == "linux" and event.action in ("exec", "exec_event", "start") and
@@ -15140,7 +15217,7 @@ not (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1612
+Index: geneve-ut-1631
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -15153,7 +15230,7 @@ process.name : "* "
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1613
+Index: geneve-ut-1632
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15185,7 +15262,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1614
+Index: geneve-ut-1633
 
 ```python
 process where event.action == "exec" and host.os.type == "macos" and
@@ -15209,7 +15286,7 @@ process where event.action == "exec" and host.os.type == "macos" and
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-1616
+Index: geneve-ut-1635
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15242,7 +15319,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1617
+Index: geneve-ut-1636
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : ("ssh.exe", "sftp.exe") and
@@ -15259,7 +15336,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1619
+Index: geneve-ut-1638
 
 ```python
 process where host.os.type == "linux" and  event.type == "start" and event.action == "exec" and process.parent.name == "busybox" and
@@ -15288,7 +15365,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1620
+Index: geneve-ut-1639
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -15302,7 +15379,7 @@ process.name == "proxychains"
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1621
+Index: geneve-ut-1640
 
 ```python
 sequence by process.entity_id
@@ -15327,7 +15404,7 @@ sequence by process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1622
+Index: geneve-ut-1641
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.extension == "pth" and
@@ -15361,7 +15438,7 @@ file.path like (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1623
+Index: geneve-ut-1642
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and process.executable != null and
@@ -15389,7 +15466,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1624
+Index: geneve-ut-1643
 
 ```python
 file where event.action == "extended_attributes_delete" and host.os.type == "macos" and process.executable != null and
@@ -15408,7 +15485,7 @@ file where event.action == "extended_attributes_delete" and host.os.type == "mac
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1630
+Index: geneve-ut-1649
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15436,7 +15513,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1631
+Index: geneve-ut-1650
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -15455,7 +15532,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1635
+Index: geneve-ut-1654
 
 ```python
 event.kind : alert and event.code : ransomware and (event.type : allowed or (event.type: denied and event.outcome: failure))
@@ -15467,7 +15544,7 @@ event.kind : alert and event.code : ransomware and (event.type : allowed or (eve
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1636
+Index: geneve-ut-1655
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:detection and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15479,7 +15556,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:detection an
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1637
+Index: geneve-ut-1656
 
 ```python
 event.kind : alert and event.code : ransomware and event.type : denied and event.outcome : success
@@ -15491,7 +15568,7 @@ event.kind : alert and event.code : ransomware and event.type : denied and event
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1638
+Index: geneve-ut-1657
 
 ```python
 event.kind:alert and event.module:endgame and endgame.metadata.type:prevention and (event.action:ransomware_event or endgame.event_subtype_full:ransomware_event)
@@ -15503,7 +15580,7 @@ event.kind:alert and event.module:endgame and endgame.metadata.type:prevention a
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1649
+Index: geneve-ut-1668
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15516,7 +15593,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1650
+Index: geneve-ut-1669
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -15554,7 +15631,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1652
+Index: geneve-ut-1671
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15569,7 +15646,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1653
+Index: geneve-ut-1672
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15588,7 +15665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 120  
 Document count: 240  
-Index: geneve-ut-1654
+Index: geneve-ut-1673
 
 ```python
 sequence with maxspan=1m
@@ -15636,7 +15713,7 @@ sequence with maxspan=1m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1656
+Index: geneve-ut-1675
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and process.name : "TeamViewer.exe" and
@@ -15659,7 +15736,7 @@ file where host.os.type == "windows" and event.type == "creation" and process.na
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1658
+Index: geneve-ut-1677
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15673,7 +15750,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1659
+Index: geneve-ut-1678
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15687,7 +15764,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 68  
 Document count: 136  
-Index: geneve-ut-1661
+Index: geneve-ut-1680
 
 ```python
 sequence by host.id, process.entity_id
@@ -15704,7 +15781,7 @@ sequence by host.id, process.entity_id
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1662
+Index: geneve-ut-1681
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started") and
@@ -15718,7 +15795,7 @@ process where event.type == "start" and event.action in ("exec", "exec_event", "
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1663
+Index: geneve-ut-1682
 
 ```python
 sequence by host.id with maxspan=1m
@@ -15738,7 +15815,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1664
+Index: geneve-ut-1683
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -15767,7 +15844,7 @@ not process.parent.executable like ("/usr/local/jamf/bin/jamf", "/usr/libexec/xp
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1665
+Index: geneve-ut-1684
 
 ```python
 /* Task Scheduler service incoming connection followed by TaskCache registry modification  */
@@ -15787,7 +15864,7 @@ sequence by host.id, process.entity_id with maxspan = 1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1666
+Index: geneve-ut-1685
 
 ```python
 iam where host.os.type == "windows" and event.action == "scheduled-task-created" and
@@ -15800,7 +15877,7 @@ iam where host.os.type == "windows" and event.action == "scheduled-task-created"
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1668
+Index: geneve-ut-1687
 
 ```python
 sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
@@ -15842,7 +15919,7 @@ sequence by winlog.logon.id, winlog.computer_name with maxspan=1m
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1669
+Index: geneve-ut-1688
 
 ```python
 sequence with maxspan=1m
@@ -15865,7 +15942,7 @@ sequence with maxspan=1m
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1670
+Index: geneve-ut-1689
 
 ```python
 sequence with maxspan=1s
@@ -15913,7 +15990,7 @@ sequence with maxspan=1s
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1671
+Index: geneve-ut-1690
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -15930,7 +16007,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1673
+Index: geneve-ut-1692
 
 ```python
 event.category:file and host.os.type:linux and event.type:change and 
@@ -15959,7 +16036,7 @@ not (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1676
+Index: geneve-ut-1695
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -15987,7 +16064,7 @@ process.name in ("update-ca-trust", "update-ca-certificates") and not (
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1677
+Index: geneve-ut-1696
 
 ```python
 sequence by host.id, process.entry_leader.entity_id with maxspan=30s
@@ -16004,7 +16081,7 @@ sequence by host.id, process.entry_leader.entity_id with maxspan=30s
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1679
+Index: geneve-ut-1698
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -16023,7 +16100,7 @@ and file.path : "/etc/selinux/config" and not (
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1680
+Index: geneve-ut-1699
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : ("Dll", "$Dll") and
@@ -16044,7 +16121,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1689
+Index: geneve-ut-1710
 
 ```python
 file where host.os.type == "linux" and event.type in ("change", "creation") and
@@ -16058,7 +16135,7 @@ container.id like "*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1691
+Index: geneve-ut-1712
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.name in ("authorized_keys", "authorized_keys2") and
@@ -16077,7 +16154,7 @@ not (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1692
+Index: geneve-ut-1713
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -16091,7 +16168,7 @@ not file.name : "known_hosts.*"
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1693
+Index: geneve-ut-1714
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and process.executable != null and
@@ -16111,7 +16188,7 @@ not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1695
+Index: geneve-ut-1716
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16129,7 +16206,7 @@ process.name == "find" and process.args : "-perm" and process.args : (
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1696
+Index: geneve-ut-1717
 
 ```python
 sequence by host.id with maxspan = 30s
@@ -16150,7 +16227,7 @@ sequence by host.id with maxspan = 30s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1698
+Index: geneve-ut-1719
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16164,7 +16241,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1699
+Index: geneve-ut-1720
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16179,7 +16256,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 27  
 Document count: 27  
-Index: geneve-ut-1700
+Index: geneve-ut-1721
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -16220,7 +16297,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 9  
 Document count: 18  
-Index: geneve-ut-1702
+Index: geneve-ut-1723
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -16245,7 +16322,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1703
+Index: geneve-ut-1724
 
 ```python
 any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Security-Auditing" and
@@ -16284,7 +16361,7 @@ any where host.os.type == "windows" and event.provider: "Microsoft-Windows-Secur
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1704
+Index: geneve-ut-1725
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16298,7 +16375,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 672  
 Document count: 672  
-Index: geneve-ut-1705
+Index: geneve-ut-1726
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16337,7 +16414,7 @@ process.args like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1706
+Index: geneve-ut-1727
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16351,7 +16428,7 @@ process.args : "/namespace:\\\\root\\SecurityCenter2" and process.args : "Get"
 
 Branch count: 480  
 Document count: 480  
-Index: geneve-ut-1707
+Index: geneve-ut-1728
 
 ```python
 process where event.type == "start" and
@@ -16423,7 +16500,7 @@ process.name : ("grep", "egrep", "pgrep") and user.id != "0" and
 
 Branch count: 33  
 Document count: 66  
-Index: geneve-ut-1711
+Index: geneve-ut-1732
 
 ```python
 sequence by process.entity_id with maxspan=30s
@@ -16444,7 +16521,7 @@ sequence by process.entity_id with maxspan=30s
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1714
+Index: geneve-ut-1735
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16461,7 +16538,7 @@ process.command_line like~ (
 
 Branch count: 42  
 Document count: 42  
-Index: geneve-ut-1717
+Index: geneve-ut-1738
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16479,7 +16556,7 @@ process.command_line like~ (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1718
+Index: geneve-ut-1739
 
 ```python
 event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"SeEnableDelegationPrivilege"
@@ -16491,7 +16568,7 @@ event.code:4704 and host.os.type:"windows" and winlog.event_data.PrivilegeList:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1719
+Index: geneve-ut-1740
 
 ```python
 file where host.os.type == "windows" and
@@ -16524,7 +16601,7 @@ file where host.os.type == "windows" and
 
 Branch count: 37  
 Document count: 37  
-Index: geneve-ut-1722
+Index: geneve-ut-1743
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16556,7 +16633,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 74  
 Document count: 74  
-Index: geneve-ut-1724
+Index: geneve-ut-1745
 
 ```python
 any where host.os.type == "linux" and container.id like "*" and (
@@ -16592,7 +16669,7 @@ any where host.os.type == "linux" and container.id like "*" and (
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1725
+Index: geneve-ut-1746
 
 ```python
 sequence by process.entity_id with maxspan = 1m
@@ -16609,7 +16686,7 @@ sequence by process.entity_id with maxspan = 1m
 
 Branch count: 96  
 Document count: 96  
-Index: geneve-ut-1726
+Index: geneve-ut-1747
 
 ```python
 /* This rule is not compatible with Sysmon due to user.id issues */
@@ -16629,7 +16706,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1728
+Index: geneve-ut-1749
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16644,7 +16721,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1729
+Index: geneve-ut-1750
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16665,7 +16742,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1730
+Index: geneve-ut-1751
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -16688,7 +16765,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1731
+Index: geneve-ut-1752
 
 ```python
 process where event.type == "start" and process.name : "sc.exe" and
@@ -16701,7 +16778,7 @@ process where event.type == "start" and process.name : "sc.exe" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1732
+Index: geneve-ut-1753
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -16718,7 +16795,7 @@ process.name == "setcap" and process.args : "cap_set?id+ep" and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1735
+Index: geneve-ut-1756
 
 ```python
 file where host.os.type == "linux" and event.type == "change" and event.action == "rename" and
@@ -16743,7 +16820,7 @@ not (
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-1738
+Index: geneve-ut-1759
 
 ```python
 any where host.os.type == "linux" and event.category in ("file", "process") and container.id like "?*" and (
@@ -16774,7 +16851,7 @@ any where host.os.type == "linux" and event.category in ("file", "process") and 
 
 Branch count: 140  
 Document count: 140  
-Index: geneve-ut-1739
+Index: geneve-ut-1760
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and file.path : (
@@ -16823,7 +16900,7 @@ file where host.os.type == "linux" and event.action == "creation" and file.path 
 
 Branch count: 60  
 Document count: 120  
-Index: geneve-ut-1740
+Index: geneve-ut-1761
 
 ```python
 sequence by host.id with maxspan=10s
@@ -16837,7 +16914,7 @@ sequence by host.id with maxspan=10s
 
 Branch count: 64  
 Document count: 64  
-Index: geneve-ut-1741
+Index: geneve-ut-1762
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "start") and
@@ -16852,7 +16929,7 @@ process.args in ("-c", "-cl", "-lc", "--command")
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1742
+Index: geneve-ut-1763
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -16867,7 +16944,7 @@ process.env_vars like~ (
 
 Branch count: 162  
 Document count: 162  
-Index: geneve-ut-1743
+Index: geneve-ut-1764
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.extension == "lnk" and
@@ -16889,7 +16966,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.exten
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1744
+Index: geneve-ut-1765
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -16910,7 +16987,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1748
+Index: geneve-ut-1769
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -16924,7 +17001,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1749
+Index: geneve-ut-1770
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "Start" and
@@ -16947,7 +17024,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 12  
 Document count: 24  
-Index: geneve-ut-1779
+Index: geneve-ut-1800
 
 ```python
 sequence by host.id, process.entity_id with maxspan=5s
@@ -16972,7 +17049,7 @@ sequence by host.id, process.entity_id with maxspan=5s
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1780
+Index: geneve-ut-1801
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -17005,7 +17082,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-1781
+Index: geneve-ut-1802
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and 
@@ -17064,7 +17141,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1783
+Index: geneve-ut-1804
 
 ```python
 beacon_stats.is_beaconing: true and
@@ -17082,7 +17159,7 @@ not process.name: ("WaAppAgent.exe" or "metricbeat.exe" or "packetbeat.exe" or "
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1784
+Index: geneve-ut-1805
 
 ```python
 beacon_stats.beaconing_score: 3
@@ -17094,7 +17171,7 @@ beacon_stats.beaconing_score: 3
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1787
+Index: geneve-ut-1808
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and file.extension == "py" and
@@ -17119,7 +17196,7 @@ file where host.os.type == "macos" and event.action == "modification" and file.e
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1793
+Index: geneve-ut-1814
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17134,7 +17211,7 @@ process where host.os.type == "linux" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1794
+Index: geneve-ut-1815
 
 ```python
 file where host.os.type in ("linux", "macos") and event.type in ("creation", "change") and
@@ -17157,7 +17234,7 @@ file.path like ("/etc/sudoers*", "/private/etc/sudoers*") and not (
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-1797
+Index: geneve-ut-1818
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17169,9 +17246,9 @@ process where host.os.type == "windows" and event.type == "start" and
 
 ### Suspicious /proc/maps Discovery
 
-Branch count: 48  
-Document count: 48  
-Index: geneve-ut-1799
+Branch count: 96  
+Document count: 96  
+Index: geneve-ut-1820
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -17183,7 +17260,9 @@ not (
   ?process.parent.name == "uac" or
   ?process.parent.executable in ("/opt/secl/linux-ir-scripts-v3/thieves.sh", "/opt/traps/rpm-installer/setup.sh") or
   ?process.working_directory like ("/opt/traps/deb-installer", "/opt/Tanium/TaniumClient/*") or
-  ?process.parent.executable like ("/home/*/sunlight/thieves.sh")
+  ?process.parent.executable like ("/home/*/sunlight/thieves.sh") or
+  (?process.parent.executable == "/usr/lib/systemd/systemd" and ?process.parent.command_line == "/sbin/init") or
+  ?process.group_leader.executable in ("/usr/local/qualys/cloud-agent/bin/qualys-cloud-agent", "/opt/traps/bin/cytool")
 )
 ```
 
@@ -17193,7 +17272,7 @@ not (
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1801
+Index: geneve-ut-1822
 
 ```python
 sequence by host.id with maxspan=5s
@@ -17220,7 +17299,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1805
+Index: geneve-ut-1826
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and file.path != null and
@@ -17259,7 +17338,7 @@ file where host.os.type == "windows" and event.type != "deletion" and file.path 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1806
+Index: geneve-ut-1827
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and
@@ -17282,7 +17361,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1807
+Index: geneve-ut-1828
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17296,7 +17375,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 518  
 Document count: 518  
-Index: geneve-ut-1808
+Index: geneve-ut-1829
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17312,7 +17391,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1809
+Index: geneve-ut-1830
 
 ```python
 file where host.os.type == "macos" and event.action == "modification" and
@@ -17328,7 +17407,7 @@ file where host.os.type == "macos" and event.action == "modification" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1810
+Index: geneve-ut-1831
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17342,7 +17421,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1812
+Index: geneve-ut-1833
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17361,11 +17440,76 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 
 
+### Suspicious Child Process of PaperCut Server Component
+
+Branch count: 92  
+Document count: 92  
+Index: geneve-ut-1834
+
+```python
+process where host.os.type == "windows" and event.type == "start" and
+  process.parent.name : ("pc-app.exe", "pc-printjob-spooler.exe") and
+  (
+    process.name : (
+      "cmd.exe",
+      "powershell.exe",
+      "pwsh.exe",
+      "powershell_ise.exe",
+      "wscript.exe",
+      "cscript.exe",
+      "mshta.exe",
+      "rundll32.exe",
+      "regsvr32.exe",
+      "bitsadmin.exe",
+      "certutil.exe",
+      "curl.exe",
+      "wget.exe",
+      "net.exe",
+      "net1.exe",
+      "whoami.exe",
+      "tasklist.exe",
+      "ipconfig.exe",
+      "nltest.exe",
+      "systeminfo.exe",
+      "charmap.exe",
+      "calc.exe",
+      "mspaint.exe"
+    ) or
+    ?process.pe.original_file_name : (
+      "Cmd.Exe",
+      "PowerShell.EXE",
+      "pwsh.dll",
+      "powershell_ise.EXE",
+      "wscript.exe",
+      "cscript.exe",
+      "MSHTA.EXE",
+      "RUNDLL32.EXE",
+      "REGSVR32.EXE",
+      "bitsadmin.exe",
+      "CertUtil.exe",
+      "curl.exe",
+      "wget.exe",
+      "net.exe",
+      "net1.exe",
+      "whoami.exe",
+      "tasklist.exe",
+      "ipconfig.exe",
+      "nltest.exe",
+      "systeminfo.exe",
+      "charmap.exe",
+      "CALC.EXE",
+      "mspaint.exe"
+    )
+  )
+```
+
+
+
 ### Suspicious Child Process via Azure VM CustomScript Extension
 
 Branch count: 100  
 Document count: 200  
-Index: geneve-ut-1813
+Index: geneve-ut-1835
 
 ```python
 sequence by host.id with maxspan=1m
@@ -17393,7 +17537,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-1814
+Index: geneve-ut-1836
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17408,7 +17552,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 22  
 Document count: 44  
-Index: geneve-ut-1817
+Index: geneve-ut-1839
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17435,7 +17579,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1819
+Index: geneve-ut-1841
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17466,7 +17610,7 @@ not process.parent.executable in (
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1820
+Index: geneve-ut-1842
 
 ```python
 process where host.os.type == "linux" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17482,7 +17626,7 @@ not (process.parent.name in ("sh", "sudo") and ?process.parent.command_line : "*
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1821
+Index: geneve-ut-1843
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and process.name != null and
@@ -17495,7 +17639,7 @@ file where host.os.type == "macos" and event.type != "deletion" and process.name
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1823
+Index: geneve-ut-1845
 
 ```python
 sequence by process.entity_id with maxspan=15s
@@ -17511,7 +17655,7 @@ sequence by process.entity_id with maxspan=15s
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1824
+Index: geneve-ut-1846
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and event.action == "exec" and
@@ -17527,7 +17671,7 @@ process where host.os.type == "macos" and event.type == "start" and event.action
 
 Branch count: 83  
 Document count: 83  
-Index: geneve-ut-1825
+Index: geneve-ut-1847
 
 ```python
 any where host.os.type == "windows" and 
@@ -17594,7 +17738,7 @@ any where host.os.type == "windows" and
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1827
+Index: geneve-ut-1849
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2", "executed", "process_started")
@@ -17610,7 +17754,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 44  
 Document count: 44  
-Index: geneve-ut-1829
+Index: geneve-ut-1851
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17646,7 +17790,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1830
+Index: geneve-ut-1852
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17684,7 +17828,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 352  
 Document count: 352  
-Index: geneve-ut-1831
+Index: geneve-ut-1853
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
@@ -17719,7 +17863,7 @@ process.parent.name in ("foomatic-rip", "cupsd") and process.command_line like (
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1832
+Index: geneve-ut-1854
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17753,7 +17897,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 70  
 Document count: 70  
-Index: geneve-ut-1834
+Index: geneve-ut-1856
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.executable : "C:\\*" and
@@ -17774,7 +17918,7 @@ process where host.os.type == "windows" and event.type == "start" and process.ex
 
 Branch count: 201  
 Document count: 201  
-Index: geneve-ut-1839
+Index: geneve-ut-1861
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -17851,7 +17995,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-1840
+Index: geneve-ut-1862
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17873,7 +18017,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1841
+Index: geneve-ut-1863
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -17897,7 +18041,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1843
+Index: geneve-ut-1865
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event") and
@@ -17918,7 +18062,7 @@ process.name : "kworker*" and not (
 
 Branch count: 84  
 Document count: 84  
-Index: geneve-ut-1846
+Index: geneve-ut-1868
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -17933,7 +18077,7 @@ process.args like ("/dev/shm/*", "/tmp/*", "/var/tmp/*", "/run/*", "/var/run/*",
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1849
+Index: geneve-ut-1871
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -17946,7 +18090,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1850
+Index: geneve-ut-1872
 
 ```python
 any where host.os.type == "windows" and
@@ -17961,7 +18105,7 @@ any where host.os.type == "windows" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1851
+Index: geneve-ut-1873
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -17977,7 +18121,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 16  
 Document count: 32  
-Index: geneve-ut-1852
+Index: geneve-ut-1874
 
 ```python
 sequence by host.id, process.entity_id with maxspan=15s
@@ -17991,7 +18135,7 @@ sequence by host.id, process.entity_id with maxspan=15s
 
 Branch count: 405  
 Document count: 405  
-Index: geneve-ut-1856
+Index: geneve-ut-1878
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -18044,11 +18188,32 @@ process.parent.executable != null and (
 
 
 
+### Suspicious Java Class File Created in PaperCut Server Library
+
+Branch count: 30  
+Document count: 30  
+Index: geneve-ut-1879
+
+```python
+file where host.os.type in ("windows", "linux", "macos") and
+  event.action in ("creation", "overwrite") and
+  file.extension : "class" and
+  file.path : (
+    "?:\\Program Files\\PaperCut*\\server\\lib\\*",
+    "?:\\Program Files (x86)\\PaperCut*\\server\\lib\\*",
+    "/opt/papercut/server/lib/*",
+    "/usr/local/papercut/server/lib/*",
+    "/Applications/PaperCut*/server/lib/*"
+  )
+```
+
+
+
 ### Suspicious JavaScript Execution via Deno
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1857
+Index: geneve-ut-1880
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18062,7 +18227,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 8  
-Index: geneve-ut-1859
+Index: geneve-ut-1882
 
 ```python
 sequence by source.port, source.ip with maxspan=3s
@@ -18094,7 +18259,7 @@ sequence by source.port, source.ip with maxspan=3s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1861
+Index: geneve-ut-1884
 
 ```python
 process where host.os.type == "linux" and event.action == "session_id_change" and process.name : "kworker*" and
@@ -18107,7 +18272,7 @@ user.id == "0"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1862
+Index: geneve-ut-1885
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18126,7 +18291,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1863
+Index: geneve-ut-1886
 
 ```python
 process where host.os.type == "windows" and event.code == "10" and
@@ -18172,7 +18337,7 @@ process where host.os.type == "windows" and event.code == "10" and
 
 Branch count: 52  
 Document count: 52  
-Index: geneve-ut-1865
+Index: geneve-ut-1888
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18193,7 +18358,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1866
+Index: geneve-ut-1889
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18213,7 +18378,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 72  
 Document count: 72  
-Index: geneve-ut-1867
+Index: geneve-ut-1890
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -18227,7 +18392,7 @@ process.name in ("grep", "egrep", "fgrep", "rgrep") and process.args in ("[stack
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1868
+Index: geneve-ut-1891
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18259,7 +18424,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1871
+Index: geneve-ut-1894
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and event.action in ("creation", "file_create_event") and (
@@ -18280,7 +18445,7 @@ file where host.os.type == "linux" and event.type == "creation" and event.action
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1873
+Index: geneve-ut-1896
 
 ```python
 library where host.os.type == "windows" and event.action == "load" and
@@ -18381,7 +18546,7 @@ library where host.os.type == "windows" and event.action == "load" and
 
 Branch count: 34  
 Document count: 68  
-Index: geneve-ut-1877
+Index: geneve-ut-1900
 
 ```python
 sequence by host.id with maxspan=5s
@@ -18429,7 +18594,7 @@ sequence by host.id with maxspan=5s
 
 Branch count: 2  
 Document count: 4  
-Index: geneve-ut-1880
+Index: geneve-ut-1903
 
 ```python
 sequence by process.entity_id with maxspan=1m
@@ -18455,7 +18620,7 @@ sequence by process.entity_id with maxspan=1m
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1881
+Index: geneve-ut-1904
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18500,7 +18665,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 212  
 Document count: 212  
-Index: geneve-ut-1882
+Index: geneve-ut-1905
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18524,7 +18689,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1883
+Index: geneve-ut-1906
 
 ```python
 sequence by host.id, process.parent.pid with maxspan=1m
@@ -18540,7 +18705,7 @@ sequence by host.id, process.parent.pid with maxspan=1m
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1885
+Index: geneve-ut-1908
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "mount" and 
@@ -18565,7 +18730,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1886
+Index: geneve-ut-1909
 
 ```python
 event.category:process and host.os.type:windows and
@@ -18580,7 +18745,7 @@ event.category:process and host.os.type:windows and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1889
+Index: geneve-ut-1912
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -18594,7 +18759,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1890
+Index: geneve-ut-1913
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18614,7 +18779,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1891
+Index: geneve-ut-1914
 
 ```python
 file where host.os.type == "windows" and event.type != "deletion" and
@@ -18649,7 +18814,7 @@ file where host.os.type == "windows" and event.type != "deletion" and
 
 Branch count: 9  
 Document count: 9  
-Index: geneve-ut-1895
+Index: geneve-ut-1918
 
 ```python
 process where event.type == "start" and event.action == "exec" and (
@@ -18667,7 +18832,7 @@ process where event.type == "start" and event.action == "exec" and (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1896
+Index: geneve-ut-1920
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18680,7 +18845,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-1899
+Index: geneve-ut-1923
 
 ```python
 any where host.os.type == "windows" and
@@ -18709,11 +18874,41 @@ any where host.os.type == "windows" and
 
 
 
+### Suspicious Reading of procfs Syscall File
+
+Branch count: 120  
+Document count: 120  
+Index: geneve-ut-1925
+
+```python
+process where host.os.type == "linux" and event.type == "start" and
+event.action in ("exec", "exec_event", "start", "ProcessRollup2") and
+(
+  process.name in (
+    "cat", "less", "more", "head", "tail", "nano", "vi", "vim", "strings", "nvim", "vim.basic",
+    "vim.tiny", "od", "hexdump", "xxd", "hx", "hexedit", "pager", "tr"
+  ) or
+  (
+    process.name in (
+      "find", "awk", "gawk", "mawk", "nawk", "grep", "fgrep", "rgrep", "xargs", "sed", "tee"
+    ) and
+    process.args_count <= 20
+  )
+) and
+process.command_line like "*/proc/*/syscall*" and
+not (
+  process.command_line like ("*/proc/self/syscall*", "*/proc/thread-self/syscall*") or
+  process.args like "/proc/*/syscall/comm"
+)
+```
+
+
+
 ### Suspicious Remote Registry Access via SeBackupPrivilege
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1901
+Index: geneve-ut-1926
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=1m
@@ -18731,7 +18926,7 @@ sequence by winlog.computer_name, winlog.event_data.SubjectLogonId with maxspan=
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1902
+Index: geneve-ut-1927
 
 ```python
 file where host.os.type == "linux" and event.action == "rename" and (
@@ -18753,7 +18948,7 @@ and not (
 
 Branch count: 414  
 Document count: 828  
-Index: geneve-ut-1905
+Index: geneve-ut-1930
 
 ```python
 sequence by host.id with maxspan=30s
@@ -18792,7 +18987,7 @@ sequence by host.id with maxspan=30s
 
 Branch count: 152  
 Document count: 152  
-Index: geneve-ut-1906
+Index: geneve-ut-1931
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18822,7 +19017,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1907
+Index: geneve-ut-1932
 
 ```python
 any where host.os.type == "windows" and
@@ -18856,7 +19051,7 @@ any where host.os.type == "windows" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1908
+Index: geneve-ut-1933
 
 ```python
 event.category:iam and host.os.type:"windows" and event.code:"4674" and
@@ -18870,7 +19065,7 @@ winlog.event_data.AccessMask:"512" and not winlog.event_data.SubjectUserSid:("S-
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1911
+Index: geneve-ut-1936
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -18901,7 +19096,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-1912
+Index: geneve-ut-1937
 
 ```python
 any where host.os.type == "windows" and
@@ -18921,7 +19116,7 @@ any where host.os.type == "windows" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1913
+Index: geneve-ut-1938
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -18962,7 +19157,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1914
+Index: geneve-ut-1939
 
 ```python
 file where host.os.type == "macos" and event.type != "deletion" and 
@@ -18978,7 +19173,7 @@ file where host.os.type == "macos" and event.type != "deletion" and
 
 Branch count: 918  
 Document count: 918  
-Index: geneve-ut-1915
+Index: geneve-ut-1940
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -19008,7 +19203,7 @@ process.name == "ln" and process.args in ("-s", "-sf") and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1919
+Index: geneve-ut-1944
 
 ```python
 process where host.os.type == "linux" and event.type == "end" and process.name in ("vmware-vmx", "vmx")
@@ -19021,7 +19216,7 @@ and process.parent.name == "kill"
 
 Branch count: 160  
 Document count: 160  
-Index: geneve-ut-1920
+Index: geneve-ut-1945
 
 ```python
 process where host.os.type == "windows" and event.action == "start" and
@@ -19045,7 +19240,7 @@ process where host.os.type == "windows" and event.action == "start" and
 
 Branch count: 204  
 Document count: 204  
-Index: geneve-ut-1923
+Index: geneve-ut-1948
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19063,7 +19258,7 @@ process.name == "proxychains" and process.args : (
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1925
+Index: geneve-ut-1950
 
 ```python
 any where host.os.type == "windows" and
@@ -19078,7 +19273,7 @@ any where host.os.type == "windows" and
 
 Branch count: 48  
 Document count: 96  
-Index: geneve-ut-1926
+Index: geneve-ut-1951
 
 ```python
 sequence by process.entity_id with maxspan = 2m
@@ -19096,7 +19291,7 @@ sequence by process.entity_id with maxspan = 2m
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1927
+Index: geneve-ut-1952
 
 ```python
 file where event.action == "open" and host.os.type == "macos" and process.executable != null and
@@ -19117,7 +19312,7 @@ not ?Effective_process.executable like "/Library/Elastic/Endpoint/elastic-endpoi
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1928
+Index: geneve-ut-1953
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19136,7 +19331,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 336  
 Document count: 336  
-Index: geneve-ut-1931
+Index: geneve-ut-1956
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19161,7 +19356,7 @@ process.command_line like (
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1932
+Index: geneve-ut-1957
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19174,7 +19369,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 5  
-Index: geneve-ut-1934
+Index: geneve-ut-1959
 
 ```python
 sequence by host.hostname, host.id with maxspan=1m
@@ -19187,7 +19382,7 @@ sequence by host.hostname, host.id with maxspan=1m
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1936
+Index: geneve-ut-1961
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -19210,7 +19405,7 @@ process.parent.name in ("bash", "dash", "ash", "sh", "tcsh", "csh", "zsh", "ksh"
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1938
+Index: geneve-ut-1963
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19229,7 +19424,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1939
+Index: geneve-ut-1964
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and process.name in ("cp", "mv") and
@@ -19251,7 +19446,7 @@ file.Ext.original.path : (
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1940
+Index: geneve-ut-1965
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and process.name == "chmod" and
@@ -19284,7 +19479,7 @@ process.args in ("4755", "755", "000", "777", "444", "+x") and not (
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-1942
+Index: geneve-ut-1967
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19302,7 +19497,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-1943
+Index: geneve-ut-1968
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19316,7 +19511,7 @@ not ?process.working_directory in ("/opt/SolarWinds/Agent/bin/Plugins/SCM", "/op
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1944
+Index: geneve-ut-1969
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19340,7 +19535,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1945
+Index: geneve-ut-1970
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -19363,7 +19558,7 @@ process.parent.args == "-c" and not (
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1946
+Index: geneve-ut-1971
 
 ```python
 file where host.os.type == "linux" and event.type == "deletion" and file.path in (
@@ -19382,7 +19577,7 @@ file where host.os.type == "linux" and event.type == "deletion" and file.path in
 
 Branch count: 54  
 Document count: 54  
-Index: geneve-ut-1949
+Index: geneve-ut-1974
 
 ```python
 file where host.os.type == "linux" and event.type == "creation" and
@@ -19401,7 +19596,7 @@ file.path like (
 
 Branch count: 14  
 Document count: 14  
-Index: geneve-ut-1951
+Index: geneve-ut-1976
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.parent.executable != null and
@@ -19436,7 +19631,7 @@ process where host.os.type == "windows" and event.type == "start" and process.pa
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1952
+Index: geneve-ut-1977
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19453,7 +19648,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1953
+Index: geneve-ut-1978
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19473,7 +19668,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 128  
 Document count: 128  
-Index: geneve-ut-1954
+Index: geneve-ut-1979
 
 ```python
 file where host.os.type == "linux" and event.action in ("creation", "file_create_event", "rename", "file_rename_event")
@@ -19513,7 +19708,7 @@ and file.path like "/etc/init.d/*" and not (
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1955
+Index: geneve-ut-1980
 
 ```python
 file where host.os.type == "macos" and event.action == "open" and 
@@ -19529,7 +19724,7 @@ file where host.os.type == "macos" and event.action == "open" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1956
+Index: geneve-ut-1981
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -19543,7 +19738,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-1957
+Index: geneve-ut-1982
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19581,7 +19776,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1958
+Index: geneve-ut-1983
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19635,7 +19830,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-1959
+Index: geneve-ut-1984
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -19663,7 +19858,7 @@ not process.executable in (
 
 Branch count: 7  
 Document count: 7  
-Index: geneve-ut-1961
+Index: geneve-ut-1986
 
 ```python
 process where host.os.type == "linux" and event.type == "info" and event.action == "already_running" and
@@ -19677,7 +19872,7 @@ process.parent.command_line == "/sbin/init" and process.args_count >= 2
 
 Branch count: 80  
 Document count: 80  
-Index: geneve-ut-1962
+Index: geneve-ut-1987
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and file.path : (
@@ -19723,7 +19918,7 @@ file where host.os.type == "linux" and event.action in ("rename", "creation") an
 
 Branch count: 10  
 Document count: 10  
-Index: geneve-ut-1963
+Index: geneve-ut-1988
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and
@@ -19762,7 +19957,7 @@ file.path like (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1964
+Index: geneve-ut-1989
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and process.name == "mount_apfs" and
@@ -19775,7 +19970,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 180  
 Document count: 180  
-Index: geneve-ut-1968
+Index: geneve-ut-1993
 
 ```python
 process where event.action in ("exec", "exec_event", "executed", "process_started") and event.type == "start" and
@@ -19808,7 +20003,7 @@ process where event.action in ("exec", "exec_event", "executed", "process_starte
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1969
+Index: geneve-ut-1994
 
 ```python
 process where host.os.type in ("linux", "macos") and event.type == "start" and event.action == "exec" and
@@ -19822,7 +20017,7 @@ not process.env_vars like~ "RUNNER_TRACKING_ID=github_*"
 
 Branch count: 8  
 Document count: 16  
-Index: geneve-ut-1970
+Index: geneve-ut-1995
 
 ```python
 sequence by host.id with maxspan=1s
@@ -19836,7 +20031,7 @@ sequence by host.id with maxspan=1s
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-1971
+Index: geneve-ut-1996
 
 ```python
 sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
@@ -19850,7 +20045,7 @@ sequence by winlog.computer_name, winlog.event_data.TaskName with maxspan=5m
 
 Branch count: 30  
 Document count: 30  
-Index: geneve-ut-1972
+Index: geneve-ut-1997
 
 ```python
 file where host.os.type == "windows" and event.type == "deletion" and
@@ -19889,7 +20084,7 @@ file where host.os.type == "windows" and event.type == "deletion" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-1980
+Index: geneve-ut-2005
 
 ```python
 process where event.type == "start" and event.action == "exec" and process.name == "touch" and
@@ -19931,7 +20126,7 @@ process.parent.executable != null and process.args like (
 
 Branch count: 325  
 Document count: 325  
-Index: geneve-ut-1982
+Index: geneve-ut-2007
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and (
@@ -19953,7 +20148,7 @@ process where host.os.type == "linux" and event.type == "start" and event.action
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1984
+Index: geneve-ut-2009
 
 ```python
 process where event.type == "start" and event.action in ("exec", "exec_event", "executed", "process_started") and
@@ -19966,7 +20161,7 @@ process.name == "trap" and process.args : "SIG*"
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1987
+Index: geneve-ut-2012
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -19983,7 +20178,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-1988
+Index: geneve-ut-2013
 
 ```python
 file where host.os.type == "windows" and event.type : "change" and process.name : "dllhost.exe" and
@@ -19999,7 +20194,7 @@ file where host.os.type == "windows" and event.type : "change" and process.name 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-1989
+Index: geneve-ut-2014
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20012,7 +20207,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1990
+Index: geneve-ut-2015
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "Clipup.exe" and
@@ -20027,7 +20222,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1991
+Index: geneve-ut-2016
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20050,7 +20245,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-1992
+Index: geneve-ut-2017
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20066,7 +20261,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1993
+Index: geneve-ut-2018
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20082,7 +20277,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-1999
+Index: geneve-ut-2024
 
 ```python
 process where host.os.type == "macos" and event.type == "start" and process.parent.name == "ScreenSaverEngine"
@@ -20094,7 +20289,7 @@ process where host.os.type == "macos" and event.type == "start" and process.pare
 
 Branch count: 68  
 Document count: 68  
-Index: geneve-ut-2000
+Index: geneve-ut-2025
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -20123,7 +20318,7 @@ not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2002
+Index: geneve-ut-2027
 
 ```python
 library where dll.name : "Bitsproxy.dll" and process.executable != null and
@@ -20137,7 +20332,7 @@ not process.code_signature.status : ("errorExpired", "errorCode_endpoint*")
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2007
+Index: geneve-ut-2032
 
 ```python
 library where host.os.type == "windows" and process.name : "AzureADConnectAuthenticationAgentService.exe" and
@@ -20157,7 +20352,7 @@ not dll.path : (
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2008
+Index: geneve-ut-2033
 
 ```python
 driver where host.os.type == "windows" and process.pid == 4 and
@@ -20182,7 +20377,7 @@ driver where host.os.type == "windows" and process.pid == 4 and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2015
+Index: geneve-ut-2040
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20196,7 +20391,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2016
+Index: geneve-ut-2041
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20219,7 +20414,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2025
+Index: geneve-ut-2050
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action in ("exec", "exec_event", "start") and
@@ -20253,7 +20448,7 @@ process.parent.name == "dbus-daemon" and process.args_count > 1 and not (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2027
+Index: geneve-ut-2052
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and event.action == "exec" and
@@ -20272,7 +20467,7 @@ process.group_leader.name != null and not (
 
 Branch count: 248  
 Document count: 248  
-Index: geneve-ut-2034
+Index: geneve-ut-2059
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -20291,7 +20486,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 39  
 Document count: 39  
-Index: geneve-ut-2049
+Index: geneve-ut-2074
 
 ```python
 process where host.os.type == "linux" and event.action == "killed-pid" and auditd.data.syscall == "kill" and
@@ -20308,7 +20503,7 @@ auditd.data.a1 in (
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2052
+Index: geneve-ut-2077
 
 ```python
 library where host.os.type == "macos" and event.action == "load" and
@@ -20325,7 +20520,7 @@ library where host.os.type == "macos" and event.action == "load" and
 
 Branch count: 1  
 Document count: 2  
-Index: geneve-ut-2068
+Index: geneve-ut-2093
 
 ```python
 sequence by host.id, process.entity_id with maxspan=1m
@@ -20344,7 +20539,7 @@ sequence by host.id, process.entity_id with maxspan=1m
 
 Branch count: 66  
 Document count: 66  
-Index: geneve-ut-2072
+Index: geneve-ut-2097
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20386,7 +20581,7 @@ process.parent.name != null and process.parent.executable like ("?:\\*", "\\Devi
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2073
+Index: geneve-ut-2098
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -20431,7 +20626,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 32  
 Document count: 32  
-Index: geneve-ut-2076
+Index: geneve-ut-2101
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20473,7 +20668,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2078
+Index: geneve-ut-2103
 
 ```python
 host.os.type:"linux" and 
@@ -20501,7 +20696,7 @@ process.executable:(* and not
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2082
+Index: geneve-ut-2107
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20525,7 +20720,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 256  
 Document count: 256  
-Index: geneve-ut-2083
+Index: geneve-ut-2108
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20565,7 +20760,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 198  
 Document count: 198  
-Index: geneve-ut-2084
+Index: geneve-ut-2109
 
 ```python
 process where event.type == "start" and host.os.type == "windows" and
@@ -20612,7 +20807,7 @@ process where event.type == "start" and host.os.type == "windows" and
 
 Branch count: 144  
 Document count: 288  
-Index: geneve-ut-2088
+Index: geneve-ut-2113
 
 ```python
 sequence by process.entity_id
@@ -20649,7 +20844,7 @@ sequence by process.entity_id
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2120
+Index: geneve-ut-2145
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20663,7 +20858,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 20  
 Document count: 20  
-Index: geneve-ut-2121
+Index: geneve-ut-2146
 
 ```python
 iam where host.os.type == "windows" and event.action == "added-member-to-group" and
@@ -20706,7 +20901,7 @@ iam where host.os.type == "windows" and event.action == "added-member-to-group" 
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2122
+Index: geneve-ut-2147
 
 ```python
 configuration where host.os.type == "macos" and event.type == "change" and
@@ -20719,7 +20914,7 @@ configuration where host.os.type == "macos" and event.type == "change" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2125
+Index: geneve-ut-2150
 
 ```python
 event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"%%14674" and
@@ -20733,7 +20928,7 @@ event.code:5136 and host.os.type:"windows" and winlog.event_data.OperationType:"
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2126
+Index: geneve-ut-2151
 
 ```python
 iam where host.os.type == "linux" and event.type in ("creation", "change") and auditd.result == "success" and
@@ -20746,7 +20941,7 @@ event.action in ("changed-password", "added-user-account", "added-group-account-
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2130
+Index: geneve-ut-2155
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and 
@@ -20771,7 +20966,7 @@ process.args in (
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2131
+Index: geneve-ut-2156
 
 ```python
 process where event.type == "start" and
@@ -20786,7 +20981,7 @@ process where event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2132
+Index: geneve-ut-2157
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and
@@ -20803,7 +20998,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2133
+Index: geneve-ut-2158
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20817,7 +21012,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 60  
 Document count: 60  
-Index: geneve-ut-2134
+Index: geneve-ut-2159
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20833,7 +21028,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2135
+Index: geneve-ut-2160
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20847,7 +21042,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2136
+Index: geneve-ut-2161
 
 ```python
 file where host.os.type == "windows" and event.action != "deletion" and
@@ -20874,7 +21069,7 @@ file where host.os.type == "windows" and event.action != "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2138
+Index: geneve-ut-2163
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wbemtest.exe"
@@ -20886,7 +21081,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 3  
 Document count: 3  
-Index: geneve-ut-2139
+Index: geneve-ut-2164
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -20902,7 +21097,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 6  
 Document count: 6  
-Index: geneve-ut-2140
+Index: geneve-ut-2165
 
 ```python
 any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" and
@@ -20925,7 +21120,7 @@ any where host.os.type == "windows" and process.name : "promecefpluginhost.exe" 
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2141
+Index: geneve-ut-2166
 
 ```python
 host.os.type: "windows" and event.action : ("Directory Service Access" or "object-operation-performed") and
@@ -20938,7 +21133,7 @@ host.os.type: "windows" and event.action : ("Directory Service Access" or "objec
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2143
+Index: geneve-ut-2168
 
 ```python
 http.response.status_code:403 and http.request.method:(POST or post)
@@ -20950,7 +21145,7 @@ http.response.status_code:403 and http.request.method:(POST or post)
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2144
+Index: geneve-ut-2169
 
 ```python
 http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or OPTIONS or POST))
@@ -20962,7 +21157,7 @@ http.response.status_code:405 and http.request.method:(* and not (GET or HEAD or
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2145
+Index: geneve-ut-2170
 
 ```python
 user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
@@ -20974,7 +21169,7 @@ user_agent.original:"sqlmap/1.3.11#stable (http://sqlmap.org)"
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2146
+Index: geneve-ut-2171
 
 ```python
 web where (
@@ -21002,7 +21197,7 @@ web where (
 
 Branch count: 91  
 Document count: 91  
-Index: geneve-ut-2152
+Index: geneve-ut-2177
 
 ```python
 any where (
@@ -21065,6 +21260,11 @@ url.original like~ (
     "*select @@version*", "*select user()*", "*select current_user()*", "*select database()*",
     "*sp_executesql*exec*", "*xp_dirtree*"
   )
+) and
+not user_agent.original like~ (
+    "*Nessus*", "*Qualys*", "*Acunetix*",  "*Tenable*", "*CensysInspect*", "*Detectify*",
+    "*Assetnote*", "*ExposureScan*", "*RecordedFuture*", "*AppSpider*", "*WebInspect*",
+    "*Rapid7*", "*InsightVM*", "*Probely*"
 )
 ```
 
@@ -21074,7 +21274,7 @@ url.original like~ (
 
 Branch count: 40  
 Document count: 40  
-Index: geneve-ut-2154
+Index: geneve-ut-2179
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21095,7 +21295,7 @@ not process.parent.executable == "/usr/lib/systemd/systemd"
 
 Branch count: 48  
 Document count: 48  
-Index: geneve-ut-2157
+Index: geneve-ut-2182
 
 ```python
 process where host.os.type == "macos" and event.type in ("start", "process_started") and event.action == "exec" and
@@ -21109,7 +21309,7 @@ process where host.os.type == "macos" and event.type in ("start", "process_start
 
 Branch count: 5  
 Document count: 5  
-Index: geneve-ut-2158
+Index: geneve-ut-2183
 
 ```python
 file where event.type == "deletion" and
@@ -21126,7 +21326,7 @@ file where event.type == "deletion" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2159
+Index: geneve-ut-2184
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21144,7 +21344,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2162
+Index: geneve-ut-2187
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21182,7 +21382,7 @@ and not process.parent.name : "LTSVC.exe" and not user.id : "S-1-5-18"
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2164
+Index: geneve-ut-2189
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and
@@ -21219,7 +21419,7 @@ registry where host.os.type == "windows" and event.type == "change" and
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2165
+Index: geneve-ut-2190
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21234,7 +21434,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2166
+Index: geneve-ut-2191
 
 ```python
 host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
@@ -21247,7 +21447,7 @@ host.os.type:windows and event.action:("audit-log-cleared" or "Log clear") and
 
 Branch count: 24  
 Document count: 24  
-Index: geneve-ut-2167
+Index: geneve-ut-2192
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21266,7 +21466,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 10  
 Document count: 20  
-Index: geneve-ut-2168
+Index: geneve-ut-2193
 
 ```python
 sequence by host.id with maxspan=1m
@@ -21291,7 +21491,7 @@ sequence by host.id with maxspan=1m
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2169
+Index: geneve-ut-2194
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21317,7 +21517,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2170
+Index: geneve-ut-2195
 
 ```python
 file where host.os.type == "windows" and event.type == "creation" and
@@ -21339,7 +21539,7 @@ file where host.os.type == "windows" and event.type == "creation" and
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2171
+Index: geneve-ut-2196
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21356,7 +21556,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 15  
 Document count: 15  
-Index: geneve-ut-2173
+Index: geneve-ut-2198
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and process.name : "wscript.exe" and
@@ -21375,7 +21575,7 @@ process where host.os.type == "windows" and event.type == "start" and process.na
 
 Branch count: 216  
 Document count: 432  
-Index: geneve-ut-2174
+Index: geneve-ut-2199
 
 ```python
 sequence by host.id with maxspan = 5s
@@ -21415,7 +21615,7 @@ sequence by host.id with maxspan = 5s
 
 Branch count: 12  
 Document count: 12  
-Index: geneve-ut-2175
+Index: geneve-ut-2200
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21432,7 +21632,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 1  
 Document count: 1  
-Index: geneve-ut-2177
+Index: geneve-ut-2202
 
 ```python
 registry where host.os.type == "windows" and event.type == "change" and registry.value : "PackageFamilyName" and
@@ -21445,7 +21645,7 @@ registry where host.os.type == "windows" and event.type == "change" and registry
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2178
+Index: geneve-ut-2203
 
 ```python
 process where host.os.type == "windows" and event.type : "start" and
@@ -21459,7 +21659,7 @@ process where host.os.type == "windows" and event.type : "start" and
 
 Branch count: 4  
 Document count: 4  
-Index: geneve-ut-2179
+Index: geneve-ut-2204
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21487,7 +21687,7 @@ process.parent.executable : (
 
 Branch count: 18  
 Document count: 18  
-Index: geneve-ut-2180
+Index: geneve-ut-2205
 
 ```python
 process where event.type == "start" and
@@ -21512,7 +21712,7 @@ process where event.type == "start" and
 
 Branch count: 2  
 Document count: 2  
-Index: geneve-ut-2181
+Index: geneve-ut-2206
 
 ```python
 process where host.os.type == "windows" and event.type == "start" and
@@ -21526,7 +21726,7 @@ process where host.os.type == "windows" and event.type == "start" and
 
 Branch count: 25  
 Document count: 25  
-Index: geneve-ut-2182
+Index: geneve-ut-2207
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21542,7 +21742,7 @@ event.action in ("exec", "exec_event", "executed", "process_started", "ProcessRo
 
 Branch count: 16  
 Document count: 16  
-Index: geneve-ut-2183
+Index: geneve-ut-2208
 
 ```python
 file where host.os.type == "linux" and event.action in ("rename", "creation") and
@@ -21577,7 +21777,7 @@ file.path : ("/usr/lib/yum-plugins/*", "/etc/yum/pluginconf.d/*") and not (
 
 Branch count: 36  
 Document count: 36  
-Index: geneve-ut-2184
+Index: geneve-ut-2209
 
 ```python
 process where host.os.type == "linux" and event.type == "start" and
@@ -21595,7 +21795,7 @@ not ?process.parent.executable == "/usr/lib/venv-salt-minion/bin/python.original
 
 Branch count: 8  
 Document count: 8  
-Index: geneve-ut-2187
+Index: geneve-ut-2212
 
 ```python
 file where host.os.type == "linux" and event.action == "creation" and

--- a/tests/reports/documents_from_rules-8.19.md
+++ b/tests/reports/documents_from_rules-8.19.md
@@ -5,12 +5,12 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 8.19.31
+Rules version: 8.19.32
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (239)](#unsupported-rule-type-new_terms-239)
-      1. [Unsupported rule type: esql (189)](#unsupported-rule-type-esql-189)
+      1. [Unsupported rule type: new_terms (238)](#unsupported-rule-type-new_terms-238)
+      1. [Unsupported rule type: esql (198)](#unsupported-rule-type-esql-198)
       1. [Unsupported rule type: machine_learning (95)](#unsupported-rule-type-machine_learning-95)
       1. [Unsupported rule type: threshold (27)](#unsupported-rule-type-threshold-27)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -34,7 +34,7 @@ invalid-syntax
 -------------------1)
    1. [Generation errors](#generation-errors)
       1. [Field type solver: constant_keyword (385)](#field-type-solver-constant_keyword-385)
-      1. [Unsupported function: match (33)](#unsupported-function-match-33)
+      1. [Unsupported function: match (34)](#unsupported-function-match-34)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
       1. [Root with too many branches (limit: 10000) (23)](#root-with-too-many-branches-limit-10000-23)
       1. [Unsupported LHS type: <class 'eql.ast.FunctionCall'> (11)](#unsupported-lhs-type-class-eqlastfunctioncall-11)
@@ -62,7 +62,6 @@ invalid-syntax
       1. [Unsolvable constraints: file.extension (cannot be non-null) (1)](#unsolvable-constraints-fileextension-cannot-be-non-null-1)
       1. [Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)](#unsolvable-constraints-filename-excluded-by-stringslocal-state-local-state-1)
       1. [Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)](#unsolvable-constraints-filename-not-in-stringsso-so-1)
-      1. [Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringsswipuploadashx-post-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringschild_process-exec-1)
       1. [Unsolvable constraints: kubernetes.audit.requestObject.spec.containers.image (cannot be null) (1)](#unsolvable-constraints-kubernetesauditrequestobjectspeccontainersimage-cannot-be-null-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (excluded by Strings({'DsGetSiteName'}): ('DsGetSiteName')) (1)](#unsolvable-constraints-powershellfilescript_block_text-excluded-by-stringsdsgetsitename-dsgetsitename-1)
@@ -87,7 +86,6 @@ invalid-syntax
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[Ref].Assembly.GetType(('System.Management.Automation'}): ('.SetValue(')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsrefassemblygettypesystemmanagementautomation-setvalue-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[System.Reflection.Assembly]::Load'}): ('FromBase64String')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringssystemreflectionassemblyload-frombase64string-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[dbo].[Credentials]'}): ('Veeam')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsdbocredentials-veeam-1)
-      1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[string]::join'}): ('$pSHoMe[')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsstringjoin-pshome-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'capCreateCaptureWindowA'}): ('avicap32.dll')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringscapcreatecapturewindowa-avicap32dll-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'defaultNamingContext'}): ('.MinLengthPassword')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsdefaultnamingcontext-minlengthpassword-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'shi1_netname'}): ('shi1_remark')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsshi1_netname-shi1_remark-1)
@@ -106,6 +104,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.command_line (not in Strings({'*vm.swappiness*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsvmswappiness-echo--1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'arp.exe'}): ('arp.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsarpexe-arpexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)](#unsolvable-constraints-processname-excluded-by-stringscp-cp-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'elastic-agent.exe'}): ('elastic-agent.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselastic-agentexe-elastic-agentexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselevation_serviceexe-elevation_serviceexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'kubectl'}): ('kubectl')) (1)](#unsolvable-constraints-processname-excluded-by-stringskubectl-kubectl-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msdt.exe'}): ('msdt.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsdtexe-msdtexe-1)
@@ -114,6 +113,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'net1.exe'}): ('net1.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnet1exe-net1exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nohup'}): ('nohup')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnohup-nohup-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsscexe-scexe-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)](#unsolvable-constraints-processname-excluded-by-stringssh-sh-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringssmssexe-smssexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sysctl'}): ('sysctl')) (1)](#unsolvable-constraints-processname-excluded-by-stringssysctl-sysctl-1)
       1. [Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)](#unsolvable-constraints-processname-not-in-stringsrundll32exe-mshtaexe-1)
@@ -141,9 +141,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (239)
+### Unsupported rule type: new_terms (238)
 
-239 rules:
+238 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Batch Job Submitted with Container Override by Unusual Identity
@@ -177,6 +177,7 @@ invalid-syntax
 * AWS Lambda Function Invoked from an Unusual Source ASN
 * AWS S3 Bucket ACL Modified to Allow Public Access by New Identity
 * AWS S3 Unauthenticated Bucket Access by Rare Source
+* AWS SES Full Access Policy Attached to IAM Entity by Unusual User
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
 * AWS SNS Topic Message Publish by Rare User
@@ -213,7 +214,6 @@ invalid-syntax
 * Azure VM Serial Console Connection with Unusual User and ASN
 * DPKG Package Installed by Unusual Parent Process
 * Delegated Managed Service Account Modification by an Unusual User
-* Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
 * Deprecated TLS Version or Weak Cipher Negotiated Externally
 * Direct Process Execution via Background Utility
@@ -254,6 +254,7 @@ invalid-syntax
 * First Occurrence of Private Repo Event from Specific GitHub Personal Access Token (PAT)
 * First Occurrence of User Agent For a GitHub Personal Access Token (PAT)
 * First Occurrence of User-Agent For a GitHub User
+* First Seen SonicWall Remote Access Login by User and Source
 * First Time AWS CloudFormation Stack Creation
 * First Time Python Accessed Sensitive Credential Files
 * First Time Python Created a LaunchAgent or LaunchDaemon
@@ -287,12 +288,10 @@ invalid-syntax
 * Kernel Object File Creation
 * Kill Command Execution
 * Kubernetes Anonymous Request Authorized by Unusual User Agent
-* Kubernetes Denied Service Account Request via Unusual User Agent
 * Kubernetes Forbidden Request from Unusual User Agent
 * Kubernetes Pod Creation Using Common Debug or Base Images
 * Kubernetes Secret Access via Unusual User Agent
 * Kubernetes Suspicious Self-Subject Review via Unusual User Agent
-* Kubernetes Unusual Decision by User Agent
 * LSASS Memory Dump Handle Access
 * Linux Audio Recording Activity Detected
 * Linux Clipboard Activity Detected
@@ -385,9 +384,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (189)
+### Unsupported rule type: esql (198)
 
-189 rules:
+198 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -418,6 +417,7 @@ invalid-syntax
 * AWS Rare Source AS Organization Activity
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SES Email Identity Verified Then Deleted
 * AWS SageMaker Execution Role Passed by Unusual Principal
 * AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
@@ -455,6 +455,7 @@ invalid-syntax
 * First-Time FortiGate Administrator Login
 * FortiGate Administrator Login from Multiple IP Addresses
 * FortiGate FortiCloud SSO Login from Unusual Source
+* GCP Secret Manager ListSecrets Across Multiple Projects
 * GKE API Request Failure Burst by User
 * GKE Anonymous Endpoint Permission Enumeration
 * GKE Certificate Signing Request Self-Approved
@@ -513,6 +514,7 @@ invalid-syntax
 * Newly Observed FortiGate Alert
 * Newly Observed High Severity Detection Alert
 * Newly Observed High Severity Suricata Alert
+* Newly Observed IPSEC NAT Traversal Peer
 * Newly Observed Palo Alto Network Alert
 * Newly Observed Process Exhibiting High CPU Usage
 * Newly Observed ScreenConnect Host Server
@@ -528,8 +530,11 @@ invalid-syntax
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries
+* Potential DNS Rebinding from Public to Private Address
+* Potential DNS Tunneling via Long and Unique Subdomains
 * Potential Denial of Azure OpenAI ML Service
 * Potential Dynamic IEX Reconstruction via Environment Variables
+* Potential Evasion via Boot Time Removal Tool
 * Potential Linux Local Account Brute Force Detected
 * Potential Malicious PowerShell Based on Alert Correlation
 * Potential Malware-Driven SSH Brute Force Attempt
@@ -553,6 +558,7 @@ invalid-syntax
 * Potential PowerShell Obfuscation via String Reordering
 * Potential Ransomware Behavior - Note Files by System
 * Potential SQL Injection Against Microsoft SQL Server
+* Potential Self-Signed TLS Certificate Recently Issued on External Connection
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
 * Potential Widespread Malware Infection Across Multiple Hosts
@@ -560,6 +566,8 @@ invalid-syntax
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
 * Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
+* SSFileCopyReceiver Writing to Common Persistence Locations
+* SSFileCopySender Executed as Root
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
 * Successful AMQP Multi-Queue Purge Burst
@@ -775,6 +783,7 @@ Invalid syntax
 * AWS CloudWatch Log Stream Deletion
 * AWS Config Resource Deletion
 * AWS Configuration Recorder Stopped
+* AWS Detective Graph Deleted
 * AWS EC2 AMI Shared with Another Account
 * AWS EC2 Deprecated AMI Discovery
 * AWS EC2 Encryption Disabled
@@ -786,6 +795,7 @@ Invalid syntax
 * AWS EC2 Security Group Configuration Change
 * AWS EC2 Serial Console Access Enabled
 * AWS EFS File System Deleted
+* AWS EKS Access Entry Created Then Deleted by Same Identity
 * AWS EKS Access Entry Granted Cluster Admin Policy
 * AWS EKS Access Entry Modified
 * AWS EKS Control Plane Logging Disabled
@@ -793,6 +803,8 @@ Invalid syntax
 * AWS GuardDuty Detection Suppression
 * AWS GuardDuty Detector Deletion
 * AWS GuardDuty Member Account Manipulation
+* AWS GuardDuty Publishing Destination Deleted
+* AWS GuardDuty Threat Intelligence Set Deleted
 * AWS IAM Account Password Policy Deleted
 * AWS IAM Deactivation of MFA Device
 * AWS IAM Group Creation
@@ -888,13 +900,11 @@ Invalid syntax
 * CyberArk Privileged Access Security Recommended Monitor
 * Default Cobalt Strike Team Server Certificate
 * Deprecated - M365 Exchange DLP Policy Deleted
-* Deprecated - M365 Security Compliance Email Reported by User as Malware or Phish
 * Deprecated - M365 Security Compliance Potential Ransomware Activity
 * Deprecated - M365 Security Compliance Unusual Volume of File Deletion
 * Deprecated - M365 Security Compliance User Restricted from Sending Email
 * Deprecated - M365 Teams External Access Enabled
 * Deprecated - M365 Teams Guest Access Enabled
-* Deprecated - MFA Disabled for Google Workspace Organization
 * Domain Added to Google Workspace Trusted Domains
 * EKS Authentication Configuration Modified
 * Elastic Security External Alerts
@@ -997,7 +1007,6 @@ Invalid syntax
 * GKE Secret Access from Node or Denied Service Account
 * GKE Secret get or list with Suspicious User Agent
 * GKE Service Account Modified RBAC Objects
-* GKE Service Account Token Created via TokenRequest API
 * GKE Suspicious Assignment of Controller Service Account
 * GKE Suspicious Self-Subject Review via Service Account
 * GitHub App Deleted
@@ -1028,7 +1037,6 @@ Invalid syntax
 * IBM QRadar External Alerts
 * ICMP Redirect Message from Internal Host
 * ICMP Timestamp or Information Request from the Internet
-* IPSEC NAT Traversal Port Activity
 * Inbound Connection to an Unsecure Elasticsearch Node
 * Initial Access via File Upload Followed by GET Request
 * Insecure AWS EC2 VPC Security Group Ingress Rule Added
@@ -1047,8 +1055,8 @@ Invalid syntax
 * Kubernetes Pod Created With HostPID
 * Kubernetes Pod Created with a Sensitive hostPath Volume
 * Kubernetes Privileged Pod Created
-* Kubernetes Secret get or list from Node or Pod Service Account
-* Kubernetes Secret get or list with Suspicious User Agent
+* Kubernetes Secret Get or List from Node or Pod Service Account
+* Kubernetes Secret Get or List with Suspicious User Agent
 * Kubernetes Sensitive RBAC Change Followed by Workload Modification
 * Kubernetes Service Account Modified RBAC Objects
 * Kubernetes Service Account Token Created via TokenRequest API
@@ -1133,15 +1141,16 @@ Invalid syntax
 * Whoami Process Activity
 * Zoom Meeting with no Passcode
 
-### Unsupported function: match (33)
+### Unsupported function: match (34)
 
-33 rules:
+34 rules:
 * Alternate Data Stream Creation/Execution at Volume Root Directory
 * Command Obfuscation via Unicode Modifier Letters
 * Creation of Hidden Files and Directories via CommandLine
 * Entra ID Sign-in BloodHound Suite User-Agent Detected
 * Executable File Creation with Multiple Extensions
 * File Deletion via Shred
+* File Downloaded by Curl/Wget and Piped to Interpreter
 * GenAI Process Connection to Suspicious Top Level Domain
 * Masquerading Space After Filename
 * Network Activity to a Suspicious Top Level Domain
@@ -1406,11 +1415,6 @@ Invalid syntax
 1 rules:
 * Creation of Hidden Shared Object File
 
-### Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)
-
-1 rules:
-* Deprecated - SUNBURST Command and Control Activity
-
 ### Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)
 
 1 rules:
@@ -1531,11 +1535,6 @@ Invalid syntax
 1 rules:
 * PowerShell Script with Veeam Credential Access Capabilities
 
-### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[string]::join'}): ('$pSHoMe[')) (1)
-
-1 rules:
-* Deprecated - Potential PowerShell Obfuscated Script
-
 ### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'capCreateCaptureWindowA'}): ('avicap32.dll')) (1)
 
 1 rules:
@@ -1626,6 +1625,11 @@ Invalid syntax
 1 rules:
 * Boot File Copy
 
+### Unsolvable constraints: process.name (excluded by Strings({'elastic-agent.exe'}): ('elastic-agent.exe')) (1)
+
+1 rules:
+* Elastic Agent Service Terminated
+
 ### Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)
 
 1 rules:
@@ -1665,6 +1669,11 @@ Invalid syntax
 
 1 rules:
 * Enumeration Command Spawned via WMIPrvSE
+
+### Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)
+
+1 rules:
+* Suspicious Process Execution by Zoom
 
 ### Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)
 

--- a/tests/reports/documents_from_rules-9.3.md
+++ b/tests/reports/documents_from_rules-9.3.md
@@ -5,12 +5,12 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.3.19
+Rules version: 9.3.20
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (242)](#unsupported-rule-type-new_terms-242)
-      1. [Unsupported rule type: esql (203)](#unsupported-rule-type-esql-203)
+      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
+      1. [Unsupported rule type: esql (212)](#unsupported-rule-type-esql-212)
       1. [Unsupported rule type: machine_learning (105)](#unsupported-rule-type-machine_learning-105)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -34,7 +34,7 @@ invalid-syntax
 -------------------1)
    1. [Generation errors](#generation-errors)
       1. [Field type solver: constant_keyword (389)](#field-type-solver-constant_keyword-389)
-      1. [Unsupported function: match (35)](#unsupported-function-match-35)
+      1. [Unsupported function: match (36)](#unsupported-function-match-36)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
       1. [Root without branches (11)](#root-without-branches-11)
@@ -64,7 +64,6 @@ invalid-syntax
       1. [Unsolvable constraints: file.extension (cannot be non-null) (1)](#unsolvable-constraints-fileextension-cannot-be-non-null-1)
       1. [Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)](#unsolvable-constraints-filename-excluded-by-stringslocal-state-local-state-1)
       1. [Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)](#unsolvable-constraints-filename-not-in-stringsso-so-1)
-      1. [Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringsswipuploadashx-post-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringschild_process-exec-1)
       1. [Unsolvable constraints: kubernetes.audit.requestObject.spec.containers.image (cannot be null) (1)](#unsolvable-constraints-kubernetesauditrequestobjectspeccontainersimage-cannot-be-null-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (excluded by Strings({'DsGetSiteName'}): ('DsGetSiteName')) (1)](#unsolvable-constraints-powershellfilescript_block_text-excluded-by-stringsdsgetsitename-dsgetsitename-1)
@@ -89,7 +88,6 @@ invalid-syntax
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[Ref].Assembly.GetType(('System.Management.Automation'}): ('.SetValue(')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsrefassemblygettypesystemmanagementautomation-setvalue-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[System.Reflection.Assembly]::Load'}): ('FromBase64String')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringssystemreflectionassemblyload-frombase64string-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[dbo].[Credentials]'}): ('Veeam')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsdbocredentials-veeam-1)
-      1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[string]::join'}): ('$pSHoMe[')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsstringjoin-pshome-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'capCreateCaptureWindowA'}): ('avicap32.dll')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringscapcreatecapturewindowa-avicap32dll-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'defaultNamingContext'}): ('.MinLengthPassword')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsdefaultnamingcontext-minlengthpassword-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'shi1_netname'}): ('shi1_remark')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsshi1_netname-shi1_remark-1)
@@ -108,6 +106,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.command_line (not in Strings({'*vm.swappiness*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsvmswappiness-echo--1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'arp.exe'}): ('arp.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsarpexe-arpexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)](#unsolvable-constraints-processname-excluded-by-stringscp-cp-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'elastic-agent.exe'}): ('elastic-agent.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselastic-agentexe-elastic-agentexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselevation_serviceexe-elevation_serviceexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'modprobe'}): ('modprobe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmodprobe-modprobe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msdt.exe'}): ('msdt.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsdtexe-msdtexe-1)
@@ -115,6 +114,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'net1.exe'}): ('net1.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnet1exe-net1exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nohup'}): ('nohup')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnohup-nohup-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsscexe-scexe-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)](#unsolvable-constraints-processname-excluded-by-stringssh-sh-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringssmssexe-smssexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sysctl'}): ('sysctl')) (1)](#unsolvable-constraints-processname-excluded-by-stringssysctl-sysctl-1)
       1. [Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)](#unsolvable-constraints-processname-not-in-stringsrundll32exe-mshtaexe-1)
@@ -142,9 +142,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (242)
+### Unsupported rule type: new_terms (241)
 
-242 rules:
+241 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -179,6 +179,7 @@ invalid-syntax
 * AWS Lambda Function Invoked from an Unusual Source ASN
 * AWS S3 Bucket ACL Modified to Allow Public Access by New Identity
 * AWS S3 Unauthenticated Bucket Access by Rare Source
+* AWS SES Full Access Policy Attached to IAM Entity by Unusual User
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
 * AWS SNS Topic Message Publish by Rare User
@@ -215,7 +216,6 @@ invalid-syntax
 * Azure VM Serial Console Connection with Unusual User and ASN
 * DPKG Package Installed by Unusual Parent Process
 * Delegated Managed Service Account Modification by an Unusual User
-* Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
 * Deprecated TLS Version or Weak Cipher Negotiated Externally
 * Direct Process Execution via Background Utility
@@ -256,6 +256,7 @@ invalid-syntax
 * First Occurrence of Private Repo Event from Specific GitHub Personal Access Token (PAT)
 * First Occurrence of User Agent For a GitHub Personal Access Token (PAT)
 * First Occurrence of User-Agent For a GitHub User
+* First Seen SonicWall Remote Access Login by User and Source
 * First Time AWS CloudFormation Stack Creation
 * First Time Python Accessed Sensitive Credential Files
 * First Time Python Created a LaunchAgent or LaunchDaemon
@@ -289,12 +290,10 @@ invalid-syntax
 * Kernel Object File Creation
 * Kill Command Execution
 * Kubernetes Anonymous Request Authorized by Unusual User Agent
-* Kubernetes Denied Service Account Request via Unusual User Agent
 * Kubernetes Forbidden Request from Unusual User Agent
 * Kubernetes Pod Creation Using Common Debug or Base Images
 * Kubernetes Secret Access via Unusual User Agent
 * Kubernetes Suspicious Self-Subject Review via Unusual User Agent
-* Kubernetes Unusual Decision by User Agent
 * LSASS Memory Dump Handle Access
 * Linux Audio Recording Activity Detected
 * Linux Clipboard Activity Detected
@@ -389,9 +388,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (203)
+### Unsupported rule type: esql (212)
 
-203 rules:
+212 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -424,6 +423,7 @@ invalid-syntax
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SES Email Identity Verified Then Deleted
 * AWS SageMaker Execution Role Passed by Unusual Principal
 * AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
@@ -463,6 +463,7 @@ invalid-syntax
 * First-Time FortiGate Administrator Login
 * FortiGate Administrator Login from Multiple IP Addresses
 * FortiGate FortiCloud SSO Login from Unusual Source
+* GCP Secret Manager ListSecrets Across Multiple Projects
 * GKE API Request Failure Burst by User
 * GKE Anonymous Endpoint Permission Enumeration
 * GKE Certificate Signing Request Self-Approved
@@ -527,6 +528,7 @@ invalid-syntax
 * Newly Observed FortiGate Alert
 * Newly Observed High Severity Detection Alert
 * Newly Observed High Severity Suricata Alert
+* Newly Observed IPSEC NAT Traversal Peer
 * Newly Observed Palo Alto Network Alert
 * Newly Observed Process Exhibiting High CPU Usage
 * Newly Observed ScreenConnect Host Server
@@ -542,8 +544,11 @@ invalid-syntax
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries
+* Potential DNS Rebinding from Public to Private Address
+* Potential DNS Tunneling via Long and Unique Subdomains
 * Potential Denial of Azure OpenAI ML Service
 * Potential Dynamic IEX Reconstruction via Environment Variables
+* Potential Evasion via Boot Time Removal Tool
 * Potential Linux Local Account Brute Force Detected
 * Potential Malicious PowerShell Based on Alert Correlation
 * Potential Malware-Driven SSH Brute Force Attempt
@@ -568,6 +573,7 @@ invalid-syntax
 * Potential PowerShell Obfuscation via String Reordering
 * Potential Ransomware Behavior - Note Files by System
 * Potential SQL Injection Against Microsoft SQL Server
+* Potential Self-Signed TLS Certificate Recently Issued on External Connection
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
 * Potential Widespread Malware Infection Across Multiple Hosts
@@ -575,6 +581,8 @@ invalid-syntax
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
 * Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
+* SSFileCopyReceiver Writing to Common Persistence Locations
+* SSFileCopySender Executed as Root
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
@@ -804,6 +812,7 @@ Invalid syntax
 * AWS CloudWatch Log Stream Deletion
 * AWS Config Resource Deletion
 * AWS Configuration Recorder Stopped
+* AWS Detective Graph Deleted
 * AWS EC2 AMI Shared with Another Account
 * AWS EC2 Deprecated AMI Discovery
 * AWS EC2 Encryption Disabled
@@ -815,6 +824,7 @@ Invalid syntax
 * AWS EC2 Security Group Configuration Change
 * AWS EC2 Serial Console Access Enabled
 * AWS EFS File System Deleted
+* AWS EKS Access Entry Created Then Deleted by Same Identity
 * AWS EKS Access Entry Granted Cluster Admin Policy
 * AWS EKS Access Entry Modified
 * AWS EKS Control Plane Logging Disabled
@@ -822,6 +832,8 @@ Invalid syntax
 * AWS GuardDuty Detection Suppression
 * AWS GuardDuty Detector Deletion
 * AWS GuardDuty Member Account Manipulation
+* AWS GuardDuty Publishing Destination Deleted
+* AWS GuardDuty Threat Intelligence Set Deleted
 * AWS IAM Account Password Policy Deleted
 * AWS IAM Deactivation of MFA Device
 * AWS IAM Group Creation
@@ -917,13 +929,11 @@ Invalid syntax
 * CyberArk Privileged Access Security Recommended Monitor
 * Default Cobalt Strike Team Server Certificate
 * Deprecated - M365 Exchange DLP Policy Deleted
-* Deprecated - M365 Security Compliance Email Reported by User as Malware or Phish
 * Deprecated - M365 Security Compliance Potential Ransomware Activity
 * Deprecated - M365 Security Compliance Unusual Volume of File Deletion
 * Deprecated - M365 Security Compliance User Restricted from Sending Email
 * Deprecated - M365 Teams External Access Enabled
 * Deprecated - M365 Teams Guest Access Enabled
-* Deprecated - MFA Disabled for Google Workspace Organization
 * Direct Interactive Kubernetes API Request by Common Utilities
 * Direct Interactive Kubernetes API Request by Unusual Utilities
 * Domain Added to Google Workspace Trusted Domains
@@ -1029,7 +1039,6 @@ Invalid syntax
 * GKE Secret Access from Node or Denied Service Account
 * GKE Secret get or list with Suspicious User Agent
 * GKE Service Account Modified RBAC Objects
-* GKE Service Account Token Created via TokenRequest API
 * GKE Suspicious Assignment of Controller Service Account
 * GKE Suspicious Self-Subject Review via Service Account
 * GitHub App Deleted
@@ -1060,7 +1069,6 @@ Invalid syntax
 * IBM QRadar External Alerts
 * ICMP Redirect Message from Internal Host
 * ICMP Timestamp or Information Request from the Internet
-* IPSEC NAT Traversal Port Activity
 * Inbound Connection to an Unsecure Elasticsearch Node
 * Initial Access via File Upload Followed by GET Request
 * Insecure AWS EC2 VPC Security Group Ingress Rule Added
@@ -1079,8 +1087,8 @@ Invalid syntax
 * Kubernetes Pod Created With HostPID
 * Kubernetes Pod Created with a Sensitive hostPath Volume
 * Kubernetes Privileged Pod Created
-* Kubernetes Secret get or list from Node or Pod Service Account
-* Kubernetes Secret get or list with Suspicious User Agent
+* Kubernetes Secret Get or List from Node or Pod Service Account
+* Kubernetes Secret Get or List with Suspicious User Agent
 * Kubernetes Sensitive RBAC Change Followed by Workload Modification
 * Kubernetes Service Account Modified RBAC Objects
 * Kubernetes Service Account Token Created via TokenRequest API
@@ -1166,15 +1174,16 @@ Invalid syntax
 * Whoami Process Activity
 * Zoom Meeting with no Passcode
 
-### Unsupported function: match (35)
+### Unsupported function: match (36)
 
-35 rules:
+36 rules:
 * Alternate Data Stream Creation/Execution at Volume Root Directory
 * Command Obfuscation via Unicode Modifier Letters
 * Creation of Hidden Files and Directories via CommandLine
 * Entra ID Sign-in BloodHound Suite User-Agent Detected
 * Executable File Creation with Multiple Extensions
 * File Deletion via Shred
+* File Downloaded by Curl/Wget and Piped to Interpreter
 * GenAI Process Connection to Suspicious Top Level Domain
 * Masquerading Space After Filename
 * Network Activity to a Suspicious Top Level Domain
@@ -1460,11 +1469,6 @@ Invalid syntax
 1 rules:
 * Creation of Hidden Shared Object File
 
-### Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)
-
-1 rules:
-* Deprecated - SUNBURST Command and Control Activity
-
 ### Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)
 
 1 rules:
@@ -1585,11 +1589,6 @@ Invalid syntax
 1 rules:
 * PowerShell Script with Veeam Credential Access Capabilities
 
-### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[string]::join'}): ('$pSHoMe[')) (1)
-
-1 rules:
-* Deprecated - Potential PowerShell Obfuscated Script
-
 ### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'capCreateCaptureWindowA'}): ('avicap32.dll')) (1)
 
 1 rules:
@@ -1680,6 +1679,11 @@ Invalid syntax
 1 rules:
 * Boot File Copy
 
+### Unsolvable constraints: process.name (excluded by Strings({'elastic-agent.exe'}): ('elastic-agent.exe')) (1)
+
+1 rules:
+* Elastic Agent Service Terminated
+
 ### Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)
 
 1 rules:
@@ -1714,6 +1718,11 @@ Invalid syntax
 
 1 rules:
 * Enumeration Command Spawned via WMIPrvSE
+
+### Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)
+
+1 rules:
+* Suspicious Process Execution by Zoom
 
 ### Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)
 

--- a/tests/reports/documents_from_rules-9.4.md
+++ b/tests/reports/documents_from_rules-9.4.md
@@ -5,13 +5,13 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.4.11
+Rules version: 9.4.12
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (242)](#unsupported-rule-type-new_terms-242)
-      1. [Unsupported rule type: esql (209)](#unsupported-rule-type-esql-209)
-      1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
+      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
+      1. [Unsupported rule type: esql (218)](#unsupported-rule-type-esql-218)
+      1. ['types.SimpleNamespace' object has no attribute 'type' (129)](#typessimplenamespace-object-has-no-attribute-type-129)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -35,7 +35,7 @@ invalid-syntax
 -------------------1)
    1. [Generation errors](#generation-errors)
       1. [Field type solver: constant_keyword (389)](#field-type-solver-constant_keyword-389)
-      1. [Unsupported function: match (35)](#unsupported-function-match-35)
+      1. [Unsupported function: match (36)](#unsupported-function-match-36)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
       1. [Root without branches (11)](#root-without-branches-11)
@@ -65,7 +65,6 @@ invalid-syntax
       1. [Unsolvable constraints: file.extension (cannot be non-null) (1)](#unsolvable-constraints-fileextension-cannot-be-non-null-1)
       1. [Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)](#unsolvable-constraints-filename-excluded-by-stringslocal-state-local-state-1)
       1. [Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)](#unsolvable-constraints-filename-not-in-stringsso-so-1)
-      1. [Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringsswipuploadashx-post-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringschild_process-exec-1)
       1. [Unsolvable constraints: kubernetes.audit.requestObject.spec.containers.image (cannot be null) (1)](#unsolvable-constraints-kubernetesauditrequestobjectspeccontainersimage-cannot-be-null-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (excluded by Strings({'DsGetSiteName'}): ('DsGetSiteName')) (1)](#unsolvable-constraints-powershellfilescript_block_text-excluded-by-stringsdsgetsitename-dsgetsitename-1)
@@ -90,7 +89,6 @@ invalid-syntax
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[Ref].Assembly.GetType(('System.Management.Automation'}): ('.SetValue(')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsrefassemblygettypesystemmanagementautomation-setvalue-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[System.Reflection.Assembly]::Load'}): ('FromBase64String')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringssystemreflectionassemblyload-frombase64string-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[dbo].[Credentials]'}): ('Veeam')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsdbocredentials-veeam-1)
-      1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[string]::join'}): ('$pSHoMe[')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsstringjoin-pshome-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'capCreateCaptureWindowA'}): ('avicap32.dll')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringscapcreatecapturewindowa-avicap32dll-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'defaultNamingContext'}): ('.MinLengthPassword')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsdefaultnamingcontext-minlengthpassword-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'shi1_netname'}): ('shi1_remark')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsshi1_netname-shi1_remark-1)
@@ -109,6 +107,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.command_line (not in Strings({'*vm.swappiness*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsvmswappiness-echo--1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'arp.exe'}): ('arp.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsarpexe-arpexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)](#unsolvable-constraints-processname-excluded-by-stringscp-cp-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'elastic-agent.exe'}): ('elastic-agent.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselastic-agentexe-elastic-agentexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselevation_serviceexe-elevation_serviceexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'modprobe'}): ('modprobe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmodprobe-modprobe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msdt.exe'}): ('msdt.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsdtexe-msdtexe-1)
@@ -116,6 +115,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'net1.exe'}): ('net1.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnet1exe-net1exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nohup'}): ('nohup')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnohup-nohup-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsscexe-scexe-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)](#unsolvable-constraints-processname-excluded-by-stringssh-sh-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringssmssexe-smssexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sysctl'}): ('sysctl')) (1)](#unsolvable-constraints-processname-excluded-by-stringssysctl-sysctl-1)
       1. [Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)](#unsolvable-constraints-processname-not-in-stringsrundll32exe-mshtaexe-1)
@@ -143,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (242)
+### Unsupported rule type: new_terms (241)
 
-242 rules:
+241 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -180,6 +180,7 @@ invalid-syntax
 * AWS Lambda Function Invoked from an Unusual Source ASN
 * AWS S3 Bucket ACL Modified to Allow Public Access by New Identity
 * AWS S3 Unauthenticated Bucket Access by Rare Source
+* AWS SES Full Access Policy Attached to IAM Entity by Unusual User
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
 * AWS SNS Topic Message Publish by Rare User
@@ -216,7 +217,6 @@ invalid-syntax
 * Azure VM Serial Console Connection with Unusual User and ASN
 * DPKG Package Installed by Unusual Parent Process
 * Delegated Managed Service Account Modification by an Unusual User
-* Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
 * Deprecated TLS Version or Weak Cipher Negotiated Externally
 * Direct Process Execution via Background Utility
@@ -257,6 +257,7 @@ invalid-syntax
 * First Occurrence of Private Repo Event from Specific GitHub Personal Access Token (PAT)
 * First Occurrence of User Agent For a GitHub Personal Access Token (PAT)
 * First Occurrence of User-Agent For a GitHub User
+* First Seen SonicWall Remote Access Login by User and Source
 * First Time AWS CloudFormation Stack Creation
 * First Time Python Accessed Sensitive Credential Files
 * First Time Python Created a LaunchAgent or LaunchDaemon
@@ -290,12 +291,10 @@ invalid-syntax
 * Kernel Object File Creation
 * Kill Command Execution
 * Kubernetes Anonymous Request Authorized by Unusual User Agent
-* Kubernetes Denied Service Account Request via Unusual User Agent
 * Kubernetes Forbidden Request from Unusual User Agent
 * Kubernetes Pod Creation Using Common Debug or Base Images
 * Kubernetes Secret Access via Unusual User Agent
 * Kubernetes Suspicious Self-Subject Review via Unusual User Agent
-* Kubernetes Unusual Decision by User Agent
 * LSASS Memory Dump Handle Access
 * Linux Audio Recording Activity Detected
 * Linux Clipboard Activity Detected
@@ -390,9 +389,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (209)
+### Unsupported rule type: esql (218)
 
-209 rules:
+218 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -425,6 +424,7 @@ invalid-syntax
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SES Email Identity Verified Then Deleted
 * AWS SageMaker Execution Role Passed by Unusual Principal
 * AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
@@ -464,6 +464,7 @@ invalid-syntax
 * First-Time FortiGate Administrator Login
 * FortiGate Administrator Login from Multiple IP Addresses
 * FortiGate FortiCloud SSO Login from Unusual Source
+* GCP Secret Manager ListSecrets Across Multiple Projects
 * GKE API Request Failure Burst by User
 * GKE Anonymous Endpoint Permission Enumeration
 * GKE Certificate Signing Request Self-Approved
@@ -531,6 +532,7 @@ invalid-syntax
 * Newly Observed FortiGate Alert
 * Newly Observed High Severity Detection Alert
 * Newly Observed High Severity Suricata Alert
+* Newly Observed IPSEC NAT Traversal Peer
 * Newly Observed Palo Alto Network Alert
 * Newly Observed Process Exhibiting High CPU Usage
 * Newly Observed ScreenConnect Host Server
@@ -546,8 +548,11 @@ invalid-syntax
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries
+* Potential DNS Rebinding from Public to Private Address
+* Potential DNS Tunneling via Long and Unique Subdomains
 * Potential Denial of Azure OpenAI ML Service
 * Potential Dynamic IEX Reconstruction via Environment Variables
+* Potential Evasion via Boot Time Removal Tool
 * Potential Linux Local Account Brute Force Detected
 * Potential Malicious PowerShell Based on Alert Correlation
 * Potential Malware-Driven SSH Brute Force Attempt
@@ -575,6 +580,7 @@ invalid-syntax
 * Potential SIP Extension Enumeration
 * Potential SIP REGISTER Brute Force
 * Potential SQL Injection Against Microsoft SQL Server
+* Potential Self-Signed TLS Certificate Recently Issued on External Connection
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
 * Potential Widespread Malware Infection Across Multiple Hosts
@@ -582,6 +588,8 @@ invalid-syntax
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
 * Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
+* SSFileCopyReceiver Writing to Common Persistence Locations
+* SSFileCopySender Executed as Root
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
@@ -604,9 +612,9 @@ invalid-syntax
 * Web Server Potential Spike in Error Response Codes
 * Web Server Suspicious User Agent Requests
 
-### 'types.SimpleNamespace' object has no attribute 'type' (119)
+### 'types.SimpleNamespace' object has no attribute 'type' (129)
 
-119 rules:
+129 rules:
 
 * AWS RDS Snapshot Export
 * Attempt to Disable IPTables or Firewall
@@ -627,21 +635,25 @@ invalid-syntax
 * Deprecated - AWS RDS Security Group Deletion
 * Deprecated - AWS Redshift Cluster Creation
 * Deprecated - AWS Root Login Without MFA
+* Deprecated - Adobe Hijack Persistence
 * Deprecated - Agent Spoofing - Mismatched Agent ID
 * Deprecated - Azure Entra Sign-in Brute Force Microsoft 365 Accounts by Repeat Source
 * Deprecated - Azure Virtual Network Device Modified or Deleted
 * Deprecated - CAP_SYS_ADMIN Assigned to Binary
 * Deprecated - Creation of Kernel Module
 * Deprecated - EggShell Backdoor Execution
+* Deprecated - Encoded Executable Stored in the Registry
 * Deprecated - Execution of File Written or Modified by PDF Reader
 * Deprecated - LaunchDaemon Creation or Modification and Immediate Loading
 * Deprecated - Linux Restricted Shell Breakout via Linux Binary(s)
+* Deprecated - M365 Security Compliance Email Reported by User as Malware or Phish
 * Deprecated - Modification of Standard Authentication Module or Configuration
 * Deprecated - Network Connection via Sudo Binary
 * Deprecated - Potential DNS Tunneling via Iodine
 * Deprecated - Potential Non-Standard Port HTTP/HTTPS connection
 * Deprecated - Potential Non-Standard Port SSH connection
 * Deprecated - Potential Password Spraying of Microsoft 365 User Accounts
+* Deprecated - Potential PowerShell Obfuscated Script
 * Deprecated - Potential Privilege Escalation via UID INT_MAX Bug Detected
 * Deprecated - Potential Process Injection via LD_PRELOAD Environment Variable
 * Deprecated - Potential Protocol Tunneling via Chisel Server
@@ -655,9 +667,11 @@ invalid-syntax
 * Deprecated - SSH Connection Established Inside A Running Container
 * Deprecated - SSH Process Launched From Inside A Container
 * Deprecated - SSH Process Launched From Inside A Container via Elastic Defend
+* Deprecated - SUNBURST Command and Control Activity
 * Deprecated - Sudo Heap-Based Buffer Overflow Attempt
 * Deprecated - Suspicious File Creation in /etc for Persistence
 * Deprecated - Suspicious JAVA Child Process
+* Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Suspicious Renaming of ESXI index.html File
 * Deprecated - Threat Intel Filebeat Module (v8.x) Indicator Match
 * Deprecated - Threat Intel Indicator Match
@@ -668,9 +682,12 @@ invalid-syntax
 * FTP (File Transfer Protocol) Activity to the Internet
 * File and Directory Discovery
 * GCP Kubernetes Rolebindings Created or Patched
+* GKE Service Account Token Created via TokenRequest API
 * Google Workspace User Group Access Modified to Allow External Access
 * Hex Encoding/Decoding Activity
 * IRC (Internet Relay Chat) Protocol Activity to the Internet
+* Kubernetes Denied Service Account Request via Unusual User Agent
+* Kubernetes Unusual Decision by User Agent
 * Linux Restricted Shell Breakout via  apt/apt-get Changelog Escape
 * Linux Restricted Shell Breakout via awk Commands
 * Linux Restricted Shell Breakout via busybox Shell Evasion
@@ -685,6 +702,7 @@ invalid-syntax
 * Linux Restricted Shell Breakout via the gcc command
 * Linux Restricted Shell Breakout via the mysql command
 * Linux Restricted Shell Breakout via the vi command
+* MFA Disabled for Google Workspace Organization
 * Malicious Remote File Creation
 * Mknod Process Activity
 * Multiple Alerts in Different ATT&CK Tactics on a Single Host
@@ -936,6 +954,7 @@ Invalid syntax
 * AWS CloudWatch Log Stream Deletion
 * AWS Config Resource Deletion
 * AWS Configuration Recorder Stopped
+* AWS Detective Graph Deleted
 * AWS EC2 AMI Shared with Another Account
 * AWS EC2 Deprecated AMI Discovery
 * AWS EC2 Encryption Disabled
@@ -947,6 +966,7 @@ Invalid syntax
 * AWS EC2 Security Group Configuration Change
 * AWS EC2 Serial Console Access Enabled
 * AWS EFS File System Deleted
+* AWS EKS Access Entry Created Then Deleted by Same Identity
 * AWS EKS Access Entry Granted Cluster Admin Policy
 * AWS EKS Access Entry Modified
 * AWS EKS Control Plane Logging Disabled
@@ -954,6 +974,8 @@ Invalid syntax
 * AWS GuardDuty Detection Suppression
 * AWS GuardDuty Detector Deletion
 * AWS GuardDuty Member Account Manipulation
+* AWS GuardDuty Publishing Destination Deleted
+* AWS GuardDuty Threat Intelligence Set Deleted
 * AWS IAM Account Password Policy Deleted
 * AWS IAM Deactivation of MFA Device
 * AWS IAM Group Creation
@@ -1049,13 +1071,11 @@ Invalid syntax
 * CyberArk Privileged Access Security Recommended Monitor
 * Default Cobalt Strike Team Server Certificate
 * Deprecated - M365 Exchange DLP Policy Deleted
-* Deprecated - M365 Security Compliance Email Reported by User as Malware or Phish
 * Deprecated - M365 Security Compliance Potential Ransomware Activity
 * Deprecated - M365 Security Compliance Unusual Volume of File Deletion
 * Deprecated - M365 Security Compliance User Restricted from Sending Email
 * Deprecated - M365 Teams External Access Enabled
 * Deprecated - M365 Teams Guest Access Enabled
-* Deprecated - MFA Disabled for Google Workspace Organization
 * Direct Interactive Kubernetes API Request by Common Utilities
 * Direct Interactive Kubernetes API Request by Unusual Utilities
 * Domain Added to Google Workspace Trusted Domains
@@ -1161,7 +1181,6 @@ Invalid syntax
 * GKE Secret Access from Node or Denied Service Account
 * GKE Secret get or list with Suspicious User Agent
 * GKE Service Account Modified RBAC Objects
-* GKE Service Account Token Created via TokenRequest API
 * GKE Suspicious Assignment of Controller Service Account
 * GKE Suspicious Self-Subject Review via Service Account
 * GitHub App Deleted
@@ -1192,7 +1211,6 @@ Invalid syntax
 * IBM QRadar External Alerts
 * ICMP Redirect Message from Internal Host
 * ICMP Timestamp or Information Request from the Internet
-* IPSEC NAT Traversal Port Activity
 * Inbound Connection to an Unsecure Elasticsearch Node
 * Initial Access via File Upload Followed by GET Request
 * Insecure AWS EC2 VPC Security Group Ingress Rule Added
@@ -1211,8 +1229,8 @@ Invalid syntax
 * Kubernetes Pod Created With HostPID
 * Kubernetes Pod Created with a Sensitive hostPath Volume
 * Kubernetes Privileged Pod Created
-* Kubernetes Secret get or list from Node or Pod Service Account
-* Kubernetes Secret get or list with Suspicious User Agent
+* Kubernetes Secret Get or List from Node or Pod Service Account
+* Kubernetes Secret Get or List with Suspicious User Agent
 * Kubernetes Sensitive RBAC Change Followed by Workload Modification
 * Kubernetes Service Account Modified RBAC Objects
 * Kubernetes Service Account Token Created via TokenRequest API
@@ -1298,15 +1316,16 @@ Invalid syntax
 * Whoami Process Activity
 * Zoom Meeting with no Passcode
 
-### Unsupported function: match (35)
+### Unsupported function: match (36)
 
-35 rules:
+36 rules:
 * Alternate Data Stream Creation/Execution at Volume Root Directory
 * Command Obfuscation via Unicode Modifier Letters
 * Creation of Hidden Files and Directories via CommandLine
 * Entra ID Sign-in BloodHound Suite User-Agent Detected
 * Executable File Creation with Multiple Extensions
 * File Deletion via Shred
+* File Downloaded by Curl/Wget and Piped to Interpreter
 * GenAI Process Connection to Suspicious Top Level Domain
 * Masquerading Space After Filename
 * Network Activity to a Suspicious Top Level Domain
@@ -1592,11 +1611,6 @@ Invalid syntax
 1 rules:
 * Creation of Hidden Shared Object File
 
-### Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)
-
-1 rules:
-* Deprecated - SUNBURST Command and Control Activity
-
 ### Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)
 
 1 rules:
@@ -1717,11 +1731,6 @@ Invalid syntax
 1 rules:
 * PowerShell Script with Veeam Credential Access Capabilities
 
-### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[string]::join'}): ('$pSHoMe[')) (1)
-
-1 rules:
-* Deprecated - Potential PowerShell Obfuscated Script
-
 ### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'capCreateCaptureWindowA'}): ('avicap32.dll')) (1)
 
 1 rules:
@@ -1812,6 +1821,11 @@ Invalid syntax
 1 rules:
 * Boot File Copy
 
+### Unsolvable constraints: process.name (excluded by Strings({'elastic-agent.exe'}): ('elastic-agent.exe')) (1)
+
+1 rules:
+* Elastic Agent Service Terminated
+
 ### Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)
 
 1 rules:
@@ -1846,6 +1860,11 @@ Invalid syntax
 
 1 rules:
 * Enumeration Command Spawned via WMIPrvSE
+
+### Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)
+
+1 rules:
+* Suspicious Process Execution by Zoom
 
 ### Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)
 

--- a/tests/reports/documents_from_rules-9.5.md
+++ b/tests/reports/documents_from_rules-9.5.md
@@ -5,13 +5,13 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.4
+Rules version: 9.5.5
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (242)](#unsupported-rule-type-new_terms-242)
-      1. [Unsupported rule type: esql (209)](#unsupported-rule-type-esql-209)
-      1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
+      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
+      1. [Unsupported rule type: esql (218)](#unsupported-rule-type-esql-218)
+      1. ['types.SimpleNamespace' object has no attribute 'type' (129)](#typessimplenamespace-object-has-no-attribute-type-129)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -35,7 +35,7 @@ invalid-syntax
 -------------------1)
    1. [Generation errors](#generation-errors)
       1. [Field type solver: constant_keyword (389)](#field-type-solver-constant_keyword-389)
-      1. [Unsupported function: match (35)](#unsupported-function-match-35)
+      1. [Unsupported function: match (36)](#unsupported-function-match-36)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
       1. [Root without branches (11)](#root-without-branches-11)
@@ -65,7 +65,6 @@ invalid-syntax
       1. [Unsolvable constraints: file.extension (cannot be non-null) (1)](#unsolvable-constraints-fileextension-cannot-be-non-null-1)
       1. [Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)](#unsolvable-constraints-filename-excluded-by-stringslocal-state-local-state-1)
       1. [Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)](#unsolvable-constraints-filename-not-in-stringsso-so-1)
-      1. [Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringsswipuploadashx-post-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringschild_process-exec-1)
       1. [Unsolvable constraints: kubernetes.audit.requestObject.spec.containers.image (cannot be null) (1)](#unsolvable-constraints-kubernetesauditrequestobjectspeccontainersimage-cannot-be-null-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (excluded by Strings({'DsGetSiteName'}): ('DsGetSiteName')) (1)](#unsolvable-constraints-powershellfilescript_block_text-excluded-by-stringsdsgetsitename-dsgetsitename-1)
@@ -90,7 +89,6 @@ invalid-syntax
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[Ref].Assembly.GetType(('System.Management.Automation'}): ('.SetValue(')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsrefassemblygettypesystemmanagementautomation-setvalue-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[System.Reflection.Assembly]::Load'}): ('FromBase64String')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringssystemreflectionassemblyload-frombase64string-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[dbo].[Credentials]'}): ('Veeam')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsdbocredentials-veeam-1)
-      1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[string]::join'}): ('$pSHoMe[')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsstringjoin-pshome-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'capCreateCaptureWindowA'}): ('avicap32.dll')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringscapcreatecapturewindowa-avicap32dll-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'defaultNamingContext'}): ('.MinLengthPassword')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsdefaultnamingcontext-minlengthpassword-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'shi1_netname'}): ('shi1_remark')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsshi1_netname-shi1_remark-1)
@@ -109,6 +107,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.command_line (not in Strings({'*vm.swappiness*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsvmswappiness-echo--1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'arp.exe'}): ('arp.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsarpexe-arpexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)](#unsolvable-constraints-processname-excluded-by-stringscp-cp-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'elastic-agent.exe'}): ('elastic-agent.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselastic-agentexe-elastic-agentexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselevation_serviceexe-elevation_serviceexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'modprobe'}): ('modprobe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmodprobe-modprobe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msdt.exe'}): ('msdt.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsdtexe-msdtexe-1)
@@ -116,6 +115,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'net1.exe'}): ('net1.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnet1exe-net1exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nohup'}): ('nohup')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnohup-nohup-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsscexe-scexe-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)](#unsolvable-constraints-processname-excluded-by-stringssh-sh-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringssmssexe-smssexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sysctl'}): ('sysctl')) (1)](#unsolvable-constraints-processname-excluded-by-stringssysctl-sysctl-1)
       1. [Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)](#unsolvable-constraints-processname-not-in-stringsrundll32exe-mshtaexe-1)
@@ -143,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (242)
+### Unsupported rule type: new_terms (241)
 
-242 rules:
+241 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -180,6 +180,7 @@ invalid-syntax
 * AWS Lambda Function Invoked from an Unusual Source ASN
 * AWS S3 Bucket ACL Modified to Allow Public Access by New Identity
 * AWS S3 Unauthenticated Bucket Access by Rare Source
+* AWS SES Full Access Policy Attached to IAM Entity by Unusual User
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
 * AWS SNS Topic Message Publish by Rare User
@@ -216,7 +217,6 @@ invalid-syntax
 * Azure VM Serial Console Connection with Unusual User and ASN
 * DPKG Package Installed by Unusual Parent Process
 * Delegated Managed Service Account Modification by an Unusual User
-* Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
 * Deprecated TLS Version or Weak Cipher Negotiated Externally
 * Direct Process Execution via Background Utility
@@ -257,6 +257,7 @@ invalid-syntax
 * First Occurrence of Private Repo Event from Specific GitHub Personal Access Token (PAT)
 * First Occurrence of User Agent For a GitHub Personal Access Token (PAT)
 * First Occurrence of User-Agent For a GitHub User
+* First Seen SonicWall Remote Access Login by User and Source
 * First Time AWS CloudFormation Stack Creation
 * First Time Python Accessed Sensitive Credential Files
 * First Time Python Created a LaunchAgent or LaunchDaemon
@@ -290,12 +291,10 @@ invalid-syntax
 * Kernel Object File Creation
 * Kill Command Execution
 * Kubernetes Anonymous Request Authorized by Unusual User Agent
-* Kubernetes Denied Service Account Request via Unusual User Agent
 * Kubernetes Forbidden Request from Unusual User Agent
 * Kubernetes Pod Creation Using Common Debug or Base Images
 * Kubernetes Secret Access via Unusual User Agent
 * Kubernetes Suspicious Self-Subject Review via Unusual User Agent
-* Kubernetes Unusual Decision by User Agent
 * LSASS Memory Dump Handle Access
 * Linux Audio Recording Activity Detected
 * Linux Clipboard Activity Detected
@@ -390,9 +389,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (209)
+### Unsupported rule type: esql (218)
 
-209 rules:
+218 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -425,6 +424,7 @@ invalid-syntax
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SES Email Identity Verified Then Deleted
 * AWS SageMaker Execution Role Passed by Unusual Principal
 * AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
@@ -464,6 +464,7 @@ invalid-syntax
 * First-Time FortiGate Administrator Login
 * FortiGate Administrator Login from Multiple IP Addresses
 * FortiGate FortiCloud SSO Login from Unusual Source
+* GCP Secret Manager ListSecrets Across Multiple Projects
 * GKE API Request Failure Burst by User
 * GKE Anonymous Endpoint Permission Enumeration
 * GKE Certificate Signing Request Self-Approved
@@ -531,6 +532,7 @@ invalid-syntax
 * Newly Observed FortiGate Alert
 * Newly Observed High Severity Detection Alert
 * Newly Observed High Severity Suricata Alert
+* Newly Observed IPSEC NAT Traversal Peer
 * Newly Observed Palo Alto Network Alert
 * Newly Observed Process Exhibiting High CPU Usage
 * Newly Observed ScreenConnect Host Server
@@ -546,8 +548,11 @@ invalid-syntax
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries
+* Potential DNS Rebinding from Public to Private Address
+* Potential DNS Tunneling via Long and Unique Subdomains
 * Potential Denial of Azure OpenAI ML Service
 * Potential Dynamic IEX Reconstruction via Environment Variables
+* Potential Evasion via Boot Time Removal Tool
 * Potential Linux Local Account Brute Force Detected
 * Potential Malicious PowerShell Based on Alert Correlation
 * Potential Malware-Driven SSH Brute Force Attempt
@@ -575,6 +580,7 @@ invalid-syntax
 * Potential SIP Extension Enumeration
 * Potential SIP REGISTER Brute Force
 * Potential SQL Injection Against Microsoft SQL Server
+* Potential Self-Signed TLS Certificate Recently Issued on External Connection
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
 * Potential Widespread Malware Infection Across Multiple Hosts
@@ -582,6 +588,8 @@ invalid-syntax
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
 * Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
+* SSFileCopyReceiver Writing to Common Persistence Locations
+* SSFileCopySender Executed as Root
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
@@ -604,9 +612,9 @@ invalid-syntax
 * Web Server Potential Spike in Error Response Codes
 * Web Server Suspicious User Agent Requests
 
-### 'types.SimpleNamespace' object has no attribute 'type' (119)
+### 'types.SimpleNamespace' object has no attribute 'type' (129)
 
-119 rules:
+129 rules:
 
 * AWS RDS Snapshot Export
 * Attempt to Disable IPTables or Firewall
@@ -627,21 +635,25 @@ invalid-syntax
 * Deprecated - AWS RDS Security Group Deletion
 * Deprecated - AWS Redshift Cluster Creation
 * Deprecated - AWS Root Login Without MFA
+* Deprecated - Adobe Hijack Persistence
 * Deprecated - Agent Spoofing - Mismatched Agent ID
 * Deprecated - Azure Entra Sign-in Brute Force Microsoft 365 Accounts by Repeat Source
 * Deprecated - Azure Virtual Network Device Modified or Deleted
 * Deprecated - CAP_SYS_ADMIN Assigned to Binary
 * Deprecated - Creation of Kernel Module
 * Deprecated - EggShell Backdoor Execution
+* Deprecated - Encoded Executable Stored in the Registry
 * Deprecated - Execution of File Written or Modified by PDF Reader
 * Deprecated - LaunchDaemon Creation or Modification and Immediate Loading
 * Deprecated - Linux Restricted Shell Breakout via Linux Binary(s)
+* Deprecated - M365 Security Compliance Email Reported by User as Malware or Phish
 * Deprecated - Modification of Standard Authentication Module or Configuration
 * Deprecated - Network Connection via Sudo Binary
 * Deprecated - Potential DNS Tunneling via Iodine
 * Deprecated - Potential Non-Standard Port HTTP/HTTPS connection
 * Deprecated - Potential Non-Standard Port SSH connection
 * Deprecated - Potential Password Spraying of Microsoft 365 User Accounts
+* Deprecated - Potential PowerShell Obfuscated Script
 * Deprecated - Potential Privilege Escalation via UID INT_MAX Bug Detected
 * Deprecated - Potential Process Injection via LD_PRELOAD Environment Variable
 * Deprecated - Potential Protocol Tunneling via Chisel Server
@@ -655,9 +667,11 @@ invalid-syntax
 * Deprecated - SSH Connection Established Inside A Running Container
 * Deprecated - SSH Process Launched From Inside A Container
 * Deprecated - SSH Process Launched From Inside A Container via Elastic Defend
+* Deprecated - SUNBURST Command and Control Activity
 * Deprecated - Sudo Heap-Based Buffer Overflow Attempt
 * Deprecated - Suspicious File Creation in /etc for Persistence
 * Deprecated - Suspicious JAVA Child Process
+* Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Suspicious Renaming of ESXI index.html File
 * Deprecated - Threat Intel Filebeat Module (v8.x) Indicator Match
 * Deprecated - Threat Intel Indicator Match
@@ -668,9 +682,12 @@ invalid-syntax
 * FTP (File Transfer Protocol) Activity to the Internet
 * File and Directory Discovery
 * GCP Kubernetes Rolebindings Created or Patched
+* GKE Service Account Token Created via TokenRequest API
 * Google Workspace User Group Access Modified to Allow External Access
 * Hex Encoding/Decoding Activity
 * IRC (Internet Relay Chat) Protocol Activity to the Internet
+* Kubernetes Denied Service Account Request via Unusual User Agent
+* Kubernetes Unusual Decision by User Agent
 * Linux Restricted Shell Breakout via  apt/apt-get Changelog Escape
 * Linux Restricted Shell Breakout via awk Commands
 * Linux Restricted Shell Breakout via busybox Shell Evasion
@@ -685,6 +702,7 @@ invalid-syntax
 * Linux Restricted Shell Breakout via the gcc command
 * Linux Restricted Shell Breakout via the mysql command
 * Linux Restricted Shell Breakout via the vi command
+* MFA Disabled for Google Workspace Organization
 * Malicious Remote File Creation
 * Mknod Process Activity
 * Multiple Alerts in Different ATT&CK Tactics on a Single Host
@@ -936,6 +954,7 @@ Invalid syntax
 * AWS CloudWatch Log Stream Deletion
 * AWS Config Resource Deletion
 * AWS Configuration Recorder Stopped
+* AWS Detective Graph Deleted
 * AWS EC2 AMI Shared with Another Account
 * AWS EC2 Deprecated AMI Discovery
 * AWS EC2 Encryption Disabled
@@ -947,6 +966,7 @@ Invalid syntax
 * AWS EC2 Security Group Configuration Change
 * AWS EC2 Serial Console Access Enabled
 * AWS EFS File System Deleted
+* AWS EKS Access Entry Created Then Deleted by Same Identity
 * AWS EKS Access Entry Granted Cluster Admin Policy
 * AWS EKS Access Entry Modified
 * AWS EKS Control Plane Logging Disabled
@@ -954,6 +974,8 @@ Invalid syntax
 * AWS GuardDuty Detection Suppression
 * AWS GuardDuty Detector Deletion
 * AWS GuardDuty Member Account Manipulation
+* AWS GuardDuty Publishing Destination Deleted
+* AWS GuardDuty Threat Intelligence Set Deleted
 * AWS IAM Account Password Policy Deleted
 * AWS IAM Deactivation of MFA Device
 * AWS IAM Group Creation
@@ -1049,13 +1071,11 @@ Invalid syntax
 * CyberArk Privileged Access Security Recommended Monitor
 * Default Cobalt Strike Team Server Certificate
 * Deprecated - M365 Exchange DLP Policy Deleted
-* Deprecated - M365 Security Compliance Email Reported by User as Malware or Phish
 * Deprecated - M365 Security Compliance Potential Ransomware Activity
 * Deprecated - M365 Security Compliance Unusual Volume of File Deletion
 * Deprecated - M365 Security Compliance User Restricted from Sending Email
 * Deprecated - M365 Teams External Access Enabled
 * Deprecated - M365 Teams Guest Access Enabled
-* Deprecated - MFA Disabled for Google Workspace Organization
 * Direct Interactive Kubernetes API Request by Common Utilities
 * Direct Interactive Kubernetes API Request by Unusual Utilities
 * Domain Added to Google Workspace Trusted Domains
@@ -1161,7 +1181,6 @@ Invalid syntax
 * GKE Secret Access from Node or Denied Service Account
 * GKE Secret get or list with Suspicious User Agent
 * GKE Service Account Modified RBAC Objects
-* GKE Service Account Token Created via TokenRequest API
 * GKE Suspicious Assignment of Controller Service Account
 * GKE Suspicious Self-Subject Review via Service Account
 * GitHub App Deleted
@@ -1192,7 +1211,6 @@ Invalid syntax
 * IBM QRadar External Alerts
 * ICMP Redirect Message from Internal Host
 * ICMP Timestamp or Information Request from the Internet
-* IPSEC NAT Traversal Port Activity
 * Inbound Connection to an Unsecure Elasticsearch Node
 * Initial Access via File Upload Followed by GET Request
 * Insecure AWS EC2 VPC Security Group Ingress Rule Added
@@ -1211,8 +1229,8 @@ Invalid syntax
 * Kubernetes Pod Created With HostPID
 * Kubernetes Pod Created with a Sensitive hostPath Volume
 * Kubernetes Privileged Pod Created
-* Kubernetes Secret get or list from Node or Pod Service Account
-* Kubernetes Secret get or list with Suspicious User Agent
+* Kubernetes Secret Get or List from Node or Pod Service Account
+* Kubernetes Secret Get or List with Suspicious User Agent
 * Kubernetes Sensitive RBAC Change Followed by Workload Modification
 * Kubernetes Service Account Modified RBAC Objects
 * Kubernetes Service Account Token Created via TokenRequest API
@@ -1298,15 +1316,16 @@ Invalid syntax
 * Whoami Process Activity
 * Zoom Meeting with no Passcode
 
-### Unsupported function: match (35)
+### Unsupported function: match (36)
 
-35 rules:
+36 rules:
 * Alternate Data Stream Creation/Execution at Volume Root Directory
 * Command Obfuscation via Unicode Modifier Letters
 * Creation of Hidden Files and Directories via CommandLine
 * Entra ID Sign-in BloodHound Suite User-Agent Detected
 * Executable File Creation with Multiple Extensions
 * File Deletion via Shred
+* File Downloaded by Curl/Wget and Piped to Interpreter
 * GenAI Process Connection to Suspicious Top Level Domain
 * Masquerading Space After Filename
 * Network Activity to a Suspicious Top Level Domain
@@ -1592,11 +1611,6 @@ Invalid syntax
 1 rules:
 * Creation of Hidden Shared Object File
 
-### Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)
-
-1 rules:
-* Deprecated - SUNBURST Command and Control Activity
-
 ### Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)
 
 1 rules:
@@ -1717,11 +1731,6 @@ Invalid syntax
 1 rules:
 * PowerShell Script with Veeam Credential Access Capabilities
 
-### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[string]::join'}): ('$pSHoMe[')) (1)
-
-1 rules:
-* Deprecated - Potential PowerShell Obfuscated Script
-
 ### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'capCreateCaptureWindowA'}): ('avicap32.dll')) (1)
 
 1 rules:
@@ -1812,6 +1821,11 @@ Invalid syntax
 1 rules:
 * Boot File Copy
 
+### Unsolvable constraints: process.name (excluded by Strings({'elastic-agent.exe'}): ('elastic-agent.exe')) (1)
+
+1 rules:
+* Elastic Agent Service Terminated
+
 ### Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)
 
 1 rules:
@@ -1846,6 +1860,11 @@ Invalid syntax
 
 1 rules:
 * Enumeration Command Spawned via WMIPrvSE
+
+### Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)
+
+1 rules:
+* Suspicious Process Execution by Zoom
 
 ### Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)
 

--- a/tests/reports/documents_from_rules-serverless.md
+++ b/tests/reports/documents_from_rules-serverless.md
@@ -5,13 +5,13 @@ can learn what rules are still problematic and for which no documents can be gen
 
 Curious about the inner workings? Read [here](signals_generation.md).
 
-Rules version: 9.5.4
+Rules version: 9.5.5
 
 ## Table of contents
    1. [Skipped rules](#skipped-rules)
-      1. [Unsupported rule type: new_terms (242)](#unsupported-rule-type-new_terms-242)
-      1. [Unsupported rule type: esql (209)](#unsupported-rule-type-esql-209)
-      1. ['types.SimpleNamespace' object has no attribute 'type' (119)](#typessimplenamespace-object-has-no-attribute-type-119)
+      1. [Unsupported rule type: new_terms (241)](#unsupported-rule-type-new_terms-241)
+      1. [Unsupported rule type: esql (218)](#unsupported-rule-type-esql-218)
+      1. ['types.SimpleNamespace' object has no attribute 'type' (129)](#typessimplenamespace-object-has-no-attribute-type-129)
       1. [Unsupported rule type: machine_learning (106)](#unsupported-rule-type-machine_learning-106)
       1. [Unsupported rule type: threshold (28)](#unsupported-rule-type-threshold-28)
       1. [Unsupported rule type: threat_match (6)](#unsupported-rule-type-threat_match-6)
@@ -35,7 +35,7 @@ invalid-syntax
 -------------------1)
    1. [Generation errors](#generation-errors)
       1. [Field type solver: constant_keyword (389)](#field-type-solver-constant_keyword-389)
-      1. [Unsupported function: match (35)](#unsupported-function-match-35)
+      1. [Unsupported function: match (36)](#unsupported-function-match-36)
       1. [Root with too many branches (limit: 10000) (27)](#root-with-too-many-branches-limit-10000-27)
       1. [Unsupported function: stringContains (25)](#unsupported-function-stringcontains-25)
       1. [Root without branches (11)](#root-without-branches-11)
@@ -65,7 +65,6 @@ invalid-syntax
       1. [Unsolvable constraints: file.extension (cannot be non-null) (1)](#unsolvable-constraints-fileextension-cannot-be-non-null-1)
       1. [Unsolvable constraints: file.name (excluded by Strings({'Local State'}): ('Local State')) (1)](#unsolvable-constraints-filename-excluded-by-stringslocal-state-local-state-1)
       1. [Unsolvable constraints: file.name (not in Strings({'*.so.*'}): ('.*.so')) (1)](#unsolvable-constraints-filename-not-in-stringsso-so-1)
-      1. [Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringsswipuploadashx-post-1)
       1. [Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)](#unsolvable-constraints-httprequestbodycontent-not-in-stringschild_process-exec-1)
       1. [Unsolvable constraints: kubernetes.audit.requestObject.spec.containers.image (cannot be null) (1)](#unsolvable-constraints-kubernetesauditrequestobjectspeccontainersimage-cannot-be-null-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (excluded by Strings({'DsGetSiteName'}): ('DsGetSiteName')) (1)](#unsolvable-constraints-powershellfilescript_block_text-excluded-by-stringsdsgetsitename-dsgetsitename-1)
@@ -90,7 +89,6 @@ invalid-syntax
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[Ref].Assembly.GetType(('System.Management.Automation'}): ('.SetValue(')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsrefassemblygettypesystemmanagementautomation-setvalue-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[System.Reflection.Assembly]::Load'}): ('FromBase64String')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringssystemreflectionassemblyload-frombase64string-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[dbo].[Credentials]'}): ('Veeam')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsdbocredentials-veeam-1)
-      1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[string]::join'}): ('$pSHoMe[')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsstringjoin-pshome-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'capCreateCaptureWindowA'}): ('avicap32.dll')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringscapcreatecapturewindowa-avicap32dll-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'defaultNamingContext'}): ('.MinLengthPassword')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsdefaultnamingcontext-minlengthpassword-1)
       1. [Unsolvable constraints: powershell.file.script_block_text (not in Strings({'shi1_netname'}): ('shi1_remark')) (1)](#unsolvable-constraints-powershellfilescript_block_text-not-in-stringsshi1_netname-shi1_remark-1)
@@ -109,6 +107,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.command_line (not in Strings({'*vm.swappiness*'}): ('*echo *')) (1)](#unsolvable-constraints-processcommand_line-not-in-stringsvmswappiness-echo--1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'arp.exe'}): ('arp.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsarpexe-arpexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'cp'}): ('cp')) (1)](#unsolvable-constraints-processname-excluded-by-stringscp-cp-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'elastic-agent.exe'}): ('elastic-agent.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselastic-agentexe-elastic-agentexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringselevation_serviceexe-elevation_serviceexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'modprobe'}): ('modprobe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmodprobe-modprobe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'msdt.exe'}): ('msdt.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsmsdtexe-msdtexe-1)
@@ -116,6 +115,7 @@ invalid-syntax
       1. [Unsolvable constraints: process.name (excluded by Strings({'net1.exe'}): ('net1.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnet1exe-net1exe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'nohup'}): ('nohup')) (1)](#unsolvable-constraints-processname-excluded-by-stringsnohup-nohup-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sc.exe'}): ('sc.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringsscexe-scexe-1)
+      1. [Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)](#unsolvable-constraints-processname-excluded-by-stringssh-sh-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)](#unsolvable-constraints-processname-excluded-by-stringssmssexe-smssexe-1)
       1. [Unsolvable constraints: process.name (excluded by Strings({'sysctl'}): ('sysctl')) (1)](#unsolvable-constraints-processname-excluded-by-stringssysctl-sysctl-1)
       1. [Unsolvable constraints: process.name (not in Strings({'rundll32.exe'}): ('mshta.exe')) (1)](#unsolvable-constraints-processname-not-in-stringsrundll32exe-mshtaexe-1)
@@ -143,9 +143,9 @@ invalid-syntax
 
 ## Skipped rules
 
-### Unsupported rule type: new_terms (242)
+### Unsupported rule type: new_terms (241)
 
-242 rules:
+241 rules:
 
 * AWS API Activity from Uncommon S3 Client by Rare User
 * AWS Account Discovery By Rare User
@@ -180,6 +180,7 @@ invalid-syntax
 * AWS Lambda Function Invoked from an Unusual Source ASN
 * AWS S3 Bucket ACL Modified to Allow Public Access by New Identity
 * AWS S3 Unauthenticated Bucket Access by Rare Source
+* AWS SES Full Access Policy Attached to IAM Entity by Unusual User
 * AWS SNS Rare Protocol Subscription by User
 * AWS SNS Topic Created by Rare User
 * AWS SNS Topic Message Publish by Rare User
@@ -216,7 +217,6 @@ invalid-syntax
 * Azure VM Serial Console Connection with Unusual User and ASN
 * DPKG Package Installed by Unusual Parent Process
 * Delegated Managed Service Account Modification by an Unusual User
-* Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Unusual Discovery Activity by User
 * Deprecated TLS Version or Weak Cipher Negotiated Externally
 * Direct Process Execution via Background Utility
@@ -257,6 +257,7 @@ invalid-syntax
 * First Occurrence of Private Repo Event from Specific GitHub Personal Access Token (PAT)
 * First Occurrence of User Agent For a GitHub Personal Access Token (PAT)
 * First Occurrence of User-Agent For a GitHub User
+* First Seen SonicWall Remote Access Login by User and Source
 * First Time AWS CloudFormation Stack Creation
 * First Time Python Accessed Sensitive Credential Files
 * First Time Python Created a LaunchAgent or LaunchDaemon
@@ -290,12 +291,10 @@ invalid-syntax
 * Kernel Object File Creation
 * Kill Command Execution
 * Kubernetes Anonymous Request Authorized by Unusual User Agent
-* Kubernetes Denied Service Account Request via Unusual User Agent
 * Kubernetes Forbidden Request from Unusual User Agent
 * Kubernetes Pod Creation Using Common Debug or Base Images
 * Kubernetes Secret Access via Unusual User Agent
 * Kubernetes Suspicious Self-Subject Review via Unusual User Agent
-* Kubernetes Unusual Decision by User Agent
 * LSASS Memory Dump Handle Access
 * Linux Audio Recording Activity Detected
 * Linux Clipboard Activity Detected
@@ -390,9 +389,9 @@ invalid-syntax
 * Web Shell Detection: Script Process Child of Common Web Processes
 * dMSA Account Creation by an Unusual User
 
-### Unsupported rule type: esql (209)
+### Unsupported rule type: esql (218)
 
-209 rules:
+218 rules:
 
 * AWS Access Token Used from Multiple Addresses
 * AWS Bedrock API Key Used for Destructive or Anti-Recovery Action
@@ -425,6 +424,7 @@ invalid-syntax
 * AWS S3 Object Encryption Using External KMS Key
 * AWS S3 Rapid Bucket Posture API Calls from a Single Principal
 * AWS S3 Static Site JavaScript File Uploaded
+* AWS SES Email Identity Verified Then Deleted
 * AWS SageMaker Execution Role Passed by Unusual Principal
 * AWS SageMaker Notebook Lifecycle Configuration With Suspicious Script Content
 * AWS Service Quotas Multi-Region GetServiceQuota Requests
@@ -464,6 +464,7 @@ invalid-syntax
 * First-Time FortiGate Administrator Login
 * FortiGate Administrator Login from Multiple IP Addresses
 * FortiGate FortiCloud SSO Login from Unusual Source
+* GCP Secret Manager ListSecrets Across Multiple Projects
 * GKE API Request Failure Burst by User
 * GKE Anonymous Endpoint Permission Enumeration
 * GKE Certificate Signing Request Self-Approved
@@ -531,6 +532,7 @@ invalid-syntax
 * Newly Observed FortiGate Alert
 * Newly Observed High Severity Detection Alert
 * Newly Observed High Severity Suricata Alert
+* Newly Observed IPSEC NAT Traversal Peer
 * Newly Observed Palo Alto Network Alert
 * Newly Observed Process Exhibiting High CPU Usage
 * Newly Observed ScreenConnect Host Server
@@ -546,8 +548,11 @@ invalid-syntax
 * Potential Credential Discovery via Recursive Grep
 * Potential DHCP Starvation via High Client MAC Cardinality
 * Potential DNS Exfiltration via Excessive Chunked Queries
+* Potential DNS Rebinding from Public to Private Address
+* Potential DNS Tunneling via Long and Unique Subdomains
 * Potential Denial of Azure OpenAI ML Service
 * Potential Dynamic IEX Reconstruction via Environment Variables
+* Potential Evasion via Boot Time Removal Tool
 * Potential Linux Local Account Brute Force Detected
 * Potential Malicious PowerShell Based on Alert Correlation
 * Potential Malware-Driven SSH Brute Force Attempt
@@ -575,6 +580,7 @@ invalid-syntax
 * Potential SIP Extension Enumeration
 * Potential SIP REGISTER Brute Force
 * Potential SQL Injection Against Microsoft SQL Server
+* Potential Self-Signed TLS Certificate Recently Issued on External Connection
 * Potential Spike in Web Server Error Logs
 * Potential Subnet Scanning Activity from Compromised Host
 * Potential Widespread Malware Infection Across Multiple Hosts
@@ -582,6 +588,8 @@ invalid-syntax
 * Privileged Accounts Brute Force
 * Rare Connection to WebDAV Target
 * Repeated Stalled TLS Handshakes via ALPN acme-tls/1 Extension
+* SSFileCopyReceiver Writing to Common Persistence Locations
+* SSFileCopySender Executed as Root
 * Sensitive Audit Policy Sub-Category Disabled
 * Several Failed Protected Branch Force Pushes by User
 * Splunk Enterprise PostgreSQL Backup-to-Restore Potential RCE Sequence
@@ -604,9 +612,9 @@ invalid-syntax
 * Web Server Potential Spike in Error Response Codes
 * Web Server Suspicious User Agent Requests
 
-### 'types.SimpleNamespace' object has no attribute 'type' (119)
+### 'types.SimpleNamespace' object has no attribute 'type' (129)
 
-119 rules:
+129 rules:
 
 * AWS RDS Snapshot Export
 * Attempt to Disable IPTables or Firewall
@@ -627,21 +635,25 @@ invalid-syntax
 * Deprecated - AWS RDS Security Group Deletion
 * Deprecated - AWS Redshift Cluster Creation
 * Deprecated - AWS Root Login Without MFA
+* Deprecated - Adobe Hijack Persistence
 * Deprecated - Agent Spoofing - Mismatched Agent ID
 * Deprecated - Azure Entra Sign-in Brute Force Microsoft 365 Accounts by Repeat Source
 * Deprecated - Azure Virtual Network Device Modified or Deleted
 * Deprecated - CAP_SYS_ADMIN Assigned to Binary
 * Deprecated - Creation of Kernel Module
 * Deprecated - EggShell Backdoor Execution
+* Deprecated - Encoded Executable Stored in the Registry
 * Deprecated - Execution of File Written or Modified by PDF Reader
 * Deprecated - LaunchDaemon Creation or Modification and Immediate Loading
 * Deprecated - Linux Restricted Shell Breakout via Linux Binary(s)
+* Deprecated - M365 Security Compliance Email Reported by User as Malware or Phish
 * Deprecated - Modification of Standard Authentication Module or Configuration
 * Deprecated - Network Connection via Sudo Binary
 * Deprecated - Potential DNS Tunneling via Iodine
 * Deprecated - Potential Non-Standard Port HTTP/HTTPS connection
 * Deprecated - Potential Non-Standard Port SSH connection
 * Deprecated - Potential Password Spraying of Microsoft 365 User Accounts
+* Deprecated - Potential PowerShell Obfuscated Script
 * Deprecated - Potential Privilege Escalation via UID INT_MAX Bug Detected
 * Deprecated - Potential Process Injection via LD_PRELOAD Environment Variable
 * Deprecated - Potential Protocol Tunneling via Chisel Server
@@ -655,9 +667,11 @@ invalid-syntax
 * Deprecated - SSH Connection Established Inside A Running Container
 * Deprecated - SSH Process Launched From Inside A Container
 * Deprecated - SSH Process Launched From Inside A Container via Elastic Defend
+* Deprecated - SUNBURST Command and Control Activity
 * Deprecated - Sudo Heap-Based Buffer Overflow Attempt
 * Deprecated - Suspicious File Creation in /etc for Persistence
 * Deprecated - Suspicious JAVA Child Process
+* Deprecated - Suspicious PrintSpooler Service Executable File Creation
 * Deprecated - Suspicious Renaming of ESXI index.html File
 * Deprecated - Threat Intel Filebeat Module (v8.x) Indicator Match
 * Deprecated - Threat Intel Indicator Match
@@ -668,9 +682,12 @@ invalid-syntax
 * FTP (File Transfer Protocol) Activity to the Internet
 * File and Directory Discovery
 * GCP Kubernetes Rolebindings Created or Patched
+* GKE Service Account Token Created via TokenRequest API
 * Google Workspace User Group Access Modified to Allow External Access
 * Hex Encoding/Decoding Activity
 * IRC (Internet Relay Chat) Protocol Activity to the Internet
+* Kubernetes Denied Service Account Request via Unusual User Agent
+* Kubernetes Unusual Decision by User Agent
 * Linux Restricted Shell Breakout via  apt/apt-get Changelog Escape
 * Linux Restricted Shell Breakout via awk Commands
 * Linux Restricted Shell Breakout via busybox Shell Evasion
@@ -685,6 +702,7 @@ invalid-syntax
 * Linux Restricted Shell Breakout via the gcc command
 * Linux Restricted Shell Breakout via the mysql command
 * Linux Restricted Shell Breakout via the vi command
+* MFA Disabled for Google Workspace Organization
 * Malicious Remote File Creation
 * Mknod Process Activity
 * Multiple Alerts in Different ATT&CK Tactics on a Single Host
@@ -936,6 +954,7 @@ Invalid syntax
 * AWS CloudWatch Log Stream Deletion
 * AWS Config Resource Deletion
 * AWS Configuration Recorder Stopped
+* AWS Detective Graph Deleted
 * AWS EC2 AMI Shared with Another Account
 * AWS EC2 Deprecated AMI Discovery
 * AWS EC2 Encryption Disabled
@@ -947,6 +966,7 @@ Invalid syntax
 * AWS EC2 Security Group Configuration Change
 * AWS EC2 Serial Console Access Enabled
 * AWS EFS File System Deleted
+* AWS EKS Access Entry Created Then Deleted by Same Identity
 * AWS EKS Access Entry Granted Cluster Admin Policy
 * AWS EKS Access Entry Modified
 * AWS EKS Control Plane Logging Disabled
@@ -954,6 +974,8 @@ Invalid syntax
 * AWS GuardDuty Detection Suppression
 * AWS GuardDuty Detector Deletion
 * AWS GuardDuty Member Account Manipulation
+* AWS GuardDuty Publishing Destination Deleted
+* AWS GuardDuty Threat Intelligence Set Deleted
 * AWS IAM Account Password Policy Deleted
 * AWS IAM Deactivation of MFA Device
 * AWS IAM Group Creation
@@ -1049,13 +1071,11 @@ Invalid syntax
 * CyberArk Privileged Access Security Recommended Monitor
 * Default Cobalt Strike Team Server Certificate
 * Deprecated - M365 Exchange DLP Policy Deleted
-* Deprecated - M365 Security Compliance Email Reported by User as Malware or Phish
 * Deprecated - M365 Security Compliance Potential Ransomware Activity
 * Deprecated - M365 Security Compliance Unusual Volume of File Deletion
 * Deprecated - M365 Security Compliance User Restricted from Sending Email
 * Deprecated - M365 Teams External Access Enabled
 * Deprecated - M365 Teams Guest Access Enabled
-* Deprecated - MFA Disabled for Google Workspace Organization
 * Direct Interactive Kubernetes API Request by Common Utilities
 * Direct Interactive Kubernetes API Request by Unusual Utilities
 * Domain Added to Google Workspace Trusted Domains
@@ -1161,7 +1181,6 @@ Invalid syntax
 * GKE Secret Access from Node or Denied Service Account
 * GKE Secret get or list with Suspicious User Agent
 * GKE Service Account Modified RBAC Objects
-* GKE Service Account Token Created via TokenRequest API
 * GKE Suspicious Assignment of Controller Service Account
 * GKE Suspicious Self-Subject Review via Service Account
 * GitHub App Deleted
@@ -1192,7 +1211,6 @@ Invalid syntax
 * IBM QRadar External Alerts
 * ICMP Redirect Message from Internal Host
 * ICMP Timestamp or Information Request from the Internet
-* IPSEC NAT Traversal Port Activity
 * Inbound Connection to an Unsecure Elasticsearch Node
 * Initial Access via File Upload Followed by GET Request
 * Insecure AWS EC2 VPC Security Group Ingress Rule Added
@@ -1211,8 +1229,8 @@ Invalid syntax
 * Kubernetes Pod Created With HostPID
 * Kubernetes Pod Created with a Sensitive hostPath Volume
 * Kubernetes Privileged Pod Created
-* Kubernetes Secret get or list from Node or Pod Service Account
-* Kubernetes Secret get or list with Suspicious User Agent
+* Kubernetes Secret Get or List from Node or Pod Service Account
+* Kubernetes Secret Get or List with Suspicious User Agent
 * Kubernetes Sensitive RBAC Change Followed by Workload Modification
 * Kubernetes Service Account Modified RBAC Objects
 * Kubernetes Service Account Token Created via TokenRequest API
@@ -1298,15 +1316,16 @@ Invalid syntax
 * Whoami Process Activity
 * Zoom Meeting with no Passcode
 
-### Unsupported function: match (35)
+### Unsupported function: match (36)
 
-35 rules:
+36 rules:
 * Alternate Data Stream Creation/Execution at Volume Root Directory
 * Command Obfuscation via Unicode Modifier Letters
 * Creation of Hidden Files and Directories via CommandLine
 * Entra ID Sign-in BloodHound Suite User-Agent Detected
 * Executable File Creation with Multiple Extensions
 * File Deletion via Shred
+* File Downloaded by Curl/Wget and Piped to Interpreter
 * GenAI Process Connection to Suspicious Top Level Domain
 * Masquerading Space After Filename
 * Network Activity to a Suspicious Top Level Domain
@@ -1592,11 +1611,6 @@ Invalid syntax
 1 rules:
 * Creation of Hidden Shared Object File
 
-### Unsolvable constraints: http.request.body.content (not in Strings({'*/swip/Upload.ashx*'}): ('POST*')) (1)
-
-1 rules:
-* Deprecated - SUNBURST Command and Control Activity
-
 ### Unsolvable constraints: http.request.body.content (not in Strings({'*child_process*'}): ('*.exec*')) (1)
 
 1 rules:
@@ -1717,11 +1731,6 @@ Invalid syntax
 1 rules:
 * PowerShell Script with Veeam Credential Access Capabilities
 
-### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'[string]::join'}): ('$pSHoMe[')) (1)
-
-1 rules:
-* Deprecated - Potential PowerShell Obfuscated Script
-
 ### Unsolvable constraints: powershell.file.script_block_text (not in Strings({'capCreateCaptureWindowA'}): ('avicap32.dll')) (1)
 
 1 rules:
@@ -1812,6 +1821,11 @@ Invalid syntax
 1 rules:
 * Boot File Copy
 
+### Unsolvable constraints: process.name (excluded by Strings({'elastic-agent.exe'}): ('elastic-agent.exe')) (1)
+
+1 rules:
+* Elastic Agent Service Terminated
+
 ### Unsolvable constraints: process.name (excluded by Strings({'elevation_service.exe'}): ('elevation_service.exe')) (1)
 
 1 rules:
@@ -1846,6 +1860,11 @@ Invalid syntax
 
 1 rules:
 * Enumeration Command Spawned via WMIPrvSE
+
+### Unsolvable constraints: process.name (excluded by Strings({'sh'}): ('sh')) (1)
+
+1 rules:
+* Suspicious Process Execution by Zoom
 
 ### Unsolvable constraints: process.name (excluded by Strings({'smss.exe'}): ('smss.exe')) (1)
 


### PR DESCRIPTION
Serverless:
- serverless: 9.5.4 -> 9.5.5 (PR #830)

ECH:
- 9.5: 9.5.4 -> 9.5.5 (PR #833)
- 9.4: 9.4.11 -> 9.4.12 (PR #832)
- 9.3: 9.3.19 -> 9.3.20 (PR #831)
- 8.19: 8.19.31 -> 8.19.32 (PR #829)